### PR TITLE
Fix: Better error and retry handling for Uploader

### DIFF
--- a/src/api/BaseUpload.js
+++ b/src/api/BaseUpload.js
@@ -1,0 +1,81 @@
+/**
+ * @flow
+ * @file Base helper for the Box Upload APIs
+ * @author Box
+ */
+
+import Base from './Base';
+import { DEFAULT_RETRY_DELAY_MS, MS_IN_S } from '../constants';
+
+class BaseUpload extends Base {
+    file: File;
+    overwrite: boolean;
+    retryCount: number = 0;
+    retryTimeout: number;
+    errorCallback: Function;
+
+    /**
+     * Shared upload error handler for initial upload (preflight for plain upload, session creation for chunked)
+     *
+     * @private
+     * @param {Object} error - Upload error
+     * @param {Function} retryUploadFunc - Function to retry the initial upload
+     * @return {void}
+     */
+    baseUploadErrorHandler = (error: any, retryUploadFunc: Function): void => {
+        const fileName = this.file ? this.file.name : '';
+
+        // Automatically handle name conflict errors
+        if (error && error.status === 409) {
+            if (this.overwrite) {
+                // Error response contains file ID to upload a new file version for
+                retryUploadFunc({
+                    fileId: error.context_info.conflicts.id,
+                    fileName
+                });
+            } else {
+                // Otherwise, reupload and append timestamp
+                // 'test.jpg' becomes 'test-TIMESTAMP.jpg'
+                const extension = fileName.substr(fileName.lastIndexOf('.')) || '';
+                retryUploadFunc({
+                    fileName: `${fileName.substr(0, fileName.lastIndexOf('.'))}-${Date.now()}${extension}`
+                });
+            }
+            // Retry after interval defined in header
+        } else if (error && (error.status === 429 || error.code === 'too_many_requests')) {
+            let retryAfterMs = DEFAULT_RETRY_DELAY_MS;
+
+            if (error.headers) {
+                const retryAfterSec = parseInt(error.headers.get('Retry-After'), 10);
+
+                if (!isNaN(retryAfterSec)) {
+                    retryAfterMs = retryAfterSec * MS_IN_S;
+                }
+            }
+
+            this.retryTimeout = setTimeout(
+                () =>
+                    retryUploadFunc({
+                        fileName
+                    }),
+                retryAfterMs
+            );
+
+            // If another error status that isn't name conflict or rate limiting, fail upload
+        } else if (error && error.status && typeof this.errorCallback === 'function') {
+            this.errorCallback(error);
+            // Retry with exponential backoff for other failures since these are likely to be network errors
+        } else {
+            this.retryTimeout = setTimeout(
+                () =>
+                    retryUploadFunc({
+                        fileName
+                    }),
+                2 ** this.retryCount * MS_IN_S
+            );
+            this.retryCount += 1;
+        }
+    };
+}
+
+export default BaseUpload;

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -224,6 +224,7 @@ class ContentUploader extends Component<DefaultProps, Props, State> {
             });
         } else {
             updatedItems = items.concat(newItems);
+            this.setState({ message: '' });
         }
 
         this.updateViewAndCollection(updatedItems);
@@ -241,6 +242,9 @@ class ContentUploader extends Component<DefaultProps, Props, State> {
      * @return {void}
      */
     removeFileFromUploadQueue(item: UploadItem) {
+        // Clear any error message in footer
+        this.setState({ message: '' });
+
         const { api } = item;
         api.cancel();
 
@@ -369,10 +373,16 @@ class ContentUploader extends Component<DefaultProps, Props, State> {
      * @return {void}
      */
     handleUploadError = () => {
-        this.setState({
-            view: VIEW_ERROR,
-            items: []
-        });
+        const { items } = this.state;
+
+        // Show error state if there are items being uploaded - this check prevents the error state from flashing in
+        // from an asynchronous failure after there are no more items being uploaded
+        if (items.length !== 0) {
+            this.setState({
+                view: VIEW_ERROR,
+                items: []
+            });
+        }
     };
 
     /**

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -67,7 +67,7 @@ type DefaultProps = {|
 type State = {
     view: View,
     items: UploadItem[],
-    message: string
+    message?: string
 };
 
 const CHUNKED_UPLOAD_MIN_SIZE_BYTES = 52428800; // 50MB
@@ -360,10 +360,16 @@ class ContentUploader extends Component<DefaultProps, Props, State> {
             items = []; // Reset item collection after successful upload
         }
 
-        this.setState({
-            view,
-            items
-        });
+        const state: State = {
+            items,
+            view
+        };
+
+        if (items.length === 0) {
+            state.message = '';
+        }
+
+        this.setState(state);
     }
 
     /**

--- a/src/components/ContentUploader/Footer.js
+++ b/src/components/ContentUploader/Footer.js
@@ -10,7 +10,7 @@ import './Footer.scss';
 type Props = {
     isLoading: boolean,
     hasFiles: boolean,
-    message: string,
+    message?: string,
     onCancel: Function,
     onClose?: Function,
     onUpload: Function,

--- a/src/constants.js
+++ b/src/constants.js
@@ -152,3 +152,7 @@ const X_REP_HINT_VIDEO_DASH = '[dash,mp4][filmstrip]';
 const X_REP_HINT_VIDEO_MP4 = '[mp4]';
 const videoHint = canPlayDash() ? X_REP_HINT_VIDEO_DASH : X_REP_HINT_VIDEO_MP4;
 export const X_REP_HINTS = `${X_REP_HINT_BASE}${X_REP_HINT_DOC_THUMBNAIL}${X_REP_HINT_IMAGE}${videoHint}`;
+
+/* ------------------ Uploader  ---------------------- */
+export const DEFAULT_RETRY_DELAY_MS = 3000;
+export const MS_IN_S = 1000;


### PR DESCRIPTION
- Consolidate upload error & retry logic for plain and chunked uploads
- Add exponential back-off for non-429 retries
- Properly handle 429 retries based on the `Retry-After` header