### PR TITLE
Fix: upload reachability test should accept empty preflight response

### DIFF
--- a/src/api/uploads/UploadReachability.js
+++ b/src/api/uploads/UploadReachability.js
@@ -125,13 +125,11 @@ class UploadsReachability {
      * @return {string}
      */
     handlePreflightResponse(response?: Object) {
-        if (!response) {
+        if (!response || !response.upload_url) {
             return DEFAULT_HOSTNAME_UPLOAD;
         }
 
-        const { upload_url } = response;
-
-        const splitUrl = upload_url.split('/');
+        const splitUrl = response.upload_url.split('/');
         return `${splitUrl[0]}//${splitUrl[2]}`;
     }
 }

--- a/src/api/uploads/__tests__/UploadsReachability-test.js
+++ b/src/api/uploads/__tests__/UploadsReachability-test.js
@@ -44,6 +44,7 @@ describe('api/UploadsReachability', () => {
     describe('handlePreflightResponse()', () => {
         withData(
             [
+                [{random: 1}, DEFAULT_HOSTNAME_UPLOAD],
                 [undefined, DEFAULT_HOSTNAME_UPLOAD],
                 [null, DEFAULT_HOSTNAME_UPLOAD],
                 [{ upload_url: 'http://random.com/hello123' }, 'http://random.com']


### PR DESCRIPTION
On the staging environment when uploading from the webapp, the preflight returns 204 with no upload_url. Also, this API behavior is undocumented.

Adding an extra check to handle this case.