### PR TITLE
Fix: Fix sandboxed iframe case for GET integrations

### DIFF
--- a/src/components/ContentOpenWith/ContentOpenWith.js
+++ b/src/components/ContentOpenWith/ContentOpenWith.js
@@ -264,8 +264,8 @@ class ContentOpenWith extends PureComponent<Props, State> {
                     );
                     return;
                 } else {
-                    windowRef.opener = null;
                     windowRef.location = url;
+                    windowRef.opener = null;
                     this.onExecute();
                 }
                 // Prevents abuse of window.opener


### PR DESCRIPTION
Fixes the codepen case where we are operating in a sandboxed iframe. Setting the URL first allows the redirect to happen, although chrome still throws errors. 