### PR TITLE
New: Upload & error events per file and manual retries

### DIFF
--- a/src/api/Chunk.js
+++ b/src/api/Chunk.js
@@ -73,7 +73,7 @@ class Chunk extends BaseUpload {
 
         this.uploadHeaders = {
             'Content-Type': 'application/octet-stream',
-            Digest: `SHA=${sha1}}`,
+            Digest: `sha=${sha1}`,
             'Content-Range': `bytes ${rangeStart}-${rangeEnd}/${totalSize}`
         };
 

--- a/src/api/ChunkedUpload.js
+++ b/src/api/ChunkedUpload.js
@@ -13,7 +13,7 @@ import type { BoxItem, StringAnyMap } from '../flowTypes';
 import int32ArrayToBase64 from '../util/base64';
 
 const DIGEST_DELAY_MS = 1000; // Delay 1s before retry-ing digest update or fetch
-const UPLOAD_PARALLELISM = 5; // Maximum concurrent chunks to upload per file
+const UPLOAD_PARALLELISM = 4; // Maximum concurrent chunks to upload per file
 
 class ChunkedUpload extends BaseUpload {
     digest: string;
@@ -131,10 +131,7 @@ class ChunkedUpload extends BaseUpload {
 
         for (let i = 0; i < UPLOAD_PARALLELISM; i += 1) {
             this.getNextChunk().then((chunk) => (chunk ? this.uploadChunk(chunk) : this.commitFile())).catch(() => {
-                /* eslint-disable no-console */
-                console.log('Error fetching next chunk');
-                /* eslint-enable no-console */
-                this.errorCallback();
+                this.errorCallback(new Error('Error fetching next chunk'));
             });
         }
     }

--- a/src/wrappers/ContentUploader.js
+++ b/src/wrappers/ContentUploader.js
@@ -22,13 +22,33 @@ class ContentUploader extends ES6Wrapper {
     };
 
     /**
-     * Callback on completed upload. Emits 'complete' event with Box File objects of uploaded items as data.
+     * Callback when all files finish uploading. Emits 'complete' event with Box File objects of uploaded items as data.
      *
      * @param {Array} data - Completed upload items
      * @return {void}
      */
     onComplete = (data: BoxItem[]): void => {
         this.emit('complete', data);
+    };
+
+    /**
+     * Callback on a single upload error. Emits 'uploaderror' event with information about the failed upload.
+     *
+     * @param {Object} data - File and error info about failed upload
+     * @return {void}
+     */
+    onError = (data: any): void => {
+        this.emit('error', data);
+    };
+
+    /**
+     * Callback on a single successful upload. Emits 'uploadsuccess' event with Box File object of uploaded item.
+     *
+     * @param {BoxItem} data - Successfully uploaded item
+     * @return {void}
+     */
+    onUpload = (data: BoxItem): void => {
+        this.emit('upload', data);
     };
 
     /** @inheritdoc */
@@ -43,6 +63,8 @@ class ContentUploader extends ES6Wrapper {
                 token={this.token}
                 onClose={this.onClose}
                 onComplete={this.onComplete}
+                onError={this.onError}
+                onUpload={this.onUpload}
                 modal={modal}
                 {...rest}
             />,

--- a/test/uploader.html
+++ b/test/uploader.html
@@ -88,6 +88,17 @@
 
                 const uploader1 = new ContentUploader();
                 document.querySelector('.uploader1').innerHTML = '';
+
+                uploader1.on('upload', (data) => {
+                    console.log(`Successfully uploaded a file: ${data ? data.id : 'No File ID'}`);
+                });
+                uploader1.on('error', (data) => {
+                    console.log(`Failed to upload: ${JSON.stringify(data)}`);
+                });
+                uploader1.on('complete', (data) => {
+                    console.log(`All files successfully uploaded: ${JSON.stringify(data)}`);
+                });
+
                 uploader1.show(folderId, tokenGenerator, {
                     container: '.uploader1'
                 });


### PR DESCRIPTION
- Add 'upload' and 'error' events that are emitted when single files are either uploaded successfully or not
- When uploads fail, show an error indicator per row instead of cancelling all uploads
- Allow retries of failed uploads