### PR TITLE
Update: Improve file fetch isolation across elements

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,17 @@
 {
-    "presets": [
-        ["env", {
-            "modules": false
-        }],
-        "stage-1",
-        "react",
-        "flow"
-    ],
     "env": {
         "dev": {
+            "presets": [
+                ["env", {
+                    "modules": false,
+                    "targets": {
+                        "browsers": ["last 1 Chrome versions", "last 1 Firefox versions"]
+                    }
+                }],
+                "stage-1",
+                "react",
+                "flow"
+            ],
             "plugins": [
                 "flow-react-proptypes",
                 [
@@ -21,6 +24,14 @@
             ]
         },
         "production": {
+            "presets": [
+                ["env", {
+                    "modules": false
+                }],
+                "stage-1",
+                "react",
+                "flow"
+            ],
             "plugins": [
                 [
                     "react-intl",
@@ -32,6 +43,14 @@
             ]
         },
         "npm": {
+            "presets": [
+                ["env", {
+                    "modules": false
+                }],
+                "stage-1",
+                "react",
+                "flow"
+            ],
             "plugins": [
                 [
                     "react-intl",
@@ -48,6 +67,14 @@
             ]
         },
         "test": {
+            "presets": [
+                ["env", {
+                    "modules": false
+                }],
+                "stage-1",
+                "react",
+                "flow"
+            ],
             "plugins": [
                 "transform-es2015-modules-commonjs",
                 [

--- a/examples/src/ContentSidebar/ContentSidebarExample.scss
+++ b/examples/src/ContentSidebar/ContentSidebarExample.scss
@@ -1,4 +1,10 @@
-.bcs {
-    box-shadow: 0 0 20px 0 rgba(85, 85, 85, .42);
-    height: 1000px;
+[data-preview="ContentSidebar"] {
+    > div {
+        display: inline-block;
+    }
+
+    .bcs {
+        box-shadow: 0 0 20px 0 rgba(85, 85, 85, .42);
+        height: 1000px;
+    }
 }

--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -292,7 +292,7 @@ type BoxItem = {
     selected?: boolean,
     metadata?: MetadataType,
     file_version?: BoxItemVersion,
-    is_download_available: boolean,
+    is_download_available?: boolean,
     version_number?: string,
     restored_from?: BoxItemVersion
 };
@@ -573,4 +573,10 @@ type UploadFile = File & { webkitRelativePath?: string };
 
 type DirectoryReader = {
     readEntries: (Function, Function) => void
+};
+
+type FetchOptions = {
+    forceFetch?: boolean,
+    refreshCache?: boolean,
+    fields?: Array<string>
 };

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -677,7 +677,7 @@ class Feed extends Base {
     fetchTaskAssignments(tasksWithoutAssignments: Tasks): Promise<?Tasks> {
         const requestData = {
             params: {
-                fields: TASK_ASSIGNMENTS_FIELDS_TO_FETCH
+                fields: TASK_ASSIGNMENTS_FIELDS_TO_FETCH.toString()
             }
         };
         const { entries } = tasksWithoutAssignments;

--- a/src/api/Recents.js
+++ b/src/api/Recents.js
@@ -11,8 +11,8 @@ import WebLinkAPI from '../api/WebLink';
 import flatten from '../util/flatten';
 import sort from '../util/sorter';
 import { getBadItemError } from '../util/error';
-import { getFieldsAsString } from '../util/fields';
-import { DEFAULT_ROOT, CACHE_PREFIX_RECENTS, SORT_DESC, FIELD_INTERACTED_AT, X_REP_HINTS } from '../constants';
+import { FOLDER_FIELDS_TO_FETCH } from '../util/fields';
+import { DEFAULT_ROOT, CACHE_PREFIX_RECENTS, SORT_DESC, FIELD_INTERACTED_AT } from '../constants';
 
 class Recents extends Base {
     /**
@@ -44,16 +44,6 @@ class Recents extends Base {
      * @property {string}
      */
     sortDirection: SortDirection;
-
-    /**
-     * @property {boolean}
-     */
-    includePreviewFields: boolean;
-
-    /**
-     * @property {boolean}
-     */
-    includePreviewSidebarFields: boolean;
 
     /**
      * Creates a key for the cache
@@ -181,9 +171,8 @@ class Recents extends Base {
             .get({
                 url: this.getUrl(),
                 params: {
-                    fields: getFieldsAsString(this.includePreviewFields, this.includePreviewSidebarFields)
-                },
-                headers: { 'X-Rep-Hints': X_REP_HINTS }
+                    fields: FOLDER_FIELDS_TO_FETCH.toString()
+                }
             })
             .then(this.recentsSuccessHandler)
             .catch(this.recentsErrorHandler);
@@ -197,9 +186,7 @@ class Recents extends Base {
      * @param {string} sortDirection - sort direction
      * @param {Function} successCallback - Function to call with results
      * @param {Function} errorCallback - Function to call with errors
-     * @param {boolean|void} [forceFetch] - Bypasses the cache
-     * @param {boolean|void} [includePreview] - Optionally include preview fields
-     * @param {boolean|void} [includePreviewSidebar] - Optionally include preview sidebar fields
+     * @param {boolean|void} [options.forceFetch] - Bypasses the cache
      * @return {void}
      */
     recents(
@@ -208,9 +195,7 @@ class Recents extends Base {
         sortDirection: SortDirection,
         successCallback: Function,
         errorCallback: Function,
-        forceFetch: boolean = false,
-        includePreviewFields: boolean = false,
-        includePreviewSidebarFields: boolean = false
+        options: Object = {}
     ): void {
         if (this.isDestroyed()) {
             return;
@@ -222,14 +207,12 @@ class Recents extends Base {
         this.errorCallback = errorCallback;
         this.sortBy = sortBy;
         this.sortDirection = sortDirection;
-        this.includePreviewFields = includePreviewFields;
-        this.includePreviewSidebarFields = includePreviewSidebarFields;
 
         const cache: APICache = this.getCache();
         this.key = this.getCacheKey(this.id);
 
         // Clear the cache if needed
-        if (forceFetch) {
+        if (options.forceFetch) {
             cache.unset(this.key);
         }
 

--- a/src/api/Search.js
+++ b/src/api/Search.js
@@ -10,8 +10,8 @@ import FolderAPI from './Folder';
 import WebLinkAPI from '../api/WebLink';
 import flatten from '../util/flatten';
 import sort from '../util/sorter';
-import { getFieldsAsString } from '../util/fields';
-import { CACHE_PREFIX_SEARCH, X_REP_HINTS } from '../constants';
+import { FOLDER_FIELDS_TO_FETCH } from '../util/fields';
+import { CACHE_PREFIX_SEARCH } from '../constants';
 import { getBadItemError } from '../util/error';
 
 const LIMIT_ITEM_FETCH = 200;
@@ -61,16 +61,6 @@ class Search extends Base {
      * @property {Array}
      */
     itemCache: string[];
-
-    /**
-     * @property {boolean}
-     */
-    includePreviewFields: boolean;
-
-    /**
-     * @property {boolean}
-     */
-    includePreviewSidebarFields: boolean;
 
     /**
      * Creates a key for the cache
@@ -239,9 +229,8 @@ class Search extends Base {
                     query: this.query,
                     ancestor_folder_ids: this.id,
                     limit: LIMIT_ITEM_FETCH,
-                    fields: getFieldsAsString(this.includePreviewFields, this.includePreviewSidebarFields)
-                },
-                headers: { 'X-Rep-Hints': X_REP_HINTS }
+                    fields: FOLDER_FIELDS_TO_FETCH.toString()
+                }
             })
             .then(this.searchSuccessHandler)
             .catch(this.searchErrorHandler);
@@ -256,9 +245,7 @@ class Search extends Base {
      * @param {string} sortDirection - sort direction
      * @param {Function} successCallback - Function to call with results
      * @param {Function} errorCallback - Function to call with errors
-     * @param {boolean|void} [forceFetch] - Bypasses the cache
-     * @param {boolean|void} [includePreview] - Optionally include preview fields
-     * @param {boolean|void} [includePreviewSidebar] - Optionally include preview sidebar fields
+     * @param {boolean|void} [options.forceFetch] - Bypasses the cache
      * @return {void}
      */
     search(
@@ -268,9 +255,7 @@ class Search extends Base {
         sortDirection: SortDirection,
         successCallback: Function,
         errorCallback: Function,
-        forceFetch: boolean = false,
-        includePreviewFields: boolean = false,
-        includePreviewSidebarFields: boolean = false
+        options: Object = {}
     ): void {
         if (this.isDestroyed()) {
             return;
@@ -285,11 +270,9 @@ class Search extends Base {
         this.errorCallback = errorCallback;
         this.sortBy = sortBy;
         this.sortDirection = sortDirection;
-        this.includePreviewFields = includePreviewFields;
-        this.includePreviewSidebarFields = includePreviewSidebarFields;
 
         // Clear the cache if needed
-        if (forceFetch) {
+        if (options.forceFetch) {
             this.getCache().unset(this.key);
         }
 

--- a/src/api/__tests__/Folder-test.js
+++ b/src/api/__tests__/Folder-test.js
@@ -1,7 +1,6 @@
 import Folder from '../Folder';
 import Cache from '../../util/Cache';
-import { getFieldsAsString } from '../../util/fields';
-import { X_REP_HINTS } from '../../constants';
+import { FOLDER_FIELDS_TO_FETCH } from '../../util/fields';
 import * as sort from '../../util/sorter';
 
 let folder;
@@ -58,13 +57,13 @@ describe('api/Folder', () => {
         });
     });
 
-    describe('folder()', () => {
+    describe('getFolder()', () => {
         test('should not do anything if destroyed', () => {
             folder.isDestroyed = jest.fn().mockReturnValueOnce(true);
             folder.folderRequest = jest.fn();
             folder.getCache = jest.fn();
             folder.getCacheKey = jest.fn();
-            folder.folder('id', 'query', 'by', 'direction', 'success', 'fail');
+            folder.getFolder('id', 'query', 'by', 'direction', 'success', 'fail');
             expect(folder.folderRequest).not.toHaveBeenCalled();
             expect(folder.getCache).not.toHaveBeenCalled();
             expect(folder.getCacheKey).not.toHaveBeenCalled();
@@ -73,7 +72,7 @@ describe('api/Folder', () => {
             folder.folderRequest = jest.fn();
             folder.getCacheKey = jest.fn().mockReturnValueOnce('key');
             folder.isLoaded = jest.fn().mockReturnValueOnce(false);
-            folder.folder('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
+            folder.getFolder('id', 'by', 'direction', 'success', 'fail');
             expect(folder.getCacheKey).toHaveBeenCalledWith('id');
             expect(folder.id).toBe('id');
             expect(folder.successCallback).toBe('success');
@@ -82,15 +81,13 @@ describe('api/Folder', () => {
             expect(folder.sortDirection).toBe('direction');
             expect(folder.key).toBe('key');
             expect(folder.offset).toBe(0);
-            expect(folder.includePreviewFields).toBe('preview');
-            expect(folder.includePreviewSidebarFields).toBe('sidebar');
         });
         test('should save args and not make folder request when cached', () => {
             folder.folderRequest = jest.fn();
             folder.finish = jest.fn();
             folder.getCacheKey = jest.fn().mockReturnValueOnce('key');
             folder.isLoaded = jest.fn().mockReturnValueOnce(true);
-            folder.folder('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
+            folder.getFolder('id', 'by', 'direction', 'success', 'fail');
             expect(folder.getCacheKey).toHaveBeenCalledWith('id');
             expect(folder.folderRequest).not.toHaveBeenCalled();
             expect(folder.id).toBe('id');
@@ -100,8 +97,6 @@ describe('api/Folder', () => {
             expect(folder.sortDirection).toBe('direction');
             expect(folder.key).toBe('key');
             expect(folder.offset).toBe(0);
-            expect(folder.includePreviewFields).toBe('preview');
-            expect(folder.includePreviewSidebarFields).toBe('sidebar');
         });
         test('should save args and make folder request when cached but forced to fetch', () => {
             const unsetMock = jest.fn();
@@ -109,7 +104,7 @@ describe('api/Folder', () => {
             folder.getCache = jest.fn().mockReturnValueOnce({ unset: unsetMock });
             folder.getCacheKey = jest.fn().mockReturnValueOnce('key');
             folder.isLoaded = jest.fn().mockReturnValueOnce(false);
-            folder.folder('id', 'by', 'direction', 'success', 'fail', true, 'preview', 'sidebar');
+            folder.getFolder('id', 'by', 'direction', 'success', 'fail', { forceFetch: true });
             expect(unsetMock).toHaveBeenCalledWith('key');
             expect(folder.getCacheKey).toHaveBeenCalledWith('id');
             expect(folder.id).toBe('id');
@@ -119,8 +114,6 @@ describe('api/Folder', () => {
             expect(folder.sortDirection).toBe('direction');
             expect(folder.key).toBe('key');
             expect(folder.offset).toBe(0);
-            expect(folder.includePreviewFields).toBe('preview');
-            expect(folder.includePreviewSidebarFields).toBe('sidebar');
         });
     });
 
@@ -156,10 +149,7 @@ describe('api/Folder', () => {
                     params: {
                         offset: 0,
                         limit: 1000,
-                        fields: getFieldsAsString(true)
-                    },
-                    headers: {
-                        'X-Rep-Hints': X_REP_HINTS
+                        fields: FOLDER_FIELDS_TO_FETCH.toString()
                     }
                 });
             });
@@ -181,10 +171,7 @@ describe('api/Folder', () => {
                     params: {
                         offset: 0,
                         limit: 1000,
-                        fields: getFieldsAsString(true, true)
-                    },
-                    headers: {
-                        'X-Rep-Hints': X_REP_HINTS
+                        fields: FOLDER_FIELDS_TO_FETCH.toString()
                     }
                 });
             });
@@ -624,7 +611,7 @@ describe('api/Folder', () => {
                 expect(folder.createSuccessHandler).toHaveBeenCalledWith('success');
                 expect(folder.errorHandler).not.toHaveBeenCalled();
                 expect(folder.xhr.post).toHaveBeenCalledWith({
-                    url: `https://api.box.com/2.0/folders?fields=${getFieldsAsString()}`,
+                    url: `https://api.box.com/2.0/folders?fields=${FOLDER_FIELDS_TO_FETCH.toString()}`,
                     data: {
                         name: 'foo',
                         parent: {
@@ -645,7 +632,7 @@ describe('api/Folder', () => {
                 expect(folder.errorHandler).toHaveBeenCalledWith(error);
                 expect(folder.createSuccessHandler).not.toHaveBeenCalled();
                 expect(folder.xhr.post).toHaveBeenCalledWith({
-                    url: `https://api.box.com/2.0/folders?fields=${getFieldsAsString()}`,
+                    url: `https://api.box.com/2.0/folders?fields=${FOLDER_FIELDS_TO_FETCH.toString()}`,
                     data: {
                         name: 'foo',
                         parent: {

--- a/src/api/__tests__/Recents-test.js
+++ b/src/api/__tests__/Recents-test.js
@@ -1,7 +1,6 @@
 import Recents from '../Recents';
 import Cache from '../../util/Cache';
-import { getFieldsAsString } from '../../util/fields';
-import { X_REP_HINTS } from '../../constants';
+import { FOLDER_FIELDS_TO_FETCH } from '../../util/fields';
 import * as sort from '../../util/sorter';
 
 let recents;
@@ -40,7 +39,7 @@ describe('api/Recents', () => {
             recents.recentsRequest = jest.fn();
             recents.getCache = jest.fn().mockReturnValueOnce(cache);
             recents.getCacheKey = jest.fn().mockReturnValueOnce('key');
-            recents.recents('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
+            recents.recents('id', 'by', 'direction', 'success', 'fail');
             expect(recents.getCacheKey).toHaveBeenCalledWith('id');
             expect(recents.id).toBe('id');
             expect(recents.successCallback).toBe('success');
@@ -48,15 +47,13 @@ describe('api/Recents', () => {
             expect(recents.sortBy).toBe('interacted_at');
             expect(recents.sortDirection).toBe('DESC');
             expect(recents.key).toBe('key');
-            expect(recents.includePreviewFields).toBe('preview');
-            expect(recents.includePreviewSidebarFields).toBe('sidebar');
         });
         test('should save args and not make recents request when cached', () => {
             cache.set('key', 'value');
             recents.finish = jest.fn();
             recents.getCache = jest.fn().mockReturnValueOnce(cache);
             recents.getCacheKey = jest.fn().mockReturnValueOnce('key');
-            recents.recents('id', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
+            recents.recents('id', 'by', 'direction', 'success', 'fail');
             expect(recents.getCacheKey).toHaveBeenCalledWith('id');
             expect(recents.id).toBe('id');
             expect(recents.successCallback).toBe('success');
@@ -64,15 +61,13 @@ describe('api/Recents', () => {
             expect(recents.sortBy).toBe('by');
             expect(recents.sortDirection).toBe('direction');
             expect(recents.key).toBe('key');
-            expect(recents.includePreviewFields).toBe('preview');
-            expect(recents.includePreviewSidebarFields).toBe('sidebar');
         });
         test('should save args and make recents request when cached but forced to fetch', () => {
             cache.set('key', 'value');
             recents.recentsRequest = jest.fn();
             recents.getCache = jest.fn().mockReturnValueOnce(cache);
             recents.getCacheKey = jest.fn().mockReturnValueOnce('key');
-            recents.recents('id', 'by', 'direction', 'success', 'fail', true, 'preview', 'sidebar');
+            recents.recents('id', 'by', 'direction', 'success', 'fail', { forceFetch: true });
             expect(recents.getCacheKey).toHaveBeenCalledWith('id');
             expect(recents.id).toBe('id');
             expect(recents.successCallback).toBe('success');
@@ -80,8 +75,6 @@ describe('api/Recents', () => {
             expect(recents.sortBy).toBe('interacted_at');
             expect(recents.sortDirection).toBe('DESC');
             expect(recents.key).toBe('key');
-            expect(recents.includePreviewFields).toBe('preview');
-            expect(recents.includePreviewSidebarFields).toBe('sidebar');
         });
     });
 
@@ -107,8 +100,7 @@ describe('api/Recents', () => {
                 expect(recents.recentsErrorHandler).not.toHaveBeenCalled();
                 expect(recents.xhr.get).toHaveBeenCalledWith({
                     url: 'https://api.box.com/2.0/recent_items',
-                    params: { fields: getFieldsAsString(true) },
-                    headers: { 'X-Rep-Hints': X_REP_HINTS }
+                    params: { fields: FOLDER_FIELDS_TO_FETCH.toString() }
                 });
             });
         });
@@ -127,8 +119,7 @@ describe('api/Recents', () => {
                 expect(recents.recentsErrorHandler).not.toHaveBeenCalled();
                 expect(recents.xhr.get).toHaveBeenCalledWith({
                     url: 'https://api.box.com/2.0/recent_items',
-                    params: { fields: getFieldsAsString(true, true) },
-                    headers: { 'X-Rep-Hints': X_REP_HINTS }
+                    params: { fields: FOLDER_FIELDS_TO_FETCH.toString() }
                 });
             });
         });

--- a/src/api/__tests__/Search-test.js
+++ b/src/api/__tests__/Search-test.js
@@ -1,7 +1,6 @@
 import Search from '../Search';
 import Cache from '../../util/Cache';
-import { getFieldsAsString } from '../../util/fields';
-import { X_REP_HINTS } from '../../constants';
+import { FOLDER_FIELDS_TO_FETCH } from '../../util/fields';
 import * as sort from '../../util/sorter';
 
 let search;
@@ -79,7 +78,7 @@ describe('api/Search', () => {
             search.searchRequest = jest.fn();
             search.getCacheKey = jest.fn().mockReturnValueOnce('key');
             search.isLoaded = jest.fn().mockReturnValueOnce(false);
-            search.search('id', 'foo query', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
+            search.search('id', 'foo query', 'by', 'direction', 'success', 'fail');
             expect(search.getCacheKey).toHaveBeenCalledWith('id', 'foo%20query');
             expect(search.id).toBe('id');
             expect(search.successCallback).toBe('success');
@@ -89,15 +88,13 @@ describe('api/Search', () => {
             expect(search.key).toBe('key');
             expect(search.offset).toBe(0);
             expect(search.query).toBe('foo query');
-            expect(search.includePreviewFields).toBe('preview');
-            expect(search.includePreviewSidebarFields).toBe('sidebar');
         });
         test('should save args and not make search request when cached', () => {
             search.searchRequest = jest.fn();
             search.finish = jest.fn();
             search.getCacheKey = jest.fn().mockReturnValueOnce('key');
             search.isLoaded = jest.fn().mockReturnValueOnce(true);
-            search.search('id', 'foo query', 'by', 'direction', 'success', 'fail', false, 'preview', 'sidebar');
+            search.search('id', 'foo query', 'by', 'direction', 'success', 'fail');
             expect(search.searchRequest).not.toHaveBeenCalled();
             expect(search.getCacheKey).toHaveBeenCalledWith('id', 'foo%20query');
             expect(search.id).toBe('id');
@@ -108,8 +105,6 @@ describe('api/Search', () => {
             expect(search.key).toBe('key');
             expect(search.offset).toBe(0);
             expect(search.query).toBe('foo query');
-            expect(search.includePreviewFields).toBe('preview');
-            expect(search.includePreviewSidebarFields).toBe('sidebar');
         });
         test('should save args and make search request when cached but forced to fetch', () => {
             const unsetMock = jest.fn();
@@ -117,7 +112,7 @@ describe('api/Search', () => {
             search.getCache = jest.fn().mockReturnValueOnce({ unset: unsetMock });
             search.getCacheKey = jest.fn().mockReturnValueOnce('key');
             search.isLoaded = jest.fn().mockReturnValueOnce(false);
-            search.search('id', 'foo query', 'by', 'direction', 'success', 'fail', true, 'preview', 'sidebar');
+            search.search('id', 'foo query', 'by', 'direction', 'success', 'fail', { forceFetch: true });
             expect(unsetMock).toHaveBeenCalledWith('key');
             expect(search.getCacheKey).toHaveBeenCalledWith('id', 'foo%20query');
             expect(search.id).toBe('id');
@@ -128,8 +123,6 @@ describe('api/Search', () => {
             expect(search.key).toBe('key');
             expect(search.offset).toBe(0);
             expect(search.query).toBe('foo query');
-            expect(search.includePreviewFields).toBe('preview');
-            expect(search.includePreviewSidebarFields).toBe('sidebar');
         });
     });
 
@@ -168,9 +161,8 @@ describe('api/Search', () => {
                         query: 'query',
                         ancestor_folder_ids: 'id',
                         limit: 200,
-                        fields: getFieldsAsString(true)
-                    },
-                    headers: { 'X-Rep-Hints': X_REP_HINTS }
+                        fields: FOLDER_FIELDS_TO_FETCH.toString()
+                    }
                 });
             });
         });
@@ -194,9 +186,8 @@ describe('api/Search', () => {
                         query: 'query',
                         ancestor_folder_ids: 'id',
                         limit: 200,
-                        fields: getFieldsAsString(true, true)
-                    },
-                    headers: { 'X-Rep-Hints': X_REP_HINTS }
+                        fields: FOLDER_FIELDS_TO_FETCH.toString()
+                    }
                 });
             });
         });

--- a/src/components/ContentExplorer/ContentExplorer.js
+++ b/src/components/ContentExplorer/ContentExplorer.js
@@ -25,7 +25,6 @@ import makeResponsive from '../makeResponsive';
 import openUrlInsideIframe from '../../util/iframe';
 import { isFocusableElement, isInputElement, focus } from '../../util/dom';
 import Internationalize from '../Internationalize';
-import SidebarUtils from '../ContentSidebar/SidebarUtils';
 import {
     DEFAULT_HOSTNAME_UPLOAD,
     DEFAULT_HOSTNAME_API,
@@ -395,8 +394,8 @@ class ContentExplorer extends Component<Props, State> {
      * @param {Boolean|void} [forceFetch] To void the cache
      * @return {void}
      */
-    fetchFolder = (id?: string, triggerNavigationEvent: boolean = true, forceFetch: boolean = false) => {
-        const { rootFolderId, canPreview, contentPreviewProps }: Props = this.props;
+    fetchFolder = (id?: string, triggerNavigationEvent?: boolean = true, fetchOptions?: FetchOptions) => {
+        const { rootFolderId }: Props = this.props;
         const { sortBy, sortDirection }: State = this.state;
         const folderId: string = typeof id === 'string' ? id : rootFolderId;
 
@@ -416,7 +415,7 @@ class ContentExplorer extends Component<Props, State> {
         });
 
         // Fetch the folder using folder API
-        this.api.getFolderAPI().folder(
+        this.api.getFolderAPI().getFolder(
             folderId,
             sortBy,
             sortDirection,
@@ -424,9 +423,7 @@ class ContentExplorer extends Component<Props, State> {
                 this.fetchFolderSuccessCallback(collection, triggerNavigationEvent);
             },
             this.errorCallback,
-            forceFetch,
-            canPreview,
-            SidebarUtils.canHaveSidebar(contentPreviewProps.contentSidebarProps)
+            fetchOptions
         );
     };
 
@@ -491,21 +488,12 @@ class ContentExplorer extends Component<Props, State> {
      * @return {void}
      */
     debouncedSearch = debounce((id: string, query: string, forceFetch?: boolean) => {
-        const { canPreview, contentPreviewProps }: Props = this.props;
         const { sortBy, sortDirection }: State = this.state;
         this.api
             .getSearchAPI()
-            .search(
-                id,
-                query,
-                sortBy,
-                sortDirection,
-                this.searchSuccessCallback,
-                this.errorCallback,
-                forceFetch,
-                canPreview,
-                SidebarUtils.canHaveSidebar(contentPreviewProps.contentSidebarProps)
-            );
+            .search(id, query, sortBy, sortDirection, this.searchSuccessCallback, this.errorCallback, {
+                forceFetch
+            });
     }, DEFAULT_SEARCH_DEBOUNCE);
 
     /**
@@ -581,7 +569,7 @@ class ContentExplorer extends Component<Props, State> {
      * @return {void}
      */
     showRecents(triggerNavigationEvent: boolean = true, forceFetch: boolean = true): void {
-        const { rootFolderId, canPreview, contentPreviewProps }: Props = this.props;
+        const { rootFolderId }: Props = this.props;
         const { sortBy, sortDirection }: State = this.state;
 
         // Recents are sorted by a different date field than the rest
@@ -603,9 +591,9 @@ class ContentExplorer extends Component<Props, State> {
                 this.recentsSuccessCallback(collection, triggerNavigationEvent);
             },
             this.errorCallback,
-            forceFetch,
-            canPreview,
-            SidebarUtils.canHaveSidebar(contentPreviewProps.contentSidebarProps)
+            {
+                forceFetch
+            }
         );
     }
 
@@ -642,7 +630,9 @@ class ContentExplorer extends Component<Props, State> {
      */
     uploadSuccessHandler = () => {
         const { currentCollection: { id } }: State = this.state;
-        this.fetchFolder(id, false, true);
+        this.fetchFolder(id, false, {
+            forceFetch: true
+        });
     };
 
     /**
@@ -1354,4 +1344,5 @@ class ContentExplorer extends Component<Props, State> {
     }
 }
 
+export { ContentExplorer as ContentExplorerComponent };
 export default makeResponsive(ContentExplorer);

--- a/src/components/ContentExplorer/__tests__/ContentExplorer-test.js
+++ b/src/components/ContentExplorer/__tests__/ContentExplorer-test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { ContentExplorerComponent as ContentExplorer } from '../ContentExplorer';
+
+jest.mock('../../Header/Header', () => 'mock-header');
+jest.mock('../../SubHeader/SubHeader', () => 'mock-subheader');
+jest.mock('../Content', () => 'mock-content');
+jest.mock('../../UploadDialog/UploadDialog', () => 'mock-uploaddialog');
+jest.mock('../../CreateFolderDialog/CreateFolderDialog', () => 'mock-createfolderdialog');
+jest.mock('../DeleteConfirmationDialog', () => 'mock-deletedialog');
+jest.mock('../RenameDialog', () => 'mock-renamedialog');
+jest.mock('../ShareDialog', () => 'mock-sharedialog');
+jest.mock('../PreviewDialog', () => 'mock-previewdialog');
+
+describe('components/ContentExplorer/ContentExplorer', () => {
+    let rootElement;
+    const getWrapper = (props) => mount(<ContentExplorer {...props} />, { attachTo: rootElement });
+
+    beforeEach(() => {
+        rootElement = document.createElement('div');
+        document.body.appendChild(rootElement);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(rootElement);
+    });
+
+    describe('uploadSuccessHandler()', () => {
+        test('should force reload the files list', () => {
+            const wrapper = getWrapper({});
+            const instance = wrapper.instance();
+            instance.setState({
+                currentCollection: {
+                    id: '123'
+                }
+            });
+            instance.fetchFolder = jest.fn();
+            instance.uploadSuccessHandler();
+            expect(instance.fetchFolder).toHaveBeenCalledWith('123', false, {
+                forceFetch: true
+            });
+        });
+    });
+});

--- a/src/components/ContentPicker/ContentPicker.js
+++ b/src/components/ContentPicker/ContentPicker.js
@@ -418,7 +418,7 @@ class ContentPicker extends Component<Props, State> {
      * @param {Boolean|void} [forceFetch] To void cache
      * @return {void}
      */
-    fetchFolder = (id?: string, triggerNavigationEvent: boolean = true, forceFetch: boolean = false): void => {
+    fetchFolder = (id?: string, triggerNavigationEvent?: boolean = true, fetchOptions?: FetchOptions): void => {
         const { rootFolderId }: Props = this.props;
         const { sortBy, sortDirection }: State = this.state;
         const folderId: string = typeof id === 'string' ? id : rootFolderId;
@@ -439,7 +439,7 @@ class ContentPicker extends Component<Props, State> {
         });
 
         // Fetch the folder using folder API
-        this.api.getFolderAPI().folder(
+        this.api.getFolderAPI().getFolder(
             folderId,
             sortBy,
             sortDirection,
@@ -447,7 +447,7 @@ class ContentPicker extends Component<Props, State> {
                 this.fetchFolderSuccessCallback(collection, triggerNavigationEvent);
             },
             this.errorCallback,
-            forceFetch
+            fetchOptions
         );
     };
 
@@ -500,7 +500,9 @@ class ContentPicker extends Component<Props, State> {
                 this.recentsSuccessCallback(collection, triggerNavigationEvent);
             },
             this.errorCallback,
-            forceFetch
+            {
+                forceFetch
+            }
         );
     }
 
@@ -554,7 +556,9 @@ class ContentPicker extends Component<Props, State> {
         const { sortBy, sortDirection }: State = this.state;
         this.api
             .getSearchAPI()
-            .search(id, query, sortBy, sortDirection, this.searchSuccessCallback, this.errorCallback, forceFetch);
+            .search(id, query, sortBy, sortDirection, this.searchSuccessCallback, this.errorCallback, {
+                forceFetch
+            });
     }, DEFAULT_SEARCH_DEBOUNCE);
 
     /**
@@ -627,7 +631,9 @@ class ContentPicker extends Component<Props, State> {
      */
     uploadSuccessHandler = (): void => {
         const { currentCollection: { id } }: State = this.state;
-        this.fetchFolder(id, false, true);
+        this.fetchFolder(id, false, {
+            forceFetch: true
+        });
     };
 
     /**
@@ -1080,4 +1086,5 @@ class ContentPicker extends Component<Props, State> {
     }
 }
 
+export { ContentPicker as ContentPickerComponent };
 export default makeResponsive(ContentPicker);

--- a/src/components/ContentPicker/__tests__/ContentPicker-test.js
+++ b/src/components/ContentPicker/__tests__/ContentPicker-test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { ContentPickerComponent as ContentPicker } from '../ContentPicker';
+
+jest.mock('../../Header/Header', () => 'mock-header');
+jest.mock('../../SubHeader/SubHeader', () => 'mock-subheader');
+jest.mock('../Footer', () => 'mock-footer');
+jest.mock('../Content', () => 'mock-content');
+jest.mock('../../UploadDialog/UploadDialog', () => 'mock-uploaddialog');
+jest.mock('../../CreateFolderDialog/CreateFolderDialog', () => 'mock-createfolderdialog');
+
+describe('components/ContentPicker/ContentPicker', () => {
+    let rootElement;
+    const getWrapper = (props) => mount(<ContentPicker {...props} />, { attachTo: rootElement });
+
+    beforeEach(() => {
+        rootElement = document.createElement('div');
+        document.body.appendChild(rootElement);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(rootElement);
+    });
+
+    describe('uploadSuccessHandler()', () => {
+        test('should force reload the files list', () => {
+            const wrapper = getWrapper({});
+            const instance = wrapper.instance();
+            instance.setState({
+                currentCollection: {
+                    id: '123'
+                }
+            });
+            instance.fetchFolder = jest.fn();
+            instance.uploadSuccessHandler();
+            expect(instance.fetchFolder).toHaveBeenCalledWith('123', false, {
+                forceFetch: true
+            });
+        });
+    });
+});

--- a/src/components/ContentPreview/ContentPreview.js
+++ b/src/components/ContentPreview/ContentPreview.js
@@ -24,11 +24,10 @@ import API from '../../api';
 import makeResponsive from '../makeResponsive';
 import Internationalize from '../Internationalize';
 import TokenService from '../../util/TokenService';
-import { isValidBoxFile } from '../../util/fields';
 import { isInputElement, focus } from '../../util/dom';
 import { getTypedFileId } from '../../util/file';
-import SidebarUtils from '../ContentSidebar/SidebarUtils';
 import ReloadNotification from './ReloadNotification';
+import { PREVIEW_FIELDS_TO_FETCH } from '../../util/fields';
 import {
     DEFAULT_HOSTNAME_API,
     DEFAULT_HOSTNAME_APP,
@@ -116,7 +115,7 @@ class ContentPreview extends PureComponent<Props, State> {
     rootElement: HTMLElement;
     retryCount: number = 0;
     retryTimeout: TimeoutID;
-    updatedFile: ?BoxItem;
+    stagedFile: ?BoxItem;
 
     initialState: State = {
         isFileError: false,
@@ -406,7 +405,9 @@ class ContentPreview extends PureComponent<Props, State> {
         await TokenService.cacheTokens(typedIds, token);
         files.forEach((file) => {
             const fileId = this.getFileId(file);
-            this.fetchFile(fileId, noop, noop);
+            this.fetchFile(fileId, noop, noop, {
+                refreshCache: false
+            });
         });
     }
 
@@ -589,14 +590,14 @@ class ContentPreview extends PureComponent<Props, State> {
     };
 
     /**
-     * Updates preview file.
+     * Updates preview file from temporary staged file.
      *
      * @return {void}
      */
-    updateFile = () => {
-        if (this.updatedFile) {
-            this.setState({ ...this.initialState, file: this.updatedFile }, () => {
-                this.updatedFile = undefined;
+    loadFileFromStage = () => {
+        if (this.stagedFile) {
+            this.setState({ ...this.initialState, file: this.stagedFile }, () => {
+                this.stagedFile = undefined;
             });
         }
     };
@@ -643,7 +644,7 @@ class ContentPreview extends PureComponent<Props, State> {
         } else if (currentFile.file_version.sha1 !== file.file_version.sha1) {
             // If we are already prevewing the file that got updated then show the
             // user a notification to reload the file only if its sha1 changed
-            this.updatedFile = file;
+            this.stagedFile = file;
             this.setState({ ...this.initialState, isReloadNotificationVisible: true });
         }
     };
@@ -685,9 +686,15 @@ class ContentPreview extends PureComponent<Props, State> {
      * @param {string} id file id
      * @param {Function|void} [successCallback] - Callback after file is fetched
      * @param {Function|void} [errorCallback] - Callback after error
+     * @param {Object|void} [fetchOptions] - Fetch options
      * @return {void}
      */
-    fetchFile(id: string, successCallback?: Function, errorCallback?: Function): void {
+    fetchFile(
+        id: string,
+        successCallback?: Function,
+        errorCallback?: Function,
+        fetchOptions?: FetchOptions = {}
+    ): void {
         if (!id) {
             throw InvalidIdError;
         }
@@ -702,9 +709,8 @@ class ContentPreview extends PureComponent<Props, State> {
                 successCallback || this.fetchFileSuccessCallback,
                 errorCallback || this.fetchFileErrorCallback,
                 {
-                    forceFetch: false,
-                    refreshCache: true,
-                    includePreviewSidebarFields: SidebarUtils.canHaveSidebar(this.props.contentSidebarProps)
+                    ...fetchOptions,
+                    fields: PREVIEW_FIELDS_TO_FETCH
                 }
             );
     }
@@ -962,8 +968,7 @@ class ContentPreview extends PureComponent<Props, State> {
         const fileIndex = this.getFileIndex();
         const hasLeftNavigation = collection.length > 1 && fileIndex > 0 && fileIndex < collection.length;
         const hasRightNavigation = collection.length > 1 && fileIndex > -1 && fileIndex < collection.length - 1;
-        const isValidFile = isValidBoxFile(file, true, true);
-        const isSidebarVisible = isValidFile && SidebarUtils.shouldRenderSidebar(contentSidebarProps, file);
+        const fileId = file ? file.id : undefined;
 
         /* eslint-disable jsx-a11y/no-static-element-interactions */
         /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
@@ -1010,14 +1015,14 @@ class ContentPreview extends PureComponent<Props, State> {
                                 </PlainButton>
                             )}
                         </div>
-                        {isSidebarVisible && (
+                        {file && (
                             <ContentSidebar
                                 {...contentSidebarProps}
                                 isLarge={isLarge}
                                 apiHost={apiHost}
                                 token={token}
                                 cache={this.api.getCache()}
-                                fileId={this.getFileId(file)}
+                                fileId={fileId}
                                 getPreview={this.getPreview}
                                 getViewer={this.getViewer}
                                 sharedLink={sharedLink}
@@ -1028,7 +1033,7 @@ class ContentPreview extends PureComponent<Props, State> {
                         )}
                     </div>
                     {isReloadNotificationVisible && (
-                        <ReloadNotification onClose={this.closeReloadNotification} onClick={this.updateFile} />
+                        <ReloadNotification onClose={this.closeReloadNotification} onClick={this.loadFileFromStage} />
                     )}
                 </div>
             </Internationalize>

--- a/src/components/ContentPreview/__tests__/ContentPreview-test.js
+++ b/src/components/ContentPreview/__tests__/ContentPreview-test.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import noop from 'lodash/noop';
 import { shallow } from 'enzyme';
 import { ContentPreviewComponent as ContentPreview } from '../ContentPreview';
 import PreviewLoading from '../PreviewLoading';
 import * as TokenService from '../../../util/TokenService';
 import SidebarUtils from '../../ContentSidebar/SidebarUtils';
+import { PREVIEW_FIELDS_TO_FETCH } from '../../../util/fields';
 
 jest.mock('../../Internationalize', () => 'mock-internationalize');
 
@@ -229,13 +231,15 @@ describe('components/ContentPreview/ContentPreview', () => {
             const success = jest.fn();
             const error = jest.fn();
             SidebarUtils.canHaveSidebar = jest.fn().mockReturnValueOnce(true);
-            instance.fetchFile(file.id, success, error);
+            instance.fetchFile(file.id, success, error, {
+                forceFetch: false,
+                refreshCache: true
+            });
             expect(getFileStub).toBeCalledWith(file.id, success, error, {
                 forceFetch: false,
                 refreshCache: true,
-                includePreviewSidebarFields: true
+                fields: PREVIEW_FIELDS_TO_FETCH
             });
-            expect(SidebarUtils.canHaveSidebar).toHaveBeenCalledWith(props.contentSidebarProps);
         });
 
         test('should fetch the file with default success and error callback', () => {
@@ -248,12 +252,9 @@ describe('components/ContentPreview/ContentPreview', () => {
                 instance.fetchFileSuccessCallback,
                 instance.fetchFileErrorCallback,
                 {
-                    forceFetch: false,
-                    refreshCache: true,
-                    includePreviewSidebarFields: true
+                    fields: PREVIEW_FIELDS_TO_FETCH
                 }
             );
-            expect(SidebarUtils.canHaveSidebar).toHaveBeenCalledWith(props.contentSidebarProps);
         });
 
         test('should fetch the file without sidebar fields', () => {
@@ -266,12 +267,9 @@ describe('components/ContentPreview/ContentPreview', () => {
                 instance.fetchFileSuccessCallback,
                 instance.fetchFileErrorCallback,
                 {
-                    forceFetch: false,
-                    refreshCache: true,
-                    includePreviewSidebarFields: false
+                    fields: PREVIEW_FIELDS_TO_FETCH
                 }
             );
-            expect(SidebarUtils.canHaveSidebar).toHaveBeenCalledWith(props.contentSidebarProps);
         });
     });
 
@@ -329,7 +327,7 @@ describe('components/ContentPreview/ContentPreview', () => {
             instance.fetchFileSuccessCallback(newFile);
 
             expect(instance.retryCount).toEqual(0);
-            expect(instance.updatedFile).toEqual(newFile);
+            expect(instance.stagedFile).toEqual(newFile);
             expect(instance.state.file).toEqual(file);
             expect(instance.state.isFileError).toBeFalsy();
             expect(instance.state.isReloadNotificationVisible).toBeTruthy();
@@ -562,7 +560,7 @@ describe('components/ContentPreview/ContentPreview', () => {
         });
     });
 
-    describe('updateFile()', () => {
+    describe('loadFileFromStage()', () => {
         test('should set new file in state if it exists', () => {
             const wrapper = getWrapper(props);
             const instance = wrapper.instance();
@@ -571,10 +569,10 @@ describe('components/ContentPreview/ContentPreview', () => {
                 isFileError: true
             });
             file = { id: '123' };
-            instance.updatedFile = file;
-            instance.updateFile();
+            instance.stagedFile = file;
+            instance.loadFileFromStage();
             expect(instance.state.file).toEqual(file);
-            expect(instance.updatedFile).toBeUndefined();
+            expect(instance.stagedFile).toBeUndefined();
             expect(instance.state.isReloadNotificationVisible).toBeFalsy();
             expect(instance.state.isFileError).toBeFalsy();
         });
@@ -589,6 +587,27 @@ describe('components/ContentPreview/ContentPreview', () => {
             });
             instance.closeReloadNotification();
             expect(instance.state.isReloadNotificationVisible).toBeFalsy();
+        });
+    });
+
+    describe('prefetch()', () => {
+        test('should prefetch files', async () => {
+            props.token = jest.fn();
+            const wrapper = getWrapper(props);
+            const instance = wrapper.instance();
+            const options = {
+                refreshCache: false
+            };
+
+            instance.fetchFile = jest.fn();
+            TokenService.default.cacheTokens = jest.fn().mockReturnValueOnce(Promise.resolve());
+            await instance.prefetch(['1', '2', '3']);
+
+            expect(TokenService.default.cacheTokens).toHaveBeenCalledWith(['file_1', 'file_2', 'file_3'], props.token);
+            expect(instance.fetchFile).toHaveBeenCalledTimes(3);
+            expect(instance.fetchFile).toHaveBeenNthCalledWith(1, '1', noop, noop, options);
+            expect(instance.fetchFile).toHaveBeenNthCalledWith(2, '2', noop, noop, options);
+            expect(instance.fetchFile).toHaveBeenNthCalledWith(3, '3', noop, noop, options);
         });
     });
 });

--- a/src/components/ContentSidebar/ContentSidebar.js
+++ b/src/components/ContentSidebar/ContentSidebar.js
@@ -15,6 +15,7 @@ import Sidebar from './Sidebar';
 import API from '../../api';
 import APIContext from '../APIContext';
 import Internationalize from '../Internationalize';
+import { SIDEBAR_FIELDS_TO_FETCH } from '../../util/fields';
 import {
     DEFAULT_HOSTNAME_API,
     CLIENT_NAME_CONTENT_SIDEBAR,
@@ -68,6 +69,7 @@ type State = {
     accessStats?: FileAccessStats,
     fileError?: Errors,
     accessStatsError?: Errors,
+    isVisible: boolean,
     isFileLoading?: boolean,
     feedItems?: FeedItems,
     hasBeenToggled?: boolean
@@ -77,8 +79,6 @@ class ContentSidebar extends PureComponent<Props, State> {
     id: string;
     props: Props;
     state: State;
-    rootElement: HTMLElement;
-    appElement: HTMLElement;
     api: API;
 
     static defaultProps = {
@@ -97,6 +97,7 @@ class ContentSidebar extends PureComponent<Props, State> {
     };
 
     initialState: State = {
+        isVisible: true,
         file: undefined,
         accessStats: undefined,
         fileError: undefined,
@@ -168,9 +169,6 @@ class ContentSidebar extends PureComponent<Props, State> {
      * @return {void}
      */
     componentDidMount() {
-        this.rootElement = ((document.getElementById(this.id): any): HTMLElement);
-        this.appElement = ((this.rootElement.firstElementChild: any): HTMLElement);
-
         this.fetchData(this.props);
     }
 
@@ -220,7 +218,13 @@ class ContentSidebar extends PureComponent<Props, State> {
      * @param {Object} Props the component props
      * @param {boolean} hasFileIdChanged true if the file id has changed
      */
-    fetchData({ fileId, detailsSidebarProps }: Props) {
+    fetchData(props: Props) {
+        // If nothing to show then just return
+        if (!SidebarUtils.canHaveSidebar(props)) {
+            return;
+        }
+
+        const { fileId, detailsSidebarProps }: Props = props;
         const { hasAccessStats = false } = detailsSidebarProps;
         if (!fileId) {
             return;
@@ -416,13 +420,24 @@ class ContentSidebar extends PureComponent<Props, State> {
 
     /**
      * File fetch success callback that sets the file and view
+     * Only set file if there is data to show in the sidebar.
+     * Skills sidebar doesn't show when there is no data.
      *
      * @private
      * @param {Object} file - Box file
      * @return {void}
      */
     fetchFileSuccessCallback = (file: BoxItem): void => {
-        this.setState({ file, view: this.getDefaultSidebarView(file, this.props), isFileLoading: false });
+        if (SidebarUtils.shouldRenderSidebar(this.props, file)) {
+            this.setState({
+                file,
+                isVisible: true,
+                view: this.getDefaultSidebarView(file, this.props),
+                isFileLoading: false
+            });
+        } else {
+            this.setState({ isVisible: false });
+        }
     };
 
     /**
@@ -441,18 +456,18 @@ class ContentSidebar extends PureComponent<Props, State> {
      *
      * @private
      * @param {string} id - File id
-     * @param {Boolean|void} [forceFetch] - To void cache
+     * @param {Object|void} [fetchOptions] - Fetch options
      * @return {void}
      */
-    fetchFile(id: string, forceFetch: boolean = false): void {
+    fetchFile(id: string, fetchOptions: FetchOptions = {}): void {
         if (SidebarUtils.canHaveSidebar(this.props)) {
             this.setState({
                 isFileLoading: true
             });
 
             this.api.getFileAPI().getFile(id, this.fetchFileSuccessCallback, this.fetchFileErrorCallback, {
-                forceFetch,
-                includePreviewSidebarFields: true
+                ...fetchOptions,
+                fields: SIDEBAR_FIELDS_TO_FETCH
             });
         }
     }
@@ -486,7 +501,9 @@ class ContentSidebar extends PureComponent<Props, State> {
             return;
         }
 
-        this.fetchFile(fileId, true);
+        this.fetchFile(fileId, {
+            forceFetch: true
+        });
     };
 
     /**
@@ -521,7 +538,26 @@ class ContentSidebar extends PureComponent<Props, State> {
             metadataSidebarProps,
             onVersionHistoryClick
         }: Props = this.props;
-        const { file, view, accessStats, accessStatsError, fileError, isFileLoading, feedItems }: State = this.state;
+        const {
+            file,
+            view,
+            accessStats,
+            accessStatsError,
+            fileError,
+            isFileLoading,
+            feedItems,
+            isVisible
+        }: State = this.state;
+
+        // By default sidebar is always visible if there is something configured
+        // to show via props. At least one of the sidebars is needed for visibility.
+        // However we may turn the visibility off if there is no data to show
+        // in the sidebar. This can only happen if skills sidebar was showing
+        // however there is no skills data to show. For all other sidebars
+        // we show them by default even if there is no data in them.
+        if (!isVisible || !SidebarUtils.canHaveSidebar(this.props)) {
+            return null;
+        }
 
         const styleClassName = classNames(
             'be bcs',
@@ -535,14 +571,14 @@ class ContentSidebar extends PureComponent<Props, State> {
         const hasSkills = SidebarUtils.shouldRenderSkillsSidebar(this.props, file);
         const hasDetails = SidebarUtils.canHaveDetailsSidebar(this.props);
         const hasMetadata = SidebarUtils.canHaveMetadataSidebar(this.props);
+        const hasSidebar = SidebarUtils.shouldRenderSidebar(this.props, file);
 
         return (
             <Internationalize language={language} messages={intlMessages}>
                 <aside id={this.id} className={styleClassName}>
                     <div className='be-app-element'>
-                        {SidebarUtils.shouldRenderSidebar(this.props, file) ? (
-                            // $FlowFixMe
-                            <APIContext.Provider value={this.api}>
+                        {hasSidebar ? (
+                            <APIContext.Provider value={(this.api: any)}>
                                 <Sidebar
                                     file={((file: any): BoxItem)}
                                     view={view}

--- a/src/components/ContentTree/ContentTree.js
+++ b/src/components/ContentTree/ContentTree.js
@@ -303,7 +303,9 @@ class ContentTree extends Component<Props, State> {
         // Fetch the folder using folder API
         this.api
             .getFolderAPI()
-            .folder(folderId, SORT_NAME, SORT_ASC, this.fetchFolderSuccessCallback, this.errorCallback, forceFetch);
+            .getFolder(folderId, SORT_NAME, SORT_ASC, this.fetchFolderSuccessCallback, this.errorCallback, {
+                forceFetch
+            });
     };
 
     /**

--- a/src/util/Cache.js
+++ b/src/util/Cache.js
@@ -4,6 +4,8 @@
  * @author Box
  */
 
+import merge from 'lodash/merge';
+
 class Cache {
     /**
      * @property {*}
@@ -39,7 +41,7 @@ class Cache {
      */
     merge(key: string, value: any): void {
         if (this.has(key)) {
-            this.set(key, Object.assign({}, this.get(key), value));
+            this.set(key, merge({}, this.get(key), value));
         } else {
             throw new Error(`Key ${key} not in cache!`);
         }

--- a/src/util/__tests__/fields-test.js
+++ b/src/util/__tests__/fields-test.js
@@ -1,14 +1,24 @@
-import { getFieldsAsString, isValidBoxFile } from '../fields';
+import {
+    FOLDER_FIELDS_TO_FETCH,
+    PREVIEW_FIELDS_TO_FETCH,
+    SIDEBAR_FIELDS_TO_FETCH,
+    TASKS_FIELDS_TO_FETCH,
+    VERSIONS_FIELDS_TO_FETCH,
+    TASK_ASSIGNMENTS_FIELDS_TO_FETCH,
+    COMMENTS_FIELDS_TO_FETCH,
+    findMissingProperties,
+    fillMissingProperties
+} from '../fields';
 import {
     FIELD_ID,
     FIELD_NAME,
     FIELD_TYPE,
     FIELD_SIZE,
-    FIELD_RESTORED_FROM,
     FIELD_PARENT,
     FIELD_EXTENSION,
     FIELD_PERMISSIONS,
     FIELD_ITEM_COLLECTION,
+    FIELD_ITEM_EXPIRATION,
     FIELD_PATH_COLLECTION,
     FIELD_MODIFIED_AT,
     FIELD_CREATED_AT,
@@ -28,133 +38,155 @@ import {
     FIELD_IS_DOWNLOAD_AVAILABLE,
     FIELD_VERSION_NUMBER,
     FIELD_METADATA_SKILLS,
-    FIELD_ITEM_EXPIRATION,
-    FIELD_METADATA_CLASSIFICATION
+    FIELD_METADATA_CLASSIFICATION,
+    FIELD_TASK_ASSIGNMENT_COLLECTION,
+    FIELD_IS_COMPLETED,
+    FIELD_MESSAGE,
+    FIELD_TAGGED_MESSAGE,
+    FIELD_DUE_AT,
+    FIELD_TRASHED_AT,
+    FIELD_ASSIGNED_TO,
+    FIELD_RESOLUTION_STATE,
+    FIELD_RESTORED_FROM
 } from '../../constants';
 
-describe('util/fields/getFieldsAsString()', () => {
-    describe('getFieldsAsString()', () => {
-        test('should return default set of fields', () => {
-            expect(getFieldsAsString()).toBe(
-                [
-                    FIELD_ID,
-                    FIELD_NAME,
-                    FIELD_TYPE,
-                    FIELD_SIZE,
-                    FIELD_PARENT,
-                    FIELD_EXTENSION,
-                    FIELD_PERMISSIONS,
-                    FIELD_PATH_COLLECTION,
-                    FIELD_MODIFIED_AT,
-                    FIELD_CREATED_AT,
-                    FIELD_MODIFIED_BY,
-                    FIELD_SHARED_LINK,
-                    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
-                    FIELD_HAS_COLLABORATIONS,
-                    FIELD_IS_EXTERNALLY_OWNED,
-                    FIELD_ITEM_COLLECTION
-                ].join(',')
-            );
+describe('util/fields', () => {
+    test('should fetch correct folder fields', () => {
+        expect(FOLDER_FIELDS_TO_FETCH).toEqual([
+            FIELD_ID,
+            FIELD_NAME,
+            FIELD_TYPE,
+            FIELD_SIZE,
+            FIELD_PARENT,
+            FIELD_EXTENSION,
+            FIELD_PERMISSIONS,
+            FIELD_PATH_COLLECTION,
+            FIELD_MODIFIED_AT,
+            FIELD_CREATED_AT,
+            FIELD_MODIFIED_BY,
+            FIELD_SHARED_LINK,
+            FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
+            FIELD_HAS_COLLABORATIONS,
+            FIELD_IS_EXTERNALLY_OWNED,
+            FIELD_ITEM_COLLECTION
+        ]);
+    });
+
+    test('should fetch correct preview fields', () => {
+        expect(PREVIEW_FIELDS_TO_FETCH).toEqual([
+            FIELD_ID,
+            FIELD_PERMISSIONS,
+            FIELD_SHARED_LINK,
+            FIELD_SHA1,
+            FIELD_FILE_VERSION,
+            FIELD_NAME,
+            FIELD_SIZE,
+            FIELD_EXTENSION,
+            FIELD_REPRESENTATIONS,
+            FIELD_WATERMARK_INFO,
+            FIELD_AUTHENTICATED_DOWNLOAD_URL,
+            FIELD_IS_DOWNLOAD_AVAILABLE
+        ]);
+    });
+
+    test('should fetch correct sidebar fields', () => {
+        expect(SIDEBAR_FIELDS_TO_FETCH).toEqual([
+            FIELD_ID,
+            FIELD_NAME,
+            FIELD_SIZE,
+            FIELD_EXTENSION,
+            FIELD_FILE_VERSION,
+            FIELD_SHARED_LINK,
+            FIELD_PERMISSIONS,
+            FIELD_CREATED_AT,
+            FIELD_CREATED_BY,
+            FIELD_MODIFIED_AT,
+            FIELD_MODIFIED_BY,
+            FIELD_OWNED_BY,
+            FIELD_DESCRIPTION,
+            FIELD_METADATA_SKILLS,
+            FIELD_METADATA_CLASSIFICATION,
+            FIELD_ITEM_EXPIRATION,
+            FIELD_VERSION_NUMBER,
+            FIELD_IS_EXTERNALLY_OWNED,
+            FIELD_RESTORED_FROM
+        ]);
+    });
+
+    test('should fetch correct tasks fields', () => {
+        expect(TASKS_FIELDS_TO_FETCH).toEqual([
+            FIELD_TASK_ASSIGNMENT_COLLECTION,
+            FIELD_IS_COMPLETED,
+            FIELD_CREATED_AT,
+            FIELD_CREATED_BY,
+            FIELD_DUE_AT,
+            FIELD_MESSAGE
+        ]);
+    });
+
+    test('should fetch correct version fields', () => {
+        expect(VERSIONS_FIELDS_TO_FETCH).toEqual([
+            FIELD_TRASHED_AT,
+            FIELD_CREATED_AT,
+            FIELD_MODIFIED_AT,
+            FIELD_MODIFIED_BY,
+            FIELD_VERSION_NUMBER
+        ]);
+    });
+
+    test('should fetch correct task assignment fields', () => {
+        expect(TASK_ASSIGNMENTS_FIELDS_TO_FETCH).toEqual([FIELD_ASSIGNED_TO, FIELD_RESOLUTION_STATE, FIELD_MESSAGE]);
+    });
+
+    test('should fetch correct comments fields', () => {
+        expect(COMMENTS_FIELDS_TO_FETCH).toEqual([
+            FIELD_TAGGED_MESSAGE,
+            FIELD_MESSAGE,
+            FIELD_CREATED_AT,
+            FIELD_CREATED_BY,
+            FIELD_MODIFIED_AT,
+            FIELD_PERMISSIONS
+        ]);
+    });
+
+    describe('findMissingProperties()', () => {
+        test('should return passed in properties when object is null', () => {
+            const properties = ['foo', 'bar'];
+            expect(findMissingProperties(null, properties)).toBe(properties);
         });
-        test('should return default set + preview fields', () => {
-            expect(getFieldsAsString(true)).toBe(
-                [
-                    FIELD_ID,
-                    FIELD_NAME,
-                    FIELD_TYPE,
-                    FIELD_SIZE,
-                    FIELD_PARENT,
-                    FIELD_EXTENSION,
-                    FIELD_PERMISSIONS,
-                    FIELD_PATH_COLLECTION,
-                    FIELD_MODIFIED_AT,
-                    FIELD_CREATED_AT,
-                    FIELD_MODIFIED_BY,
-                    FIELD_SHARED_LINK,
-                    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
-                    FIELD_HAS_COLLABORATIONS,
-                    FIELD_IS_EXTERNALLY_OWNED,
-                    FIELD_ITEM_COLLECTION,
-                    FIELD_REPRESENTATIONS,
-                    FIELD_SHA1,
-                    FIELD_WATERMARK_INFO,
-                    FIELD_AUTHENTICATED_DOWNLOAD_URL,
-                    FIELD_FILE_VERSION,
-                    FIELD_IS_DOWNLOAD_AVAILABLE
-                ].join(',')
-            );
+        test('should return passed in properties when object is empty', () => {
+            const properties = ['foo', 'bar'];
+            expect(findMissingProperties({}, properties)).toBe(properties);
         });
-        test('should return default set + preview + sidebar fields', () => {
-            expect(getFieldsAsString(true, true)).toBe(
-                [
-                    FIELD_ID,
-                    FIELD_NAME,
-                    FIELD_TYPE,
-                    FIELD_SIZE,
-                    FIELD_PARENT,
-                    FIELD_EXTENSION,
-                    FIELD_PERMISSIONS,
-                    FIELD_PATH_COLLECTION,
-                    FIELD_MODIFIED_AT,
-                    FIELD_CREATED_AT,
-                    FIELD_MODIFIED_BY,
-                    FIELD_SHARED_LINK,
-                    FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS,
-                    FIELD_HAS_COLLABORATIONS,
-                    FIELD_IS_EXTERNALLY_OWNED,
-                    FIELD_ITEM_COLLECTION,
-                    FIELD_CREATED_BY,
-                    FIELD_OWNED_BY,
-                    FIELD_DESCRIPTION,
-                    FIELD_METADATA_SKILLS,
-                    FIELD_ITEM_EXPIRATION,
-                    FIELD_METADATA_CLASSIFICATION,
-                    FIELD_VERSION_NUMBER,
-                    FIELD_RESTORED_FROM,
-                    FIELD_REPRESENTATIONS,
-                    FIELD_SHA1,
-                    FIELD_WATERMARK_INFO,
-                    FIELD_AUTHENTICATED_DOWNLOAD_URL,
-                    FIELD_FILE_VERSION,
-                    FIELD_IS_DOWNLOAD_AVAILABLE
-                ].join(',')
-            );
+
+        test('should return passed in properties when object is invalid', () => {
+            const properties = ['foo', 'bar'];
+            expect(findMissingProperties('string', properties)).toBe(properties);
+        });
+
+        test('should return missing properties', () => {
+            const properties = ['foo', 'bar'];
+            expect(findMissingProperties({ foo: 1, baz: 2 }, properties)).toEqual(['bar']);
         });
     });
-    describe('isValidBoxFile()', () => {
-        test('should return false for incomplete file object', () => {
-            expect(isValidBoxFile()).toBeFalsy();
+
+    describe('fillMissingProperties()', () => {
+        test('should return passed in object when properties is null', () => {
+            const obj = { foo: 1 };
+            expect(fillMissingProperties(obj)).toBe(obj);
         });
-        test('should return true for complete file object', () => {
-            expect(
-                isValidBoxFile({
-                    type: 'file',
-                    id: '13',
-                    name: 'Box',
-                    size: 123,
-                    parent: {},
-                    extension: 'mp4',
-                    permissions: {},
-                    path_collection: {},
-                    modified_at: '2018-02-05T11:28:21-08:00',
-                    created_at: '2017-10-03T16:20:18-07:00',
-                    shared_link: null,
-                    allowed_shared_link_access_levels: null,
-                    has_collaborations: true,
-                    is_externally_owned: false,
-                    created_by: {},
-                    modified_by: {},
-                    owned_by: {},
-                    description: '',
-                    metadata: null,
-                    representations: {},
-                    sha1: '81a2233716220ed21707d9e158b69019739d1062',
-                    watermark_info: {},
-                    authenticated_download_url: '',
-                    file_version: {},
-                    is_download_available: true
-                })
-            ).toBeTruthy();
+        test('should return passed in object when properties is empty', () => {
+            const obj = { foo: 1 };
+            expect(fillMissingProperties(obj, [])).toBe(obj);
+        });
+
+        test('should return object with missing properties nulled', () => {
+            const obj = { foo: { bar: 1 } };
+            const properties = ['foo', 'bar', 'foo.baz.bum', 'bar.bum', 'foo.baz.bup', 'bar.bop.bip'];
+            expect(fillMissingProperties(obj, properties)).toEqual({
+                foo: { bar: 1, baz: { bum: null, bup: null } },
+                bar: { bum: null, bop: { bip: null } }
+            });
         });
     });
 });

--- a/src/wrappers/ContentExplorer.js
+++ b/src/wrappers/ContentExplorer.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import ES6Wrapper from './ES6Wrapper';
-import ContentExplorerComponent from '../components/ContentExplorer/ContentExplorer';
+import ContentExplorerReactComponent from '../components/ContentExplorer/ContentExplorer';
 
 class ContentExplorer extends ES6Wrapper {
     /**
@@ -100,7 +100,7 @@ class ContentExplorer extends ES6Wrapper {
     /** @inheritdoc */
     render() {
         render(
-            <ContentExplorerComponent
+            <ContentExplorerReactComponent
                 language={this.language}
                 messages={this.messages}
                 rootFolderId={this.id}

--- a/src/wrappers/ContentPicker.js
+++ b/src/wrappers/ContentPicker.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import ES6Wrapper from './ES6Wrapper';
 import ContentPickerPopup from '../components/ContentPicker/ContentPickerPopup';
-import ContentPickerComponent from '../components/ContentPicker/ContentPicker';
+import ContentPickerReactComponent from '../components/ContentPicker/ContentPicker';
 import { TYPE_FOLDER, TYPE_FILE, TYPE_WEBLINK, CLIENT_NAME_CONTENT_PICKER } from '../constants';
 
 class ContentPicker extends ES6Wrapper {
@@ -53,7 +53,7 @@ class ContentPicker extends ES6Wrapper {
     /** @inheritdoc */
     render() {
         const { modal, ...rest }: { modal?: ModalOptions } = this.options;
-        const PickerComponent = modal ? ContentPickerPopup : ContentPickerComponent;
+        const PickerComponent = modal ? ContentPickerPopup : ContentPickerReactComponent;
         render(
             <PickerComponent
                 language={this.language}

--- a/test/preview.html
+++ b/test/preview.html
@@ -19,7 +19,7 @@
         <link rel="stylesheet" type="text/css" href="../dev/en-US/explorer.css" />
         <script src="../dev/en-US/explorer.js"></script>
         <script>
-            var ACCESS_TOKEN = 'htXetWuPFla33pfZiEFr4WKaOPIjH4ye';
+            var ACCESS_TOKEN = '';
             var FOLDER_ID = '0';
 
             window.onload = function() {


### PR DESCRIPTION
Fetching file details are now isolated between explorer/picker, preview and sidebar.
The file API will fetch file fields that are missing from the cached file object.

eg:

If explorer wants { a, b } => it will request for a and b
If preview wants { a, b, c } => it will request for b and c using cache from explorer if available
If sidebar wants { b, c, d } => it will request for d using cache from preview if available


Also changes babelrc to have presets per environment so that we target latest chrome and firefox only for dev builds which makes testing easier. It will not need babel transform to use generators as such break points will work for debugging. Only will work in dev mode.

**TODO: Fix broken tests / add more tests**