### PR TITLE
feat(openwith): Add support for 'beta' google integrations

### DIFF
--- a/src/components/ContentOpenWith/IconFileMap.js
+++ b/src/components/ContentOpenWith/IconFileMap.js
@@ -12,8 +12,11 @@ import FileIcon from 'box-react-ui/lib/icons/file-icon/FileIcon';
 const ICON_FILE_MAP = {
     'Adobe Sign': IconAdobeSign,
     'Google Docs': IconGoogleDocs,
+    'Google Docs (beta)': IconGoogleDocs,
     'Google Sheets': IconGoogleSheets,
+    'Google Sheets (beta)': IconGoogleSheets,
     'Google Slides': IconGoogleSlides,
+    'Google Slides (beta)': IconGoogleSlides,
 };
 
 function getIcon(iconName: string): Element {


### PR DESCRIPTION
the platform version of the gsuite integrations will be considered "beta" for now. This change will allow the correct icons to be used during and after this beta period. 