### PR TITLE
Fix: Update MultiputUpload successHandler to parse the response

### DIFF
--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -805,7 +805,12 @@ class MultiputUpload extends BaseMultiput {
             return;
         }
 
-        const { entries } = data;
+        let { entries } = data;
+        // v2.1 API response format is different from v2.0. v2.1 returns individual upload entry directly inside data,
+        // while v2.0 returns a collection of entries under data.entries
+        if (!entries && data.id) {
+            entries = [data];
+        }
 
         this.destroy();
 


### PR DESCRIPTION
If MultiputUpload is used as Upload Embed Widget, the format of the response data of xhr is different. Instead of having "entries" as an attribute in "data", "data" itself is entries[0].