### PR TITLE
Chore: fix occurred typos in messages

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -97,7 +97,7 @@ be.editLabel = Edit
 # Shown as the title in the sub header while showing an error.
 be.errorBreadcrumb = Error
 # Title when an error occurs
-be.errorOccured = An error occured
+be.errorOccured = An error occurred
 # Label for error skill card in the preview sidebar
 be.errorSkill = Error
 # Message shown when there is an error.
@@ -239,7 +239,7 @@ be.sidebarDetailsTitle = Details
 # Label for the hide sidebar button.
 be.sidebarHide = Hide Sidebar
 # Generic error content for metadata editing.
-be.sidebarMetadataErrorContent = An error has occured while editing metadata. Please refresh the page and try again.
+be.sidebarMetadataErrorContent = An error has occurred while editing metadata. Please refresh the page and try again.
 # Generic error title for metadata editing.
 be.sidebarMetadataErrorTitle = Metadata Error
 # Title for the preview metadata.
@@ -249,7 +249,7 @@ be.sidebarProperties = File Properties
 # Label for the show sidebar button.
 be.sidebarShow = Show Sidebar
 # Generic error content for skills editing.
-be.sidebarSkillsErrorContent = An error has occured while updating skills. Please refresh the page and try again.
+be.sidebarSkillsErrorContent = An error has occurred while updating skills. Please refresh the page and try again.
 # Generic error title for skills editing.
 be.sidebarSkillsErrorTitle = Skills Error
 # Title for the preview details skills.
@@ -309,7 +309,7 @@ be.uploadEmptyWithFolderUploadDisabled = Drag and Drop Files
 # Message shown when there are no items to upload and folder upload is enabled
 be.uploadEmptyWithFolderUploadEnabled = Drag and Drop Files and Folders
 # Message shown when there is a network error when uploading
-be.uploadError = A network error has occured while trying to upload.
+be.uploadError = A network error has occurred while trying to upload.
 # Message shown when too many files are uploaded at once
 be.uploadErrorTooManyFiles = You can only upload up to {fileLimit} file(s) at a time.
 # Message shown when user drag and drops files onto uploads in progress

--- a/src/components/ContentSidebar/__tests__/__snapshots__/MetadataSidebar-test.js.snap
+++ b/src/components/ContentSidebar/__tests__/__snapshots__/MetadataSidebar-test.js.snap
@@ -68,7 +68,7 @@ exports[`components/ContentSidebar/Metadata/MetadataSidebar should render error 
     }
   >
     <FormattedMessage
-      defaultMessage="An error has occured while editing metadata. Please refresh the page and try again."
+      defaultMessage="An error has occurred while editing metadata. Please refresh the page and try again."
       id="be.sidebarMetadataErrorContent"
     />
   </InlineError>

--- a/src/components/ContentUploader/__tests__/__snapshots__/UploadState-test.js.snap
+++ b/src/components/ContentUploader/__tests__/__snapshots__/UploadState-test.js.snap
@@ -9,7 +9,7 @@ exports[`components/ContentUploader/UploadState should render VIEW_ERROR correct
     <UploadStateContent
       message={
         <FormattedMessage
-          defaultMessage="A network error has occured while trying to upload."
+          defaultMessage="A network error has occurred while trying to upload."
           id="be.uploadError"
         />
       }

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -356,8 +356,7 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     sidebarSkillsErrorContent: {
         id: 'be.sidebarSkillsErrorContent',
         description: 'Generic error content for skills editing.',
-        defaultMessage:
-            'An error has occured while updating skills. Please refresh the page and try again.',
+        defaultMessage: 'An error has occurred while updating skills. Please refresh the page and try again.'
     },
     sidebarActivityTitle: {
         id: 'be.sidebarActivityTitle',
@@ -377,8 +376,7 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     sidebarMetadataErrorContent: {
         id: 'be.sidebarMetadataErrorContent',
         description: 'Generic error content for metadata editing.',
-        defaultMessage:
-            'An error has occured while editing metadata. Please refresh the page and try again.',
+        defaultMessage: 'An error has occurred while editing metadata. Please refresh the page and try again.'
     },
     sidebarProperties: {
         id: 'be.sidebarProperties',
@@ -470,9 +468,8 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     },
     uploadError: {
         id: 'be.uploadError',
-        description:
-            'Message shown when there is a network error when uploading',
-        defaultMessage: 'A network error has occured while trying to upload.',
+        description: 'Message shown when there is a network error when uploading',
+        defaultMessage: 'A network error has occurred while trying to upload.'
     },
     uploadEmptyWithFolderUploadEnabled: {
         id: 'be.uploadEmptyWithFolderUploadEnabled',
@@ -721,8 +718,8 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     },
     errorOccured: {
         id: 'be.errorOccured',
-        defaultMessage: 'An error occured',
-        description: 'Title when an error occurs',
+        defaultMessage: 'An error occurred',
+        description: 'Title when an error occurs'
     },
     commentCancel: {
         id: 'be.commentCancel',

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -356,7 +356,8 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     sidebarSkillsErrorContent: {
         id: 'be.sidebarSkillsErrorContent',
         description: 'Generic error content for skills editing.',
-        defaultMessage: 'An error has occurred while updating skills. Please refresh the page and try again.'
+        defaultMessage:
+            'An error has occurred while updating skills. Please refresh the page and try again.',
     },
     sidebarActivityTitle: {
         id: 'be.sidebarActivityTitle',
@@ -376,7 +377,8 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     sidebarMetadataErrorContent: {
         id: 'be.sidebarMetadataErrorContent',
         description: 'Generic error content for metadata editing.',
-        defaultMessage: 'An error has occurred while editing metadata. Please refresh the page and try again.'
+        defaultMessage:
+            'An error has occurred while editing metadata. Please refresh the page and try again.',
     },
     sidebarProperties: {
         id: 'be.sidebarProperties',
@@ -468,8 +470,9 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     },
     uploadError: {
         id: 'be.uploadError',
-        description: 'Message shown when there is a network error when uploading',
-        defaultMessage: 'A network error has occurred while trying to upload.'
+        description:
+            'Message shown when there is a network error when uploading',
+        defaultMessage: 'A network error has occurred while trying to upload.',
     },
     uploadEmptyWithFolderUploadEnabled: {
         id: 'be.uploadEmptyWithFolderUploadEnabled',
@@ -719,7 +722,7 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     errorOccured: {
         id: 'be.errorOccured',
         defaultMessage: 'An error occurred',
-        description: 'Title when an error occurs'
+        description: 'Title when an error occurs',
     },
     commentCancel: {
         id: 'be.commentCancel',


### PR DESCRIPTION
What this PR does:

Changes a typo in the messages key from occured to => occurred