### PR TITLE
Chore: Remove unnecessary inclusion of babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,9 +87,6 @@
       "!**/node_modules/**",
       "!**/__tests__/**"
     ],
-    "setupFiles": [
-      "<rootDir>/node_modules/babel-polyfill/dist/polyfill.js"
-    ],
     "setupTestFrameworkScriptFile": "<rootDir>/build/enzyme-adapter.js"
   },
   "devEngines": {


### PR DESCRIPTION
core-js is already imported in the enzyme adaptor