### PR TITLE
fix(uploader): add new event for upload widget

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 src/api/uploads/uploads-sha1-worker.js
+README.md

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ render(
 | rootFolderId | string | `0` | The root folder for the content uploader. |
 | onClose | function |  | Callback function for when the close button is pressed. |
 | onComplete | function(Array&lt;[File](https://developer.box.com/reference#file-object)&gt;) |  | Callback function for when uploads are complete. |
+| onBeforeUpload | function(Array&lt;[File](https://developer.box.com/reference#file-object)&gt;) |  | Callback function for retrieving an item before it has uploaded |
 | isTouch | boolean |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
 | logoUrl | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
 | sharedLink | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ render(
 | rootFolderId | string | `0` | The root folder for the content uploader. |
 | onClose | function |  | Callback function for when the close button is pressed. |
 | onComplete | function(Array&lt;[File](https://developer.box.com/reference#file-object)&gt;) |  | Callback function for when uploads are complete. |
-| onBeforeUpload | function(Array&lt;[File](https://developer.box.com/reference#file-object)&gt;) |  | Callback function for retrieving an item before it has uploaded |
+| onBeforeUpload | function(Array&lt;[File](https://developer.box.com/reference#file-object)&gt;) |  | Callback function for retrieving an item before it has uploaded on files only, doesn't work on folders|
 | isTouch | boolean |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
 | logoUrl | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |
 | sharedLink | string |  | *See the [developer docs](https://developer.box.com/docs/box-content-uploader#section-options).* |

--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -66,7 +66,7 @@ type Props = {
     onComplete: Function,
     onError: Function,
     onMinimize?: Function,
-    onUpload: Function,
+    onBeforeUpload: (file: Array<UploadFileWithAPIOptions | File>) => void,
     onUpload: Function,
     overwrite: boolean,
     requestInterceptor?: Function,
@@ -120,6 +120,7 @@ class ContentUploader extends Component<Props, State> {
         clientName: CLIENT_NAME_CONTENT_UPLOADER,
         fileLimit: FILE_LIMIT_DEFAULT,
         uploadHost: DEFAULT_HOSTNAME_UPLOAD,
+        onBeforeUpload: noop,
         onClose: noop,
         onComplete: noop,
         onError: noop,
@@ -286,7 +287,7 @@ class ContentUploader extends Component<Props, State> {
         itemUpdateCallback: Function,
         isRelativePathIgnored?: boolean = false,
     ) => {
-        const { rootFolderId } = this.props;
+        const { onBeforeUpload, rootFolderId } = this.props;
         if (!files || files.length === 0) {
             return;
         }
@@ -311,6 +312,8 @@ class ContentUploader extends Component<Props, State> {
             this.addFilesWithRelativePathToQueue(newFiles, itemUpdateCallback);
             return;
         }
+
+        onBeforeUpload(newFiles);
 
         this.addFilesWithoutRelativePathToQueue(newFiles, itemUpdateCallback);
     };

--- a/src/components/ContentUploader/__tests__/ContentUploader-test.js
+++ b/src/components/ContentUploader/__tests__/ContentUploader-test.js
@@ -34,6 +34,16 @@ describe('components/ContentUploader/ContentUploader', () => {
         });
     };
 
+    describe('onBeforeUpload()', () => {
+        const onBeforeUpload = jest.fn();
+        const wrapper = getWrapper({
+            onBeforeUpload,
+        });
+        wrapper.instance().addFilesToUploadQueue([{ name: 'yoyo', size: 1000 }], jest.fn(), false);
+
+        expect(onBeforeUpload).toBeCalled();
+    });
+
     describe('getUploadAPI()', () => {
         const CHUNKED_UPLOAD_MIN_SIZE_BYTES = 52428800; // 50MB
         let wrapper;

--- a/src/wrappers/ContentUploader.js
+++ b/src/wrappers/ContentUploader.js
@@ -41,6 +41,16 @@ class ContentUploader extends ES6Wrapper {
     };
 
     /**
+     * Callback on a single pre-uploaded file. Emits 'beforeupload' event with the Box File object pre-upload.
+     *
+     * @param {Object} data - Upload item
+     * @return {void}
+     */
+    onBeforeUpload = (data: UploadFileWithAPIOptions | File): void => {
+        this.emit('beforeupload', data);
+    };
+
+    /**
      * Callback on a single successful upload. Emits 'uploadsuccess' event with Box File object of uploaded item.
      *
      * @param {BoxItem} data - Successfully uploaded item
@@ -65,6 +75,7 @@ class ContentUploader extends ES6Wrapper {
                 onClose={this.onClose}
                 onComplete={this.onComplete}
                 onError={this.onError}
+                onBeforeUpload={this.onBeforeUpload}
                 onUpload={this.onUpload}
                 modal={((modal: any): ModalOptions)}
                 {...rest}


### PR DESCRIPTION
UEW -> Upload Embed Widget for Webapp.
onStage is the new event that gets introduced for the purposes of the UEW.

The general idea is that the way the new v2 Upload Widget wasn't properly set up for handling drag and dropping files into the UEW.
If a user did drag and drop, it was querying the ItemList React Virtualized Column to render the items name.
However for the v2 UEW it was requested that the item size would also be included in the rendered item info.
And the item list didn't have a column for item size, and it would be best if we passed a file object back to the UEW. (Props to jpress for the suggestion!)

Therefore this onStage event was introduced, The idea being that if a user drags or drops an item into the Upload embed widget it then emits an event that can be intercepted by the UEW and then used to render the proper information.

Since you can't drag folders into the UEW, I only added it to the item getNewDataForTransferItems, giving access to the file object