### PR TITLE
Breaking: Render dropdowns and tooltips popups into body

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "babel-template": "^6.25.0",
     "babel-types": "^6.25.0",
     "box-locales": "^0.0.1",
-    "box-react-ui": "^22.7.0",
+    "box-react-ui": "^22.8.1",
     "circular-dependency-plugin": "^4.4.0",
     "classnames": "^2.2.5",
     "color": "^3.0.0",
@@ -192,7 +192,7 @@
   },
   "peerDependencies": {
     "axios": "^0.18.0",
-    "box-react-ui": "^22.7.0",
+    "box-react-ui": "^22.8.1",
     "classnames": "^2.2.5",
     "filesize": "^3.6.0",
     "jsuri": "^1.3.1",

--- a/src/components/Breadcrumbs/BreadcrumbDropdown.js
+++ b/src/components/Breadcrumbs/BreadcrumbDropdown.js
@@ -15,12 +15,11 @@ import './BreadcrumbDropdown.scss';
 type Props = {
     className: string,
     onCrumbClick: Function,
-    crumbs: Crumb[],
-    rootElement: HTMLElement
+    crumbs: Crumb[]
 };
 
-const BreadcrumbDropdown = ({ crumbs, onCrumbClick, className = '', rootElement }: Props) => (
-    <DropdownMenu constrainToScrollParent bodyElement={rootElement}>
+const BreadcrumbDropdown = ({ crumbs, onCrumbClick, className = '' }: Props) => (
+    <DropdownMenu constrainToScrollParent>
         <PlainButton type='button' className={`be-breadcrumbs-drop-down ${className}`}>
             ···
         </PlainButton>

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -17,8 +17,7 @@ type Props = {
     onCrumbClick: Function,
     crumbs: Crumb[],
     delimiter: Delimiter,
-    isSmall?: boolean,
-    rootElement: HTMLElement
+    isSmall?: boolean
 };
 
 /**
@@ -43,19 +42,12 @@ function filterCrumbs(rootId: string, crumbs: Crumb[]): Crumb[] {
  * @param {boolean} isLast is this the last crumb
  * @return {Element}
  */
-function getBreadcrumb(
-    crumbs: Crumb | Crumb[],
-    isLast: boolean,
-    onCrumbClick: Function,
-    delimiter: Delimiter,
-    rootElement: HTMLElement
-) {
+function getBreadcrumb(crumbs: Crumb | Crumb[], isLast: boolean, onCrumbClick: Function, delimiter: Delimiter) {
     if (Array.isArray(crumbs)) {
         const condensed = delimiter !== DELIMITER_CARET;
         return (
             <span className='be-breadcrumb-more'>
                 <BreadcrumbDropdown
-                    rootElement={rootElement}
                     onCrumbClick={onCrumbClick}
                     crumbs={crumbs}
                     className={condensed ? 'be-breadcrumbs-condensed' : ''}
@@ -69,7 +61,7 @@ function getBreadcrumb(
     return <Breadcrumb name={name} onClick={() => onCrumbClick(id)} isLast={isLast} delimiter={delimiter} />;
 }
 
-const Breadcrumbs = ({ rootId, crumbs, onCrumbClick, delimiter, isSmall = false, rootElement }: Props) => {
+const Breadcrumbs = ({ rootId, crumbs, onCrumbClick, delimiter, isSmall = false }: Props) => {
     if (!rootId || crumbs.length === 0) {
         return <span />;
     }
@@ -85,17 +77,14 @@ const Breadcrumbs = ({ rootId, crumbs, onCrumbClick, delimiter, isSmall = false,
 
     // Always show the second last/parent breadcrumb when there are at least 2 crumbs.
     const secondLastBreadcrumb =
-        length > 1 ? getBreadcrumb(filteredCrumbs[length - 2], false, onCrumbClick, delimiter, rootElement) : null;
+        length > 1 ? getBreadcrumb(filteredCrumbs[length - 2], false, onCrumbClick, delimiter) : null;
 
     // Only show the more dropdown when there were at least 4 crumbs.
     const moreBreadcrumbs =
-        length > 3
-            ? getBreadcrumb(filteredCrumbs.slice(1, length - 2), false, onCrumbClick, delimiter, rootElement)
-            : null;
+        length > 3 ? getBreadcrumb(filteredCrumbs.slice(1, length - 2), false, onCrumbClick, delimiter) : null;
 
     // Only show the root breadcrumb when there are at least 3 crumbs.
-    const firstBreadcrumb =
-        length > 2 ? getBreadcrumb(filteredCrumbs[0], false, onCrumbClick, delimiter, rootElement) : null;
+    const firstBreadcrumb = length > 2 ? getBreadcrumb(filteredCrumbs[0], false, onCrumbClick, delimiter) : null;
 
     return (
         <div className='be-breadcrumbs'>

--- a/src/components/Breadcrumbs/InlineBreadcrumbs.js
+++ b/src/components/Breadcrumbs/InlineBreadcrumbs.js
@@ -15,24 +15,17 @@ import './InlineBreadcrumbs.scss';
 type Props = {
     rootId: string,
     item: BoxItem,
-    onItemClick: Function,
-    rootElement: HTMLElement
+    onItemClick: Function
 };
 
-const InlineBreadcrumbs = ({ rootId, item, onItemClick, rootElement }: Props) => {
+const InlineBreadcrumbs = ({ rootId, item, onItemClick }: Props) => {
     const { path_collection }: BoxItem = item;
     const { entries: breadcrumbs = [] } = path_collection || {};
     return (
         <span className='be-inline-breadcrumbs'>
             <FormattedMessage {...messages.in} />
             &nbsp;
-            <Breadcrumbs
-                rootId={rootId}
-                crumbs={breadcrumbs}
-                onCrumbClick={onItemClick}
-                delimiter={DELIMITER_SLASH}
-                rootElement={rootElement}
-            />
+            <Breadcrumbs rootId={rootId} crumbs={breadcrumbs} onCrumbClick={onItemClick} delimiter={DELIMITER_SLASH} />
         </span>
     );
 };

--- a/src/components/ContentExplorer/ContentExplorer.js
+++ b/src/components/ContentExplorer/ContentExplorer.js
@@ -1228,7 +1228,6 @@ class ContentExplorer extends Component<Props, State> {
                             rootId={rootFolderId}
                             isSmall={isSmall}
                             rootName={rootName}
-                            rootElement={this.rootElement}
                             currentCollection={currentCollection}
                             canUpload={allowUpload}
                             canCreateNewFolder={allowCreate}

--- a/src/components/ContentExplorer/ItemList.js
+++ b/src/components/ContentExplorer/ItemList.js
@@ -84,7 +84,6 @@ const ItemList = ({
     const nameCell = nameCellRenderer(
         rootId,
         view,
-        rootElement,
         onItemClick,
         onItemSelect,
         canPreview,
@@ -106,8 +105,7 @@ const ItemList = ({
         onItemRename,
         onItemShare,
         onItemPreview,
-        isSmall,
-        rootElement
+        isSmall
     );
     const isRecents: boolean = view === VIEW_RECENTS;
     const { id, items = [], sortBy, sortDirection }: Collection = currentCollection;

--- a/src/components/ContentExplorer/moreOptionsCellRenderer.js
+++ b/src/components/ContentExplorer/moreOptionsCellRenderer.js
@@ -36,8 +36,7 @@ export default (
     onItemRename: Function,
     onItemShare: Function,
     onItemPreview: Function,
-    isSmall: boolean,
-    rootElement: HTMLElement
+    isSmall: boolean
 ) => ({ rowData }: { rowData: BoxItem }) => {
     const onFocus = () => onItemSelect(rowData);
     const onDelete = () => onItemDelete(rowData);
@@ -67,7 +66,7 @@ export default (
 
     return (
         <div className='bce-more-options'>
-            <DropdownMenu isRightAligned constrainToScrollParent bodyElement={rootElement}>
+            <DropdownMenu isRightAligned constrainToScrollParent>
                 <Button type='button' onFocus={onFocus} className='bce-btn-more-options'>
                     ···
                 </Button>

--- a/src/components/ContentPicker/ContentPicker.js
+++ b/src/components/ContentPicker/ContentPicker.js
@@ -1011,7 +1011,6 @@ class ContentPicker extends Component<Props, State> {
                         />
                         <SubHeader
                             view={view}
-                            rootElement={this.rootElement}
                             rootId={rootFolderId}
                             isSmall={isSmall}
                             rootName={rootName}

--- a/src/components/ContentPicker/ItemList.js
+++ b/src/components/ContentPicker/ItemList.js
@@ -56,7 +56,7 @@ const ItemList = ({
     tableRef
 }: Props) => {
     const iconCell = iconCellRenderer();
-    const nameCell = nameCellRenderer(rootId, view, rootElement, onItemClick);
+    const nameCell = nameCellRenderer(rootId, view, onItemClick);
     const checkboxCell = checkboxCellRenderer(onItemSelect, selectableType, extensionsWhitelist, hasHitSelectionLimit);
     const shareAccessCell = shareAccessCellRenderer(
         onShareAccessChange,

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -765,7 +765,6 @@ class ContentUploader extends Component<Props, State> {
                             onItemActionClick={this.onClick}
                             toggleUploadsManager={this.toggleUploadsManager}
                             view={view}
-                            rootElement={this.rootElement}
                         />
                     </div>
                 ) : (
@@ -777,7 +776,6 @@ class ContentUploader extends Component<Props, State> {
                             isTouch={isTouch}
                             view={view}
                             onClick={this.onClick}
-                            rootElement={this.rootElement}
                         />
                         <Footer
                             hasFiles={hasFiles}

--- a/src/components/ContentUploader/DroppableContent.js
+++ b/src/components/ContentUploader/DroppableContent.js
@@ -49,18 +49,17 @@ type Props = {
     view: View,
     items: UploadItem[],
     addFiles: Function,
-    onClick: Function,
-    rootElement: HTMLElement
+    onClick: Function
 };
 
 const DroppableContent = makeDroppable(dropDefinition)(
-    ({ canDrop, isOver, isTouch, view, items, addFiles, onClick, rootElement }: Props) => {
+    ({ canDrop, isOver, isTouch, view, items, addFiles, onClick }: Props) => {
         const handleSelectFiles = ({ target: { files } }: any) => addFiles(files);
         const hasItems = items.length > 0;
 
         return (
             <div className='bcu-droppable-content'>
-                <ItemList items={items} view={view} onClick={onClick} rootElement={rootElement} />
+                <ItemList items={items} view={view} onClick={onClick} />
                 <UploadState
                     canDrop={canDrop}
                     hasItems={hasItems}

--- a/src/components/ContentUploader/ItemAction.js
+++ b/src/components/ContentUploader/ItemAction.js
@@ -21,11 +21,10 @@ const ICON_CHECK_COLOR = '#26C281';
 type Props = {
     status: UploadStatus,
     onClick: Function,
-    intl: any,
-    rootElement: HTMLElement
+    intl: any
 };
 
-const ItemAction = ({ status, onClick, intl, rootElement }: Props) => {
+const ItemAction = ({ status, onClick, intl }: Props) => {
     let icon = <IconClose />;
     let tooltip = intl.formatMessage(messages.uploadsCancelButtonTooltip);
 
@@ -48,7 +47,7 @@ const ItemAction = ({ status, onClick, intl, rootElement }: Props) => {
 
     return (
         <div className='bcu-item-action'>
-            <Tooltip text={tooltip} position='top-left' bodyElement={rootElement}>
+            <Tooltip text={tooltip} position='top-left'>
                 <PlainButton type='button' onClick={onClick}>
                     {icon}
                 </PlainButton>

--- a/src/components/ContentUploader/ItemList.js
+++ b/src/components/ContentUploader/ItemList.js
@@ -15,16 +15,15 @@ import './ItemList.scss';
 
 type Props = {
     items: UploadItem[],
-    onClick: Function,
-    rootElement: HTMLElement
+    onClick: Function
 };
 
-const ItemList = ({ items, onClick, rootElement }: Props) => (
+const ItemList = ({ items, onClick }: Props) => (
     <AutoSizer>
         {({ width, height }) => {
             const nameCell = nameCellRenderer();
             const progressCell = progressCellRenderer();
-            const actionCell = actionCellRenderer(onClick, rootElement);
+            const actionCell = actionCellRenderer(onClick);
 
             return (
                 <Table

--- a/src/components/ContentUploader/UploadsManager.js
+++ b/src/components/ContentUploader/UploadsManager.js
@@ -16,11 +16,10 @@ type Props = {
     items: UploadItem[],
     onItemActionClick: Function,
     toggleUploadsManager: Function,
-    view: View,
-    rootElement: HTMLElement
+    view: View
 };
 
-const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, isExpanded, rootElement }: Props) => {
+const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, isExpanded }: Props) => {
     const isVisible = items.length > 0;
 
     /**
@@ -66,7 +65,7 @@ const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, 
                 view={view}
             />
             <div className='bcu-uploads-manager-item-list'>
-                <ItemList items={items} view={view} onClick={onItemActionClick} rootElement={rootElement} />
+                <ItemList items={items} view={view} onClick={onItemActionClick} />
             </div>
         </div>
     );

--- a/src/components/ContentUploader/actionCellRenderer.js
+++ b/src/components/ContentUploader/actionCellRenderer.js
@@ -11,6 +11,6 @@ type Props = {
     rowData: UploadItem
 };
 
-export default (onClick: Function, rootElement: HTMLElement) => ({ rowData }: Props) => (
-    <ItemAction {...rowData} onClick={() => onClick(rowData)} rootElement={rootElement} />
+export default (onClick: Function) => ({ rowData }: Props) => (
+    <ItemAction {...rowData} onClick={() => onClick(rowData)} />
 );

--- a/src/components/Item/ItemDetails.js
+++ b/src/components/Item/ItemDetails.js
@@ -15,14 +15,13 @@ type Props = {
     rootId: string,
     item: BoxItem,
     onItemClick: Function,
-    view: View,
-    rootElement: HTMLElement
+    view: View
 };
 
-const ItemDetails = ({ view, rootId, item, onItemClick, rootElement }: Props) => (
+const ItemDetails = ({ view, rootId, item, onItemClick }: Props) => (
     <div className='be-item-details'>
         {view === VIEW_SELECTED || view === VIEW_SEARCH ? (
-            <InlineBreadcrumbs rootId={rootId} item={item} onItemClick={onItemClick} rootElement={rootElement} />
+            <InlineBreadcrumbs rootId={rootId} item={item} onItemClick={onItemClick} />
         ) : (
             <ItemSubDetails view={view} item={item} />
         )}

--- a/src/components/Item/nameCellRenderer.js
+++ b/src/components/Item/nameCellRenderer.js
@@ -14,7 +14,6 @@ import './NameCell.scss';
 export default (
     rootId: string,
     view: View,
-    rootElement: HTMLElement,
     onItemClick: Function,
     onItemSelect?: Function,
     canPreview: boolean = false,
@@ -30,13 +29,7 @@ export default (
             onFocus={onItemSelect}
         />
         {view === VIEW_SEARCH || showDetails ? (
-            <ItemDetails
-                item={rowData}
-                view={view}
-                rootId={rootId}
-                onItemClick={onItemClick}
-                rootElement={rootElement}
-            />
+            <ItemDetails item={rowData} view={view} rootId={rootId} onItemClick={onItemClick} />
         ) : null}
     </div>
 );

--- a/src/components/SubHeader/Add.js
+++ b/src/components/SubHeader/Add.js
@@ -19,12 +19,11 @@ type Props = {
     showCreate: boolean,
     onUpload: Function,
     onCreate: Function,
-    isLoaded: boolean,
-    rootElement: HTMLElement
+    isLoaded: boolean
 };
 
-const Add = ({ onUpload, onCreate, isLoaded, showUpload = true, showCreate = true, rootElement }: Props) => (
-    <DropdownMenu isRightAligned constrainToScrollParent bodyElement={rootElement}>
+const Add = ({ onUpload, onCreate, isLoaded, showUpload = true, showCreate = true }: Props) => (
+    <DropdownMenu isRightAligned constrainToScrollParent>
         <Button type='button' className='be-btn-add' isDisabled={!isLoaded}>
             <IconAddThin />
         </Button>

--- a/src/components/SubHeader/Sort.js
+++ b/src/components/SubHeader/Sort.js
@@ -32,8 +32,7 @@ type Props = {
     isLoaded: boolean,
     sortBy: SortBy,
     sortDirection: SortDirection,
-    isRecents: boolean,
-    rootElement: HTMLElement
+    isRecents: boolean
 };
 
 function getMenuItem(
@@ -53,8 +52,8 @@ function getMenuItem(
     );
 }
 
-const Sort = ({ isRecents, isLoaded, sortBy, sortDirection, onSortChange, rootElement }: Props) => (
-    <DropdownMenu isRightAligned constrainToScrollParent bodyElement={rootElement}>
+const Sort = ({ isRecents, isLoaded, sortBy, sortDirection, onSortChange }: Props) => (
+    <DropdownMenu isRightAligned constrainToScrollParent>
         <Button type='button' isDisabled={!isLoaded} className='be-btn-sort'>
             <IconSort />
         </Button>

--- a/src/components/SubHeader/SubHeader.js
+++ b/src/components/SubHeader/SubHeader.js
@@ -21,14 +21,12 @@ type Props = {
     canUpload: boolean,
     canCreateNewFolder: boolean,
     view: View,
-    rootElement: HTMLElement,
     isSmall: boolean
 };
 
 const SubHeader = ({
     rootId,
     rootName,
-    rootElement,
     onItemClick,
     onSortChange,
     currentCollection,
@@ -43,7 +41,6 @@ const SubHeader = ({
         <SubHeaderLeft
             rootId={rootId}
             rootName={rootName}
-            rootElement={rootElement}
             onItemClick={onItemClick}
             currentCollection={currentCollection}
             view={view}
@@ -51,7 +48,6 @@ const SubHeader = ({
         />
         <SubHeaderRight
             view={view}
-            rootElement={rootElement}
             currentCollection={currentCollection}
             canUpload={canUpload}
             canCreateNewFolder={canCreateNewFolder}

--- a/src/components/SubHeader/SubHeaderLeft.js
+++ b/src/components/SubHeader/SubHeaderLeft.js
@@ -14,7 +14,6 @@ import type { View, Collection } from '../../flowTypes';
 type Props = {
     rootId: string,
     rootName?: string,
-    rootElement: HTMLElement,
     onItemClick: Function,
     currentCollection: Collection,
     view: View,
@@ -22,16 +21,7 @@ type Props = {
     intl: any
 };
 
-const SubHeaderLeft = ({
-    view,
-    rootElement,
-    isSmall,
-    rootId,
-    rootName,
-    currentCollection,
-    onItemClick,
-    intl
-}: Props) => {
+const SubHeaderLeft = ({ view, isSmall, rootId, rootName, currentCollection, onItemClick, intl }: Props) => {
     let crumbs;
 
     if (view === VIEW_FOLDER || view === VIEW_SEARCH) {
@@ -66,7 +56,6 @@ const SubHeaderLeft = ({
         <Breadcrumbs
             isSmall={isSmall}
             rootId={rootId}
-            rootElement={rootElement}
             crumbs={crumbs}
             onCrumbClick={onItemClick}
             delimiter={DELIMITER_CARET}

--- a/src/components/SubHeader/SubHeaderRight.js
+++ b/src/components/SubHeader/SubHeaderRight.js
@@ -18,13 +18,11 @@ type Props = {
     onCreate: Function,
     canUpload: boolean,
     canCreateNewFolder: boolean,
-    view: View,
-    rootElement: HTMLElement
+    view: View
 };
 
 const SubHeaderRight = ({
     view,
-    rootElement,
     onUpload,
     onCreate,
     canUpload,
@@ -46,7 +44,6 @@ const SubHeaderRight = ({
                 !!sortBy &&
                 !!sortDirection && (
                     <Sort
-                        rootElement={rootElement}
                         isRecents={isRecents}
                         isLoaded={isLoaded}
                         sortBy={sortBy}
@@ -56,7 +53,6 @@ const SubHeaderRight = ({
                 )}
             {showAdd && (
                 <Add
-                    rootElement={rootElement}
                     showUpload={canUpload}
                     showCreate={canCreateNewFolder}
                     onUpload={onUpload}

--- a/src/components/base.scss
+++ b/src/components/base.scss
@@ -202,8 +202,8 @@
     }
 
     ul {
-        padding: 0;
         margin: 0;
+        padding: 0;
     }
 }
 

--- a/test/preview.html
+++ b/test/preview.html
@@ -51,7 +51,7 @@
                             break;
                     }
                 });
-                explorer.show('0', 'CiLsXs4gyVT9iE1VetskGZ46FLYsePJ5', {
+                explorer.show('0', '9upIfU2zEFyB1Yzhgy1AN9COgNzURifL', {
                     currentFolderId: '39695871110',
                     hasPreviewSidebar: true,
                     sharedLink: 'https://app.box.com/s/sdfsdf'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,9 +1561,9 @@ box-locales@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/box-locales/-/box-locales-0.0.1.tgz#1724959f293ae85f235b681b775d0f1a52a76b54"
 
-box-react-ui@^22.7.0:
-  version "22.7.0"
-  resolved "https://registry.yarnpkg.com/box-react-ui/-/box-react-ui-22.7.0.tgz#14ff057cc7b76fcedda35765817ce83306d7058e"
+box-react-ui@^22.8.1:
+  version "22.8.1"
+  resolved "https://registry.yarnpkg.com/box-react-ui/-/box-react-ui-22.8.1.tgz#3074654ae677fbb08e11927be285fb0e46dc8385"
 
 brace-expansion@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Previously they used to render into the UI Element's container element. This has been causing issues when the UI Element was rendered in some 3rd party library modal (#183) due to stacking context issues (absolute/fixed positioning) and compatibility with tether.js positioning via bodyElement.

This change removes use of bodyElement making tether render the popups directly into the document body. While this breaks a bit of encapsulation, at least now tether should be able to position them better.

However the tooltip or dropdown menu can be hidden due to z-index issues. In that case, the parent app, folks using the UI Element, need to override and add z-index based on their app's use case. 

Classes to add z-index to would be `dropdown-menu-element` and `tooltip-element`. And z-index only needs to be added/overridden if needed.