### PR TITLE
Chore: removed display style from bcs-comment-mention

### DIFF
--- a/src/components/ContentSidebar/ActivityFeed/comment/Comment.scss
+++ b/src/components/ContentSidebar/ActivityFeed/comment/Comment.scss
@@ -95,7 +95,6 @@
             word-wrap: break-word;
 
             .bcs-comment-mention {
-                display: inline-block;
                 overflow: initial;
                 white-space: normal;
             }


### PR DESCRIPTION
Doesn't look like `display: inline-block` makes a difference in any browser. Images below are with it removed.

Chrome:
<img width="414" alt="screen shot 2018-08-14 at 10 41 37 am" src="https://user-images.githubusercontent.com/763560/44116185-141e86b8-9fcd-11e8-96e9-d38cf6152c2a.png">

IE 11:
<img width="414" alt="screen shot 2018-08-14 at 10 41 20 am" src="https://user-images.githubusercontent.com/763560/44116207-21f33b8a-9fcd-11e8-94d4-cc3a2166905f.png">

Safari:
<img width="416" alt="screen shot 2018-08-14 at 2 28 12 pm" src="https://user-images.githubusercontent.com/763560/44116666-64cd0eee-9fce-11e8-8fb6-7779a25e3923.png">

Firefox:
<img width="398" alt="screen shot 2018-08-14 at 2 31 31 pm" src="https://user-images.githubusercontent.com/763560/44116871-ee2274ea-9fce-11e8-9a50-3deada8424fd.png">

