### PR TITLE
Chore: use enzyme-to-json to serialize snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,10 @@
       "!**/node_modules/**",
       "!**/__tests__/**"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/build/enzyme-adapter.js"
+    "setupTestFrameworkScriptFile": "<rootDir>/build/enzyme-adapter.js",
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   },
   "devEngines": {
     "node": ">=8.x",
@@ -138,6 +141,7 @@
     "deepmerge": "^2.1.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-to-json": "^3.3.3",
     "eslint": "^4.18.2",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-prettier": "^2.9.0",

--- a/src/components/ContentSidebar/__tests__/__snapshots__/SidebarAccessStats-test.js.snap
+++ b/src/components/ContentSidebar/__tests__/__snapshots__/SidebarAccessStats-test.js.snap
@@ -1,147 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/ContentSidebar/SidebarAccessStats should not render the component when there are no access stats 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <SidebarVersions
-    accessStats={
-      Object {
-        "comment_count": 0,
-        "download_count": 0,
-        "edit_count": 0,
-        "preview_count": 0,
-      }
-    }
-  />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "function",
-    "props": Object {
-      "accessStats": Object {
-        "comment_count": 0,
-        "download_count": 0,
-        "edit_count": 0,
-        "preview_count": 0,
-      },
-      "intl": Object {
-        "formatDate": [Function],
-        "formatMessage": [Function],
-      },
-    },
-    "ref": null,
-    "rendered": null,
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
+<SidebarVersions
+  accessStats={
     Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "accessStats": Object {
-          "comment_count": 0,
-          "download_count": 0,
-          "edit_count": 0,
-          "preview_count": 0,
-        },
-        "intl": Object {
-          "formatDate": [Function],
-          "formatMessage": [Function],
-        },
-      },
-      "ref": null,
-      "rendered": null,
-      "type": [Function],
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
+      "comment_count": 0,
+      "download_count": 0,
+      "edit_count": 0,
+      "preview_count": 0,
+    }
+  }
+  intl={
+    Object {
+      "formatDate": [Function],
+      "formatMessage": [Function],
+    }
+  }
+/>
 `;
 
 exports[`components/ContentSidebar/SidebarAccessStats should render the component when there is at least one type of access stat 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <SidebarVersions
-    accessStats={
-      Object {
-        "comment_count": 0,
-        "download_count": 0,
-        "edit_count": 0,
-        "preview_count": 1,
-      }
-    }
-  />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "function",
-    "props": Object {
-      "accessStats": Object {
-        "comment_count": 0,
-        "download_count": 0,
-        "edit_count": 0,
-        "preview_count": 1,
-      },
-      "intl": Object {
-        "formatDate": [Function],
-        "formatMessage": [Function],
-      },
-    },
-    "ref": null,
-    "rendered": null,
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
+<SidebarVersions
+  accessStats={
     Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "accessStats": Object {
-          "comment_count": 0,
-          "download_count": 0,
-          "edit_count": 0,
-          "preview_count": 1,
-        },
-        "intl": Object {
-          "formatDate": [Function],
-          "formatMessage": [Function],
-        },
-      },
-      "ref": null,
-      "rendered": null,
-      "type": [Function],
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
+      "comment_count": 0,
+      "download_count": 0,
+      "edit_count": 0,
+      "preview_count": 1,
+    }
+  }
+  intl={
+    Object {
+      "formatDate": [Function],
+      "formatMessage": [Function],
+    }
+  }
+/>
 `;

--- a/src/components/ContentSidebar/__tests__/__snapshots__/SidebarVersions-test.js.snap
+++ b/src/components/ContentSidebar/__tests__/__snapshots__/SidebarVersions-test.js.snap
@@ -1,121 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/ContentSidebar/SidebarVersions should not render the versions when total_count is falsy 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <SidebarVersions
-    versions={
-      Object {
-        "total_count": 0,
-      }
-    }
-  />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): null,
-  Symbol(enzyme.__nodes__): Array [
-    null,
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
-`;
+exports[`components/ContentSidebar/SidebarVersions should not render the versions when total_count is falsy 1`] = `""`;
 
 exports[`components/ContentSidebar/SidebarVersions should render the versions when total_count > 0 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <SidebarVersions
-    versions={
-      Object {
-        "total_count": 1,
-      }
-    }
-  />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "class",
-    "props": Object {
-      "children": <VersionHistoryLink
-        className=""
-        onClick={undefined}
-        versionCount={2}
-      />,
-      "className": "",
-      "isOpen": true,
-    },
-    "ref": null,
-    "rendered": Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "className": "",
-        "onClick": undefined,
-        "versionCount": 2,
-      },
-      "ref": null,
-      "rendered": null,
-      "type": [Function],
-    },
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "class",
-      "props": Object {
-        "children": <VersionHistoryLink
-          className=""
-          onClick={undefined}
-          versionCount={2}
-        />,
-        "className": "",
-        "isOpen": true,
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "className": "",
-          "onClick": undefined,
-          "versionCount": 2,
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      "type": [Function],
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
+<SidebarSection
+  className=""
+  isOpen={true}
+>
+  <VersionHistoryLink
+    className=""
+    versionCount={2}
+  />
+</SidebarSection>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,6 +3425,12 @@ enzyme-adapter-utils@^1.3.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
+enzyme-to-json@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.3.tgz#ede45938fb309cd87ebd4386f60c754525515a07"
+  dependencies:
+    lodash "^4.17.4"
+
 enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"


### PR DESCRIPTION
Snapshots were not being serialized correctly, thus we were getting massive unreadable snapshots. This fixes the serialization and adds correct snapshots