### PR TITLE
New: UploadsManager drag and drop upload empty state

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -316,6 +316,8 @@ be.uploadsManagerUploadComplete = Completed
 be.uploadsManagerUploadFailed = Some Uploads Failed
 # Text shown when uploads are in progress
 be.uploadsManagerUploadInProgress = Uploading
+# Text shown to guide the user to drag drop file to upload
+be.uploadsManagerUploadPrompt = Drop files on this page to upload them into this folder.
 # Error message shown when pending app folder size exceeds the limit
 be.uploadsPendingFolderSizeLimitErrorMessage = Pending app folder size limit exceeded
 # Retry upload button tooltip

--- a/src/api/uploads/FolderUploadNode.js
+++ b/src/api/uploads/FolderUploadNode.js
@@ -99,6 +99,7 @@ class FolderUploadNode {
             this.folderId = error.context_info.conflicts[0].id;
         }
 
+        // The root folder has already been added to the upload queue in ContentUploader
         if (isRoot) {
             return;
         }

--- a/src/api/uploads/FolderUploadNode.js
+++ b/src/api/uploads/FolderUploadNode.js
@@ -9,13 +9,13 @@ import { STATUS_COMPLETE, ERROR_CODE_ITEM_NAME_IN_USE } from '../../constants';
 import { getFileFromEntry } from '../../util/uploads';
 
 class FolderUploadNode {
-    addFolderToQueue: Function;
+    addFolderToUploadQueue: Function;
     files: Array<File> = [];
     folderId: string;
     folders: Object = {};
     name: string;
     parentFolderId: string;
-    uploadFile: Function;
+    addFilesToUploadQueue: Function;
     fileAPIOptions: Object;
     baseAPIOptions: Object;
     entry: ?FileSystemFileEntry;
@@ -24,21 +24,21 @@ class FolderUploadNode {
      * [constructor]
      *
      * @param {string} name
-     * @param {Function} uploadFile
-     * @param {Function} addFolderToQueue
+     * @param {Function} addFilesToUploadQueue
+     * @param {Function} addFolderToUploadQueue
      * @returns {void}
      */
     constructor(
         name: string,
-        uploadFile: Function,
-        addFolderToQueue: Function,
+        addFilesToUploadQueue: Function,
+        addFolderToUploadQueue: Function,
         fileAPIOptions: Object,
         baseAPIOptions: Object,
         entry?: FileSystemFileEntry
     ) {
         this.name = name;
-        this.uploadFile = uploadFile;
-        this.addFolderToQueue = addFolderToQueue;
+        this.addFilesToUploadQueue = addFilesToUploadQueue;
+        this.addFolderToUploadQueue = addFolderToUploadQueue;
         this.fileAPIOptions = fileAPIOptions;
         this.baseAPIOptions = baseAPIOptions;
         this.entry = entry;
@@ -57,7 +57,7 @@ class FolderUploadNode {
         this.parentFolderId = parentFolderId;
 
         await this.createAndUploadFolder(errorCallback, isRoot);
-        this.uploadFile(this.getFormattedFiles(), noop);
+        this.addFilesToUploadQueue(this.getFormattedFiles(), noop, true);
         await this.uploadChildFolders(errorCallback);
     }
 
@@ -103,7 +103,7 @@ class FolderUploadNode {
             return;
         }
 
-        this.addFolderToQueue([
+        this.addFolderToUploadQueue([
             {
                 extension: '',
                 name: this.name,
@@ -167,8 +167,8 @@ class FolderUploadNode {
 
                 this.folders[name] = new FolderUploadNode(
                     name,
-                    this.uploadFile,
-                    this.addFolderToQueue,
+                    this.addFilesToUploadQueue,
+                    this.addFolderToUploadQueue,
                     this.fileAPIOptions,
                     {
                         ...this.baseAPIOptions,

--- a/src/api/uploads/__tests__/FolderUpload-test.js
+++ b/src/api/uploads/__tests__/FolderUpload-test.js
@@ -19,9 +19,7 @@ describe('api/uploads/FolderUpload', () => {
         test('should upload folder node', () => {
             const upload1 = jest.fn();
             const errorCallback = () => 'errorCallback';
-            folderUploadInstance.folders = {
-                1: { upload: upload1 }
-            };
+            folderUploadInstance.folder = { upload: upload1 };
 
             folderUploadInstance.upload({ errorCallback, noop });
 
@@ -41,14 +39,13 @@ describe('api/uploads/FolderUpload', () => {
 
             // /
             // - a/
-            expect(Object.values(folderUploadInstance.folders)).toHaveLength(1);
-            expect(Object.keys(folderUploadInstance.folders)).toEqual(['a']);
+            expect(folderUploadInstance.folder.name).toEqual('a');
             // /a/
             // - f1
             // - f2
             // - b/
             // - c/
-            const folderA = folderUploadInstance.folders.a;
+            const folderA = folderUploadInstance.folder;
             expect(Object.keys(folderA.folders)).toHaveLength(2);
             expect(Object.keys(folderA.folders)).toEqual(['b', 'c']);
             expect(folderA.files).toHaveLength(2);
@@ -79,14 +76,13 @@ describe('api/uploads/FolderUpload', () => {
 
             // /
             // - a/
-            expect(Object.values(folderUploadInstance.folders)).toHaveLength(1);
-            expect(Object.keys(folderUploadInstance.folders)).toEqual(['a']);
+            expect(folderUploadInstance.folder.name).toEqual('a');
             // /a/
             // - f1
             // - f2
             // - b/
             // - c/
-            const folderA = folderUploadInstance.folders.a;
+            const folderA = folderUploadInstance.folder;
             expect(Object.keys(folderA.folders)).toHaveLength(2);
             expect(Object.keys(folderA.folders)).toEqual(['b', 'c']);
             expect(folderA.files).toHaveLength(2);

--- a/src/api/uploads/__tests__/FolderUpload-test.js
+++ b/src/api/uploads/__tests__/FolderUpload-test.js
@@ -16,19 +16,16 @@ describe('api/uploads/FolderUpload', () => {
     });
 
     describe('upload()', () => {
-        test('should upload each folder node', () => {
+        test('should upload folder node', () => {
             const upload1 = jest.fn();
-            const upload2 = jest.fn();
             const errorCallback = () => 'errorCallback';
             folderUploadInstance.folders = {
-                1: { upload: upload1 },
-                2: { upload: upload2 }
+                1: { upload: upload1 }
             };
 
-            folderUploadInstance.upload({ errorCallback });
+            folderUploadInstance.upload({ errorCallback, noop });
 
             expect(upload1).toHaveBeenCalledWith(destinationFolderID, errorCallback, true);
-            expect(upload2).toHaveBeenCalledWith(destinationFolderID, errorCallback, true);
         });
     });
 
@@ -109,17 +106,16 @@ describe('api/uploads/FolderUpload', () => {
         });
     });
 
-    describe('buildFolderTreeFromDataTransferItems()', () => {
+    describe('buildFolderTreeFromDataTransferItem()', () => {
         test('should construct folders correctly', async () => {
             const createFolderUploadNodeMock = jest.fn();
             folderUploadInstance.createFolderUploadNode = createFolderUploadNodeMock;
 
-            await folderUploadInstance.buildFolderTreeFromDataTransferItems([
-                { item: { name: 'f1', webkitRelativePath: 'a/f1' }, options: {} },
-                { item: { name: 'f4', webkitRelativePath: 'a/c/f4' }, options: {} }
+            await folderUploadInstance.buildFolderTreeFromDataTransferItem([
+                { item: { name: 'f1', webkitRelativePath: 'a/f1' }, options: {} }
             ]);
 
-            expect(createFolderUploadNodeMock).toHaveBeenCalledTimes(2);
+            expect(createFolderUploadNodeMock).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/api/uploads/__tests__/FolderUploadNode-test.js
+++ b/src/api/uploads/__tests__/FolderUploadNode-test.js
@@ -27,20 +27,24 @@ describe('api/uploads/FolderUploadNode', () => {
     });
 
     describe('upload()', () => {
-        test('should call createAndUploadFolder(), uploadFile() and uploadChildFolders()', async () => {
+        test('should call createAndUploadFolder(), addFilesToUploadQueue() and uploadChildFolders()', async () => {
             const errorCallback = () => 'errorCallback';
             const parentFolderId = '0';
             const isRoot = true;
             const files = [{ file: 1 }];
             folderUploadNodeInstance.createAndUploadFolder = jest.fn(() => Promise.resolve());
-            folderUploadNodeInstance.uploadFile = jest.fn();
+            folderUploadNodeInstance.addFilesToUploadQueue = jest.fn();
             folderUploadNodeInstance.uploadChildFolders = jest.fn();
             folderUploadNodeInstance.getFormattedFiles = jest.fn(() => files);
 
             await folderUploadNodeInstance.upload(parentFolderId, errorCallback, isRoot);
 
             expect(folderUploadNodeInstance.createAndUploadFolder).toHaveBeenCalledWith(errorCallback, isRoot);
-            expect(folderUploadNodeInstance.uploadFile).toHaveBeenCalledWith(files, expect.any(Function));
+            expect(folderUploadNodeInstance.addFilesToUploadQueue).toHaveBeenCalledWith(
+                files,
+                expect.any(Function),
+                true
+            );
             expect(folderUploadNodeInstance.uploadChildFolders).toHaveBeenCalledWith(errorCallback);
         });
     });
@@ -72,7 +76,7 @@ describe('api/uploads/FolderUploadNode', () => {
             const errorCallback = () => 'errorCallback';
             const isRoot = true;
             folderUploadNodeInstance.createFolder = jest.fn(() => ({ id: folderId }));
-            folderUploadNodeInstance.addFolderToQueue = jest.fn();
+            folderUploadNodeInstance.addFolderToUploadQueue = jest.fn();
 
             await folderUploadNodeInstance.createAndUploadFolder(errorCallback, isRoot);
 
@@ -85,7 +89,7 @@ describe('api/uploads/FolderUploadNode', () => {
             const isRoot = true;
             const error = { code: 'random' };
             folderUploadNodeInstance.createFolder = jest.fn(() => Promise.reject(error));
-            folderUploadNodeInstance.addFolderToQueue = jest.fn();
+            folderUploadNodeInstance.addFolderToUploadQueue = jest.fn();
 
             await folderUploadNodeInstance.createAndUploadFolder(errorCallback, isRoot);
 
@@ -98,7 +102,7 @@ describe('api/uploads/FolderUploadNode', () => {
             const isRoot = true;
             const error = { code: ERROR_CODE_ITEM_NAME_IN_USE, context_info: { conflicts: [{ id: folderId }] } };
             folderUploadNodeInstance.createFolder = jest.fn(() => Promise.reject(error));
-            folderUploadNodeInstance.addFolderToQueue = jest.fn();
+            folderUploadNodeInstance.addFolderToUploadQueue = jest.fn();
 
             await folderUploadNodeInstance.createAndUploadFolder(errorCallback, isRoot);
 
@@ -106,17 +110,17 @@ describe('api/uploads/FolderUploadNode', () => {
             expect(folderUploadNodeInstance.folderId).toBe(folderId);
         });
 
-        test('should call addFolderToQueue when folder is created successfully for non-root folder', async () => {
+        test('should call addFolderToUploadQueue when folder is created successfully for non-root folder', async () => {
             const folderId = '1';
             const errorCallback = () => 'errorCallback';
             const isRoot = false;
             folderUploadNodeInstance.name = name;
             folderUploadNodeInstance.createFolder = jest.fn(() => ({ id: folderId }));
-            folderUploadNodeInstance.addFolderToQueue = jest.fn();
+            folderUploadNodeInstance.addFolderToUploadQueue = jest.fn();
 
             await folderUploadNodeInstance.createAndUploadFolder(errorCallback, isRoot);
 
-            expect(folderUploadNodeInstance.addFolderToQueue).toHaveBeenCalledWith([
+            expect(folderUploadNodeInstance.addFolderToUploadQueue).toHaveBeenCalledWith([
                 {
                     extension: '',
                     name,
@@ -128,17 +132,17 @@ describe('api/uploads/FolderUploadNode', () => {
             ]);
         });
 
-        test('should not addFolderToQueue() when folder is created successfully for root folder', async () => {
+        test('should not addFolderToUploadQueue() when folder is created successfully for root folder', async () => {
             const folderId = '1';
             const errorCallback = () => 'errorCallback';
             const isRoot = true;
             folderUploadNodeInstance.name = name;
             folderUploadNodeInstance.createFolder = jest.fn(() => ({ id: folderId }));
-            folderUploadNodeInstance.addFolderToQueue = jest.fn();
+            folderUploadNodeInstance.addFolderToUploadQueue = jest.fn();
 
             await folderUploadNodeInstance.createAndUploadFolder(errorCallback, isRoot);
 
-            expect(folderUploadNodeInstance.addFolderToQueue).not.toHaveBeenCalled();
+            expect(folderUploadNodeInstance.addFolderToUploadQueue).not.toHaveBeenCalled();
         });
     });
 

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -468,7 +468,7 @@ class ContentUploader extends Component<Props, State> {
         const { rootFolderId } = this.props;
 
         // Convert files from the file API to upload items
-        const newItems = this.getNewFiles(files).map((file) => {
+        const newItems = files.map((file) => {
             const uploadFile = getFile(file);
             const uploadAPIOptions = getFileAPIOptions(file);
             const { name, size } = uploadFile;

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -233,7 +233,7 @@ class ContentUploader extends Component<Props, State> {
         const { rootFolderId } = this.props;
         const { itemIds } = this.state;
 
-        return Array.from(files).filter((file) => !(getFileId(file, rootFolderId) in itemIds));
+        return Array.from(files).filter((file) => !itemIds[getFileId(file, rootFolderId)]);
     };
 
     /**
@@ -245,7 +245,7 @@ class ContentUploader extends Component<Props, State> {
         const { rootFolderId } = this.props;
         const { itemIds } = this.state;
 
-        return Array.from(items).filter((item) => !(getDataTransferItemId(item, rootFolderId) in itemIds));
+        return Array.from(items).filter((item) => !itemIds[getDataTransferItemId(item, rootFolderId)]);
     };
 
     /**
@@ -282,6 +282,7 @@ class ContentUploader extends Component<Props, State> {
 
         const firstFile = getFile(newFiles[0]);
 
+        // webkitRelativePath should be ignored when the upload destination folder is known
         if (firstFile.webkitRelativePath && !isRelativePathIgnored) {
             this.addFilesWithRelativePathToQueue(newFiles, itemUpdateCallback);
             return;

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -338,6 +338,10 @@ class ContentUploader extends Component<Props, State> {
     ): void => {
         dataTransferItems.forEach(async (item) => {
             const file = await getFileFromDataTransferItem(item);
+            if (!file) {
+                return;
+            }
+
             this.addFilesWithoutRelativePathToQueue([file], itemUpdateCallback);
         });
     };

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -92,12 +92,6 @@ const FILE_LIMIT_DEFAULT = 100; // Upload at most 100 files at once by default
 const HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT = 8000;
 const EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD = 5;
 const UPLOAD_CONCURRENCY = 6;
-const getFolderUploadAPIStub = () => ({
-    upload: ({ successCallback }) => {
-        successCallback();
-    },
-    cancel: noop
-});
 
 class ContentUploader extends Component<Props, State> {
     id: string;
@@ -385,7 +379,7 @@ class ContentUploader extends Component<Props, State> {
         newItems.forEach(async (item) => {
             const folderUpload = this.getFolderUploadAPI(folderId);
             await folderUpload.buildFolderTreeFromDataTransferItem(item);
-            this.addFoldersToUploadQueue(folderUpload, itemUpdateCallback, fileAPIOptions);
+            this.addFolderToUploadQueue(folderUpload, itemUpdateCallback, fileAPIOptions);
         });
     };
 
@@ -411,7 +405,7 @@ class ContentUploader extends Component<Props, State> {
         // Only 1 folder tree can be built with files having webkitRelativePath properties
         folderUpload.buildFolderTreeFromWebkitRelativePath(files);
 
-        this.addFoldersToUploadQueue(folderUpload, itemUpdateCallback, fileAPIOptions);
+        this.addFolderToUploadQueue(folderUpload, itemUpdateCallback, fileAPIOptions);
     }
 
     /**
@@ -428,7 +422,7 @@ class ContentUploader extends Component<Props, State> {
     };
 
     /**
-     * Add folders to upload queue
+     * Add folder to upload queue
      *
      * @private
      * @param {FolderUpload} folderUpload
@@ -436,28 +430,23 @@ class ContentUploader extends Component<Props, State> {
      * @param {Object} apiOptions
      * @return {void}
      */
-    addFoldersToUploadQueue = (folderUpload: FolderUpload, itemUpdateCallback: Function, apiOptions: Object): void => {
-        Object.keys(folderUpload.folders).forEach((folderName, index) => {
-            this.addToQueue(
-                [
-                    // $FlowFixMe no file property
-                    {
-                        // folderUpload.upload() uploads all folders, so we use the real folder upload api instance
-                        // for only the first folder. The rest of the folders are added to the queue with stub
-                        // API instances.
-                        api: index === 0 ? folderUpload : getFolderUploadAPIStub(),
-                        extension: '',
-                        isFolder: true,
-                        name: folderName,
-                        options: apiOptions,
-                        progress: 0,
-                        size: 1,
-                        status: STATUS_PENDING
-                    }
-                ],
-                itemUpdateCallback
-            );
-        });
+    addFolderToUploadQueue = (folderUpload: FolderUpload, itemUpdateCallback: Function, apiOptions: Object): void => {
+        this.addToQueue(
+            [
+                // $FlowFixMe no file property
+                {
+                    api: folderUpload,
+                    extension: '',
+                    isFolder: true,
+                    name: folderUpload.folder.name,
+                    options: apiOptions,
+                    progress: 0,
+                    size: 1,
+                    status: STATUS_PENDING
+                }
+            ],
+            itemUpdateCallback
+        );
     };
 
     /**

--- a/src/components/ContentUploader/OverallUploadsProgressBar.js
+++ b/src/components/ContentUploader/OverallUploadsProgressBar.js
@@ -22,8 +22,9 @@ const getUploadStatus = (view: string) => {
         case VIEW_UPLOAD_IN_PROGRESS:
             return <FormattedMessage {...messages.uploadsManagerUploadInProgress} />;
         case VIEW_UPLOAD_SUCCESS:
-        case VIEW_UPLOAD_EMPTY:
             return <FormattedMessage {...messages.uploadsManagerUploadComplete} />;
+        case VIEW_UPLOAD_EMPTY:
+            return <FormattedMessage {...messages.uploadsManagerUploadPrompt} />;
         case VIEW_ERROR:
             return <FormattedMessage {...messages.uploadsManagerUploadFailed} />;
         default:
@@ -35,17 +36,18 @@ const getUploadStatus = (view: string) => {
  * Get overall upload progress percentage
  *
  * @param {string} view
- * @param {boolean} isEmpty - true if there are no items in the upload queue
  * @param {number} percent
  */
-const getPercent = (view: string, isEmpty: boolean, percent: number): number => {
-    if (view === VIEW_UPLOAD_SUCCESS || (view === VIEW_UPLOAD_EMPTY && isEmpty)) {
-        return 100;
-    } else if (view === VIEW_ERROR) {
-        return 0;
+const getPercent = (view: string, percent: number): number => {
+    switch (view) {
+        case VIEW_UPLOAD_SUCCESS:
+            return 100;
+        case VIEW_UPLOAD_EMPTY:
+        case VIEW_ERROR:
+            return 0;
+        default:
+            return percent;
     }
-
-    return percent;
 };
 
 type Props = {
@@ -53,11 +55,10 @@ type Props = {
     percent: number,
     onClick: Function,
     onKeyDown: Function,
-    view: View,
-    isEmpty: boolean
+    view: View
 };
 
-const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isVisible, isEmpty }: Props) => (
+const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isVisible }: Props) => (
     <div
         className='bcu-overall-progress-bar'
         onClick={onClick}
@@ -66,7 +67,7 @@ const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isVisibl
         tabIndex={isVisible ? '0' : '-1'}
     >
         <span className='bcu-upload-status'>{getUploadStatus(view)}</span>
-        <ProgressBar percent={getPercent(view, isEmpty, percent)} />
+        <ProgressBar percent={getPercent(view, percent)} />
         <span className='bcu-uploads-manager-toggle' />
     </div>
 );

--- a/src/components/ContentUploader/UploadsManager.js
+++ b/src/components/ContentUploader/UploadsManager.js
@@ -12,6 +12,7 @@ import './UploadsManager.scss';
 import { STATUS_ERROR } from '../../constants';
 
 type Props = {
+    isVisible: boolean,
     isExpanded: boolean,
     items: UploadItem[],
     onItemActionClick: Function,
@@ -19,9 +20,7 @@ type Props = {
     view: View
 };
 
-const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, isExpanded }: Props) => {
-    const isVisible = items.length > 0;
-
+const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, isExpanded, isVisible }: Props) => {
     /**
      * Keydown handler for progress bar
      *
@@ -65,7 +64,6 @@ const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, 
                 onClick={toggleUploadsManager}
                 onKeyDown={handleProgressBarKeyDown}
                 view={view}
-                isEmpty={items.length === 0}
             />
             <div className='bcu-uploads-manager-item-list'>
                 <ItemList items={items} view={view} onClick={onItemActionClick} />

--- a/src/components/ContentUploader/__tests__/OverallUploadsProgressBar-test.js
+++ b/src/components/ContentUploader/__tests__/OverallUploadsProgressBar-test.js
@@ -9,7 +9,6 @@ describe('components/ContentUploader/OverallUploadsProgressBar', () => {
         shallow(
             <OverallUploadsProgressBar
                 isVisible
-                isEmpty={false}
                 view={VIEW_UPLOAD_EMPTY}
                 percent={2}
                 onClick={noop}

--- a/src/components/ContentUploader/__tests__/__snapshots__/OverallUploadsProgressBar-test.js.snap
+++ b/src/components/ContentUploader/__tests__/__snapshots__/OverallUploadsProgressBar-test.js.snap
@@ -37,12 +37,12 @@ exports[`components/ContentUploader/OverallUploadsProgressBar should render corr
     className="bcu-upload-status"
   >
     <FormattedMessage
-      defaultMessage="Completed"
-      id="be.uploadsManagerUploadComplete"
+      defaultMessage="Drop files on this page to upload them into this folder."
+      id="be.uploadsManagerUploadPrompt"
     />
   </span>
   <ProgressBar
-    percent={2}
+    percent={0}
   />
   <span
     className="bcu-uploads-manager-toggle"

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -553,6 +553,11 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
         description: 'Text shown when uploads are in progress',
         defaultMessage: 'Uploading'
     },
+    uploadsManagerUploadPrompt: {
+        id: 'be.uploadsManagerUploadPrompt',
+        description: 'Text shown to guide the user to drag drop file to upload',
+        defaultMessage: 'Drop files on this page to upload them into this folder.'
+    },
     uploadsManagerUploadComplete: {
         id: 'be.uploadsManagerUploadComplete',
         description: 'Text shown when uploads are completed',

--- a/src/util/__tests__/uploads-test.js
+++ b/src/util/__tests__/uploads-test.js
@@ -11,11 +11,14 @@ import {
     getDataTransferItem,
     getFileAPIOptions,
     getDataTransferItemAPIOptions,
-    DEFAULT_API_OPTIONS
+    DEFAULT_API_OPTIONS,
+    getFileId,
+    getDataTransferItemId
 } from '../uploads';
 
 const mockFile = { name: 'hi' };
 const entry = {
+    name: 'hi',
     file: (fn) => {
         fn(mockFile);
     }
@@ -230,6 +233,76 @@ describe('util/uploads', () => {
             const fileItem = { kind: '', webkitGetAsEntry: () => undefined };
 
             expect(isDataTransferItemAFolder(fileItem)).toBeFalsy();
+        });
+    });
+
+    describe('getFileId()', () => {
+        test('should return file id correctly when file does not contain API options', () => {
+            const file = {
+                name: 'hi'
+            };
+
+            expect(getFileId(file)).toBe('hi');
+        });
+
+        test('should return file id correctly when file does contain API options', () => {
+            const file = {
+                file: {
+                    name: 'hi'
+                },
+                options: {
+                    folderId: '0',
+                    uploadInitTimestamp: 123123
+                }
+            };
+
+            expect(getFileId(file)).toBe('hi_0_123123');
+        });
+    });
+
+    describe('getFileId()', () => {
+        test('should return file id correctly when file does not contain API options', () => {
+            const file = {
+                name: 'hi'
+            };
+
+            expect(getFileId(file)).toBe('hi');
+        });
+
+        test('should return file id correctly when file does contain API options', () => {
+            const file = {
+                file: {
+                    name: 'hi'
+                },
+                options: {
+                    folderId: '0',
+                    uploadInitTimestamp: 123123
+                }
+            };
+
+            expect(getFileId(file)).toBe('hi_0_123123');
+        });
+    });
+
+    describe('getDataTransferItemId()', () => {
+        const rootFolderId = 0;
+        const now = Date.now();
+        Date.now = jest.fn(() => now);
+
+        test('should return item id correctly when item does not contain API options', () => {
+            expect(getDataTransferItemId(mockItem, rootFolderId)).toBe(`hi_0_${now}`);
+        });
+
+        test('should return item id correctly when item does contain API options', () => {
+            const item = {
+                item: mockItem,
+                options: {
+                    folderId: '0',
+                    uploadInitTimestamp: 123123
+                }
+            };
+
+            expect(getDataTransferItemId(item, rootFolderId)).toBe('hi_0_123123');
         });
     });
 });

--- a/src/util/uploads.js
+++ b/src/util/uploads.js
@@ -207,13 +207,17 @@ function getFileFromEntry(entry: FileSystemFileEntry): Promise<UploadFile> {
  * Get file from DataTransferItem or UploadDataTransferItemWithAPIOptions
  *
  * @param {UploadDataTransferItemWithAPIOptions | DataTransferItem} itemData
- * @returns {Promise<UploadFile | UploadFileWithAPIOptions>}
+ * @returns {Promise<UploadFile | UploadFileWithAPIOptions | null>}
  */
 async function getFileFromDataTransferItem(
     itemData: UploadDataTransferItemWithAPIOptions | DataTransferItem
 ): Promise<UploadFile | UploadFileWithAPIOptions> {
     const item = getDataTransferItem(itemData);
     const entry = getEntryFromDataTransferItem(((item: any): DataTransferItem));
+    if (!entry) {
+        return null;
+    }
+
     const file = await getFileFromEntry(entry);
 
     if (doesDataTransferItemContainAPIOptions(itemData)) {

--- a/src/util/uploads.js
+++ b/src/util/uploads.js
@@ -3,6 +3,7 @@
  * @file Utility functions for uploads
  * @author Box
  */
+import getProp from 'lodash/get';
 
 const DEFAULT_API_OPTIONS = {};
 
@@ -225,20 +226,64 @@ async function getFileFromDataTransferItem(
     return file;
 }
 
+/**
+ * Generates file id based on file properties
+ *
+ * When folderId or uploadInitTimestamp is missing from file options, file name is returned as file id.
+ * Otherwise, fileName_folderId_uploadInitTimestamp is used as file id.
+ *
+ * @param {UploadFileWithAPIOptions | UploadFile} file
+ * @param {string} rootFolderId
+ * @returns {string}
+ */
+function getFileId(file: UploadFileWithAPIOptions | UploadFile, rootFolderId: string): string {
+    if (!doesFileContainAPIOptions(file)) {
+        return ((file: any): UploadFile).name;
+    }
+
+    const fileWithOptions = ((file: any): UploadFileWithAPIOptions);
+    const folderId = getProp(fileWithOptions, 'options.folderId', rootFolderId);
+    const uploadInitTimestamp = getProp(fileWithOptions, 'options.uploadInitTimestamp', Date.now());
+    const fileName = fileWithOptions.file.webkitRelativePath || fileWithOptions.file.name;
+
+    return `${fileName}_${folderId}_${uploadInitTimestamp}`;
+}
+
+/**
+ * Generates item id based on item properties
+ * E.g., folder1_0_123124124
+ *
+ * @param {DataTransferItem | UploadDataTransferItemWithAPIOptions} itemData
+ * @param {string} rootFolderId
+ * @returns {string}
+ */
+function getDataTransferItemId(
+    itemData: DataTransferItem | UploadDataTransferItemWithAPIOptions,
+    rootFolderId: string
+): string {
+    const item = getDataTransferItem(itemData);
+    const { name } = getEntryFromDataTransferItem(item);
+    const { folderId = rootFolderId, uploadInitTimestamp = Date.now() } = getDataTransferItemAPIOptions(itemData);
+
+    return `${name}_${folderId}_${uploadInitTimestamp}`;
+}
+
 export {
     DEFAULT_API_OPTIONS,
-    getFileFromEntry,
-    toISOStringNoMS,
-    getFileLastModifiedAsISONoMSIfPossible,
-    tryParseJson,
-    getBoundedExpBackoffRetryDelay,
-    getEntryFromDataTransferItem,
-    isDataTransferItemAFolder,
-    getFileFromDataTransferItem,
-    doesFileContainAPIOptions,
     doesDataTransferItemContainAPIOptions,
-    getFile,
+    doesFileContainAPIOptions,
+    getBoundedExpBackoffRetryDelay,
     getDataTransferItem,
+    getDataTransferItemAPIOptions,
+    getDataTransferItemId,
+    getEntryFromDataTransferItem,
+    getFile,
     getFileAPIOptions,
-    getDataTransferItemAPIOptions
+    getFileFromDataTransferItem,
+    getFileFromEntry,
+    getFileId,
+    getFileLastModifiedAsISONoMSIfPossible,
+    isDataTransferItemAFolder,
+    toISOStringNoMS,
+    tryParseJson
 };

--- a/src/util/uploads.js
+++ b/src/util/uploads.js
@@ -211,7 +211,7 @@ function getFileFromEntry(entry: FileSystemFileEntry): Promise<UploadFile> {
  */
 async function getFileFromDataTransferItem(
     itemData: UploadDataTransferItemWithAPIOptions | DataTransferItem
-): Promise<UploadFile | UploadFileWithAPIOptions> {
+): Promise<UploadFile | UploadFileWithAPIOptions | null> {
     const item = getDataTransferItem(itemData);
     const entry = getEntryFromDataTransferItem(((item: any): DataTransferItem));
     if (!entry) {

--- a/test/uploader-window-view.html
+++ b/test/uploader-window-view.html
@@ -107,7 +107,8 @@
             document.querySelector('.uploader1').innerHTML = '';
 
             uploader1.on('upload', (data) => {
-                console.log(`Successfully uploaded a file: ${data ? data.id : 'No File ID'}`);
+                console.log('Successfully uploaded a file:');
+                console.log(data);
             });
             uploader1.on('error', (data) => {
                 console.log(`Failed to upload: ${JSON.stringify(data)}`);

--- a/test/uploader-window-view.html
+++ b/test/uploader-window-view.html
@@ -121,6 +121,7 @@
                 container: '.uploader1',
                 useUploadsManager: true,
                 isFolderUploadEnabled: true,
+                isUploadsManagerVisible: true
             });
 
             fileInput.onchange = function (event) {
@@ -140,9 +141,14 @@
                 const itemsWithOptions = Array.from(event.dataTransfer.items).map((item) => ({
                     item,
                     options: {
-                        folderId, token: () => Promise.resolve(token)
+                        folderId,
+                        token: () => Promise.resolve(token),
+                        uploadInitTimestamp: Date.now()
                     }
                 }))
+                // Should only upload once. ContentUploader should be able to filter out identical upload attempts.
+                uploader1.component.addFilesWithOptionsToUploadQueueAndStartUpload([], itemsWithOptions)
+                uploader1.component.addFilesWithOptionsToUploadQueueAndStartUpload([], itemsWithOptions)
                 uploader1.component.addFilesWithOptionsToUploadQueueAndStartUpload([], itemsWithOptions)
             }
 


### PR DESCRIPTION
- adds an `isUploadsManagerVisible` prop to the `ContentUploader` to allow the UploadsManager to be shown when there's no ongoing uploads
- adds an empty state to the UploadsManager which instructs user to drop file to upload