### PR TITLE
Fix: PPT navigation in fullscreen

### DIFF
--- a/src/components/ContentPreview/ContentPreview.js
+++ b/src/components/ContentPreview/ContentPreview.js
@@ -229,6 +229,8 @@ class ContentPreview extends PureComponent<Props, State> {
         }
         // Don't destroy the cache while unmounting
         this.api.destroy(false);
+
+        document.removeEventListener('keydown', this.onKeyDown);
     }
 
     /**
@@ -263,6 +265,12 @@ class ContentPreview extends PureComponent<Props, State> {
 
         this.fetchFile(this.state.currentFileId);
         this.focusPreview();
+
+        // Workaround for COXP-5840. React synthetic events don't
+        // bubble up when a nested element is in fullscreen mode.
+        // However, native elements do. Can do it the React way
+        // when fix is available.
+        document.addEventListener('keydown', this.onKeyDown);
     }
 
     static getDerivedStateFromProps(props: Props, state: State) {
@@ -1000,7 +1008,7 @@ class ContentPreview extends PureComponent<Props, State> {
      *
      * @return {void}
      */
-    onKeyDown = (event: SyntheticKeyboardEvent<HTMLElement>) => {
+    onKeyDown = (event: KeyboardEvent) => {
         const { useHotkeys }: Props = this.props;
         if (!useHotkeys) {
             return;
@@ -1017,7 +1025,7 @@ class ContentPreview extends PureComponent<Props, State> {
         }
 
         if (typeof viewer.onKeydown === 'function') {
-            consumed = !!viewer.onKeydown(key, event.nativeEvent);
+            consumed = !!viewer.onKeydown(key, event);
         }
 
         if (!consumed) {
@@ -1103,8 +1111,6 @@ class ContentPreview extends PureComponent<Props, State> {
                     id={this.id}
                     className={`be bcpr ${className}`}
                     ref={measureRef}
-                    onKeyDown={this.onKeyDown}
-                    tabIndex={0}
                 >
                     {hasHeader && (
                         <Header

--- a/src/components/ContentPreview/ContentPreview.js
+++ b/src/components/ContentPreview/ContentPreview.js
@@ -1022,7 +1022,9 @@ class ContentPreview extends PureComponent<Props, State> {
      *
      * @return {void}
      */
-    onKeyDown = (event: KeyboardEvent) => {
+    onKeyDown = (
+        event: KeyboardEvent | SyntheticKeyboardEvent<HTMLElement>,
+    ) => {
         const { useHotkeys }: Props = this.props;
         if (!useHotkeys) {
             return;


### PR DESCRIPTION
React in Chrome appears to have an issue where if a nested element requests fullscreen, onKeyDown events do not bubble up to the rest of the component. However this works fine in Safari and Firefox.

In the meantime, working around this by adding an event listener to the document like what is done in box-content-preview.

Created an issue in React: https://github.com/facebook/react/issues/14077