### PR TITLE
Update: Edit task message

### DIFF
--- a/flow/DraftJSFlowStub.js.flow
+++ b/flow/DraftJSFlowStub.js.flow
@@ -1,3 +1,4 @@
 // @flow
 declare export var EditorState: any
+declare export var ContentState: any
 declare export default {}

--- a/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.js
+++ b/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.js
@@ -6,7 +6,7 @@
 import * as React from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
-import { EditorState } from 'draft-js';
+import { ContentState, EditorState } from 'draft-js';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import Form from 'box-react-ui/lib/components/form-elements/form/Form';
@@ -61,7 +61,10 @@ class ApprovalCommentForm extends React.Component<Props, State> {
         approvalDate: null,
         approvers: [],
         approverSelectorError: '',
-        commentEditorState: EditorState.createEmpty(DraftMentionDecorator),
+        commentEditorState: EditorState.createWithContent(
+            ContentState.createFromText(this.props.tagged_message || ''),
+            DraftMentionDecorator
+        ),
         isAddApprovalVisible: false
     };
 
@@ -231,7 +234,7 @@ class ApprovalCommentForm extends React.Component<Props, State> {
                             onChange={this.onMentionSelectorChangeHandler}
                             onFocus={onFocus}
                             onMention={getMentionWithQuery}
-                            placeholder={tagged_message || formatMessage(messages.commentWrite)}
+                            placeholder={tagged_message ? null : formatMessage(messages.commentWrite)}
                             validateOnBlur={false}
                         />
                         <aside


### PR DESCRIPTION
If there currently exists a `tagged_message`, don't show the placeholder message in the `DraftJSMentionSelector`, but instead initialize the `EditorState` with the message instead of an empty state.