### PR TITLE
Fix: Only focus preview when auto focus is allowed

### DIFF
--- a/src/components/ContentExplorer/PreviewDialog.js
+++ b/src/components/ContentExplorer/PreviewDialog.js
@@ -89,6 +89,7 @@ const PreviewDialog = ({
                 cache={cache}
                 token={token}
                 hasHeader
+                autoFocus
                 collection={files}
                 onLoad={onLoad}
                 onClose={onCancel}

--- a/test/explorer-no-react.html
+++ b/test/explorer-no-react.html
@@ -58,8 +58,8 @@
                 Only showing PNG files and navigating to another folder on load and token generator</h1>
             <div class="explorer1"></div>
         </div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react-dom.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.development.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.development.js"></script>
         <script src="../dev/en-US/explorer.no.react.js"></script>
         <script>
             function load() {

--- a/test/pickers-no-react.html
+++ b/test/pickers-no-react.html
@@ -73,8 +73,8 @@
             <h1>Folder Picker (max 3 items / token generator / cannot upload)</h1>
             <div class="folderPicker2"></div>
         </div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react-dom.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.development.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.development.js"></script>
         <script src="../dev/en-US/picker.no.react.js"></script>
         <script>
             function load() {

--- a/test/preview.html
+++ b/test/preview.html
@@ -51,7 +51,7 @@
                             break;
                     }
                 });
-                explorer.show('0', '9upIfU2zEFyB1Yzhgy1AN9COgNzURifL', {
+                explorer.show('0', 'VsnpLLwKW1DWPQHAeLSvawNHrLXzmMKQ', {
                     currentFolderId: '39695871110',
                     hasPreviewSidebar: true,
                     sharedLink: 'https://app.box.com/s/sdfsdf'

--- a/test/uploader-no-react.html
+++ b/test/uploader-no-react.html
@@ -54,8 +54,8 @@
             <h1>Content Uploader</h1>
             <div class="uploader1"></div>
         </div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react-dom.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.development.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.development.js"></script>
         <script src="../dev/en-US/uploader.no.react.js"></script>
         <script>
             // Set token and folder ID to locally stored values if available


### PR DESCRIPTION
So that the preview is not focusing itself and making the parent page jump. Auto focus helps with keyboard shortcuts. Autofocus is set to true when using content explorer.

Fixes typo in options to prevent preview library attach its own hotkey handlers.

Also fixes references to React 16 in test files. UI Elements aren't compatible with React 15.