### PR TITLE
Fix: Support keyboard navigation between sidebar tabs

### DIFF
--- a/src/components/ContentSidebar/SidebarNavButton.js
+++ b/src/components/ContentSidebar/SidebarNavButton.js
@@ -18,19 +18,18 @@ type Props = {
     children: React.Node
 };
 
-const SidebarNavButton = ({ tooltip, isSelected, onClick, interactionTarget, children }: Props) => (
-    <Tooltip text={tooltip} position='middle-left'>
-        <div
-            className={classNames('bcs-nav-btn', {
-                'bcs-nav-btn-is-selected': isSelected
-            })}
-        >
-            <div className='bcs-nav-btn-border' />
-            <PlainButton type='button' onClick={onClick} data-resin-target={interactionTarget}>
+const SidebarNavButton = ({ tooltip, isSelected, onClick, interactionTarget, children }: Props) => {
+    const buttonClass = classNames('bcs-nav-btn', {
+        'bcs-nav-btn-is-selected': isSelected
+    });
+
+    return (
+        <Tooltip text={tooltip} position='middle-left'>
+            <PlainButton className={buttonClass} type='button' onClick={onClick} data-resin-target={interactionTarget}>
                 {children}
             </PlainButton>
-        </div>
-    </Tooltip>
-);
+        </Tooltip>
+    );
+};
 
 export default SidebarNavButton;

--- a/src/components/ContentSidebar/SidebarNavButton.scss
+++ b/src/components/ContentSidebar/SidebarNavButton.scss
@@ -1,10 +1,17 @@
 @import '../variables';
 
 .bcs .bcs-nav-btn {
+    align-items: center;
+    background-color: transparent;
     display: flex;
+    height: 60px;
+    justify-content: center;
     position: relative;
+    width: 59px; // 1px for left border
 
-    .bcs-nav-btn-border {
+    &::before {
+        content: '';
+        display: block;
         height: 60px;
         left: -1px;
         pointer-events: none;
@@ -12,15 +19,8 @@
         width: 3px;
     }
 
-    .btn-plain {
-        background-color: transparent;
-        display: block;
-        height: 60px;
-        width: 59px; // 1px for left border
-    }
-
     &.bcs-nav-btn-is-selected {
-        .bcs-nav-btn-border {
+        &::before {
             background-color: $blue;
         }
 

--- a/src/components/ContentSidebar/__tests__/__snapshots__/SidebarNavButton-test.js.snap
+++ b/src/components/ContentSidebar/__tests__/__snapshots__/SidebarNavButton-test.js.snap
@@ -8,16 +8,10 @@ exports[`components/ContentSidebar/SidebarNavButton should render nav button pro
   text="foo"
   theme="default"
 >
-  <div
+  <PlainButton
     className="bcs-nav-btn"
-  >
-    <div
-      className="bcs-nav-btn-border"
-    />
-    <PlainButton
-      type="button"
-    />
-  </div>
+    type="button"
+  />
 </Tooltip>
 `;
 
@@ -29,15 +23,9 @@ exports[`components/ContentSidebar/SidebarNavButton should render nav button pro
   text="foo"
   theme="default"
 >
-  <div
+  <PlainButton
     className="bcs-nav-btn bcs-nav-btn-is-selected"
-  >
-    <div
-      className="bcs-nav-btn-border"
-    />
-    <PlainButton
-      type="button"
-    />
-  </div>
+    type="button"
+  />
 </Tooltip>
 `;


### PR DESCRIPTION
The Tooltip component applies `tabindex=0` to its immediate child, which causes two focus events per button upon keyboard navigation. I've eliminated the wrapper between Tooltip and PlainButton to avoid the issue.