### PR TITLE
New: ContentUploader fileLimit option

### DIFF
--- a/src/api/ChunkedUpload.js
+++ b/src/api/ChunkedUpload.js
@@ -67,7 +67,7 @@ class ChunkedUpload extends Base {
 
         // Automatically handle name conflict errors
         const { response } = error;
-        if (response.status === 409) {
+        if (response && response.status === 409) {
             const { name } = this.file;
 
             if (this.overwrite) {

--- a/src/api/PlainUpload.js
+++ b/src/api/PlainUpload.js
@@ -78,7 +78,7 @@ class PlainUpload extends Base {
         }
 
         // Automatically handle name conflict errors
-        if (error.status === 409) {
+        if (error && error.status === 409) {
             if (this.overwrite) {
                 // Error response contains file ID to upload a new file version for
                 this.makePreflightRequest({

--- a/src/components/ContentUploader/Footer.js
+++ b/src/components/ContentUploader/Footer.js
@@ -10,13 +10,14 @@ import './Footer.scss';
 type Props = {
     isLoading: boolean,
     hasFiles: boolean,
+    message: string,
     onCancel: Function,
     onClose?: Function,
     onUpload: Function,
     getLocalizedMessage: Function
 };
 
-const Footer = ({ isLoading, hasFiles, onCancel, onClose, onUpload, getLocalizedMessage }: Props) =>
+const Footer = ({ isLoading, hasFiles, message, onCancel, onClose, onUpload, getLocalizedMessage }: Props) =>
     <div className='bcu-footer'>
         <div className='bcu-footer-left'>
             {onClose
@@ -24,6 +25,9 @@ const Footer = ({ isLoading, hasFiles, onCancel, onClose, onUpload, getLocalized
                     {getLocalizedMessage('buik.footer.button.close')}
                 </Button>
                 : null}
+        </div>
+        <div className='bcu-footer-message'>
+            {message}
         </div>
         <div className='bcu-footer-right'>
             <Button isDisabled={!hasFiles} onClick={onCancel}>

--- a/src/components/ContentUploader/Footer.scss
+++ b/src/components/ContentUploader/Footer.scss
@@ -9,7 +9,16 @@
     justify-content: space-between;
     padding: 0 20px;
 
-    .bcu-footer-right .buik-btn {
-        margin-left: 8px;
+    .bcu-footer-message {
+        padding: 0 10px;
+        text-align: center;
+    }
+
+    .bcu-footer-right {
+        flex-shrink: 0;
+
+        .buik-btn {
+            margin-left: 8px;
+        }
     }
 }

--- a/src/i18n/en-US.properties
+++ b/src/i18n/en-US.properties
@@ -164,6 +164,8 @@ buik.sort.option.name.desc = Name: Z → A
 buik.sort.option.size.asc = Size: Smallest → Largest
 # Size descending option shown in the share access drop down select.
 buik.sort.option.size.desc = Size: Largest → Smallest
+# Message shown when too many files are uploaded at once
+buik.upload.message.toomanyfiles = You can only upload up to {fileLimit} files at a time.
 # Message shown when there are no items to upload
 buik.upload.state.empty = Drag and drop files or
 # Message shown for upload link when there are no items to upload

--- a/src/messages.js
+++ b/src/messages.js
@@ -298,6 +298,11 @@ const messages: { [string]: IntlDescriptor } = defineMessages({
         description: 'Text for create folder dialog button',
         defaultMessage: 'Create'
     },
+    'buik.upload.message.toomanyfiles': {
+        id: 'buik.upload.message.toomanyfiles',
+        description: 'Message shown when too many files are uploaded at once',
+        defaultMessage: 'You can only upload up to {fileLimit} files at a time.'
+    },
     'buik.upload.state.error': {
         id: 'buik.upload.state.error',
         description: 'Message shown when there is a network error when uploading',

--- a/test/uploader.html
+++ b/test/uploader.html
@@ -74,9 +74,21 @@
                 localStorage.setItem('token', token);
                 localStorage.setItem('folderId', folderId);
 
+                const typedId = `folder_${folderId}`;
+
+                const tokenGenerator = () => {
+
+                    // Resolve with a map of typed ID (aka file_{FILE_ID} or folder_{FOLDER_ID}) -> token to use
+                    const tokenMap = {
+                        [typedId]: token
+                    }
+
+                    return Promise.resolve(tokenMap);
+                };
+
                 const uploader1 = new ContentUploader();
                 document.querySelector('.uploader1').innerHTML = '';
-                uploader1.show(folderId, token, {
+                uploader1.show(folderId, tokenGenerator, {
                     container: '.uploader1'
                 });
             }


### PR DESCRIPTION
- Support `fileLimit` option that limits number of files that can be uploaded at once. If more than `fileLimit` files are selected, they will be truncated and a warning message will be shown in the footer.
- Add null checks during error handling
- Update uploader test file to use simple token generator function