### PR TITLE
Chore: Allow buttons to have outline on focus

### DIFF
--- a/src/components/base.scss
+++ b/src/components/base.scss
@@ -182,7 +182,6 @@
         line-height: 16px;
         margin: 0;
         max-width: 100%;
-        // outline: none;
         overflow: hidden;
         padding: 0;
         text-align: center;

--- a/src/components/base.scss
+++ b/src/components/base.scss
@@ -182,7 +182,7 @@
         line-height: 16px;
         margin: 0;
         max-width: 100%;
-        outline: none;
+        // outline: none;
         overflow: hidden;
         padding: 0;
         text-align: center;


### PR DESCRIPTION
Allows for buttons (info button and trash/pencil) to have browser highlight, meeting webapp parity for accessibility 