### PR TITLE
Chore: Refactor merge to return the merged item

### DIFF
--- a/src/api/Item.js
+++ b/src/api/Item.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @file Helper for the box item api
+ * @file Helper for the box item API
  * @author Box
  */
 
@@ -36,8 +36,8 @@ class Item extends Base {
      * Creates a key for the item's parent
      * This is always a folder
      *
-     * @param {string} id folder id
-     * @return {string} key
+     * @param {string} Id - folder id
+     * @return {string} Key
      */
     getParentCacheKey(id: string): string {
         return `${CACHE_PREFIX_FOLDER}${id}`;
@@ -46,7 +46,7 @@ class Item extends Base {
     /**
      * Handles error responses
      *
-     * @param {Response} error.response - error response
+     * @param {Response} error.response - Error response
      * @return {Function} Function that handles response
      */
     errorHandler = (error: any): void => {
@@ -65,8 +65,8 @@ class Item extends Base {
     /**
      * Creates a key for the cache
      *
-     * @param {string} id folder id
-     * @return {string} key
+     * @param {string} Id - Folder id
+     * @return {string} Key
      */
     getCacheKey(id: string): string {
         return `getCacheKey(${id}) should be overriden`;
@@ -75,9 +75,9 @@ class Item extends Base {
     /**
      * API URL for items
      *
-     * @param {string} id - item id
+     * @param {string} id - Item id
      * @protected
-     * @return {string} base url for files
+     * @return {string} Base url for files
      */
     getUrl(id: string): string {
         return `getUrl(${id}) should be overriden`;
@@ -86,20 +86,17 @@ class Item extends Base {
     /**
      * Merges new data with old data and returns new data
      *
-     * @param {String} cacheKey - the cache key of item to merge
-     * @param {String} key - the attribute to merge
-     * @param {Object} value - the value to merge
-     * @return {void}
+     * @param {String} cacheKey - The cache key of item to merge
+     * @param {String} key - The attribute to merge
+     * @param {Object} value - The value to merge
+     * @return {BoxItem} The newly updated object from the cache
      */
-    merge(cacheKey: string, key: string, value: any): void {
-        if (this.isDestroyed()) {
-            return;
-        }
+    merge(cacheKey: string, key: string, value: any): BoxItem {
         const cache: Cache = this.getCache();
         cache.merge(cacheKey, {
             [key]: value
         });
-        this.successCallback(cache.get(cacheKey));
+        return cache.get(cacheKey);
     }
 
     /**
@@ -156,7 +153,7 @@ class Item extends Base {
         const newEntries: string[] = entries.filter((entry: string) => entry !== childKey);
         const newCount: number = newEntries.length;
 
-        this.merge(
+        const updatedObject: BoxItem = this.merge(
             parentKey,
             'item_collection',
             Object.assign(item_collection, {
@@ -164,16 +161,18 @@ class Item extends Base {
                 total_count: total_count - (oldCount - newCount)
             })
         );
+
+        this.successCallback(updatedObject);
         this.postDeleteCleanup();
     };
 
     /**
      * API to delete an Item
      *
-     * @param {Object} item - item to delete
-     * @param {Function} successCallback - success callback
-     * @param {Function} errorCallback - error callback
-     * @param {Boolean} recursive - true for folders
+     * @param {Object} item - Item to delete
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @param {Boolean} recursive - True for folders
      * @return {void}
      */
     delete(item: BoxItem, successCallback: Function, errorCallback: Function = noop): Promise<void> {
@@ -209,22 +208,23 @@ class Item extends Base {
     /**
      * Handles response for rename
      *
-     * @param {BoxItem} item - the updated item
+     * @param {BoxItem} item - The updated item
      * @return {void}
      */
     renameSuccessHandler = (item: BoxItem): void => {
         // Get rid of all searches
         this.getCache().unsetAll(CACHE_PREFIX_SEARCH);
-        this.merge(this.getCacheKey(this.id), 'name', item.name);
+        const updatedObject: BoxItem = this.merge(this.getCacheKey(this.id), 'name', item.name);
+        this.successCallback(updatedObject);
     };
 
     /**
      * API to rename an Item
      *
-     * @param {Object} item - item to rename
-     * @param {string} name - item new name
-     * @param {Function} successCallback - success callback
-     * @param {Function} errorCallback - error callback
+     * @param {Object} item - Item to rename
+     * @param {string} name - Item new name
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
      * @return {void}
      */
     rename(item: BoxItem, name: string, successCallback: Function, errorCallback: Function = noop): Promise<void> {
@@ -257,20 +257,21 @@ class Item extends Base {
     /**
      * Handles response for shared link
      *
-     * @param {BoxItem} item - the updated item
+     * @param {BoxItem} item - The updated item
      * @return {void}
      */
     shareSuccessHandler = (item: BoxItem): void => {
-        this.merge(this.getCacheKey(this.id), 'shared_link', item.shared_link);
+        const updatedObject: BoxItem = this.merge(this.getCacheKey(this.id), 'shared_link', item.shared_link);
+        this.successCallback(updatedObject);
     };
 
     /**
-     * Api to create or remove a shared link
+     * API to create or remove a shared link
      *
-     * @param {Object} item - item to share
-     * @param {string} access - shared access level
-     * @param {Function} successCallback - success callback
-     * @param {Function|void} errorCallback - error callback
+     * @param {Object} item - Item to share
+     * @param {string} access - Shared access level
+     * @param {Function} successCallback - Success callback
+     * @param {Function|void} errorCallback - Error callback
      * @return {void}
      */
     share(item: BoxItem, access: string, successCallback: Function, errorCallback: Function = noop): Promise<void> {

--- a/src/api/__tests__/Item-test.js
+++ b/src/api/__tests__/Item-test.js
@@ -61,23 +61,13 @@ describe('api/Item', () => {
     });
 
     describe('merge()', () => {
-        test('should not do anything if destroyed', () => {
-            item.isDestroyed = jest.fn().mockReturnValueOnce(true);
-            item.errorCallback = jest.fn();
-            item.merge('foo', 'bar', 'baz');
-            expect(item.errorCallback).not.toHaveBeenCalled();
-        });
         test('should merge new value', () => {
             cache.set('key', {
                 foo: 'foo'
             });
             item.getCache = jest.fn().mockReturnValueOnce(cache);
-            item.successCallback = jest.fn();
-            item.merge('key', 'foo', 'bar');
-            expect(item.successCallback).toHaveBeenCalled();
-            expect(item.successCallback).toHaveBeenCalledWith({
-                foo: 'bar'
-            });
+            const result = item.merge('key', 'foo', 'bar');
+            expect(result.foo).toEqual('bar');
         });
     });
 
@@ -93,10 +83,10 @@ describe('api/Item', () => {
             cache.set('key', {
                 foo: 'foo'
             });
+            item.successCallback = jest.fn();
             item.getCache = () => ({
                 unsetAll: unsetAllMock
             });
-            item.successCallback = jest.fn();
             item.postDeleteCleanup();
             expect(item.successCallback).toHaveBeenCalled();
             expect(unsetAllMock).toHaveBeenCalledWith('search_');
@@ -112,6 +102,7 @@ describe('api/Item', () => {
             });
             item.getCacheKey = jest.fn().mockReturnValueOnce('key');
             item.merge = jest.fn();
+            item.successCallback = jest.fn();
             item.renameSuccessHandler({
                 name: 'name'
             });
@@ -126,6 +117,7 @@ describe('api/Item', () => {
             item.id = 'id';
             item.getCacheKey = jest.fn().mockReturnValueOnce('key');
             item.merge = jest.fn();
+            item.successCallback = jest.fn();
             item.shareSuccessHandler({
                 shared_link: 'link'
             });
@@ -472,6 +464,7 @@ describe('api/Item', () => {
             item.getCacheKey = jest.fn().mockReturnValueOnce('child');
             item.getParentCacheKey = jest.fn().mockReturnValueOnce('parent');
             item.merge = jest.fn();
+            item.successCallback = jest.fn();
             item.deleteSuccessHandler();
 
             expect(cache.get('parent')).toEqual({


### PR DESCRIPTION
Also refactors Cache.js to create a new object as opposed to editing attributes on the existing object.