### PR TITLE
fix(sidebar): allow approval date to be reset

### DIFF
--- a/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.js
+++ b/src/components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalCommentForm.js
@@ -124,10 +124,13 @@ class ApprovalCommentForm extends React.Component<Props, State> {
     onMentionSelectorChangeHandler = (nextEditorState: any): void =>
         this.setState({ commentEditorState: nextEditorState });
 
-    onApprovalDateChangeHandler = (date: Date): void => {
-        // The date given to us is midnight of the date selected.
-        // Modify date to be the end of day (minus 1 millisecond) for the given due date
-        date.setHours(23, 59, 59, 999);
+    onApprovalDateChangeHandler = (date: ?Date): void => {
+        if (date) {
+            // The date given to us is midnight of the date selected.
+            // Modify date to be the end of day (minus 1 millisecond) for the given due date
+            date.setHours(23, 59, 59, 999);
+        }
+
         this.setState({ approvalDate: date });
     };
 

--- a/src/components/ContentSidebar/ActivityFeed/approval-comment-form/__tests__/ApprovalCommentForm-test.js
+++ b/src/components/ContentSidebar/ActivityFeed/approval-comment-form/__tests__/ApprovalCommentForm-test.js
@@ -237,6 +237,20 @@ describe('components/ContentSidebar/ActivityFeed/approval-comment-form/ApprovalC
 
             expect(wrapper.state('approvalDate')).toEqual(lastMillisecondOfDate);
         });
+
+        test('should change a previously set approval date to null if there is no approval date', () => {
+            // Midnight on December 3rd GMT
+            const date = new Date('2018-12-03T00:00:00');
+            // 11:59:59:999 on December 3rd GMT
+            const lastMillisecondOfDate = new Date('2018-12-03T23:59:59.999');
+            const wrapper = render({});
+
+            wrapper.instance().onApprovalDateChangeHandler(date);
+            expect(wrapper.state('approvalDate')).toEqual(lastMillisecondOfDate);
+
+            wrapper.instance().onApprovalDateChangeHandler(null);
+            expect(wrapper.state('approvalDate')).toEqual(null);
+        });
     });
 
     describe('getFormattedCommentText()', () => {


### PR DESCRIPTION
The date can come in as null, and thus the date never gets reset from the previously set date.