### PR TITLE
Chore: Decrease parallelization in production job

### DIFF
--- a/build/prod.js
+++ b/build/prod.js
@@ -11,7 +11,7 @@ const bundleCount = locales.length * 2; // One with react, and one without
 let counter = 0;
 const workers = workerFarm(
     {
-        maxConcurrentWorkers: numCPUs - 2,
+        maxConcurrentWorkers: 3,
         maxRetries: 0
     },
     require.resolve('./build_locale.js')


### PR DESCRIPTION
Based on the conversation with @wenboyu2 this should prevent some of the memory related issues we are seeing on Jenkins.