### PR TITLE
Update: Import regnerator runtime as part of React components

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ The instructions below describe how to use the UI Elements in a [React](https://
 ## Installation
 `yarn add box-ui-elements` or `npm install box-ui-elements`
 
-To prevent duplication, the UI Elements require certain peer dependencies to be installed manually. For a list of required peer dependencies, see [package.json](package.json).
-
-This project also requires [regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime), since our source code uses async/await. This can be achieved by installing the dependency (also listed as part of the peer dependencies) and then adding the following line in your parent React project:
-
-`import 'regenerator-runtime/runtime';`
+To prevent library duplication, the UI Elements require certain peer dependencies to be installed manually. For a list of required peer dependencies, see [package.json](package.json).
 
 ## Browser Support
 * Desktop Chrome, Firefox, Safari, Edge (latest 2 versions)

--- a/src/components/ContentExplorer/ContentExplorer.js
+++ b/src/components/ContentExplorer/ContentExplorer.js
@@ -4,6 +4,7 @@
  * @author Box
  */
 
+import 'regenerator-runtime/runtime';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';

--- a/src/components/ContentPicker/ContentPicker.js
+++ b/src/components/ContentPicker/ContentPicker.js
@@ -4,6 +4,7 @@
  * @author Box
  */
 
+import 'regenerator-runtime/runtime';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';

--- a/src/components/ContentPreview/ContentPreview.js
+++ b/src/components/ContentPreview/ContentPreview.js
@@ -4,6 +4,7 @@
  * @author Box
  */
 
+import 'regenerator-runtime/runtime';
 import React, { PureComponent } from 'react';
 import uniqueid from 'lodash/uniqueId';
 import noop from 'lodash/noop';

--- a/src/components/ContentSidebar/ContentSidebar.js
+++ b/src/components/ContentSidebar/ContentSidebar.js
@@ -4,6 +4,7 @@
  * @author Box
  */
 
+import 'regenerator-runtime/runtime';
 import React, { PureComponent } from 'react';
 import uniqueid from 'lodash/uniqueId';
 import noop from 'lodash/noop';

--- a/src/components/ContentTree/ContentTree.js
+++ b/src/components/ContentTree/ContentTree.js
@@ -4,6 +4,7 @@
  * @author Box
  */
 
+import 'regenerator-runtime/runtime';
 import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -4,7 +4,7 @@
  * @author Box
  */
 
-/* eslint-disable no-param-reassign */
+import 'regenerator-runtime/runtime';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
@@ -516,7 +516,8 @@ class ContentUploader extends Component<Props, State> {
 
             if (!useUploadsManager) {
                 onComplete(cloneDeep(items.map((item) => item.boxFile)));
-                items = []; // Reset item collection after successful upload
+                // Reset item collection after successful upload
+                items = []; // eslint-disable-line
             }
         }
 

--- a/src/wrappers/ES6Wrapper.js
+++ b/src/wrappers/ES6Wrapper.js
@@ -7,7 +7,6 @@
 import EventEmitter from 'events';
 import ReactDOM from 'react-dom';
 import { addLocaleData } from 'react-intl';
-import 'regenerator-runtime/runtime';
 import { DEFAULT_CONTAINER } from '../constants';
 import i18n from '../i18n';
 import type { StringMap, Token } from '../flowTypes';


### PR DESCRIPTION
And remove it from the wrapper, so that developers are not forced
to import it themselves other than adding peer dep.