### PR TITLE
Chore: Minor uploader changes - close event, classname

### DIFF
--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -39,7 +39,7 @@ type Props = {
     uploadHost: string,
     clientName: string,
     className: string,
-    onClose?: Function,
+    onClose: Function,
     onComplete: Function,
     getLocalizedMessage: Function,
     isSmall: boolean,
@@ -73,6 +73,7 @@ class ContentUploader extends Component<DefaultProps, Props, State> {
         uploadHost: DEFAULT_HOSTNAME_UPLOAD,
         clientName: CLIENT_NAME_CONTENT_UPLOADER,
         className: '',
+        onClose: noop,
         onComplete: noop
     };
 

--- a/src/components/ContentUploader/UploadState.js
+++ b/src/components/ContentUploader/UploadState.js
@@ -3,6 +3,7 @@
  * @file Upload state component
  */
 
+import classNames from 'classnames';
 import React from 'react';
 import IconErrorEmptyState from '../icons/states/IconErrorEmptyState';
 import IconUploadStartState from '../icons/states/IconUploadStartState';
@@ -69,14 +70,11 @@ const UploadState = ({ canDrop, getLocalizedMessage, hasItems, isOver, isTouch, 
         /* eslint-enable jsx-a11y/label-has-for */
     }
 
-    let className = 'bcu-upload-state';
-    if (isOver) {
-        className = `${className} ${canDrop ? 'bcu-is-droppable' : 'bcu-is-not-droppable'}`;
-    }
-
-    if (hasItems) {
-        className = `${className} bcu-has-items`;
-    }
+    const className = classNames('bcu-upload-state', {
+        'bcu-is-droppable': isOver && canDrop,
+        'bcu-is-not-droppable': isOver && !canDrop,
+        'bcu-has-items': hasItems
+    });
 
     return (
         <div className={className}>

--- a/src/wrappers/ContentUploader.js
+++ b/src/wrappers/ContentUploader.js
@@ -13,6 +13,15 @@ import type { BoxItem, ModalOptions } from '../flowTypes';
 
 class ContentUploader extends ES6Wrapper {
     /**
+     * Callback on closing uploader. Emits 'close' event.
+     *
+     * @return {void}
+     */
+    onClose = (): void => {
+        this.emit('close');
+    };
+
+    /**
      * Callback on completed upload. Emits 'complete' event with Box File objects of uploaded items as data.
      *
      * @param {Array} data - Completed upload items
@@ -32,6 +41,7 @@ class ContentUploader extends ES6Wrapper {
                 componentRef={this.setComponent}
                 rootFolderId={this.root}
                 token={this.token}
+                onClose={this.onClose}
                 onComplete={this.onComplete}
                 modal={modal}
                 {...rest}


### PR DESCRIPTION
- Fire 'close' event when uploader is closed
- Use classname util to generate classnames based on variables