### PR TITLE
New: Show notifications for activity feed action failures

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -22,10 +22,14 @@ be.choose = Choose
 be.close = Close
 # Text for cancel button
 be.commentCancel = Cancel
+# Notification error message when a comment creation fails
+be.commentCreateErrorNotificationMessage = We're sorry, something went wrong when creating this comment.
 # Button text to cancel comment deletion
 be.commentDeleteCancel = No
 # Button text to confirm comment deletion
 be.commentDeleteConfirm = Yes
+# Notification error message when a comment deletion fails
+be.commentDeleteErrorNotificationMessage = We're sorry, something went wrong when deleting this comment.
 # Confirmation prompt text to delete comment
 be.commentDeletePrompt = Delete comment?
 # Text for post button
@@ -246,10 +250,16 @@ be.skillUnknownError = Something went wrong with running this skill or fetching 
 be.statusSkill = Status
 # Approve option for a task
 be.taskApprove = Complete
+# Notification error message when a task creation fails
+be.taskCreateErrorNotificationMessage = We're sorry, something went wrong when creating this task.
+# Notification error message when a task deletion fails
+be.taskDeleteErrorNotificationMessage = We're sorry, something went wrong when deleting this task.
 # Confirmation prompt text to delete task
 be.taskDeletePrompt = Delete task?
 # Due date for a task
 be.taskDueDate = Due
+# Notification error message when a task edit fails
+be.taskEditErrorNotificationMessage = We're sorry, something went wrong when editing this task.
 # Reject option for a task
 be.taskReject = Decline
 # Tasks for approval

--- a/src/components/ContentSidebar/ActivityFeed/activity-feed/ActivityFeed.scss
+++ b/src/components/ContentSidebar/ActivityFeed/activity-feed/ActivityFeed.scss
@@ -106,4 +106,12 @@
             padding: 10px;
         }
     }
+
+    .bcs-activity-feed-error-wrapper {
+        left: 0;
+        margin: 0 12px 0 6px;
+        position: absolute;
+        top: -12px;
+        z-index: 11;
+    }
 }

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -624,6 +624,21 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
         defaultMessage: 'Delete task?',
         description: 'Confirmation prompt text to delete task'
     },
+    taskCreateErrorNotificationMessage: {
+        id: 'be.taskCreateErrorNotificationMessage',
+        description: 'Notification error message when a task creation fails',
+        defaultMessage: 'We\'re sorry, something went wrong when creating this task.'
+    },
+    taskEditErrorNotificationMessage: {
+        id: 'be.taskEditErrorNotificationMessage',
+        description: 'Notification error message when a task edit fails',
+        defaultMessage: 'We\'re sorry, something went wrong when editing this task.'
+    },
+    taskDeleteErrorNotificationMessage: {
+        id: 'be.taskDeleteErrorNotificationMessage',
+        description: 'Notification error message when a task deletion fails',
+        defaultMessage: 'We\'re sorry, something went wrong when deleting this task.'
+    },
     commentDeleteConfirm: {
         id: 'be.commentDeleteConfirm',
         defaultMessage: 'Yes',
@@ -658,6 +673,16 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
         id: 'be.commentPostedFullDateTime',
         defaultMessage: '{time, date, full} at {time, time, short}',
         description: 'Comment posted full date time for title'
+    },
+    commentCreateErrorNotificationMessage: {
+        id: 'be.commentCreateErrorNotificationMessage',
+        description: 'Notification error message when a comment creation fails',
+        defaultMessage: 'We\'re sorry, something went wrong when creating this comment.'
+    },
+    commentDeleteErrorNotificationMessage: {
+        id: 'be.commentDeleteErrorNotificationMessage',
+        description: 'Notification error message when a comment deletion fails',
+        defaultMessage: 'We\'re sorry, something went wrong when deleting this comment.'
     },
     completedAssignment: {
         id: 'be.completedAssignment',


### PR DESCRIPTION
1. Adds notifications for various activity feed write failures
2. Updating doc strings, removing comments
3. comments on the way

Example: 
![create comment error](https://user-images.githubusercontent.com/2474027/41443883-5b54e59e-6ff4-11e8-9677-7697a3276a55.gif)
