### PR TITLE
Breaking: Add request and response intercepting to the elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ render(
 | sharedLink | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
 | sharedLinkPassword | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
 | defaultView | string | `files` | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
-| responseFilter | function | | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
+| requestInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
+| responseInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
 
 ### Keyboard Shortcuts
 *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-keyboard-shortcuts).*
@@ -160,7 +161,8 @@ render(
 | chooseButtonLabel | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-picker#section-options).* |
 | cancelButtonLabel | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-picker#section-options).* |
 | defaultView | string | `files` | *See the [developer docs](https://developer.box.com/docs/box-content-picker#section-options).* |
-| responseFilter | function | | *See the [developer docs](https://developer.box.com/docs/box-content-picker#section-options).* |
+| requestInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-picker#section-options).* |
+| responseInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-picker#section-options).* |
 
 ### Keyboard Shortcuts
 *See the [developer docs](https://developer.box.com/docs/box-content-picker#section-keyboard-shortcuts).*
@@ -203,7 +205,8 @@ render(
 | logoUrl | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
 | sharedLink | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
 | sharedLinkPassword | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
-| responseFilter | function | | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
+| requestInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
+| responseInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
 
 
 ## Content Tree ([Documentation](https://developer.box.com/docs/box-content-tree))
@@ -245,7 +248,8 @@ render(
 | logoUrl | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-tree#section-options).* |
 | sharedLink | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-tree#section-options).* |
 | sharedLinkPassword | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-tree#section-options).* |
-| responseFilter | function | | *See the [developer docs](https://developer.box.com/docs/box-content-tree#section-options).* |
+| requestInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-tree#section-options).* |
+| responseInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-tree#section-options).* |
 
 
 ## Content Preview ([Documentation](https://developer.box.com/docs/box-content-preview))
@@ -291,6 +295,8 @@ render(
 | logoUrl | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-preview#section-options).* |
 | sharedLink | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-preview#section-options).* |
 | sharedLinkPassword | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-preview#section-options).* |
+| requestInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-preview#section-options).* |
+| responseInterceptor | function | | *See the [developer docs](https://developer.box.com/docs/box-content-preview#section-options).* |
 
 
 # Questions

--- a/src/components/ContentExplorer/ContentExplorer.js
+++ b/src/components/ContentExplorer/ContentExplorer.js
@@ -106,7 +106,8 @@ type Props = {
     logoUrl?: string,
     sharedLink?: string,
     sharedLinkPassword?: string,
-    responseFilter?: Function,
+    requestInterceptor?: Function,
+    responseInterceptor?: Function,
     onInteraction: Function
 };
 
@@ -188,7 +189,8 @@ class ContentExplorer extends Component<Props, State> {
             uploadHost,
             sortBy,
             sortDirection,
-            responseFilter,
+            requestInterceptor,
+            responseInterceptor,
             rootFolderId
         }: Props = props;
 
@@ -198,7 +200,8 @@ class ContentExplorer extends Component<Props, State> {
             sharedLinkPassword,
             apiHost,
             uploadHost,
-            responseFilter,
+            requestInterceptor,
+            responseInterceptor,
             clientName: CLIENT_NAME_CONTENT_EXPLORER,
             id: `${TYPED_ID_FOLDER_PREFIX}${rootFolderId}`
         });
@@ -1176,7 +1179,9 @@ class ContentExplorer extends Component<Props, State> {
             onPreview,
             onUpload,
             hasPreviewSidebar,
-            onInteraction
+            onInteraction,
+            requestInterceptor,
+            responseInterceptor
         }: Props = this.props;
 
         const {
@@ -1267,6 +1272,8 @@ class ContentExplorer extends Component<Props, State> {
                             parentElement={this.rootElement}
                             appElement={this.appElement}
                             onUpload={onUpload}
+                            requestInterceptor={requestInterceptor}
+                            responseInterceptor={responseInterceptor}
                         />
                     ) : null}
                     {allowCreate && !!this.appElement ? (
@@ -1334,6 +1341,8 @@ class ContentExplorer extends Component<Props, State> {
                             sharedLink={sharedLink}
                             sharedLinkPassword={sharedLinkPassword}
                             onInteraction={onInteraction}
+                            requestInterceptor={requestInterceptor}
+                            responseInterceptor={responseInterceptor}
                         />
                     ) : null}
                 </div>

--- a/src/components/ContentExplorer/PreviewDialog.js
+++ b/src/components/ContentExplorer/PreviewDialog.js
@@ -32,6 +32,8 @@ type Props = {
     sharedLink?: string,
     sharedLinkPassword?: string,
     onInteraction: Function,
+    requestInterceptor?: Function,
+    responseInterceptor?: Function,
     intl: any
 };
 
@@ -52,6 +54,8 @@ const PreviewDialog = ({
     sharedLink,
     sharedLinkPassword,
     onInteraction,
+    requestInterceptor,
+    responseInterceptor,
     intl
 }: Props) => {
     const { items }: Collection = currentCollection;
@@ -90,6 +94,8 @@ const PreviewDialog = ({
                 sharedLink={sharedLink}
                 sharedLinkPassword={sharedLinkPassword}
                 onInteraction={onInteraction}
+                requestInterceptor={requestInterceptor}
+                responseInterceptor={responseInterceptor}
             />
         </Modal>
     );

--- a/src/components/ContentPicker/ContentPicker.js
+++ b/src/components/ContentPicker/ContentPicker.js
@@ -94,7 +94,8 @@ type Props = {
     logoUrl?: string,
     sharedLink?: string,
     sharedLinkPassword?: string,
-    responseFilter?: Function
+    requestInterceptor?: Function,
+    responseInterceptor?: Function
 };
 
 type State = {
@@ -163,7 +164,8 @@ class ContentPicker extends Component<Props, State> {
             sortBy,
             sortDirection,
             clientName,
-            responseFilter,
+            requestInterceptor,
+            responseInterceptor,
             rootFolderId
         } = props;
 
@@ -174,7 +176,8 @@ class ContentPicker extends Component<Props, State> {
             apiHost,
             uploadHost,
             clientName,
-            responseFilter,
+            requestInterceptor,
+            responseInterceptor,
             id: `${TYPED_ID_FOLDER_PREFIX}${rootFolderId}`
         });
 
@@ -950,7 +953,9 @@ class ContentPicker extends Component<Props, State> {
             className,
             measureRef,
             chooseButtonLabel,
-            cancelButtonLabel
+            cancelButtonLabel,
+            requestInterceptor,
+            responseInterceptor
         }: Props = this.props;
         const {
             view,
@@ -1038,6 +1043,8 @@ class ContentPicker extends Component<Props, State> {
                             onClose={this.uploadSuccessHandler}
                             parentElement={this.rootElement}
                             appElement={this.appElement}
+                            requestInterceptor={requestInterceptor}
+                            responseInterceptor={responseInterceptor}
                         />
                     ) : null}
                     {allowCreate && !!this.appElement ? (

--- a/src/components/ContentPreview/ContentPreview.js
+++ b/src/components/ContentPreview/ContentPreview.js
@@ -57,7 +57,9 @@ type Props = {
     logoUrl?: string,
     sharedLink?: string,
     sharedLinkPassword?: string,
-    onInteraction: Function
+    onInteraction: Function,
+    requestInterceptor?: Function,
+    responseInterceptor?: Function
 };
 
 type State = {
@@ -100,7 +102,17 @@ class ContentPreview extends PureComponent<Props, State> {
      */
     constructor(props: Props) {
         super(props);
-        const { hasSidebar, cache, token, sharedLink, sharedLinkPassword, apiHost, isSmall } = props;
+        const {
+            hasSidebar,
+            cache,
+            token,
+            sharedLink,
+            sharedLinkPassword,
+            apiHost,
+            isSmall,
+            requestInterceptor,
+            responseInterceptor
+        } = props;
 
         this.state = { showSidebar: hasSidebar && !isSmall };
         this.id = uniqueid('bcpr_');
@@ -110,7 +122,9 @@ class ContentPreview extends PureComponent<Props, State> {
             sharedLink,
             sharedLinkPassword,
             apiHost,
-            clientName: CLIENT_NAME_CONTENT_PREVIEW
+            clientName: CLIENT_NAME_CONTENT_PREVIEW,
+            requestInterceptor,
+            responseInterceptor
         });
     }
 
@@ -603,7 +617,9 @@ class ContentPreview extends PureComponent<Props, State> {
             measureRef,
             sharedLink,
             sharedLinkPassword,
-            onInteraction
+            onInteraction,
+            requestInterceptor,
+            responseInterceptor
         }: Props = this.props;
 
         const { file, showSidebar: showSidebarState }: State = this.state;
@@ -680,6 +696,8 @@ class ContentPreview extends PureComponent<Props, State> {
                                 sharedLink={sharedLink}
                                 sharedLinkPassword={sharedLinkPassword}
                                 onInteraction={onInteraction}
+                                requestInterceptor={requestInterceptor}
+                                responseInterceptor={responseInterceptor}
                             />
                         )}
                     </div>

--- a/src/components/ContentSidebar/ContentSidebar.js
+++ b/src/components/ContentSidebar/ContentSidebar.js
@@ -41,7 +41,8 @@ type Props = {
     cache?: Cache,
     sharedLink?: string,
     sharedLinkPassword?: string,
-    responseFilter?: Function,
+    requestInterceptor?: Function,
+    responseInterceptor?: Function,
     onInteraction: Function
 };
 
@@ -81,7 +82,16 @@ class ContentSidebar extends PureComponent<Props, State> {
      */
     constructor(props: Props) {
         super(props);
-        const { cache, token, sharedLink, sharedLinkPassword, apiHost, clientName } = props;
+        const {
+            cache,
+            token,
+            sharedLink,
+            sharedLinkPassword,
+            apiHost,
+            clientName,
+            requestInterceptor,
+            responseInterceptor
+        } = props;
 
         this.state = {};
         this.id = uniqueid('bcs_');
@@ -91,7 +101,9 @@ class ContentSidebar extends PureComponent<Props, State> {
             sharedLink,
             sharedLinkPassword,
             apiHost,
-            clientName
+            clientName,
+            requestInterceptor,
+            responseInterceptor
         });
     }
 

--- a/src/components/ContentTree/ContentTree.js
+++ b/src/components/ContentTree/ContentTree.js
@@ -49,7 +49,8 @@ type Props = {
     messages?: StringMap,
     sharedLink?: string,
     sharedLinkPassword?: string,
-    responseFilter?: Function
+    requestInterceptor?: Function,
+    responseInterceptor?: Function
 };
 
 type State = {
@@ -83,7 +84,16 @@ class ContentTree extends Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
-        const { rootFolderId, token, sharedLink, sharedLinkPassword, apiHost, clientName, responseFilter } = props;
+        const {
+            rootFolderId,
+            token,
+            sharedLink,
+            sharedLinkPassword,
+            apiHost,
+            clientName,
+            requestInterceptor,
+            responseInterceptor
+        } = props;
 
         this.api = new API({
             token,
@@ -91,7 +101,8 @@ class ContentTree extends Component<Props, State> {
             sharedLinkPassword,
             apiHost,
             clientName,
-            responseFilter,
+            requestInterceptor,
+            responseInterceptor,
             id: `${TYPED_ID_FOLDER_PREFIX}${rootFolderId}`
         });
 

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -67,7 +67,8 @@ type Props = {
     measureRef: Function,
     language?: string,
     messages?: StringMap,
-    responseFilter?: Function,
+    requestInterceptor?: Function,
+    responseInterceptor?: Function,
     intl: any,
     useUploadsManager?: boolean,
     files?: Array<UploadFileWithAPIOptions | File>,
@@ -178,7 +179,8 @@ class ContentUploader extends Component<Props, State> {
             apiHost,
             uploadHost,
             clientName,
-            responseFilter
+            requestInterceptor,
+            responseInterceptor
         } = this.props;
 
         const itemFolderId =
@@ -195,7 +197,8 @@ class ContentUploader extends Component<Props, State> {
             apiHost,
             uploadHost,
             clientName,
-            responseFilter,
+            requestInterceptor,
+            responseInterceptor,
             id: itemFileId || itemFolderId,
             ...uploadAPIOptions
         };

--- a/src/components/UploadDialog/UploadDialog.js
+++ b/src/components/UploadDialog/UploadDialog.js
@@ -24,6 +24,8 @@ type Props = {
     parentElement: HTMLElement,
     appElement: HTMLElement,
     onUpload: Function,
+    requestInterceptor?: Function,
+    responseInterceptor?: Function,
     intl: any
 };
 
@@ -40,6 +42,8 @@ const UploadDialog = ({
     parentElement,
     appElement,
     onUpload,
+    requestInterceptor,
+    responseInterceptor,
     intl
 }: Props) => (
     <Modal
@@ -61,6 +65,8 @@ const UploadDialog = ({
             uploadHost={uploadHost}
             onClose={onClose}
             onComplete={onUpload}
+            requestInterceptor={requestInterceptor}
+            responseInterceptor={responseInterceptor}
         />
     </Modal>
 );

--- a/src/flowTypes.js
+++ b/src/flowTypes.js
@@ -294,7 +294,8 @@ export type Options = {
     cache?: Cache,
     apiHost?: string,
     uploadHost?: string,
-    responseFilter?: Function,
+    responseInterceptor?: Function,
+    requestInterceptor?: Function,
     consoleLog?: boolean,
     consoleError?: boolean
 };

--- a/test/explorer-no-react.html
+++ b/test/explorer-no-react.html
@@ -54,7 +54,8 @@
             <button type="button" onclick="load()">Submit</button>
         </div>
         <div class="container">
-            <h1>Content Explorer With Filtering to folders and navigating to another folder on load and token generator</h1>
+            <h1>Content Explorer With request and response intercepting.
+                Only showing PNG files and navigating to another folder on load and token generator</h1>
             <div class="explorer1"></div>
         </div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react.min.js"></script>
@@ -82,12 +83,24 @@
                     canShare: false,
                     autoFocus: true,
                     logoUrl: 'https://d30y9cdsu7xlg0.cloudfront.net/png/12458-200.png',
-                    responseFilter: ({ request, response }) => {
-                        const { method, api } = request;
-                        const { item_collection } = response;
+                    requestInterceptor: (config) => {
+                        // Add some custom header if needed
+                        config.headers['X-MY-CUSTOM-HEADER'] = 'FuBar';
+                        // Add some custom query param if needed
+                        config.params['Fu'] = 'Bar';
+
+                        console.log(config);
+                        return config;
+                    },
+                    responseInterceptor: (response) => {
+                        const { method, parsedUrl } = response.config;
+                        const { api } = parsedUrl;
+                        const { item_collection } = response.data;
 
                         // Only apply filtering if it was a certain API request
-                        if (method === 'GET' && /^\/folders/.test(api) && !!item_collection) {
+                        // In this example we are filtering out all but PNG files
+                        // The data integreity of the response data must be maintained
+                        if (method === 'get' && /^\/folders/.test(api) && !!item_collection) {
                             const originalLength = item_collection.entries.length; // Keep track of items originally sent
                             item_collection.entries = item_collection.entries.filter((item) => item.extension === 'png'); // Filter out unwanted items
                             const newLength = item_collection.entries.length; // Calculate the new item list length
@@ -95,7 +108,7 @@
                         }
 
                         console.log(response);
-                        return Promise.resolve(response);
+                        return response;
                     }
                 });
             }

--- a/test/preview.html
+++ b/test/preview.html
@@ -51,7 +51,7 @@
                             break;
                     }
                 });
-                explorer.show('0', 'SxUSmh0dpC6IZb8CMTR8gOPjIdOFkW0X', {
+                explorer.show('0', 'dIzkyvF69IVb2Aw5yR8TPzSlKTwAlfgk', {
                     currentFolderId: '39695871110',
                     hasPreviewSidebar: true,
                     sharedLink: 'https://app.box.com/s/sdfsdf'


### PR DESCRIPTION
Adds interceptors for adding custom headers and/or query params to the request OR filtering the response data. Prior prop `responseFilter` renamed to `responseInterceptor` for consistency. Uses the format as shown here https://github.com/axios/axios#interceptors except that the `config` attribute will additionally have a `parsedUrl` object that breaks the API url into its fragments to help with filtering. See syntax below and working example [here](test/explorer-no-react.html).

```js
explorer.show(ID, TOKEN, {
    ...
    requestInterceptor: (config) => {
        // Do something with config per https://github.com/axios/axios#interceptors
        return config;
    },
    responseInterceptor: (response) => {
        // Do something with response.data per https://github.com/axios/axios#interceptors
        return response;
    }
});
```