### PR TITLE
Update: Only request applicable API fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "prettier": "^1.5.3",
     "prettier-eslint-cli": "^4.1.1",
     "properties-parser": "^0.3.1",
+    "randomcolor": "^0.5.3",
     "react": "^15.6.1",
     "react-addons-test-utils": "^15.6.0",
     "react-dom": "^15.6.1",

--- a/src/api/File.js
+++ b/src/api/File.js
@@ -5,14 +5,9 @@
  */
 
 import Item from './Item';
-import {
-    FIELD_DOWNLOAD_URL,
-    CACHE_PREFIX_FILE,
-    FIELDS_TO_FETCH,
-    X_REP_HINTS,
-    TYPED_ID_FILE_PREFIX
-} from '../constants';
 import Cache from '../util/Cache';
+import getFields from '../util/fields';
+import { FIELD_DOWNLOAD_URL, CACHE_PREFIX_FILE, X_REP_HINTS, TYPED_ID_FILE_PREFIX } from '../constants';
 import type { BoxItem } from '../flowTypes';
 
 class File extends Item {
@@ -71,13 +66,20 @@ class File extends Item {
     /**
      * Gets a box file
      *
-     * @param {string} id File id
-     * @param {Function} successCallback Function to call with results
-     * @param {Function} errorCallback Function to call with errors
-     * @param {boolean} forceFetch Bypasses the cache
+     * @param {string} id - File id
+     * @param {Function} successCallback - Function to call with results
+     * @param {Function} errorCallback - Function to call with errors
+     * @param {boolean|void} [forceFetch] - Bypasses the cache
+     * @param {boolean|void} [includePreviewSidebar] - Optionally include preview sidebar fields
      * @return {Promise}
      */
-    file(id: string, successCallback: Function, errorCallback: Function, forceFetch: boolean = false): Promise<void> {
+    file(
+        id: string,
+        successCallback: Function,
+        errorCallback: Function,
+        forceFetch: boolean = false,
+        includePreviewSidebarFields: boolean = false
+    ): Promise<void> {
         if (this.isDestroyed()) {
             return Promise.reject();
         }
@@ -104,7 +106,7 @@ class File extends Item {
                 id: this.getTypedFileId(id),
                 url: this.getUrl(id),
                 params: {
-                    fields: FIELDS_TO_FETCH
+                    fields: getFields(true, includePreviewSidebarFields)
                 },
                 headers: { 'X-Rep-Hints': X_REP_HINTS }
             })

--- a/src/api/Folder.js
+++ b/src/api/Folder.js
@@ -11,7 +11,8 @@ import sort from '../util/sorter';
 import FileAPI from '../api/File';
 import WebLinkAPI from '../api/WebLink';
 import Cache from '../util/Cache';
-import { FIELDS_TO_FETCH, CACHE_PREFIX_FOLDER, X_REP_HINTS } from '../constants';
+import getFields from '../util/fields';
+import { CACHE_PREFIX_FOLDER, X_REP_HINTS } from '../constants';
 import getBadItemError from '../util/error';
 import type {
     BoxItem,
@@ -65,6 +66,16 @@ class Folder extends Item {
      * @property {Function}
      */
     errorCallback: Function;
+
+    /**
+     * @property {boolean}
+     */
+    includePreviewFields: boolean;
+
+    /**
+     * @property {boolean}
+     */
+    includePreviewSidebarFields: boolean;
 
     /**
      * Creates a key for the cache
@@ -217,7 +228,7 @@ class Folder extends Item {
                 params: {
                     offset: this.offset,
                     limit: LIMIT_ITEM_FETCH,
-                    fields: FIELDS_TO_FETCH
+                    fields: getFields(this.includePreviewFields, this.includePreviewSidebarFields)
                 },
                 headers: { 'X-Rep-Hints': X_REP_HINTS }
             })
@@ -228,12 +239,14 @@ class Folder extends Item {
     /**
      * Gets a box folder and its items
      *
-     * @param {string} id Folder id
-     * @param {string} sortBy sort by field
-     * @param {string} sortDirection sort direction
-     * @param {Function} successCallback Function to call with results
-     * @param {Function} errorCallback Function to call with errors
-     * @param {boolean} forceFetch Bypasses the cache
+     * @param {string} id - Folder id
+     * @param {string} sortBy - sort by field
+     * @param {string} sortDirection - sort direction
+     * @param {Function} successCallback - Function to call with results
+     * @param {Function} errorCallback - Function to call with errors
+     * @param {boolean|void} [forceFetch] - Bypasses the cache
+     * @param {boolean|void} [includePreview] - Optionally include preview fields
+     * @param {boolean|void} [includePreviewSidebar] - Optionally include preview sidebar fields
      * @return {void}
      */
     folder(
@@ -242,7 +255,9 @@ class Folder extends Item {
         sortDirection: SortDirection,
         successCallback: Function,
         errorCallback: Function,
-        forceFetch: boolean = false
+        forceFetch: boolean = false,
+        includePreviewFields: boolean = false,
+        includePreviewSidebarFields: boolean = false
     ): void {
         if (this.isDestroyed()) {
             return;
@@ -256,6 +271,8 @@ class Folder extends Item {
         this.errorCallback = errorCallback;
         this.sortBy = sortBy;
         this.sortDirection = sortDirection;
+        this.includePreviewFields = includePreviewFields;
+        this.includePreviewSidebarFields = includePreviewSidebarFields; // implies preview
 
         // Clear the cache if needed
         if (forceFetch) {
@@ -316,7 +333,7 @@ class Folder extends Item {
             return Promise.reject();
         }
 
-        const url = `${this.getUrl()}?fields=${FIELDS_TO_FETCH}`;
+        const url = `${this.getUrl()}?fields=${getFields()}`;
         return this.xhr
             .post({
                 url,

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -163,7 +163,7 @@ class Metadata extends Item {
                             {
                                 id: uniqueid('time_'),
                                 start: 20,
-                                end: 30
+                                end: 80
                             },
                             {
                                 id: uniqueid('time_'),
@@ -184,12 +184,125 @@ class Metadata extends Item {
                     },
                     {
                         id: uniqueid('cardentry_'),
+                        type: 'text',
+                        text: 'Games',
+                        appears: [
+                            {
+                                id: uniqueid('time_'),
+                                start: 100,
+                                end: 810
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 1500,
+                                end: 1800
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 1950,
+                                end: 2310
+                            }
+                        ]
+                    },
+                    {
+                        id: uniqueid('cardentry_'),
                         type: 'image',
                         url: 'http://www.globalo.com/content/uploads/2015/12/darth-vader.jpg',
                         appears: [
                             {
                                 id: uniqueid('time_'),
-                                start: 2530,
+                                start: 0,
+                                end: 150
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 200,
+                                end: 400
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 800,
+                                end: 1200
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 2000,
+                                end: 2560
+                            }
+                        ]
+                    },
+                    {
+                        id: uniqueid('cardentry_'),
+                        type: 'image',
+                        url: 'http://www.globalo.com/content/uploads/2015/12/darth-vader.jpg',
+                        appears: [
+                            {
+                                id: uniqueid('time_'),
+                                start: 300,
+                                end: 600
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 1000,
+                                end: 1400
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 1500,
+                                end: 1800
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 2200,
+                                end: 2560
+                            }
+                        ]
+                    },
+                    {
+                        id: uniqueid('cardentry_'),
+                        type: 'text',
+                        text: 'Books',
+                        appears: [
+                            {
+                                id: uniqueid('time_'),
+                                start: 20,
+                                end: 300
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 1000,
+                                end: 2100
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 2500,
+                                end: 3300
+                            }
+                        ]
+                    },
+                    {
+                        id: uniqueid('cardentry_'),
+                        type: 'image',
+                        url: 'http://www.globalo.com/content/uploads/2015/12/darth-vader.jpg',
+                        appears: [
+                            {
+                                id: uniqueid('time_'),
+                                start: 100,
+                                end: 200
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 300,
+                                end: 800
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 1000,
+                                end: 1200
+                            },
+                            {
+                                id: uniqueid('time_'),
+                                start: 2200,
                                 end: 2560
                             }
                         ]

--- a/src/api/Recents.js
+++ b/src/api/Recents.js
@@ -12,14 +12,8 @@ import Cache from '../util/Cache';
 import flatten from '../util/flatten';
 import sort from '../util/sorter';
 import getBadItemError from '../util/error';
-import {
-    FIELDS_TO_FETCH,
-    DEFAULT_ROOT,
-    CACHE_PREFIX_RECENTS,
-    SORT_DESC,
-    FIELD_INTERACTED_AT,
-    X_REP_HINTS
-} from '../constants';
+import getFields from '../util/fields';
+import { DEFAULT_ROOT, CACHE_PREFIX_RECENTS, SORT_DESC, FIELD_INTERACTED_AT, X_REP_HINTS } from '../constants';
 import type {
     Crumb,
     BoxItem,
@@ -62,6 +56,16 @@ class Recents extends Base {
      * @property {string}
      */
     sortDirection: SortDirection;
+
+    /**
+     * @property {boolean}
+     */
+    includePreviewFields: boolean;
+
+    /**
+     * @property {boolean}
+     */
+    includePreviewSidebarFields: boolean;
 
     /**
      * Creates a key for the cache
@@ -187,7 +191,7 @@ class Recents extends Base {
             .get({
                 url: this.getUrl(),
                 params: {
-                    fields: FIELDS_TO_FETCH
+                    fields: getFields(this.includePreviewFields, this.includePreviewSidebarFields)
                 },
                 headers: { 'X-Rep-Hints': X_REP_HINTS }
             })
@@ -199,11 +203,13 @@ class Recents extends Base {
      * Gets recent files
      *
      * @param {string} id - parent folder id
-     * @param {string} sortBy sort by field
-     * @param {string} sortDirection sort direction
+     * @param {string} sortBy - sort by field
+     * @param {string} sortDirection - sort direction
      * @param {Function} successCallback - Function to call with results
      * @param {Function} errorCallback - Function to call with errors
-     * @param {boolean} forceUpdate Bypasses the cache
+     * @param {boolean|void} [forceFetch] - Bypasses the cache
+     * @param {boolean|void} [includePreview] - Optionally include preview fields
+     * @param {boolean|void} [includePreviewSidebar] - Optionally include preview sidebar fields
      * @return {void}
      */
     recents(
@@ -212,7 +218,9 @@ class Recents extends Base {
         sortDirection: SortDirection,
         successCallback: Function,
         errorCallback: Function,
-        forceFetch: boolean = false
+        forceFetch: boolean = false,
+        includePreviewFields: boolean = false,
+        includePreviewSidebarFields: boolean = false
     ): void {
         if (this.isDestroyed()) {
             return;
@@ -224,6 +232,8 @@ class Recents extends Base {
         this.errorCallback = errorCallback;
         this.sortBy = sortBy;
         this.sortDirection = sortDirection;
+        this.includePreviewFields = includePreviewFields;
+        this.includePreviewSidebarFields = includePreviewSidebarFields;
 
         const cache: Cache = this.getCache();
         this.key = this.getCacheKey(this.id);

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -11,7 +11,8 @@ import WebLinkAPI from '../api/WebLink';
 import flatten from '../util/flatten';
 import sort from '../util/sorter';
 import Cache from '../util/Cache';
-import { FIELDS_TO_FETCH, CACHE_PREFIX_SEARCH, X_REP_HINTS } from '../constants';
+import getFields from '../util/fields';
+import { CACHE_PREFIX_SEARCH, X_REP_HINTS } from '../constants';
 import getBadItemError from '../util/error';
 import type {
     BoxItemCollection,
@@ -69,6 +70,16 @@ class Search extends Base {
      * @property {Array}
      */
     itemCache: string[];
+
+    /**
+     * @property {boolean}
+     */
+    includePreviewFields: boolean;
+
+    /**
+     * @property {boolean}
+     */
+    includePreviewSidebarFields: boolean;
 
     /**
      * Creates a key for the cache
@@ -221,7 +232,7 @@ class Search extends Base {
                     query: this.query,
                     ancestor_folder_ids: this.id,
                     limit: LIMIT_ITEM_FETCH,
-                    fields: FIELDS_TO_FETCH
+                    fields: getFields(this.includePreviewFields, this.includePreviewSidebarFields)
                 },
                 headers: { 'X-Rep-Hints': X_REP_HINTS }
             })
@@ -232,13 +243,15 @@ class Search extends Base {
     /**
      * Gets search results
      *
-     * @param {string} id folder id
-     * @param {string} query search string
-     * @param {string} sortBy sort by field
-     * @param {string} sortDirection sort direction
-     * @param {Function} successCallback Function to call with results
-     * @param {Function} errorCallback Function to call with errors
-     * @param {boolean} forceUpdate Bypasses the cache
+     * @param {string} id - folder id
+     * @param {string} query - search string
+     * @param {string} sortBy - sort by field
+     * @param {string} sortDirection - sort direction
+     * @param {Function} successCallback - Function to call with results
+     * @param {Function} errorCallback - Function to call with errors
+     * @param {boolean|void} [forceFetch] - Bypasses the cache
+     * @param {boolean|void} [includePreview] - Optionally include preview fields
+     * @param {boolean|void} [includePreviewSidebar] - Optionally include preview sidebar fields
      * @return {void}
      */
     search(
@@ -248,7 +261,9 @@ class Search extends Base {
         sortDirection: SortDirection,
         successCallback: Function,
         errorCallback: Function,
-        forceFetch: boolean = false
+        forceFetch: boolean = false,
+        includePreviewFields: boolean = false,
+        includePreviewSidebarFields: boolean = false
     ): void {
         if (this.isDestroyed()) {
             return;
@@ -263,6 +278,8 @@ class Search extends Base {
         this.errorCallback = errorCallback;
         this.sortBy = sortBy;
         this.sortDirection = sortDirection;
+        this.includePreviewFields = includePreviewFields;
+        this.includePreviewSidebarFields = includePreviewSidebarFields;
 
         // Clear the cache if needed
         if (forceFetch) {

--- a/src/api/__tests__/File-test.js
+++ b/src/api/__tests__/File-test.js
@@ -1,6 +1,7 @@
 import File from '../File';
 import Cache from '../../util/Cache';
-import { FIELDS_TO_FETCH, X_REP_HINTS } from '../../constants';
+import getFields from '../../util/fields';
+import { X_REP_HINTS } from '../../constants';
 
 let file;
 let cache;
@@ -86,7 +87,7 @@ describe('api/File', () => {
                         id: 'file_id',
                         url: 'https://api.box.com/2.0/files/id',
                         params: {
-                            fields: FIELDS_TO_FETCH
+                            fields: getFields(true)
                         },
                         headers: {
                             'X-Rep-Hints': X_REP_HINTS
@@ -105,7 +106,7 @@ describe('api/File', () => {
                         id: 'file_id',
                         url: 'https://api.box.com/2.0/files/id',
                         params: {
-                            fields: FIELDS_TO_FETCH
+                            fields: getFields(true, true)
                         },
                         headers: {
                             'X-Rep-Hints': X_REP_HINTS
@@ -113,7 +114,7 @@ describe('api/File', () => {
                     })
                     .returns(Promise.reject('error'))
             };
-            return file.file('id', sandbox.mock().never(), sandbox.mock().withArgs('error'));
+            return file.file('id', sandbox.mock().never(), sandbox.mock().withArgs('error'), false, true);
         });
 
         it('should make xhr to get file when forced to clear cache', () => {
@@ -129,7 +130,7 @@ describe('api/File', () => {
                         id: 'file_id',
                         url: 'https://api.box.com/2.0/files/id',
                         params: {
-                            fields: FIELDS_TO_FETCH
+                            fields: getFields(true)
                         },
                         headers: {
                             'X-Rep-Hints': X_REP_HINTS

--- a/src/api/__tests__/Folder-test.js
+++ b/src/api/__tests__/Folder-test.js
@@ -2,7 +2,8 @@
 
 import Folder from '../Folder';
 import Cache from '../../util/Cache';
-import { FIELDS_TO_FETCH, X_REP_HINTS } from '../../constants';
+import getFields from '../../util/fields';
+import { X_REP_HINTS } from '../../constants';
 
 let folder;
 let cache;
@@ -75,7 +76,7 @@ describe('api/Folder', () => {
             folder.folderRequest = sandbox.mock();
             folder.getCacheKey = sandbox.mock().withArgs('id').returns('key');
             folder.isLoaded = sandbox.mock().returns(false);
-            folder.folder('id', 'by', 'direction', 'success', 'fail');
+            folder.folder('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
             expect(folder.id).to.equal('id');
             expect(folder.successCallback).to.equal('success');
             expect(folder.errorCallback).to.equal('fail');
@@ -83,13 +84,15 @@ describe('api/Folder', () => {
             expect(folder.sortDirection).to.equal('direction');
             expect(folder.key).to.equal('key');
             expect(folder.offset).to.equal(0);
+            expect(folder.includePreviewFields).to.equal('preview');
+            expect(folder.includePreviewSidebarFields).to.equal('sidebar');
         });
         it('should save args and not make folder request when cached', () => {
             folder.folderRequest = sandbox.mock().never();
             folder.finish = sandbox.mock();
             folder.getCacheKey = sandbox.mock().withArgs('id').returns('key');
             folder.isLoaded = sandbox.mock().returns(true);
-            folder.folder('id', 'by', 'direction', 'success', 'fail');
+            folder.folder('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
             expect(folder.id).to.equal('id');
             expect(folder.successCallback).to.equal('success');
             expect(folder.errorCallback).to.equal('fail');
@@ -97,13 +100,15 @@ describe('api/Folder', () => {
             expect(folder.sortDirection).to.equal('direction');
             expect(folder.key).to.equal('key');
             expect(folder.offset).to.equal(0);
+            expect(folder.includePreviewFields).to.equal('preview');
+            expect(folder.includePreviewSidebarFields).to.equal('sidebar');
         });
         it('should save args and make folder request when cached but forced to fetch', () => {
             folder.folderRequest = sandbox.mock();
             folder.getCache = sandbox.mock().returns({ unset: sandbox.mock().withArgs('key') });
             folder.getCacheKey = sandbox.mock().withArgs('id').returns('key');
             folder.isLoaded = sandbox.mock().returns(false);
-            folder.folder('id', 'by', 'direction', 'success', 'fail', true);
+            folder.folder('id', 'by', 'direction', 'success', 'fail', true, 'preview', 'sidebar');
             expect(folder.id).to.equal('id');
             expect(folder.successCallback).to.equal('success');
             expect(folder.errorCallback).to.equal('fail');
@@ -111,6 +116,8 @@ describe('api/Folder', () => {
             expect(folder.sortDirection).to.equal('direction');
             expect(folder.key).to.equal('key');
             expect(folder.offset).to.equal(0);
+            expect(folder.includePreviewFields).to.equal('preview');
+            expect(folder.includePreviewSidebarFields).to.equal('sidebar');
         });
     });
 
@@ -134,6 +141,7 @@ describe('api/Folder', () => {
         it('should make xhr to folder and call success callback', () => {
             folder.folderSuccessHandler = sandbox.mock().withArgs('success');
             folder.folderErrorHandler = sandbox.mock().never();
+            folder.includePreviewFields = true;
             folder.xhr = {
                 get: sandbox
                     .mock()
@@ -142,7 +150,7 @@ describe('api/Folder', () => {
                         params: {
                             offset: 0,
                             limit: 1000,
-                            fields: FIELDS_TO_FETCH
+                            fields: getFields(true)
                         },
                         headers: {
                             'X-Rep-Hints': X_REP_HINTS
@@ -155,6 +163,8 @@ describe('api/Folder', () => {
         it('should make xhr to folder and call error callback', () => {
             folder.folderSuccessHandler = sandbox.mock().never();
             folder.folderErrorHandler = sandbox.mock().withArgs('error');
+            folder.includePreviewFields = true;
+            folder.includePreviewSidebarFields = true;
             folder.xhr = {
                 get: sandbox
                     .mock()
@@ -163,7 +173,7 @@ describe('api/Folder', () => {
                         params: {
                             offset: 0,
                             limit: 1000,
-                            fields: FIELDS_TO_FETCH
+                            fields: getFields(true, true)
                         },
                         headers: {
                             'X-Rep-Hints': X_REP_HINTS
@@ -547,7 +557,7 @@ describe('api/Folder', () => {
                 post: sandbox
                     .mock()
                     .withArgs({
-                        url: `https://api.box.com/2.0/folders?fields=${FIELDS_TO_FETCH}`,
+                        url: `https://api.box.com/2.0/folders?fields=${getFields()}`,
                         data: {
                             name: 'foo',
                             parent: {
@@ -566,7 +576,7 @@ describe('api/Folder', () => {
                 post: sandbox
                     .mock()
                     .withArgs({
-                        url: `https://api.box.com/2.0/folders?fields=${FIELDS_TO_FETCH}`,
+                        url: `https://api.box.com/2.0/folders?fields=${getFields()}`,
                         data: {
                             name: 'foo',
                             parent: {

--- a/src/api/__tests__/Recents-test.js
+++ b/src/api/__tests__/Recents-test.js
@@ -2,7 +2,8 @@
 
 import Recents from '../Recents';
 import Cache from '../../util/Cache';
-import { FIELDS_TO_FETCH, X_REP_HINTS } from '../../constants';
+import getFields from '../../util/fields';
+import { X_REP_HINTS } from '../../constants';
 
 let recents;
 let cache;
@@ -42,39 +43,45 @@ describe('api/Recents', () => {
             recents.recentsRequest = sandbox.mock();
             recents.getCache = sandbox.mock().returns(cache);
             recents.getCacheKey = sandbox.mock().withArgs('id').returns('key');
-            recents.recents('id', 'by', 'direction', 'success', 'fail');
+            recents.recents('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
             expect(recents.id).to.equal('id');
             expect(recents.successCallback).to.equal('success');
             expect(recents.errorCallback).to.equal('fail');
             expect(recents.sortBy).to.equal('interacted_at');
             expect(recents.sortDirection).to.equal('DESC');
             expect(recents.key).to.equal('key');
+            expect(recents.includePreviewFields).to.equal('preview');
+            expect(recents.includePreviewSidebarFields).to.equal('sidebar');
         });
         it('should save args and not make recents request when cached', () => {
             cache.set('key', 'value');
             recents.finish = sandbox.mock();
             recents.getCache = sandbox.mock().returns(cache);
             recents.getCacheKey = sandbox.mock().withArgs('id').returns('key');
-            recents.recents('id', 'by', 'direction', 'success', 'fail');
+            recents.recents('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
             expect(recents.id).to.equal('id');
             expect(recents.successCallback).to.equal('success');
             expect(recents.errorCallback).to.equal('fail');
             expect(recents.sortBy).to.equal('by');
             expect(recents.sortDirection).to.equal('direction');
             expect(recents.key).to.equal('key');
+            expect(recents.includePreviewFields).to.equal('preview');
+            expect(recents.includePreviewSidebarFields).to.equal('sidebar');
         });
         it('should save args and make recents request when cached but forced to fetch', () => {
             cache.set('key', 'value');
             recents.recentsRequest = sandbox.mock();
             recents.getCache = sandbox.mock().returns(cache);
             recents.getCacheKey = sandbox.mock().withArgs('id').returns('key');
-            recents.recents('id', 'by', 'direction', 'success', 'fail', true);
+            recents.recents('id', 'by', 'direction', 'success', 'fail', true, 'preview', 'sidebar');
             expect(recents.id).to.equal('id');
             expect(recents.successCallback).to.equal('success');
             expect(recents.errorCallback).to.equal('fail');
             expect(recents.sortBy).to.equal('interacted_at');
             expect(recents.sortDirection).to.equal('DESC');
             expect(recents.key).to.equal('key');
+            expect(recents.includePreviewFields).to.equal('preview');
+            expect(recents.includePreviewSidebarFields).to.equal('sidebar');
         });
     });
 
@@ -91,12 +98,13 @@ describe('api/Recents', () => {
         it('should make xhr get recents and call success callback', () => {
             recents.recentsSuccessHandler = sandbox.mock().withArgs('success');
             recents.recentsErrorHandler = sandbox.mock().never();
+            recents.includePreviewFields = true;
             recents.xhr = {
                 get: sandbox
                     .mock()
                     .withArgs({
                         url: 'https://api.box.com/2.0/recent_items',
-                        params: { fields: FIELDS_TO_FETCH },
+                        params: { fields: getFields(true) },
                         headers: { 'X-Rep-Hints': X_REP_HINTS }
                     })
                     .returns(Promise.resolve('success'))
@@ -106,12 +114,14 @@ describe('api/Recents', () => {
         it('should make xhr to get recents and call error callback', () => {
             recents.recentsSuccessHandler = sandbox.mock().never();
             recents.recentsErrorHandler = sandbox.mock().withArgs('error');
+            recents.includePreviewFields = true;
+            recents.includePreviewSidebarFields = true;
             recents.xhr = {
                 get: sandbox
                     .mock()
                     .withArgs({
                         url: 'https://api.box.com/2.0/recent_items',
-                        params: { fields: FIELDS_TO_FETCH },
+                        params: { fields: getFields(true, true) },
                         headers: { 'X-Rep-Hints': X_REP_HINTS }
                     })
                     .returns(Promise.reject('error'))

--- a/src/components/ContentExplorer/ContentExplorer.js
+++ b/src/components/ContentExplorer/ContentExplorer.js
@@ -409,7 +409,7 @@ class ContentExplorer extends Component<DefaultProps, Props, State> {
      * @return {void}
      */
     fetchFolder = (id?: string, triggerEvent: boolean = true, forceFetch: boolean = false) => {
-        const { rootFolderId }: Props = this.props;
+        const { rootFolderId, canPreview, hasPreviewSidebar }: Props = this.props;
         const { sortBy, sortDirection }: State = this.state;
         const folderId: string = typeof id === 'string' ? id : rootFolderId;
 
@@ -437,7 +437,9 @@ class ContentExplorer extends Component<DefaultProps, Props, State> {
                 this.fetchFolderSuccessCallback(collection, triggerEvent);
             },
             this.errorCallback,
-            forceFetch
+            forceFetch,
+            canPreview,
+            hasPreviewSidebar
         );
     };
 
@@ -502,10 +504,21 @@ class ContentExplorer extends Component<DefaultProps, Props, State> {
      * @return {void}
      */
     debouncedSearch = debounce((id: string, query: string, forceFetch?: boolean) => {
+        const { canPreview, hasPreviewSidebar }: Props = this.props;
         const { sortBy, sortDirection }: State = this.state;
         this.api
             .getSearchAPI()
-            .search(id, query, sortBy, sortDirection, this.searchSuccessCallback, this.errorCallback, forceFetch);
+            .search(
+                id,
+                query,
+                sortBy,
+                sortDirection,
+                this.searchSuccessCallback,
+                this.errorCallback,
+                forceFetch,
+                canPreview,
+                hasPreviewSidebar
+            );
     }, DEFAULT_SEARCH_DEBOUNCE);
 
     /**
@@ -576,7 +589,7 @@ class ContentExplorer extends Component<DefaultProps, Props, State> {
      * @return {void}
      */
     showRecents = (forceFetch: boolean = false) => {
-        const { rootFolderId }: Props = this.props;
+        const { rootFolderId, canPreview, hasPreviewSidebar }: Props = this.props;
         const { sortBy, sortDirection }: State = this.state;
 
         // Recents are sorted by a different date field than the rest
@@ -592,7 +605,16 @@ class ContentExplorer extends Component<DefaultProps, Props, State> {
         // Fetch the folder using folder API
         this.api
             .getRecentsAPI()
-            .recents(rootFolderId, by, sortDirection, this.recentsSuccessCallback, this.errorCallback, forceFetch);
+            .recents(
+                rootFolderId,
+                by,
+                sortDirection,
+                this.recentsSuccessCallback,
+                this.errorCallback,
+                forceFetch,
+                canPreview,
+                hasPreviewSidebar
+            );
     };
 
     /**

--- a/src/components/ContentPreview/ContentPreview.js
+++ b/src/components/ContentPreview/ContentPreview.js
@@ -362,7 +362,8 @@ class ContentPreview extends PureComponent<DefaultProps, Props, State> {
      * @return {void}
      */
     fetchFile(id: string, forceFetch: boolean = false): void {
-        this.api.getFileAPI().file(id, this.fetchFileSuccessCallback, this.errorCallback, forceFetch);
+        const { hasSidebar }: Props = this.props;
+        this.api.getFileAPI().file(id, this.fetchFileSuccessCallback, this.errorCallback, forceFetch, hasSidebar);
     }
 
     /**

--- a/src/components/ContentPreview/DetailsSidebar.scss
+++ b/src/components/ContentPreview/DetailsSidebar.scss
@@ -1,8 +1,8 @@
 @import '../variables';
 
 .bcpr-sidebar-details-description {
-    height: 90px;
-    margin: 0 16px;
+    height: 80px;
+    margin: 0 20px;
 
     label span {
         color: $sevens;

--- a/src/components/ContentPreview/Sidebar.scss
+++ b/src/components/ContentPreview/Sidebar.scss
@@ -1,7 +1,6 @@
 @import '../variables';
 
 .bcpr-sidebar {
-    background-color: $haze;
     border-left: 1px solid $efive;
     display: flex;
     flex: 0 0 340px;

--- a/src/components/ContentPreview/SidebarContent.scss
+++ b/src/components/ContentPreview/SidebarContent.scss
@@ -7,7 +7,7 @@
     .bcpr-sidebar-title {
         border-bottom: 1px solid $off-white;
         line-height: 30px;
-        margin: 16px;
+        margin: 15px 20px;
     }
 
     .bcpr-sidebar-scroll-content-wrapper {

--- a/src/components/ContentPreview/SidebarSection.scss
+++ b/src/components/ContentPreview/SidebarSection.scss
@@ -1,40 +1,37 @@
 @import '../variables';
 
 .bcpr-sidebar-section {
-    background-color: $white;
-    border: 1px solid $off-white;
-    margin: 0 15px 13px;
-    padding: 15px;
+    margin: 0 20px 20px;
 }
 
 .buik-btn.buik-btn-plain.bcpr-sidebar-section-title {
     text-decoration: none;
     width: 100%;
 
-    &:hover,
-    &:active,
-    &:focus {
-        color: $blue;
-        text-decoration: none;
-    }
-
     .buik-btn-content {
         align-items: center;
-        border-bottom: 1px solid transparent;
+        border-bottom: 1px solid $off-white;
         cursor: pointer;
         display: flex;
         justify-content: space-between;
         line-height: 30px;
+        margin: 0 0 15px;
 
         .bcpr-sidebar-section-title-text {
             max-width: 250px;
             overflow: hidden;
             text-overflow: ellipsis;
         }
+    }
 
-        .bcpr-sidebar-section-open & {
-            border-bottom: 1px solid $off-white;
-            margin: 0 0 15px;
+    &:hover,
+    &:active,
+    &:focus {
+        text-decoration: none;
+
+        .buik-btn-content {
+            align-items: center;
+            border-bottom-color: $blue;
         }
     }
 }

--- a/src/components/Timeline/Line.js
+++ b/src/components/Timeline/Line.js
@@ -13,23 +13,24 @@ type Props = {
     type: CardEntryType,
     start: number,
     duration: number,
+    color?: string,
     end?: number
 };
 
-const LENGTH_IMAGE_ITEMLINE = 220;
-const LENGTH_TEXT_ITEMLINE = 260;
+const LENGTH_IMAGE_ITEMLINE = 250;
+const LENGTH_TEXT_ITEMLINE = 290;
 
-const Line = ({ type, start, end, duration }: Props) => {
+const Line = ({ type, start, end, duration, color = '#777' }: Props) => {
     if (typeof start !== 'number' || !end || !duration) {
         return null;
     }
-    const startPercent = start * 100 / duration;
-    const endPercent = end * 100 / duration;
+    const barLength = type === 'image' ? LENGTH_IMAGE_ITEMLINE : LENGTH_TEXT_ITEMLINE;
+    const startPercent = start * barLength / duration;
+    const endPercent = end * barLength / duration;
     const styles = {
-        left: `${startPercent}%`,
-        width: `${(endPercent - startPercent) *
-            (type === 'image' ? LENGTH_IMAGE_ITEMLINE : LENGTH_TEXT_ITEMLINE) /
-            100}px`
+        backgroundColor: color,
+        left: `${startPercent}px`,
+        width: `${endPercent - startPercent}px`
     };
     return <PlainButton className='buik-timeline-time' style={styles} />;
 };

--- a/src/components/Timeline/Line.scss
+++ b/src/components/Timeline/Line.scss
@@ -1,15 +1,15 @@
 @import '../variables';
 
 .buik-btn.buik-btn-plain.buik-timeline-time {
-    background-color: $bfive;
     cursor: pointer;
     height: 6px;
     position: absolute;
-    top: -2px;
 
     &:focus,
     &:active,
     &:hover {
-        background-color: $blue;
+        /* stylelint-disable declaration-no-important */
+        background-color: $blue !important;
+        /* stylelint-enable declaration-no-important */
     }
 }

--- a/src/components/Timeline/Timeline.js
+++ b/src/components/Timeline/Timeline.js
@@ -11,13 +11,14 @@ import './Timeline.scss';
 
 type Props = {
     type: CardEntryType,
+    color?: string,
     text?: string,
     url?: string,
     timeslices?: TimeSlice[],
     duration?: number
 };
 
-const Timeline = ({ type, text = '', url = '', duration = 0, timeslices = [] }: Props) =>
+const Timeline = ({ type, color, text = '', url = '', duration = 0, timeslices = [] }: Props) =>
     <div className={`buik-timeline buik-timeline-${type}`}>
         {(text || url) &&
             <div className='buik-timeline-label'>
@@ -30,7 +31,7 @@ const Timeline = ({ type, text = '', url = '', duration = 0, timeslices = [] }: 
         <div className='buik-timeline-wrapper'>
             <div className='buik-timeline-line' />
             {timeslices.map(({ id: timeId, start, end }: TimeSlice) =>
-                <Line key={timeId} type={type} start={start} end={end} duration={duration} />
+                <Line key={timeId} color={color} type={type} start={start} end={end} duration={duration} />
             )}
         </div>
     </div>;

--- a/src/components/Timeline/Timeline.scss
+++ b/src/components/Timeline/Timeline.scss
@@ -2,6 +2,7 @@
 
 .buik-timeline {
     display: flex;
+    height: 60px;
     padding: 0 0 20px;
 }
 
@@ -11,8 +12,8 @@
 }
 
 .buik-timeline-line {
-    background-color: $see-see;
-    height: 2px;
+    background-color: $ffive;
+    height: 6px;
     position: absolute;
 }
 
@@ -30,12 +31,8 @@
         margin-left: 10px;
     }
 
-    & + .buik-timeline-text {
-        margin: 10px 0;
-    }
-
     .buik-timeline-line {
-        width: 220px;
+        width: 250px;
     }
 }
 
@@ -48,11 +45,7 @@
         padding-bottom: 10px;
     }
 
-    & + .buik-timeline-image {
-        margin: 10px 0;
-    }
-
     .buik-timeline-line {
-        width: 260px;
+        width: 290px;
     }
 }

--- a/src/components/Timeline/Timelines.js
+++ b/src/components/Timeline/Timelines.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import randomcolor from 'randomcolor';
 import Timeline from './Timeline';
 import type { Card, CardEntry } from '../../flowTypes';
 
@@ -12,11 +13,23 @@ type Props = {
     card: Card
 };
 
-const Timelines = ({ card: { entries, duration } }: Props) =>
-    <div className='buik-timelines'>
-        {entries.map(({ id, type, text, url, appears }: CardEntry) =>
-            <Timeline key={id} type={type} text={text} url={url} timeslices={appears} duration={duration} />
-        )}
-    </div>;
+const Timelines = ({ card: { entries, duration } }: Props) => {
+    const colors = randomcolor({ count: entries.length, luminosity: 'dark' });
+    return (
+        <div className='buik-timelines'>
+            {entries.map(({ id, type, text, url, appears }: CardEntry, index) =>
+                <Timeline
+                    key={id}
+                    type={type}
+                    text={text}
+                    url={url}
+                    color={colors[index]}
+                    timeslices={appears}
+                    duration={duration}
+                />
+            )}
+        </div>
+    );
+};
 
 export default Timelines;

--- a/src/constants.js
+++ b/src/constants.js
@@ -97,7 +97,7 @@ export const DELIMITER_SLASH: 'slash' = 'slash';
 export const DELIMITER_CARET: 'caret' = 'caret';
 
 /* ---------------------- Defaults -------------------------- */
-export const DEFAULT_PREVIEW_VERSION = '1.9.1';
+export const DEFAULT_PREVIEW_VERSION = '1.10.0';
 export const DEFAULT_PREVIEW_LOCALE = 'en-US';
 export const DEFAULT_PREVIEW_STATIC_PATH = 'platform/preview';
 export const DEFAULT_HOSTNAME_API = 'https://api.box.com';
@@ -134,34 +134,6 @@ export const CLASS_IS_TOUCH = 'buik-is-touch';
 export const CLASS_MODAL = 'buik-modal';
 export const CLASS_BUTTON_CONTENT_SPAN = 'buik-btn-content';
 export const CLASS_CHECKBOX_SPAN = 'buik-checkbox-span';
-
-/* --------------- Feilds to fetch via API ----------------- */
-export const FIELDS_TO_FETCH = [
-    FIELD_NAME,
-    FIELD_URL,
-    FIELD_TYPE,
-    FIELD_SIZE,
-    FIELD_PARENT,
-    FIELD_EXTENSION,
-    FIELD_PERMISSIONS,
-    FIELD_ITEM_COLLECTION,
-    FIELD_PATH_COLLECTION,
-    FIELD_MODIFIED_AT,
-    FIELD_CREATED_AT,
-    FIELD_SHARED_LINK,
-    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
-    FIELD_HAS_COLLABORATIONS,
-    FIELD_IS_EXTERNALLY_OWNED,
-    FIELD_CREATED_BY,
-    FIELD_MODIFIED_BY,
-    FIELD_OWNED_BY,
-    FIELD_DESCRIPTION,
-    FIELD_REPRESENTATIONS,
-    FIELD_SHA1,
-    FIELD_WATERMARK_INFO,
-    FIELD_AUTHENTICATED_DOWNLOAD_URL,
-    FIELD_FILE_VERSION
-].join(',');
 
 /* ------------------ Error Codes  ---------------------- */
 export const ERROR_CODE_ITEM_NAME_INVALID = 'item_name_invalid';

--- a/src/util/__tests__/fields-test.js
+++ b/src/util/__tests__/fields-test.js
@@ -1,0 +1,113 @@
+import getFields from '../fields';
+import {
+    FIELD_ID,
+    FIELD_NAME,
+    FIELD_URL,
+    FIELD_TYPE,
+    FIELD_SIZE,
+    FIELD_PARENT,
+    FIELD_EXTENSION,
+    FIELD_PERMISSIONS,
+    FIELD_ITEM_COLLECTION,
+    FIELD_PATH_COLLECTION,
+    FIELD_MODIFIED_AT,
+    FIELD_CREATED_AT,
+    FIELD_SHARED_LINK,
+    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
+    FIELD_HAS_COLLABORATIONS,
+    FIELD_IS_EXTERNALLY_OWNED,
+    FIELD_CREATED_BY,
+    FIELD_MODIFIED_BY,
+    FIELD_OWNED_BY,
+    FIELD_DESCRIPTION,
+    FIELD_REPRESENTATIONS,
+    FIELD_SHA1,
+    FIELD_WATERMARK_INFO,
+    FIELD_AUTHENTICATED_DOWNLOAD_URL,
+    FIELD_FILE_VERSION
+} from '../../constants';
+
+describe('util/fields', () => {
+    describe('getDate()', () => {
+        it('should return default set of fields', () => {
+            expect(getFields()).to.deep.equal(
+                [
+                    FIELD_ID,
+                    FIELD_NAME,
+                    FIELD_URL,
+                    FIELD_TYPE,
+                    FIELD_SIZE,
+                    FIELD_PARENT,
+                    FIELD_EXTENSION,
+                    FIELD_PERMISSIONS,
+                    FIELD_ITEM_COLLECTION,
+                    FIELD_PATH_COLLECTION,
+                    FIELD_MODIFIED_AT,
+                    FIELD_CREATED_AT,
+                    FIELD_SHARED_LINK,
+                    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
+                    FIELD_HAS_COLLABORATIONS,
+                    FIELD_IS_EXTERNALLY_OWNED
+                ].join(',')
+            );
+        });
+        it('should return default set + preview fields', () => {
+            expect(getFields(true)).to.deep.equal(
+                [
+                    FIELD_ID,
+                    FIELD_NAME,
+                    FIELD_URL,
+                    FIELD_TYPE,
+                    FIELD_SIZE,
+                    FIELD_PARENT,
+                    FIELD_EXTENSION,
+                    FIELD_PERMISSIONS,
+                    FIELD_ITEM_COLLECTION,
+                    FIELD_PATH_COLLECTION,
+                    FIELD_MODIFIED_AT,
+                    FIELD_CREATED_AT,
+                    FIELD_SHARED_LINK,
+                    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
+                    FIELD_HAS_COLLABORATIONS,
+                    FIELD_IS_EXTERNALLY_OWNED,
+                    FIELD_REPRESENTATIONS,
+                    FIELD_SHA1,
+                    FIELD_WATERMARK_INFO,
+                    FIELD_AUTHENTICATED_DOWNLOAD_URL,
+                    FIELD_FILE_VERSION
+                ].join(',')
+            );
+        });
+        it('should return default set + preview + sidebar fields', () => {
+            expect(getFields(true, true)).to.deep.equal(
+                [
+                    FIELD_ID,
+                    FIELD_NAME,
+                    FIELD_URL,
+                    FIELD_TYPE,
+                    FIELD_SIZE,
+                    FIELD_PARENT,
+                    FIELD_EXTENSION,
+                    FIELD_PERMISSIONS,
+                    FIELD_ITEM_COLLECTION,
+                    FIELD_PATH_COLLECTION,
+                    FIELD_MODIFIED_AT,
+                    FIELD_CREATED_AT,
+                    FIELD_SHARED_LINK,
+                    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
+                    FIELD_HAS_COLLABORATIONS,
+                    FIELD_IS_EXTERNALLY_OWNED,
+                    FIELD_CREATED_BY,
+                    FIELD_MODIFIED_BY,
+                    FIELD_OWNED_BY,
+                    FIELD_DESCRIPTION,
+                    FIELD_REPRESENTATIONS,
+                    FIELD_SHA1,
+                    FIELD_WATERMARK_INFO,
+                    FIELD_AUTHENTICATED_DOWNLOAD_URL,
+                    FIELD_FILE_VERSION
+                ].join(',')
+            );
+        });
+    });
+});

--- a/src/util/fields.js
+++ b/src/util/fields.js
@@ -1,0 +1,101 @@
+/**
+ * @flow
+ * @file Utility to combine API fields needed
+ * @author Box
+ */
+
+import {
+    FIELD_ID,
+    FIELD_NAME,
+    FIELD_URL,
+    FIELD_TYPE,
+    FIELD_SIZE,
+    FIELD_PARENT,
+    FIELD_EXTENSION,
+    FIELD_PERMISSIONS,
+    FIELD_ITEM_COLLECTION,
+    FIELD_PATH_COLLECTION,
+    FIELD_MODIFIED_AT,
+    FIELD_CREATED_AT,
+    FIELD_SHARED_LINK,
+    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
+    FIELD_HAS_COLLABORATIONS,
+    FIELD_IS_EXTERNALLY_OWNED,
+    FIELD_CREATED_BY,
+    FIELD_MODIFIED_BY,
+    FIELD_OWNED_BY,
+    FIELD_DESCRIPTION,
+    FIELD_REPRESENTATIONS,
+    FIELD_SHA1,
+    FIELD_WATERMARK_INFO,
+    FIELD_AUTHENTICATED_DOWNLOAD_URL,
+    FIELD_FILE_VERSION
+} from '../constants';
+
+// Minimum set of fields needed for Content Explorer / Picker
+const BASE_FIELDS_TO_FETCH = [
+    FIELD_ID,
+    FIELD_NAME,
+    FIELD_URL,
+    FIELD_TYPE,
+    FIELD_SIZE,
+    FIELD_PARENT,
+    FIELD_EXTENSION,
+    FIELD_PERMISSIONS,
+    FIELD_ITEM_COLLECTION,
+    FIELD_PATH_COLLECTION,
+    FIELD_MODIFIED_AT,
+    FIELD_CREATED_AT,
+    FIELD_SHARED_LINK,
+    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
+    FIELD_HAS_COLLABORATIONS,
+    FIELD_IS_EXTERNALLY_OWNED
+];
+
+// Additional fields needed for the sidebar
+const SIDEBAR_FIELDS_TO_FETCH = [FIELD_CREATED_BY, FIELD_MODIFIED_BY, FIELD_OWNED_BY, FIELD_DESCRIPTION];
+
+// Additional fields needed for preview
+const PREVIEW_FIELDS_TO_FETCH = [
+    FIELD_REPRESENTATIONS,
+    FIELD_SHA1,
+    FIELD_WATERMARK_INFO,
+    FIELD_AUTHENTICATED_DOWNLOAD_URL,
+    FIELD_FILE_VERSION
+];
+
+/**
+ * Returns all the fields that can be fetched
+ *
+ * @return {string} comma seperated list of fields
+ */
+function getFieldsIncludingPreviewSidebar(): string {
+    return BASE_FIELDS_TO_FETCH.concat(SIDEBAR_FIELDS_TO_FETCH).concat(PREVIEW_FIELDS_TO_FETCH).join(',');
+}
+
+/**
+ * Returns base fields and preview fields
+ *
+ * @return {string} comma seperated list of fields
+ */
+function getFieldsIncludingPreview(): string {
+    return BASE_FIELDS_TO_FETCH.concat(PREVIEW_FIELDS_TO_FETCH).join(',');
+}
+
+/**
+ * Returns fields needed other than sidebar and preview
+ *
+ * @param {boolean|void} [includePreview] - Optionally include preview fields
+ * @param {boolean|void} [includePreviewSidebar] - Optionally include preview and sidebar fields
+ * @return {string} comma seperated list of fields
+ */
+export default function getFields(includePreview?: boolean = false, includePreviewSidebar?: boolean = false): string {
+    if (includePreview && includePreviewSidebar) {
+        // Only include sidebar fields if we are also including preview fields
+        return getFieldsIncludingPreviewSidebar();
+    } else if (includePreview) {
+        // Preview may not have a sidebar
+        return getFieldsIncludingPreview();
+    }
+    return BASE_FIELDS_TO_FETCH.join(',');
+}

--- a/test/preview.html
+++ b/test/preview.html
@@ -22,7 +22,7 @@
             window.onload = function() {
                 const { ContentExplorer } = Box;
                 const explorer = new ContentExplorer();
-                explorer.show('0', 'DcMR7enbzWtX1nZ6UVFniBlDhxyhPFk3', {
+                explorer.show('0', 'wPB6CDBB8hdJP5S821iqALEUau0Fa39Y', {
                     hasPreviewSidebar: true
                 });
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6051,6 +6051,10 @@ randombytes@^2.0.0, randombytes@^2.0.1:
   dependencies:
     safe-buffer "^5.1.0"
 
+randomcolor@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/randomcolor/-/randomcolor-0.5.3.tgz#7f90f2f2a7f6d5a52232161eeaeeaea9ac3b5815"
+
 range-parser@^1.0.3, range-parser@^1.2.0, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"


### PR DESCRIPTION
Only content explorer should be requesting preview related
api fields. Likewise only content explorer should get preview
sidebar related fields only if it is there.

Adds new colors to timeline component which now shows
random colors for each time line.

Some UI changes.