### PR TITLE
Fix: Metadata sidebar fixes

### DIFF
--- a/src/api/__tests__/Metadata-test.js
+++ b/src/api/__tests__/Metadata-test.js
@@ -1,6 +1,11 @@
 import Metadata from '../Metadata';
 import Cache from '../../util/Cache';
 import * as ErrorUtil from '../../util/error';
+import {
+    METADATA_TEMPLATE_CLASSIFICATION,
+    METADATA_SCOPE_GLOBAL,
+    METADATA_TEMPLATE_PROPERTIES,
+} from '../../constants';
 
 let metadata;
 
@@ -47,6 +52,17 @@ describe('api/Metadata', () => {
             expect(metadata.getMetadataTemplateUrl('scope')).toBe(
                 'https://api.box.com/2.0/metadata_templates/scope',
             );
+        });
+    });
+
+    describe('getCustomPropertiesTemplate()', () => {
+        test('should return correct properties template', () => {
+            expect(metadata.getCustomPropertiesTemplate()).toEqual({
+                id: expect.stringContaining('metadata_template_'),
+                scope: METADATA_SCOPE_GLOBAL,
+                templateKey: METADATA_TEMPLATE_PROPERTIES,
+                hidden: false,
+            });
         });
     });
 
@@ -101,7 +117,7 @@ describe('api/Metadata', () => {
     });
 
     describe('getTemplates()', () => {
-        test('should return unhidden templates', async () => {
+        test('should return unhidden templates that are not classification', async () => {
             metadata.getMetadataTemplateUrl = jest
                 .fn()
                 .mockReturnValueOnce('template_url');
@@ -112,6 +128,16 @@ describe('api/Metadata', () => {
                         { id: 2, hidden: true },
                         { id: 3, hidden: false },
                         { id: 4, hidden: false },
+                        {
+                            id: 5,
+                            hidden: true,
+                            templateKey: METADATA_TEMPLATE_CLASSIFICATION,
+                        },
+                        {
+                            id: 6,
+                            hidden: false,
+                            templateKey: METADATA_TEMPLATE_CLASSIFICATION,
+                        },
                     ],
                 },
             });

--- a/src/components/ContentSidebar/ContentSidebar.js
+++ b/src/components/ContentSidebar/ContentSidebar.js
@@ -63,6 +63,7 @@ type Props = {
 
 type State = {
     view?: SidebarView,
+    editors?: Array<MetadataEditor>,
     file?: BoxItem,
     isVisible?: boolean,
     hasBeenToggled?: boolean,
@@ -172,7 +173,7 @@ class ContentSidebar extends PureComponent<Props, State> {
      */
     componentWillReceiveProps(nextProps: Props): void {
         const { fileId, isLarge }: Props = this.props;
-        const { file, hasBeenToggled }: State = this.state;
+        const { file, editors, hasBeenToggled }: State = this.state;
         const hasVisibilityChanged = nextProps.isLarge !== isLarge;
         const hasFileIdChanged = nextProps.fileId !== fileId;
 
@@ -182,7 +183,7 @@ class ContentSidebar extends PureComponent<Props, State> {
             this.fetchData(nextProps);
         } else if (!hasBeenToggled && hasVisibilityChanged) {
             this.setState({
-                view: this.getDefaultSidebarView(file, nextProps),
+                view: this.getDefaultSidebarView(nextProps, file, editors),
             });
         }
     }
@@ -239,7 +240,11 @@ class ContentSidebar extends PureComponent<Props, State> {
      * @param {Object} file - Box file
      * @return {string} Sidebar view to use
      */
-    getDefaultSidebarView(file?: BoxItem, props: Props): SidebarView {
+    getDefaultSidebarView(
+        props: Props,
+        file?: BoxItem,
+        editors?: Array<MetadataEditor>,
+    ): SidebarView {
         const { view, hasBeenToggled }: State = this.state;
         const { isLarge, defaultView }: Props = props;
 
@@ -270,8 +275,9 @@ class ContentSidebar extends PureComponent<Props, State> {
         const canDefaultToActivity = SidebarUtils.canHaveActivitySidebar(
             this.props,
         );
-        const canDefaultToMetadata = SidebarUtils.canHaveMetadataSidebar(
+        const canDefaultToMetadata = SidebarUtils.shouldRenderMetadataSidebar(
             this.props,
+            editors,
         );
 
         // Calculate the default view with latest props
@@ -308,15 +314,54 @@ class ContentSidebar extends PureComponent<Props, State> {
      * @param {Object} file - Box file
      * @return {void}
      */
-    fetchFileSuccessCallback = (file: BoxItem): void => {
-        if (SidebarUtils.shouldRenderSidebar(this.props, file)) {
-            this.setState({
+    fetchMetadataSuccessCallback = (
+        file: BoxItem,
+        editors?: Array<MetadataEditor>,
+    ): void => {
+        let newState = { isVisible: false };
+        if (SidebarUtils.shouldRenderSidebar(this.props, file, editors)) {
+            newState = {
                 file,
+                editors,
                 isVisible: true,
-                view: this.getDefaultSidebarView(file, this.props),
-            });
+                view: this.getDefaultSidebarView(this.props, file, editors),
+            };
+        }
+        this.setState(newState);
+    };
+
+    /**
+     * File fetch success callback that sets the file and view
+     * Only set file if there is data to show in the sidebar.
+     * Skills sidebar doesn't show when there is no data.
+     *
+     * @private
+     * @param {Object} file - Box file
+     * @return {void}
+     */
+    fetchFileSuccessCallback = (file: BoxItem): void => {
+        const { metadataSidebarProps }: Props = this.props;
+        const {
+            getMetadata,
+            isFeatureEnabled = true,
+        }: MetadataSidebarProps = metadataSidebarProps;
+        const canHaveMetadataSidebar =
+            !isFeatureEnabled &&
+            SidebarUtils.canHaveMetadataSidebar(this.props);
+
+        if (canHaveMetadataSidebar) {
+            this.api
+                .getMetadataAPI(true)
+                .getEditors(
+                    file,
+                    ({ editors }: { editors?: Array<MetadataEditor> }) =>
+                        this.fetchMetadataSuccessCallback(file, editors),
+                    () => this.fetchMetadataSuccessCallback(file),
+                    getMetadata,
+                    isFeatureEnabled,
+                );
         } else {
-            this.setState({ isVisible: false });
+            this.fetchMetadataSuccessCallback(file);
         }
     };
 
@@ -364,7 +409,7 @@ class ContentSidebar extends PureComponent<Props, State> {
             metadataSidebarProps,
             onVersionHistoryClick,
         }: Props = this.props;
-        const { file, view, isVisible }: State = this.state;
+        const { editors, file, view, isVisible }: State = this.state;
 
         // By default sidebar is always visible if there is something configured
         // to show via props. At least one of the sidebars is needed for visibility.
@@ -390,8 +435,15 @@ class ContentSidebar extends PureComponent<Props, State> {
             file,
         );
         const hasDetails = SidebarUtils.canHaveDetailsSidebar(this.props);
-        const hasMetadata = SidebarUtils.canHaveMetadataSidebar(this.props);
-        const hasSidebar = SidebarUtils.shouldRenderSidebar(this.props, file);
+        const hasMetadata = SidebarUtils.shouldRenderMetadataSidebar(
+            this.props,
+            editors,
+        );
+        const hasSidebar = SidebarUtils.shouldRenderSidebar(
+            this.props,
+            file,
+            editors,
+        );
 
         return (
             <Internationalize language={language} messages={messages}>

--- a/src/components/ContentSidebar/MetadataSidebar.js
+++ b/src/components/ContentSidebar/MetadataSidebar.js
@@ -20,6 +20,7 @@ import API from '../../api';
 import './MetadataSidebar.scss';
 
 type ExternalProps = {
+    isFeatureEnabled?: boolean,
     getMetadata?: Function,
 };
 
@@ -63,7 +64,13 @@ class MetadataSidebar extends React.PureComponent<Props, State> {
      * @return {void}
      */
     getMetadataEditors = (): void => {
-        const { api, file, getMetadata }: Props = this.props;
+        const {
+            api,
+            file,
+            getMetadata,
+            isFeatureEnabled = true,
+        }: Props = this.props;
+
         api.getMetadataAPI(true).getEditors(
             file,
             ({
@@ -82,6 +89,7 @@ class MetadataSidebar extends React.PureComponent<Props, State> {
             },
             this.errorCallback,
             getMetadata,
+            isFeatureEnabled,
         );
     };
 

--- a/src/components/ContentSidebar/Sidebar.js
+++ b/src/components/ContentSidebar/Sidebar.js
@@ -96,6 +96,7 @@ const Sidebar = ({
         {view === SIDEBAR_VIEW_METADATA &&
             hasMetadata && (
                 <MetadataSidebar
+                    currentUser={currentUser}
                     key={file.id}
                     file={file}
                     {...metadataSidebarProps}

--- a/src/components/ContentSidebar/SidebarUtils.js
+++ b/src/components/ContentSidebar/SidebarUtils.js
@@ -5,6 +5,7 @@
  */
 
 import { hasSkills as hasSkillsData } from './Skills/skillUtils';
+import type { MetadataSidebarProps } from './MetadataSidebar';
 
 class SidebarUtils {
     /**
@@ -95,7 +96,36 @@ class SidebarUtils {
         props: ContentSidebarProps,
         file?: BoxItem,
     ): boolean {
-        return !!file && !!props.hasSkills && hasSkillsData(file);
+        return (
+            !!file &&
+            SidebarUtils.canHaveSkillsSidebar(props) &&
+            hasSkillsData(file)
+        );
+    }
+
+    /**
+     * Determines if we should bother rendering the metadata sidebar.
+     * Relies on props and metadata data and feature enabled or not.
+     *
+     * @private
+     * @param {ContentSidebarProps} props - User passed in props
+     * @param {Array<MetadataEditor>} editors - metadata editors
+     * @param {Boolean} isMetadataEnabled - metadata feature
+     * @return {Boolean} true if we should render
+     */
+    static shouldRenderMetadataSidebar(
+        props: ContentSidebarProps,
+        editors?: Array<MetadataEditor>,
+    ): boolean {
+        const { metadataSidebarProps = {} }: ContentSidebarProps = props;
+        const {
+            isFeatureEnabled = true,
+        }: MetadataSidebarProps = metadataSidebarProps;
+
+        return (
+            SidebarUtils.canHaveMetadataSidebar(props) &&
+            (isFeatureEnabled || (Array.isArray(editors) && editors.length > 0))
+        );
     }
 
     /**
@@ -109,13 +139,14 @@ class SidebarUtils {
     static shouldRenderSidebar(
         props: ContentSidebarProps,
         file?: BoxItem,
+        editors?: Array<MetadataEditor>,
     ): boolean {
         return (
             !!file &&
             (SidebarUtils.canHaveDetailsSidebar(props) ||
                 SidebarUtils.shouldRenderSkillsSidebar(props, file) ||
                 SidebarUtils.canHaveActivitySidebar(props) ||
-                SidebarUtils.canHaveMetadataSidebar(props))
+                SidebarUtils.shouldRenderMetadataSidebar(props, editors))
         );
     }
 }

--- a/src/components/ContentSidebar/__tests__/ContentSidebar-test.js
+++ b/src/components/ContentSidebar/__tests__/ContentSidebar-test.js
@@ -11,6 +11,8 @@ const file = {
     id: 'I_AM_A_FILE',
 };
 
+const editors = ['foo'];
+
 describe('components/ContentSidebar/ContentSidebar', () => {
     let rootElement;
     const getWrapper = props =>
@@ -57,8 +59,9 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             instance.componentWillReceiveProps(newProps);
 
             expect(instance.getDefaultSidebarView).toBeCalledWith(
-                file,
                 newProps,
+                file,
+                undefined,
             );
             expect(instance.setState).toBeCalledWith({ view: 'view' });
         });
@@ -128,14 +131,16 @@ describe('components/ContentSidebar/ContentSidebar', () => {
         test('should return undefined when no file', () => {
             const wrapper = getWrapper();
             const instance = wrapper.instance();
-            expect(instance.getDefaultSidebarView(null, {})).toBeUndefined();
+            expect(
+                instance.getDefaultSidebarView({}, null, null),
+            ).toBeUndefined();
         });
 
         test('should return default view when provided', () => {
             const wrapper = getWrapper();
             const instance = wrapper.instance();
             expect(
-                instance.getDefaultSidebarView({}, { defaultView: 'default' }),
+                instance.getDefaultSidebarView({ defaultView: 'default' }, {}),
             ).toBe('default');
         });
 
@@ -146,7 +151,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
                 .fn()
                 .mockReturnValueOnce(true);
             expect(
-                instance.getDefaultSidebarView({}, { isLarge: false }),
+                instance.getDefaultSidebarView({ isLarge: false }, {}),
             ).toBeUndefined();
         });
 
@@ -156,7 +161,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveDetailsSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            expect(instance.getDefaultSidebarView({}, { isLarge: true })).toBe(
+            expect(instance.getDefaultSidebarView({ isLarge: true }, {})).toBe(
                 'details',
             );
         });
@@ -176,12 +181,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('skills');
         });
 
@@ -200,12 +205,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('activity');
         });
 
@@ -224,12 +229,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('details');
         });
 
@@ -248,12 +253,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('metadata');
         });
 
@@ -270,12 +275,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('skills');
         });
 
@@ -292,12 +297,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('activity');
         });
 
@@ -314,12 +319,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('details');
         });
 
@@ -336,12 +341,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('metadata');
         });
 
@@ -365,7 +370,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('activity');
         });
 
@@ -384,12 +389,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('details');
         });
 
@@ -408,12 +413,12 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
 
             expect(
-                instance.getDefaultSidebarView(file, { isLarge: true }),
+                instance.getDefaultSidebarView({ isLarge: true }, file),
             ).toBe('skills');
         });
     });
@@ -478,7 +483,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
         });
     });
 
-    describe('fetchFileSuccessCallback()', () => {
+    describe('fetchMetadataSuccessCallback()', () => {
         let setState;
         let getDefaultSidebarView;
         let wrapper;
@@ -499,34 +504,130 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.shouldRenderSidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
-            instance.fetchFileSuccessCallback(file);
+            instance.fetchMetadataSuccessCallback(file);
 
             expect(getDefaultSidebarView).not.toBeCalled();
             expect(SidebarUtils.shouldRenderSidebar).toBeCalledWith(
                 instance.props,
                 file,
+                undefined,
             );
             expect(setState).toBeCalledWith({
                 isVisible: false,
             });
         });
 
-        test('should set the file state to be the file response', () => {
+        test('should set the file and metadata state from responses', () => {
             SidebarUtils.shouldRenderSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            instance.fetchFileSuccessCallback(file);
+            instance.fetchMetadataSuccessCallback(file, editors);
 
-            expect(getDefaultSidebarView).toBeCalledWith(file, instance.props);
+            expect(getDefaultSidebarView).toBeCalledWith(
+                instance.props,
+                file,
+                editors,
+            );
             expect(SidebarUtils.shouldRenderSidebar).toBeCalledWith(
                 instance.props,
                 file,
+                editors,
             );
             expect(setState).toBeCalledWith({
                 file,
+                editors,
                 view: 'view',
                 isVisible: true,
             });
+        });
+    });
+
+    describe('fetchFileSuccessCallback()', () => {
+        let setState;
+        let getDefaultSidebarView;
+        let wrapper;
+        let instance;
+        const getMetadata = jest.fn();
+
+        beforeEach(() => {
+            setState = jest.fn();
+            getDefaultSidebarView = jest.fn().mockReturnValueOnce('view');
+            wrapper = getWrapper({
+                file,
+                metadataSidebarProps: {
+                    getMetadata,
+                    isFeatureEnabled: false,
+                },
+            });
+            instance = wrapper.instance();
+            instance.getDefaultSidebarView = getDefaultSidebarView;
+            instance.setState = setState;
+        });
+
+        test('should just call metadata success callback when metadata feature is enabled', () => {
+            wrapper = getWrapper({
+                file,
+                metadataSidebarProps: {
+                    getMetadata,
+                    isFeatureEnabled: true,
+                },
+            });
+            instance = wrapper.instance();
+            instance.getDefaultSidebarView = getDefaultSidebarView;
+            instance.setState = setState;
+
+            SidebarUtils.canHaveMetadataSidebar = jest
+                .fn()
+                .mockReturnValueOnce(true);
+            instance.fetchMetadataSuccessCallback = jest.fn();
+            instance.fetchFileSuccessCallback(file);
+
+            expect(getDefaultSidebarView).not.toBeCalled();
+            expect(SidebarUtils.canHaveMetadataSidebar).not.toBeCalled();
+            expect(instance.fetchMetadataSuccessCallback).toBeCalledWith(file);
+        });
+
+        test('should call metadata success callback when no metadata sidebar', () => {
+            SidebarUtils.canHaveMetadataSidebar = jest
+                .fn()
+                .mockReturnValueOnce(false);
+            instance.fetchMetadataSuccessCallback = jest.fn();
+            instance.fetchFileSuccessCallback(file);
+
+            expect(getDefaultSidebarView).not.toBeCalled();
+            expect(SidebarUtils.canHaveMetadataSidebar).toBeCalledWith(
+                instance.props,
+            );
+            expect(instance.fetchMetadataSuccessCallback).toBeCalledWith(file);
+        });
+
+        test('should call the fetch metadata when metadata sidebar is allowed', () => {
+            const getEditors = jest.fn();
+            const getMetadataAPI = jest.fn().mockReturnValueOnce({
+                getEditors,
+            });
+
+            SidebarUtils.canHaveMetadataSidebar = jest
+                .fn()
+                .mockReturnValueOnce(true);
+
+            instance.api = {
+                getMetadataAPI,
+            };
+
+            instance.fetchFileSuccessCallback(file);
+
+            expect(getEditors).toBeCalledWith(
+                file,
+                expect.any(Function),
+                expect.any(Function),
+                getMetadata,
+                false,
+            );
+            expect(SidebarUtils.canHaveMetadataSidebar).toBeCalledWith(
+                instance.props,
+            );
+            expect(getMetadataAPI).toBeCalledWith(true);
         });
     });
 });

--- a/src/components/ContentSidebar/__tests__/SidebarUtils-test.js
+++ b/src/components/ContentSidebar/__tests__/SidebarUtils-test.js
@@ -162,6 +162,75 @@ describe('components/ContentSidebar/SidebarUtil', () => {
             ).toBeTruthy();
         });
     });
+    describe('shouldRenderMetadataSidebar()', () => {
+        test('should return false when nothing is wanted in the metadata sidebar', () => {
+            expect(SidebarUtils.shouldRenderMetadataSidebar({})).toBeFalsy();
+        });
+        test('should return false when nothing is wanted in the metadata sidebar', () => {
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar({
+                    hasMetadata: false,
+                }),
+            ).toBeFalsy();
+        });
+        test('should return true by default when we dont know availability of metadata feature', () => {
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar({ hasMetadata: true }),
+            ).toBeTruthy();
+        });
+        test('should return false when hasMetadata is false', () => {
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar(
+                    { hasMetadata: false },
+                    ['foo'],
+                ),
+            ).toBeFalsy();
+        });
+        test('should return false when hasMetadata is false', () => {
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar(
+                    {
+                        hasMetadata: false,
+                        metadataSidebarProps: { isFeatureEnabled: true },
+                    },
+                    ['foo'],
+                ),
+            ).toBeFalsy();
+        });
+        test('should return false when no metadata and no feature', () => {
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar(
+                    {
+                        hasMetadata: true,
+                        metadataSidebarProps: { isFeatureEnabled: false },
+                    },
+                    [],
+                ),
+            ).toBeFalsy();
+        });
+        test('should return true when no metadata and feature enabled', () => {
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar(
+                    {
+                        hasMetadata: true,
+                        metadataSidebarProps: { isFeatureEnabled: true },
+                    },
+                    [],
+                ),
+            ).toBeTruthy();
+        });
+        test('should return true when metadata and feature is not enabled', () => {
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar(
+                    {
+                        hasMetadata: true,
+                        metadataSidebarProps: { isFeatureEnabled: false },
+                    },
+                    ['foo'],
+                ),
+            ).toBeTruthy();
+        });
+    });
     describe('shouldRenderSidebar()', () => {
         test('should return false when nothing is wanted in the sidebar', () => {
             expect(SidebarUtils.shouldRenderSidebar({})).toBeFalsy();
@@ -181,7 +250,7 @@ describe('components/ContentSidebar/SidebarUtil', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
             expect(
@@ -201,15 +270,15 @@ describe('components/ContentSidebar/SidebarUtil', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
             expect(
-                SidebarUtils.shouldRenderSidebar('props', 'file'),
+                SidebarUtils.shouldRenderSidebar('props', 'file', 'editors'),
             ).toBeTruthy();
-            expect(SidebarUtils.canHaveMetadataSidebar).toHaveBeenCalledWith(
-                'props',
-            );
+            expect(
+                SidebarUtils.shouldRenderMetadataSidebar,
+            ).toHaveBeenCalledWith('props', 'editors');
         });
         test('should return true when we can render activity sidebar', () => {
             SidebarUtils.canHaveDetailsSidebar = jest
@@ -221,7 +290,7 @@ describe('components/ContentSidebar/SidebarUtil', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(true);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
             expect(
@@ -241,7 +310,7 @@ describe('components/ContentSidebar/SidebarUtil', () => {
             SidebarUtils.canHaveActivitySidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
-            SidebarUtils.canHaveMetadataSidebar = jest
+            SidebarUtils.shouldRenderMetadataSidebar = jest
                 .fn()
                 .mockReturnValueOnce(false);
             expect(


### PR DESCRIPTION
- Remove classification and non-properties global templates from being able to be added via drop down
- Don't show sidebar if feature is disabled and no metadata to show
- Show sidebar even when feature is disabled but there is metadata to show