### PR TITLE
Fix: Use raw loader for Rusha in webpack npm config

### DIFF
--- a/build/webpack.npm.config.js
+++ b/build/webpack.npm.config.js
@@ -49,6 +49,13 @@ module.exports = {
                         }
                     ]
                 })
+            },
+            {
+                test: /\.js$/,
+                loader: 'raw-loader',
+                include: [
+                    path.resolve('src/third-party/uploader/rusha.min.js')
+                ]
             }
         ]
     },


### PR DESCRIPTION
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md recommends no webpack loader syntax inline.

I need the raw file, not what's imported from npm since that doesn't have worker-specific code. Alternatively, I could re-implement the worker interface, not sure if that's better than this.