### PR TITLE
Fix: Pass full approvers object on task create

### DIFF
--- a/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.js
+++ b/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.js
@@ -97,7 +97,7 @@ class ApprovalCommentForm extends React.Component<Props, State> {
             }
             createTask({
                 text,
-                assignees: approvers.map(({ value }) => value),
+                assignees: approvers,
                 dueAt: approvalDate
             });
         } else if (entityId) {

--- a/src/components/ContentSidebar/ActivityFeed/approval-comment-form/__tests__/ApprovalCommentForm-test.js
+++ b/src/components/ContentSidebar/ActivityFeed/approval-comment-form/__tests__/ApprovalCommentForm-test.js
@@ -146,6 +146,7 @@ describe('components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalC
         const createCommentStub = jest.fn();
         const commentText = { text: 'a comment', hasMention: false };
         const addApproval = 'on';
+        const approvers = [{ text: '123', value: 123 }, { text: '124', value: 124 }];
 
         const wrapper = render({
             createComment: createCommentStub,
@@ -156,7 +157,7 @@ describe('components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalC
         instance.getFormattedCommentText = jest.fn().mockReturnValue(commentText);
 
         wrapper.setState({
-            approvers: [{ text: '123', value: 123 }, { text: '124', value: 124 }],
+            approvers,
             approvalDate: '2014-04-12'
         });
 
@@ -166,7 +167,7 @@ describe('components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalC
 
         expect(createTaskSpy).toHaveBeenCalledWith({
             text: commentText.text,
-            assignees: [123, 124],
+            assignees: approvers,
             dueAt: '2014-04-12'
         });
         expect(instance.getFormattedCommentText).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
We actually need it to properly set pending UI on task create