### PR TITLE
fix(uploader): refactor anti pattern in addFilesToUploadQueue

### DIFF
--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -292,16 +292,24 @@ class ContentUploader extends Component<Props, State> {
             return;
         }
 
-        const { itemIds } = this.state;
         const newFiles = this.getNewFiles(files);
 
         if (newFiles.length === 0) {
             return;
         }
 
+        const newItemIds = {};
+
         newFiles.forEach(file => {
-            itemIds[getFileId(file, rootFolderId)] = true;
+            newItemIds[getFileId(file, rootFolderId)] = true;
         });
+
+        this.setState(state => ({
+            itemIds: {
+                ...state.itemIds,
+                ...newItemIds,
+            },
+        }));
 
         clearTimeout(this.resetItemsTimeout);
 

--- a/src/elements/content-uploader/__tests__/ContentUploader-test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader-test.js
@@ -39,6 +39,7 @@ describe('elements/content-uploader/ContentUploader', () => {
         const wrapper = getWrapper({
             onBeforeUpload,
         });
+
         wrapper.instance().addFilesToUploadQueue([{ name: 'yoyo', size: 1000 }], jest.fn(), false);
 
         expect(onBeforeUpload).toBeCalled();
@@ -56,6 +57,17 @@ describe('elements/content-uploader/ContentUploader', () => {
             wrapper.instance().updateViewAndCollection([], null);
 
             expect(wrapper.state().itemIds).toEqual({});
+        });
+    });
+    describe('addFilesToUploadQueue()', () => {
+        test('should overwrite itemIds if they already exist', () => {
+            const wrapper = getWrapper();
+            wrapper.setState({ itemIds: { yoyo: false } });
+
+            wrapper.instance().addFilesToUploadQueue([{ name: 'yoyo', size: 1000 }], jest.fn(), false);
+
+            const expected = { yoyo: true };
+            expect(wrapper.state().itemIds).toMatchObject(expected);
         });
     });
 


### PR DESCRIPTION
What this PR Does: 

We shouldn't ideally set state by mutating it directly. One should typically call setState, in order to do state changes. 

this PR simply refactors the anti pattern and uses setState to not cause unnecessary side effects.