### PR TITLE
fix(uploader): autoexpand when uploading more than 5 files

### DIFF
--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -84,7 +84,6 @@ type Props = {
 type State = {
     errorCode?: string,
     isUploadsManagerExpanded: boolean,
-    isAutoExpanded: boolean,
     itemIds: Object,
     items: UploadItem[],
     view: View,
@@ -110,6 +109,8 @@ class ContentUploader extends Component<Props, State> {
     resetItemsTimeout: TimeoutID;
 
     numItemsUploading: number = 0;
+
+    isAutoExpanded: boolean = false;
 
     static defaultProps = {
         rootFolderId: DEFAULT_ROOT,
@@ -148,7 +149,6 @@ class ContentUploader extends Component<Props, State> {
             errorCode: '',
             itemIds: {},
             isUploadsManagerExpanded: false,
-            isAutoExpanded: false,
         };
         this.id = uniqueid('bcu_');
     }
@@ -564,9 +564,7 @@ class ContentUploader extends Component<Props, State> {
                 useUploadsManager &&
                 !isUploadsManagerExpanded
             ) {
-                this.setState({
-                    isAutoExpanded: true,
-                });
+                this.isAutoExpanded = true;
                 this.expandUploadsManager();
             }
         }
@@ -762,9 +760,9 @@ class ContentUploader extends Component<Props, State> {
     };
 
     resetUploadManagerExpandState = () => {
+        this.isAutoExpanded = false;
         this.setState({
             isUploadsManagerExpanded: false,
-            isAutoExpanded: false,
         });
     };
 
@@ -805,7 +803,7 @@ class ContentUploader extends Component<Props, State> {
         }
 
         if (noFileIsPendingOrInProgress && useUploadsManager) {
-            if (this.state.isAutoExpanded) {
+            if (this.isAutoExpanded) {
                 this.resetUploadManagerExpandState();
             } // Else manually expanded so don't close
             onComplete(items);
@@ -862,9 +860,7 @@ class ContentUploader extends Component<Props, State> {
         this.updateViewAndCollection(items);
 
         if (useUploadsManager) {
-            this.setState({
-                isAutoExpanded: true,
-            });
+            this.isAutoExpanded = true;
             this.expandUploadsManager();
         }
 

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -84,6 +84,7 @@ type Props = {
 type State = {
     errorCode?: string,
     isUploadsManagerExpanded: boolean,
+    isAutoExpanded: boolean,
     itemIds: Object,
     items: UploadItem[],
     view: View,
@@ -147,6 +148,7 @@ class ContentUploader extends Component<Props, State> {
             errorCode: '',
             itemIds: {},
             isUploadsManagerExpanded: false,
+            isAutoExpanded: false,
         };
         this.id = uniqueid('bcu_');
     }
@@ -561,6 +563,9 @@ class ContentUploader extends Component<Props, State> {
                 totalNumOfItems >= EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD &&
                 useUploadsManager
             ) {
+                this.setState({
+                    isAutoExpanded: true,
+                });
                 this.expandUploadsManager();
             }
         }
@@ -755,6 +760,13 @@ class ContentUploader extends Component<Props, State> {
         this.upload();
     };
 
+    resetUploadManagerExpandState = () => {
+        this.setState({
+            isUploadsManagerExpanded: false,
+            isAutoExpanded: false,
+        });
+    };
+
     /**
      * Updates view and internal upload collection with provided items.
      *
@@ -792,13 +804,15 @@ class ContentUploader extends Component<Props, State> {
         }
 
         if (noFileIsPendingOrInProgress && useUploadsManager) {
+            if (this.state.isAutoExpanded) {
+                this.resetUploadManagerExpandState();
+            } // Else manually expanded so don't close
             onComplete(items);
         }
 
         const state: Object = {
             items,
             view,
-            isUploadsManagerExpanded: this.state.isUploadsManagerExpanded,
         };
 
         if (itemIds) {
@@ -931,8 +945,7 @@ class ContentUploader extends Component<Props, State> {
         clearTimeout(this.resetItemsTimeout);
 
         onMinimize();
-        this.setState({ isUploadsManagerExpanded: false });
-
+        this.resetUploadManagerExpandState();
         this.hideUploadsManager();
     };
 

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -541,7 +541,7 @@ class ContentUploader extends Component<Props, State> {
      */
     addToQueue = (newItems: UploadItem[], itemUpdateCallback: Function) => {
         const { fileLimit, useUploadsManager } = this.props;
-        const { view, items } = this.state;
+        const { view, items, isUploadsManagerExpanded } = this.state;
 
         let updatedItems = [];
         const prevItemsNum = items.length;
@@ -561,7 +561,8 @@ class ContentUploader extends Component<Props, State> {
             if (
                 prevItemsNum < EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD &&
                 totalNumOfItems >= EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD &&
-                useUploadsManager
+                useUploadsManager &&
+                !isUploadsManagerExpanded
             ) {
                 this.setState({
                     isAutoExpanded: true,
@@ -751,7 +752,7 @@ class ContentUploader extends Component<Props, State> {
         // Broadcast that a file has been uploaded
         if (useUploadsManager) {
             onUpload(item);
-            this.hideUploadsManager();
+            this.checkClearUploadItems();
         } else {
             onUpload(item.boxFile);
         }
@@ -861,6 +862,9 @@ class ContentUploader extends Component<Props, State> {
         this.updateViewAndCollection(items);
 
         if (useUploadsManager) {
+            this.setState({
+                isAutoExpanded: true,
+            });
             this.expandUploadsManager();
         }
 
@@ -946,15 +950,15 @@ class ContentUploader extends Component<Props, State> {
 
         onMinimize();
         this.resetUploadManagerExpandState();
-        this.hideUploadsManager();
+        this.checkClearUploadItems();
     };
 
     /**
-     * Hides the upload manager
+     * Checks if the upload items should be cleared after a timeout
      *
      * @return {void}
      */
-    hideUploadsManager = () => {
+    checkClearUploadItems = () => {
         this.resetItemsTimeout = setTimeout(
             this.resetUploadsManagerItemsWhenUploadsComplete,
             HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT,

--- a/src/components/ContentUploader/__tests__/ContentUploader-test.js
+++ b/src/components/ContentUploader/__tests__/ContentUploader-test.js
@@ -104,7 +104,7 @@ describe('components/ContentUploader/ContentUploader', () => {
         let getChunkedUploadAPI;
 
         const expectAutoExpandStateToBe = expectation => {
-            expect(wrapper.state().isAutoExpanded).toBe(expectation);
+            expect(instance.isAutoExpanded).toBe(expectation);
             expect(wrapper.state().isUploadsManagerExpanded).toBe(expectation);
         };
 
@@ -170,9 +170,10 @@ describe('components/ContentUploader/ContentUploader', () => {
             });
             wrapper.setState({
                 items,
-                isAutoExpanded: true,
                 isUploadsManagerExpanded: true,
             });
+
+            instance.isAutoExpanded = true;
 
             instance.handleUploadSuccess(items[0]);
 

--- a/src/components/ContentUploader/__tests__/ContentUploader-test.js
+++ b/src/components/ContentUploader/__tests__/ContentUploader-test.js
@@ -1,10 +1,38 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { ContentUploaderComponent } from '../ContentUploader';
+import { STATUS_PENDING, VIEW_UPLOAD_SUCCESS } from '../../../constants';
 import * as UploaderUtils from '../../../util/uploads';
+
+const EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD = 5;
 
 describe('components/ContentUploader/ContentUploader', () => {
     const getWrapper = (props = {}) => shallow(<ContentUploaderComponent {...props} />);
+    const createMockFiles = length => {
+        const filesList = [];
+        for (let i = 0; i < length; i += 1) {
+            const file = new File(['contents'], `upload_file_${i}.txt`, {
+                type: 'text/plain',
+            });
+            filesList.push(file);
+        }
+
+        return filesList;
+    };
+
+    const mapToUploadItems = files => {
+        return files.map(file => {
+            return {
+                api: {},
+                extension: '',
+                file,
+                name: file.name,
+                progress: 0,
+                size: 1000,
+                status: STATUS_PENDING,
+            };
+        });
+    };
 
     describe('getUploadAPI()', () => {
         const CHUNKED_UPLOAD_MIN_SIZE_BYTES = 52428800; // 50MB
@@ -66,6 +94,95 @@ describe('components/ContentUploader/ContentUploader', () => {
             jest.spyOn(UploaderUtils, 'isMultiputSupported').mockImplementation(() => true);
             instance.getUploadAPI(file);
             expect(getPlainUploadAPI).toBeCalled();
+        });
+    });
+
+    describe('Expand and collapse when more than EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD files uploaded', () => {
+        let wrapper;
+        let instance;
+        let getPlainUploadAPI;
+        let getChunkedUploadAPI;
+
+        const expectAutoExpandStateToBe = expectation => {
+            expect(wrapper.state().isAutoExpanded).toBe(expectation);
+            expect(wrapper.state().isUploadsManagerExpanded).toBe(expectation);
+        };
+
+        beforeEach(() => {
+            wrapper = getWrapper({
+                useUploadsManager: true,
+            });
+            instance = wrapper.instance();
+
+            // Stub out upload so actual upload doesn't happen
+            const mockAPI = {
+                upload: () => {},
+            };
+            getPlainUploadAPI = () => mockAPI;
+            getChunkedUploadAPI = () => mockAPI;
+            instance.createAPIFactory = jest.fn().mockReturnValue({
+                getPlainUploadAPI,
+                getChunkedUploadAPI,
+            });
+        });
+
+        test('expand manager on upload when more than EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD files', () => {
+            const files = createMockFiles(EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD + 1);
+            wrapper.setProps({
+                files,
+            });
+
+            expectAutoExpandStateToBe(true);
+        });
+
+        test('do not expand manager on upload when less than than EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD files', () => {
+            const files = createMockFiles(EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD - 1);
+            wrapper.setProps({
+                files,
+            });
+
+            expectAutoExpandStateToBe(false);
+        });
+
+        test('expand manager on upload when two uploads totaling more than EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD files', () => {
+            const files = createMockFiles(EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD + 1);
+            wrapper.setProps({
+                files: files.slice(0, 3),
+            });
+
+            expectAutoExpandStateToBe(false);
+
+            wrapper.setProps({
+                files: files.slice(3),
+            });
+
+            expectAutoExpandStateToBe(true);
+        });
+
+        test('close upload manager when uploads are done', () => {
+            const files = createMockFiles(EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD + 1);
+
+            const items = mapToUploadItems(files).map(item => {
+                return {
+                    ...item,
+                    api: { upload: () => {} },
+                };
+            });
+            wrapper.setState({
+                items,
+                isAutoExpanded: true,
+                isUploadsManagerExpanded: true,
+            });
+
+            instance.handleUploadSuccess(items[0]);
+
+            // Verify expanded is true after one file upload succeeds
+            expectAutoExpandStateToBe(true);
+
+            items.slice(1).forEach(item => instance.handleUploadSuccess(item));
+
+            expect(wrapper.state().view).toBe(VIEW_UPLOAD_SUCCESS);
+            expectAutoExpandStateToBe(false);
         });
     });
 });


### PR DESCRIPTION
fixes #685
Removed setting of isUploadsManagerExpanded to existing state in updateViewAndCollection.  Also added isAutoExpanded flag to ContentUploader to keep track of auto-expansion to close when all uploads have completed.