### PR TITLE
Fix: Don't hide CSS overflow w/in .bcs-comment-input

### DIFF
--- a/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.scss
+++ b/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.scss
@@ -13,7 +13,6 @@
         margin-bottom: 15px;
         margin-top: 20px;
         max-height: 140px;
-        overflow: hidden;
         width: auto;
 
         .datalist-item {


### PR DESCRIPTION
- This causes the @mentions dialog to hide. We only want to hide the overflow inside the draftjs placeholders