### PR TITLE
Fix: UploadsManager should show correct message

### DIFF
--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -76,7 +76,7 @@ type Props = {
     uploadHost: string,
     useUploadsManager?: boolean,
     dataTransferItems: Array<DataTransferItem | UploadDataTransferItemWithAPIOptions>,
-    isUploadsManagerVisible?: boolean
+    isDraggingItemsToUploadsManager?: boolean
 };
 
 type State = {
@@ -120,7 +120,7 @@ class ContentUploader extends Component<Props, State> {
         onCancel: noop,
         isFolderUploadEnabled: false,
         dataTransferItems: [],
-        isUploadsManagerVisible: false
+        isDraggingItemsToUploadsManager: false
     };
 
     /**
@@ -984,11 +984,11 @@ class ContentUploader extends Component<Props, State> {
             fileLimit,
             useUploadsManager,
             isFolderUploadEnabled,
-            isUploadsManagerVisible
+            isDraggingItemsToUploadsManager
         }: Props = this.props;
         const { view, items, errorCode, isUploadsManagerExpanded }: State = this.state;
         const isEmpty = items.length === 0;
-        const isVisible = !isEmpty || !!isUploadsManagerVisible;
+        const isVisible = !isEmpty || !!isDraggingItemsToUploadsManager;
 
         const hasFiles = items.length !== 0;
         const isLoading = items.some((item) => item.status === STATUS_IN_PROGRESS);
@@ -1009,6 +1009,7 @@ class ContentUploader extends Component<Props, State> {
                             onItemActionClick={this.onClick}
                             toggleUploadsManager={this.toggleUploadsManager}
                             view={view}
+                            isDragging={isDraggingItemsToUploadsManager}
                         />
                     </div>
                 ) : (

--- a/src/components/ContentUploader/OverallUploadsProgressBar.js
+++ b/src/components/ContentUploader/OverallUploadsProgressBar.js
@@ -51,6 +51,7 @@ const getPercent = (view: string, percent: number): number => {
 };
 
 type Props = {
+    isDragging: boolean,
     isVisible: boolean,
     percent: number,
     onClick: Function,
@@ -58,18 +59,30 @@ type Props = {
     view: View
 };
 
-const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isVisible }: Props) => (
-    <div
-        className='bcu-overall-progress-bar'
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-        role='button'
-        tabIndex={isVisible ? '0' : '-1'}
-    >
-        <span className='bcu-upload-status'>{getUploadStatus(view)}</span>
-        <ProgressBar percent={getPercent(view, percent)} />
-        <span className='bcu-uploads-manager-toggle' />
-    </div>
-);
+const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isDragging, isVisible }: Props) => {
+    // Show the upload prompt and set progress to 0 when the uploads manager
+    // is invisible or is having files dragged to it
+    const shouldShowPrompt = isDragging || !isVisible;
+    const status = shouldShowPrompt ? (
+        <FormattedMessage {...messages.uploadsManagerUploadPrompt} />
+    ) : (
+        getUploadStatus(view)
+    );
+    const updatedPercent = shouldShowPrompt ? 0 : getPercent(view, percent);
+
+    return (
+        <div
+            className='bcu-overall-progress-bar'
+            onClick={onClick}
+            onKeyDown={onKeyDown}
+            role='button'
+            tabIndex={isVisible ? '0' : '-1'}
+        >
+            <span className='bcu-upload-status'>{status}</span>
+            <ProgressBar percent={updatedPercent} />
+            <span className='bcu-uploads-manager-toggle' />
+        </div>
+    );
+};
 
 export default OverallUploadsProgressBar;

--- a/src/components/ContentUploader/UploadsManager.js
+++ b/src/components/ContentUploader/UploadsManager.js
@@ -12,15 +12,24 @@ import './UploadsManager.scss';
 import { STATUS_ERROR } from '../../constants';
 
 type Props = {
-    isVisible: boolean,
+    isDragging: boolean,
     isExpanded: boolean,
+    isVisible: boolean,
     items: UploadItem[],
     onItemActionClick: Function,
     toggleUploadsManager: Function,
     view: View
 };
 
-const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, isExpanded, isVisible }: Props) => {
+const UploadsManager = ({
+    items,
+    view,
+    onItemActionClick,
+    toggleUploadsManager,
+    isExpanded,
+    isVisible,
+    isDragging
+}: Props) => {
     /**
      * Keydown handler for progress bar
      *
@@ -60,6 +69,7 @@ const UploadsManager = ({ items, view, onItemActionClick, toggleUploadsManager, 
         >
             <OverallUploadsProgressBar
                 isVisible={isVisible}
+                isDragging={isDragging}
                 percent={percent}
                 onClick={toggleUploadsManager}
                 onKeyDown={handleProgressBarKeyDown}

--- a/src/components/ContentUploader/__tests__/OverallUploadsProgressBar-test.js
+++ b/src/components/ContentUploader/__tests__/OverallUploadsProgressBar-test.js
@@ -8,6 +8,7 @@ describe('components/ContentUploader/OverallUploadsProgressBar', () => {
     const getWrapper = (props) =>
         shallow(
             <OverallUploadsProgressBar
+                isDragging={false}
                 isVisible
                 view={VIEW_UPLOAD_EMPTY}
                 percent={2}
@@ -42,6 +43,24 @@ describe('components/ContentUploader/OverallUploadsProgressBar', () => {
     test('should render correctly when view is VIEW_UPLOAD_IN_PROGRESS', () => {
         const wrapper = getWrapper({
             view: VIEW_UPLOAD_IN_PROGRESS
+        });
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render correctly when isVisible is false', () => {
+        const wrapper = getWrapper({
+            isVisible: false,
+            view: VIEW_UPLOAD_SUCCESS
+        });
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render correctly when isDragging is true', () => {
+        const wrapper = getWrapper({
+            view: VIEW_UPLOAD_SUCCESS,
+            isDragging: true
         });
 
         expect(wrapper).toMatchSnapshot();

--- a/src/components/ContentUploader/__tests__/__snapshots__/OverallUploadsProgressBar-test.js.snap
+++ b/src/components/ContentUploader/__tests__/__snapshots__/OverallUploadsProgressBar-test.js.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/ContentUploader/OverallUploadsProgressBar should render correctly when isDragging is true 1`] = `
+<div
+  className="bcu-overall-progress-bar"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  <span
+    className="bcu-upload-status"
+  >
+    <FormattedMessage
+      defaultMessage="Drop files on this page to upload them into this folder."
+      id="be.uploadsManagerUploadPrompt"
+    />
+  </span>
+  <ProgressBar
+    percent={0}
+  />
+  <span
+    className="bcu-uploads-manager-toggle"
+  />
+</div>
+`;
+
+exports[`components/ContentUploader/OverallUploadsProgressBar should render correctly when isVisible is false 1`] = `
+<div
+  className="bcu-overall-progress-bar"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  role="button"
+  tabIndex="-1"
+>
+  <span
+    className="bcu-upload-status"
+  >
+    <FormattedMessage
+      defaultMessage="Drop files on this page to upload them into this folder."
+      id="be.uploadsManagerUploadPrompt"
+    />
+  </span>
+  <ProgressBar
+    percent={0}
+  />
+  <span
+    className="bcu-uploads-manager-toggle"
+  />
+</div>
+`;
+
 exports[`components/ContentUploader/OverallUploadsProgressBar should render correctly when view is VIEW_ERROR 1`] = `
 <div
   className="bcu-overall-progress-bar"


### PR DESCRIPTION
- Drag and drop prompt should be shown when UploadsManager is invisible or is dragging files