### PR TITLE
Chore: add styleguide to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ flow-typed/**
 build/**
 i18n/**
 node_modules/**
+styleguide/**


### PR DESCRIPTION
Fixes eslint hanging when this folder is present