### PR TITLE
fix: Properly handle folder uploads with invalid names

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -364,8 +364,12 @@ be.uploadsManagerUploadFailed = Some Uploads Failed
 be.uploadsManagerUploadInProgress = Uploading
 # Text shown to guide the user to drag drop file to upload
 be.uploadsManagerUploadPrompt = Drop files on this page to upload them into this folder.
+# Error message shown when one or more child folders failed to upload
+be.uploadsOneOrMoreChildFoldersFailedToUploadMessage = One or more child folders failed to upload.
 # Error message shown when pending app folder size exceeds the limit
 be.uploadsPendingFolderSizeLimitErrorMessage = Pending app folder size limit exceeded
+# Error message shown when pending folder upload contains invalid characters
+be.uploadsProvidedFolderNameInvalidMessage = Provided folder name, {name}, could not be used to create a folder.
 # Retry upload button tooltip
 be.uploadsRetryButtonTooltip = Retry upload
 # Error message shown when account storage limit has been reached

--- a/src/api/uploads/FolderUpload.js
+++ b/src/api/uploads/FolderUpload.js
@@ -158,12 +158,14 @@ class FolderUpload {
         successCallback: Function,
     }): Promise<any> {
         await this.folder.upload(this.destinationFolderId, errorCallback, true);
-        // Simulate BoxItem
-        successCallback([
-            {
-                id: this.folder.folderId,
-            },
-        ]);
+        // If the folder upload failed then a folderID will not be set
+        if (this.folder.folderId) {
+            successCallback([
+                {
+                    id: this.folder.folderId,
+                },
+            ]);
+        }
     }
 
     /**

--- a/src/api/uploads/__tests__/FolderUploadNode-test.js
+++ b/src/api/uploads/__tests__/FolderUploadNode-test.js
@@ -36,6 +36,7 @@ describe('api/uploads/FolderUploadNode', () => {
             folderUploadNodeInstance.addFilesToUploadQueue = jest.fn();
             folderUploadNodeInstance.uploadChildFolders = jest.fn();
             folderUploadNodeInstance.getFormattedFiles = jest.fn(() => files);
+            folderUploadNodeInstance.getFolderId = jest.fn(() => 123);
 
             await folderUploadNodeInstance.upload(parentFolderId, errorCallback, isRoot);
 

--- a/src/components/ContentUploader/progressCellRenderer.js
+++ b/src/components/ContentUploader/progressCellRenderer.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import ItemProgress from './ItemProgress';
-import { STATUS_ERROR, STATUS_IN_PROGRESS } from '../../constants';
+import { STATUS_ERROR, STATUS_IN_PROGRESS, ERROR_CODE_CHILD_FOLDER_FAILED_UPLOAD } from '../../constants';
 
 import messages from '../messages';
 
@@ -18,12 +18,19 @@ type Props = {
  * Get error message for a specific error code
  *
  * @param {string} [errorCode]
+ * @param {string} [itemName]
  * @returns {FormattedMessage}
  */
-const getErrorMessage = (errorCode: ?string) => {
+const getErrorMessage = (errorCode: ?string, itemName: ?string) => {
     switch (errorCode) {
+        case ERROR_CODE_CHILD_FOLDER_FAILED_UPLOAD:
+            return <FormattedMessage {...messages.uploadsOneOrMoreChildFoldersFailedToUploadMessage} />;
         case 'file_size_limit_exceeded':
             return <FormattedMessage {...messages.uploadsFileSizeLimitExceededErrorMessage} />;
+        case 'item_name_invalid':
+            return (
+                <FormattedMessage {...messages.uploadsProvidedFolderNameInvalidMessage} values={{ name: itemName }} />
+            );
         case 'storage_limit_exceeded':
             return <FormattedMessage {...messages.uploadsStorageLimitErrorMessage} />;
         case 'pending_app_folder_size_limit':
@@ -34,7 +41,7 @@ const getErrorMessage = (errorCode: ?string) => {
 };
 
 export default () => ({ rowData }: Props) => {
-    const { status, error = {}, isFolder } = rowData;
+    const { status, error = {}, name, isFolder } = rowData;
     const { code } = error;
 
     if (isFolder && status !== STATUS_ERROR) {
@@ -45,7 +52,7 @@ export default () => ({ rowData }: Props) => {
         case STATUS_IN_PROGRESS:
             return <ItemProgress {...rowData} />;
         case STATUS_ERROR:
-            return getErrorMessage(code);
+            return getErrorMessage(code, name);
         default:
             return null;
     }

--- a/src/components/messages.js
+++ b/src/components/messages.js
@@ -637,6 +637,16 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
         description: 'Error message shown when pending app folder size exceeds the limit',
         defaultMessage: 'Pending app folder size limit exceeded',
     },
+    uploadsProvidedFolderNameInvalidMessage: {
+        id: 'be.uploadsProvidedFolderNameInvalidMessage',
+        description: 'Error message shown when pending folder upload contains invalid characters',
+        defaultMessage: 'Provided folder name, {name}, could not be used to create a folder.',
+    },
+    uploadsOneOrMoreChildFoldersFailedToUploadMessage: {
+        id: 'be.uploadsOneOrMoreChildFoldersFailedToUploadMessage',
+        description: 'Error message shown when one or more child folders failed to upload',
+        defaultMessage: 'One or more child folders failed to upload.',
+    },
     uploadsDefaultErrorMessage: {
         id: 'be.uploadsDefaultErrorMessage',
         description: 'Default error message shown when upload fails',

--- a/src/constants.js
+++ b/src/constants.js
@@ -179,6 +179,7 @@ export const ERROR_CODE_ITEM_NAME_INVALID = 'item_name_invalid';
 export const ERROR_CODE_ITEM_NAME_TOO_LONG = 'item_name_too_long';
 export const ERROR_CODE_ITEM_NAME_IN_USE = 'item_name_in_use';
 export const ERROR_CODE_UPLOAD_FILE_LIMIT = 'upload_file_limit';
+export const ERROR_CODE_CHILD_FOLDER_FAILED_UPLOAD = 'child_folder_failed_upload';
 export const ERROR_CODE_FETCH_FILE = 'fetch_file_error';
 export const ERROR_CODE_FETCH_COMMENTS = 'fetch_comments_error';
 export const ERROR_CODE_FETCH_VERSIONS = 'fetch_versions_error';


### PR DESCRIPTION
Folders uploaded via ContentUploader with invalid names were not properly being handled. The creation of the folder would fail and any items contained within it would be added to the parent.

This PR adds messaging to the user when failures occur (either at the root folder level or in child folders). Additionally, it does not process child items for folders that fail to be created.