### PR TITLE
Chore: Adding task CRUD operations 

### DIFF
--- a/src/api/Base.js
+++ b/src/api/Base.js
@@ -57,7 +57,7 @@ class Base {
     /**
      * @property {Function}
      */
-    successCallback: (data: Object) => void;
+    successCallback: (data?: Object) => void;
 
     /**
      * @property {Function}

--- a/src/api/Comments.js
+++ b/src/api/Comments.js
@@ -25,7 +25,7 @@ class Comments extends OffsetBasedAPI {
     /**
      * API URL for comments endpoint
      *
-     * @param {string} [id] - A box comment file id
+     * @param {string} [id] - A box comment id
      * @return {string} base url for comments
      */
     commentsUrl(id?: string): string {
@@ -111,7 +111,7 @@ class Comments extends OffsetBasedAPI {
     /**
      * API for updating a comment on a file
      *
-     * @param {BoxItem} file - File object for which we are creating a comment
+     * @param {BoxItem} file - File object for which we are updating a comment
      * @param {string} commentId - Comment to be edited
      * @param {string} message - Comment message
      * @param {Function} successCallback - Success callback
@@ -148,7 +148,7 @@ class Comments extends OffsetBasedAPI {
     }
 
     /**
-     * API for creating a comment on a file
+     * API for deleting a comment on a file
      *
      * @param {BoxItem} file - File object for which we are deleting a comment
      * @param {string} commentId - Id of the comment we are deleting

--- a/src/api/Tasks.js
+++ b/src/api/Tasks.js
@@ -44,7 +44,7 @@ class Tasks extends Base {
 
         // There is no response data when deleting a task
         if (!data) {
-            this.successCallback({});
+            this.successCallback();
             return;
         }
 
@@ -53,7 +53,7 @@ class Tasks extends Base {
 
         const tasks = entries.map((task: Task) => ({
             ...task,
-            assignees: task.task_assignment_collection.entries || []
+            task_assignment_collection: task.task_assignment_collection.entries || []
         }));
 
         this.successCallback({ ...data, entries: tasks });

--- a/src/api/Tasks.js
+++ b/src/api/Tasks.js
@@ -5,7 +5,8 @@
  */
 
 import Base from './Base';
-import type { Task } from '../flowTypes';
+import type { BoxItem, Task } from '../flowTypes';
+import { PERMISSION_CAN_COMMENT } from '../constants';
 
 class Tasks extends Base {
     /**
@@ -22,6 +23,17 @@ class Tasks extends Base {
     }
 
     /**
+     * API URL for tasks endpoint
+     *
+     * @param {string} [id] - A box task id
+     * @return {string} base url for tasks
+     */
+    tasksUrl(id?: string): string {
+        const baseUrl = `${this.getBaseApiUrl()}/tasks`;
+        return id ? `${baseUrl}/${id}` : baseUrl;
+    }
+
+    /**
      * Formats the tasks api response to usable data
      * @param {Object} data the api response data
      */
@@ -30,13 +42,147 @@ class Tasks extends Base {
             return;
         }
 
-        const tasks = data.entries.map((task: Task) => ({
+        // There is no response data when deleting a task
+        if (!data) {
+            this.successCallback({});
+            return;
+        }
+
+        // Manually create the entries array if creating/updating a task
+        const entries = data.entries ? data.entries : [data];
+
+        const tasks = entries.map((task: Task) => ({
             ...task,
             assignees: task.task_assignment_collection.entries || []
         }));
 
         this.successCallback({ ...data, entries: tasks });
     };
+
+    /**
+     * API for creating a task on a file
+     *
+     * @param {BoxItem} file - File object for which we are creating a task
+     * @param {string} message - Task message
+     * @param {string} dueAt - Task due date
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @return {void}
+     */
+    createTask({
+        file,
+        message,
+        dueAt,
+        successCallback,
+        errorCallback
+    }: {
+        file: BoxItem,
+        message: string,
+        dueAt?: string,
+        successCallback: Function,
+        errorCallback: Function
+    }): void {
+        const { id = '', permissions } = file;
+
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, id);
+        } catch (e) {
+            errorCallback(e);
+            return;
+        }
+
+        const requestData = {
+            data: {
+                item: {
+                    id,
+                    type: 'file'
+                },
+                message,
+                due_at: dueAt
+            }
+        };
+
+        this.post(id, this.tasksUrl(), requestData, successCallback, errorCallback);
+    }
+
+    /**
+     * API for updating a task on a file
+     *
+     * @param {BoxItem} file - File object for which we are creating a task
+     * @param {string} taskId - Task to be edited
+     * @param {string} message - Task message
+     * @param {string} dueAt - Task due date
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @return {void}
+     */
+    updateTask({
+        file,
+        taskId,
+        message,
+        dueAt,
+        successCallback,
+        errorCallback
+    }: {
+        file: BoxItem,
+        taskId: string,
+        message: string,
+        dueAt?: string,
+        successCallback: Function,
+        errorCallback: Function
+    }): void {
+        const { id = '', permissions } = file;
+
+        try {
+            // We don't know task_edit specific permissions, so let the client try and fail gracefully
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, id);
+        } catch (e) {
+            errorCallback(e);
+            return;
+        }
+
+        const data: { message: string, due_at?: string } = { message };
+        const requestData = { data };
+
+        if (dueAt) {
+            requestData.data.due_at = dueAt;
+        }
+
+        this.put(id, this.tasksUrl(taskId), requestData, successCallback, errorCallback);
+    }
+
+    /**
+     * API for deleting a task on a file
+     *
+     * @param {BoxItem} file - File object for which we are deleting a task
+     * @param {string} taskId - Id of the task we are deleting
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @return {void}
+     */
+    deleteTask({
+        file,
+        taskId,
+        successCallback,
+        errorCallback
+    }: {
+        file: BoxItem,
+        taskId: string,
+        successCallback: Function,
+        errorCallback: Function
+    }): void {
+        const { id = '', permissions } = file;
+
+        try {
+            // We don't know task_delete specific permissions, so let the client try and fail gracefully
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, id);
+        } catch (e) {
+            errorCallback(e);
+            return;
+        }
+
+        this.delete(id, this.tasksUrl(taskId), successCallback, errorCallback);
+    }
 }
 
 export default Tasks;

--- a/src/api/__tests__/Tasks-test.js
+++ b/src/api/__tests__/Tasks-test.js
@@ -1,4 +1,5 @@
 import Tasks from '../Tasks';
+import { PERMISSION_CAN_COMMENT } from '../../constants';
 
 let tasks;
 
@@ -19,26 +20,52 @@ describe('api/Tasks', () => {
     });
 
     describe('successHandler()', () => {
-        test('should return API response with properly formatted data', () => {
-            const task = {
-                type: 'task',
-                id: '1234',
-                created_at: { name: 'Jay-Z', id: 10 },
-                due_at: 1234567891,
-                message: 'test',
-                task_assignment_collection: {
-                    entries: []
+        const task = {
+            type: 'task',
+            id: '1234',
+            created_at: { name: 'Jay-Z', id: 10 },
+            due_at: 1234567891,
+            message: 'test',
+            task_assignment_collection: {
+                entries: []
+            }
+        };
+        const response = {
+            total_count: 1,
+            entries: [task]
+        };
+
+        const formattedResponse = {
+            ...response,
+            entries: [
+                {
+                    ...task,
+                    assignees: []
                 }
-            };
-            const response = {
-                total_count: 1,
-                entries: [task]
-            };
+            ]
+        };
 
+        beforeEach(() => {
             tasks.successCallback = jest.fn();
+        });
 
-            const formattedResponse = {
-                ...response,
+        test('should call the success callback with no data if none provided from API', () => {
+            tasks.successHandler();
+            expect(tasks.successCallback).toBeCalledWith({});
+        });
+
+        test('should return API response with properly formatted data', () => {
+            tasks.successHandler(response);
+            expect(tasks.successCallback).toBeCalledWith(formattedResponse);
+        });
+
+        test('should return properly formatted data if only one task is returned from API', () => {
+            const singleResponse = {
+                ...task
+            };
+
+            const singleFormattedResponse = {
+                ...singleResponse,
                 entries: [
                     {
                         ...task,
@@ -46,9 +73,110 @@ describe('api/Tasks', () => {
                     }
                 ]
             };
+            tasks.successHandler(task);
+            expect(tasks.successCallback).toBeCalledWith(singleFormattedResponse);
+        });
+    });
 
-            tasks.successHandler(response);
-            expect(tasks.successCallback).toBeCalledWith(formattedResponse);
+    describe('tasksUrl()', () => {
+        test('should add an id if provided', () => {
+            expect(tasks.tasksUrl('foo')).toBe('https://api.box.com/2.0/tasks/foo');
+        });
+    });
+
+    describe('CRUD operations', () => {
+        const file = {
+            id: 'foo',
+            permissions: {}
+        };
+
+        const taskId = '123';
+        const message = 'hello world';
+        const dueAt = '2018-09-06';
+        const successCb = jest.fn();
+        const errorCb = jest.fn();
+
+        beforeEach(() => {
+            tasks.get = jest.fn();
+            tasks.post = jest.fn();
+            tasks.put = jest.fn();
+            tasks.delete = jest.fn();
+            tasks.checkApiCallValidity = jest.fn(() => true);
+
+            const url = 'https://www.foo.com/tasks';
+            tasks.tasksUrl = jest.fn(() => url);
+        });
+
+        describe('createTask()', () => {
+            test('should check for valid task permissions', () => {
+                tasks.createTask({ file, message, successCb, errorCb });
+                expect(tasks.checkApiCallValidity).toBeCalledWith(PERMISSION_CAN_COMMENT, file.permissions, file.id);
+            });
+
+            test('should post a well formed task to the tasks endpoint', () => {
+                const requestData = {
+                    data: {
+                        item: {
+                            id: file.id,
+                            type: 'file'
+                        },
+                        message,
+                        due_at: dueAt
+                    }
+                };
+
+                tasks.createTask({ file, message, dueAt, successCallback: successCb, errorCallback: errorCb });
+                expect(tasks.post).toBeCalledWith('foo', tasks.tasksUrl(), requestData, successCb, errorCb);
+            });
+        });
+
+        describe('updateTask()', () => {
+            test('should check for valid task permissions', () => {
+                tasks.updateTask({ file, taskId, message, successCb, errorCb });
+                expect(tasks.checkApiCallValidity).toBeCalledWith(PERMISSION_CAN_COMMENT, file.permissions, file.id);
+            });
+
+            test('should put a well formed task update to the tasks endpoint', () => {
+                const requestData = {
+                    data: { message }
+                };
+
+                tasks.updateTask({
+                    file,
+                    taskId,
+                    message,
+                    successCallback: successCb,
+                    errorCallback: errorCb
+                });
+                expect(tasks.put).toBeCalledWith('foo', tasks.tasksUrl(taskId), requestData, successCb, errorCb);
+            });
+
+            test('should put a well formed task update to the tasks endpoint when due_at is included', () => {
+                const requestData = {
+                    data: { message, due_at: dueAt }
+                };
+
+                tasks.updateTask({
+                    file,
+                    taskId,
+                    message,
+                    dueAt,
+                    successCallback: successCb,
+                    errorCallback: errorCb
+                });
+                expect(tasks.put).toBeCalledWith('foo', tasks.tasksUrl(taskId), requestData, successCb, errorCb);
+            });
+        });
+        describe('deleteTask()', () => {
+            test('should check for valid task delete permissions', () => {
+                tasks.deleteTask({ file, taskId, successCb, errorCb });
+                expect(tasks.checkApiCallValidity).toBeCalledWith(PERMISSION_CAN_COMMENT, file.permissions, file.id);
+            });
+
+            test('should delete a task from the tasks endpoint', () => {
+                tasks.deleteTask({ file, taskId, successCallback: successCb, errorCallback: errorCb });
+                expect(tasks.delete).toBeCalledWith('foo', tasks.tasksUrl(taskId), successCb, errorCb);
+            });
         });
     });
 });

--- a/src/api/__tests__/Tasks-test.js
+++ b/src/api/__tests__/Tasks-test.js
@@ -40,7 +40,7 @@ describe('api/Tasks', () => {
             entries: [
                 {
                     ...task,
-                    assignees: []
+                    task_assignment_collection: []
                 }
             ]
         };
@@ -51,7 +51,7 @@ describe('api/Tasks', () => {
 
         test('should call the success callback with no data if none provided from API', () => {
             tasks.successHandler();
-            expect(tasks.successCallback).toBeCalledWith({});
+            expect(tasks.successCallback).toBeCalledWith();
         });
 
         test('should return API response with properly formatted data', () => {
@@ -69,7 +69,7 @@ describe('api/Tasks', () => {
                 entries: [
                     {
                         ...task,
-                        assignees: []
+                        task_assignment_collection: []
                     }
                 ]
             };


### PR DESCRIPTION
Note that adding an assignee or list of assignees can only be done through the /task_assignment endpoint, so this only allows the creation, update, and deletion of task messages and due dates. Assignment stuff will come in the next PR.