### PR TITLE
fix(sidebar): Ext-collabs see incorrect editors for some metadata fields

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -549,11 +549,16 @@ class Metadata extends File {
             return null;
         }
 
-        legacyInstance.fields.forEach(({ key, type, displayName, options, description }) => {
+        legacyInstance.fields.forEach(({ key, type, displayName, options, description, editor }) => {
             let v2Type = type;
             if (type === 'array') {
                 v2Type = 'multiSelect';
+            } else if (editor === 'calendar') {
+                v2Type = 'date';
+            } else if (editor === 'dropdown') {
+                v2Type = 'enum';
             }
+
             fields.push({
                 id: uniqueId('metadata_field_'),
                 type: v2Type,


### PR DESCRIPTION
Date and single-select fields would incorrectly display as text inputs when non-enterprise users were invited to collaborate on an item with an enterprise metadata template.