### PR TITLE
Fix: Match font-weight of header titles in sidebar

### DIFF
--- a/src/components/ContentSidebar/SidebarContent.scss
+++ b/src/components/ContentSidebar/SidebarContent.scss
@@ -17,7 +17,7 @@
 
         .bcs-title {
             font-size: 16px;
-            font-weight: 200;
+            font-weight: 400;
             margin: 0;
             padding: 0;
         }


### PR DESCRIPTION
Now matching font-weight of sidebar header titles in Webapp