### PR TITLE
Fix: removed padding top for metadata card container

### DIFF
--- a/src/components/ContentSidebar/SidebarContent.scss
+++ b/src/components/ContentSidebar/SidebarContent.scss
@@ -27,7 +27,6 @@
         bottom: 0;
         left: 0;
         overflow: auto;
-        padding-top: 15px;
         position: absolute; // Prevents non-sidebar parts from re-painting
         right: 0;
         top: 60px; // Same as title above


### PR DESCRIPTION
<img width="338" alt="screen shot 2018-11-05 at 10 11 26 am" src="https://user-images.githubusercontent.com/7213887/48018134-e8efe000-e0e4-11e8-8a74-19c22d2696b0.png">
