### PR TITLE
Fix: Allow preview to error on failed files call

### DIFF
--- a/src/components/ContentPreview/ContentPreview.js
+++ b/src/components/ContentPreview/ContentPreview.js
@@ -76,8 +76,7 @@ type Props = {
 };
 
 type State = {
-    file?: BoxItem,
-    fileError?: boolean
+    file?: BoxItem
 };
 
 const InvalidIdError = new Error('Invalid id for Preview!');
@@ -93,6 +92,7 @@ class ContentPreview extends PureComponent<Props, State> {
     rootElement: HTMLElement;
     onError: ?Function;
     onMetric: ?Function;
+    fileError: boolean;
 
     static defaultProps = {
         className: '',
@@ -216,19 +216,18 @@ class ContentPreview extends PureComponent<Props, State> {
      * @return {boolean}
      */
     shouldLoadPreview(prevProps: Props, prevState: State): boolean {
-        const { file, fileError }: State = this.state;
+        const { file }: State = this.state;
         const { file: prevFile }: State = prevState;
         let loadPreview = false;
 
-        // Load preview if file version ID has changed
-        if (file && file.file_version && prevFile && prevFile.file_version) {
+        if (!file) {
+            loadPreview = !!this.fileError;
+            // Load preview if file version ID has changed
+        } else if (file.file_version && prevFile && prevFile.file_version) {
             loadPreview = file.file_version.id !== prevFile.file_version.id;
-        } else if (file) {
+        } else {
             // Load preview if file object has newly been popuplated in state
             loadPreview = !prevFile && !!file;
-        } else {
-            // Load preview if there was a problem with the Elements files call
-            loadPreview = !!fileError;
         }
 
         return loadPreview;
@@ -489,7 +488,8 @@ class ContentPreview extends PureComponent<Props, State> {
      * @return {void}
      */
     fetchFileSuccessCallback = (file: BoxItem): void => {
-        this.setState({ file, fileError: false });
+        this.setState({ file });
+        this.fileError = false;
     };
 
     /**
@@ -499,7 +499,7 @@ class ContentPreview extends PureComponent<Props, State> {
      * @return {void}
      */
     fetchFileErrorCallback = (): void => {
-        this.setState({ fileError: true });
+        this.fileError = true;
     };
 
     /**


### PR DESCRIPTION
Advantages to this approach
1. Preview will now retry with a more minimal files call
2. Error logging will still be captured
3. Error UI is provided by preview

With this change, the sidebar will still not render if the original files call fails. So there could be cases where preview succeeds on the minimal files call but the sidebar still fails. Open to suggestions on how to render a minimal error sidebar, but right now all the sidebar render logic relies on the presence of a file object.

Tests on they way. 