### PR TITLE
fix(uploader): reset state when items are empty

### DIFF
--- a/src/components/ContentUploader/ContentUploader.js
+++ b/src/components/ContentUploader/ContentUploader.js
@@ -787,7 +787,6 @@ class ContentUploader extends Component<Props, State> {
         );
 
         let view = '';
-        let itemIds;
         if ((items && items.length === 0) || allItemsArePending) {
             view = VIEW_UPLOAD_EMPTY;
         } else if (someUploadHasFailed && useUploadsManager) {
@@ -801,7 +800,6 @@ class ContentUploader extends Component<Props, State> {
                 onComplete(cloneDeep(items.map(item => item.boxFile)));
                 // Reset item collection after successful upload
                 items = [];
-                itemIds = {};
             }
         }
 
@@ -817,11 +815,8 @@ class ContentUploader extends Component<Props, State> {
             view,
         };
 
-        if (itemIds) {
-            state.itemIds = itemIds;
-        }
-
         if (items.length === 0) {
+            state.itemIds = {};
             state.errorCode = '';
         }
 

--- a/src/components/ContentUploader/__tests__/ContentUploader-test.js
+++ b/src/components/ContentUploader/__tests__/ContentUploader-test.js
@@ -44,6 +44,21 @@ describe('components/ContentUploader/ContentUploader', () => {
         expect(onBeforeUpload).toBeCalled();
     });
 
+    describe('updateViewAndCollection()', () => {
+        test('should set itemIds to be an empty when method is called with an empty array', () => {
+            const onComplete = jest.fn();
+            const useUploadsManager = false;
+            const wrapper = getWrapper({
+                onComplete,
+                useUploadsManager,
+            });
+
+            wrapper.instance().updateViewAndCollection([], null);
+
+            expect(wrapper.state().itemIds).toEqual({});
+        });
+    });
+
     describe('getUploadAPI()', () => {
         const CHUNKED_UPLOAD_MIN_SIZE_BYTES = 52428800; // 50MB
         let wrapper;


### PR DESCRIPTION
There is currently a bug with the uploader that when cancel is hit, the itemIds are not reset when updateViewAndCollection is called. 
The problem being if a user hits cancel, and then tries to upload the same file, because the itemId already exists in state, it will deny the upload.

This PR checks to see if the argument passed to updateViewAndCollection if is an empty arr, if it is it resets the itemIds when it resets state. 