### PR TITLE
feat(tasks): Add "add task" button and modal in Activity Sidebar

### DIFF
--- a/examples/src/features.js
+++ b/examples/src/features.js
@@ -1,2 +1,4 @@
 // feature config for feature flags
-export default {};
+export default {
+    tasks: true,
+};

--- a/examples/src/features.js
+++ b/examples/src/features.js
@@ -1,4 +1,8 @@
 // feature config for feature flags
 export default {
-    tasks: true,
+    activityFeed: {
+        tasks: {
+            createButton: true,
+        },
+    },
 };

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -328,8 +328,12 @@ be.taskEditErrorMessage = There was an error updating this task.
 be.taskReject = Decline
 # label for button that opens task popup
 be.tasks.addTask = Add Task
+# label for task create form assignee input
+be.tasks.addTaskForm.assigneesLabel = Assignees
 # label for cancel button in create task popup
 be.tasks.addTaskForm.cancel = Cancel
+# label for task create form due date input
+be.tasks.addTaskForm.dueDateLabel = Due Date
 # label for task create form message input
 be.tasks.addTaskForm.messageLabel = Message
 # label for create button in create task popup

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -326,6 +326,16 @@ be.taskDueDate = Due
 be.taskEditErrorMessage = There was an error updating this task.
 # Reject option for a task
 be.taskReject = Decline
+# label for button that opens task popup
+be.tasks.addTask = Add Task
+# label for cancel button in create task popup
+be.tasks.addTaskForm.cancel = Cancel
+# label for task create form message input
+be.tasks.addTaskForm.messageLabel = Message
+# label for create button in create task popup
+be.tasks.addTaskForm.submit = Add Task
+# title for task popup
+be.tasks.addTaskForm.title = Add Task
 # Tasks for approval
 be.tasksForApproval = Tasks
 # Shown instead of todays date.

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -843,6 +843,31 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
         defaultMessage: 'Decline',
         description: 'Reject option for a task',
     },
+    tasksAddTask: {
+        id: 'be.tasks.addTask',
+        defaultMessage: 'Add Task',
+        description: 'label for button that opens task popup',
+    },
+    tasksAddTaskFormTitle: {
+        id: 'be.tasks.addTaskForm.title',
+        defaultMessage: 'Add Task',
+        description: 'title for task popup',
+    },
+    tasksAddTaskFormMessageLabel: {
+        id: 'be.tasks.addTaskForm.messageLabel',
+        defaultMessage: 'Message',
+        description: 'label for task create form message input',
+    },
+    tasksAddTaskFormSubmitLabel: {
+        id: 'be.tasks.addTaskForm.submit',
+        defaultMessage: 'Add Task',
+        description: 'label for create button in create task popup',
+    },
+    tasksAddTaskFormCancelLabel: {
+        id: 'be.tasks.addTaskForm.cancel',
+        defaultMessage: 'Cancel',
+        description: 'label for cancel button in create task popup',
+    },
     versionDeleted: {
         id: 'be.versionDeleted',
         defaultMessage: '{ name } deleted version { version_number }',

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -853,10 +853,20 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
         defaultMessage: 'Add Task',
         description: 'title for task popup',
     },
+    tasksAddTaskFormAssigneesLabel: {
+        id: 'be.tasks.addTaskForm.assigneesLabel',
+        defaultMessage: 'Assignees',
+        description: 'label for task create form assignee input',
+    },
     tasksAddTaskFormMessageLabel: {
         id: 'be.tasks.addTaskForm.messageLabel',
         defaultMessage: 'Message',
         description: 'label for task create form message input',
+    },
+    tasksAddTaskFormDueDateLabel: {
+        id: 'be.tasks.addTaskForm.dueDateLabel',
+        defaultMessage: 'Due Date',
+        description: 'label for task create form due date input',
     },
     tasksAddTaskFormSubmitLabel: {
         id: 'be.tasks.addTaskForm.submit',

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -49,7 +49,6 @@ type State = {
     activityFeedError?: Errors,
     currentUserError?: Errors,
     feedItems?: FeedItems,
-    isTaskFormOpen?: boolean,
 };
 
 export const activityFeedInlineError: Errors = {

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -460,7 +460,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         return (
             <SidebarContent
                 title={<FormattedMessage {...messages.sidebarActivityTitle} />}
-                actions={<FeatureFlag feature="tasks" enabled={this.renderAddTaskButton} />}
+                actions={<FeatureFlag feature="activityFeed.tasks.createButton" enabled={this.renderAddTaskButton} />}
             >
                 <ActivityFeed
                     file={file}

--- a/src/elements/content-sidebar/AddTaskButton.js
+++ b/src/elements/content-sidebar/AddTaskButton.js
@@ -1,0 +1,73 @@
+// @flow
+import * as React from 'react';
+import Button from 'box-react-ui/lib/components/button';
+import Modal from 'box-react-ui/lib/components/modal/Modal';
+import { FormattedMessage } from 'react-intl';
+import TaskForm from './activity-feed/task-form';
+import messages from '../common/messages';
+
+type AddTaskButtonProps = {
+    isDisabled: boolean,
+};
+
+// These are used by the wrapped form
+type PassThroughProps = {
+    createTask: any,
+    getApproverWithQuery: any,
+    getMentionWithQuery: any,
+    approverSelectorContacts: any,
+    mentionSelectorContacts: any,
+    getAvatarUrl: any,
+};
+
+type Props = AddTaskButtonProps & PassThroughProps;
+
+type State = {
+    isTaskFormOpen: boolean,
+};
+
+class AddTaskButton extends React.Component<Props, State> {
+    state = {
+        isTaskFormOpen: false,
+    };
+
+    static defaultProps = {
+        isDisabled: false,
+    };
+
+    handleClickAdd = () => this.setState({ isTaskFormOpen: true });
+
+    handleClose = () => this.setState({ isTaskFormOpen: false });
+
+    handleSubmit = () => this.setState({ isTaskFormOpen: false });
+
+    render() {
+        const { isDisabled, ...passThrough } = this.props;
+        const { isTaskFormOpen } = this.state;
+
+        return (
+            <React.Fragment>
+                <Button type="button" onClick={this.handleClickAdd} isDisabled={isDisabled}>
+                    <FormattedMessage {...messages.tasksAddTask} />
+                </Button>
+                <Modal
+                    isOpen={isTaskFormOpen}
+                    onRequestClose={this.handleClose}
+                    title={<FormattedMessage {...messages.tasksAddTaskFormTitle} />}
+                    className="be task-modal"
+                >
+                    <TaskForm
+                        {...passThrough}
+                        isOpen
+                        className=""
+                        isEditing={isTaskFormOpen}
+                        onCancel={this.handleClose}
+                        onSubmit={this.handleSubmit}
+                    />
+                </Modal>
+            </React.Fragment>
+        );
+    }
+}
+
+export default AddTaskButton;

--- a/src/elements/content-sidebar/AddTaskButton.js
+++ b/src/elements/content-sidebar/AddTaskButton.js
@@ -55,6 +55,7 @@ class AddTaskButton extends React.Component<Props, State> {
                     onRequestClose={this.handleClose}
                     title={<FormattedMessage {...messages.tasksAddTaskFormTitle} />}
                     className="be task-modal"
+                    data-testid="create-task-modal"
                 >
                     <TaskForm
                         {...passThrough}

--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -17,6 +17,7 @@ import APIContext from '../common/api-context';
 import Internationalize from '../common/Internationalize';
 import { withErrorBoundary } from '../common/error-boundary';
 import { SIDEBAR_FIELDS_TO_FETCH } from '../../utils/fields';
+import { withFeatureProvider } from '../common/feature-checking';
 import {
     DEFAULT_HOSTNAME_API,
     CLIENT_NAME_CONTENT_SIDEBAR,
@@ -45,6 +46,7 @@ type Props = {
     currentUser?: User,
     defaultView?: SidebarView,
     detailsSidebarProps: DetailsSidebarProps,
+    features: FeatureConfig,
     fileId?: string,
     getPreview: Function,
     getViewer: Function,
@@ -377,7 +379,7 @@ class ContentSidebar extends React.PureComponent<Props, State> {
         const styleClassName = classNames(
             'be bcs',
             {
-                [`bcs-${((selectedView: any): string)}`]: isOpen,
+                [`bcs-${selectedView || ''}`]: isOpen,
                 'bcs-is-open': isOpen,
             },
             className,
@@ -425,4 +427,4 @@ class ContentSidebar extends React.PureComponent<Props, State> {
 
 export type ContentSidebarProps = Props;
 export { ContentSidebar as ContentSidebarComponent };
-export default withErrorBoundary(ORIGIN_CONTENT_SIDEBAR)(ContentSidebar);
+export default withErrorBoundary(ORIGIN_CONTENT_SIDEBAR)(withFeatureProvider(ContentSidebar));

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar-test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`elements/content-sidebar/ActivitySidebar render() should render the activity feed sidebar 1`] = `
 <SidebarContent
+  actions={
+    <FeatureFlag
+      enabled={[Function]}
+      feature="tasks"
+    />
+  }
   title={
     <FormattedMessage
       defaultMessage="Activity"

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar-test.js.snap
@@ -5,7 +5,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
   actions={
     <FeatureFlag
       enabled={[Function]}
-      feature="tasks"
+      feature="activityFeed.tasks.createButton"
     />
   }
   title={

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -164,7 +164,7 @@ class ActivityFeed extends React.Component<Props, State> {
 
         return (
             // eslint-disable-next-line
-            <div className="bcs-activity-feed" onKeyDown={this.onKeyDown}>
+            <div className="bcs-activity-feed" data-testid="activityfeed" onKeyDown={this.onKeyDown}>
                 <div
                     ref={ref => {
                         this.feedContainer = ref;

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActivityFeed-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActivityFeed-test.js.snap
@@ -3,6 +3,7 @@
 exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should correctly render empty loading state 1`] = `
 <div
   className="bcs-activity-feed"
+  data-testid="activityfeed"
   onKeyDown={[Function]}
 >
   <div
@@ -19,6 +20,7 @@ exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should
 exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should correctly render empty state 1`] = `
 <div
   className="bcs-activity-feed"
+  data-testid="activityfeed"
   onKeyDown={[Function]}
 >
   <div
@@ -35,6 +37,7 @@ exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should
 exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should not render approval comment form if comment permissions are not present 1`] = `
 <div
   className="bcs-activity-feed"
+  data-testid="activityfeed"
   onKeyDown={[Function]}
 >
   <div
@@ -51,6 +54,7 @@ exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should
 exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should not render approval comment form if only comment submit handler is not passed in 1`] = `
 <div
   className="bcs-activity-feed"
+  data-testid="activityfeed"
   onKeyDown={[Function]}
 >
   <div
@@ -67,6 +71,7 @@ exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should
 exports[`elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed should render approval comment form if comment submit handler is passed in and comment permissions 1`] = `
 <div
   className="bcs-activity-feed"
+  data-testid="activityfeed"
   onKeyDown={[Function]}
 >
   <div

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -23,7 +23,7 @@ import { ACTIVITY_TARGETS, INTERACTION_TARGET } from '../../../common/interactio
 import './TaskForm.scss';
 
 export type TaskFormProps = {|
-    approverSelectorContacts?: SelectorItems,
+    approverSelectorContacts: SelectorItems,
     className: string,
     createTask: (text: string, approvers: SelectorItems, dueDate: ?Date) => any,
     getApproverWithQuery?: Function,
@@ -46,6 +46,10 @@ type State = {|
 |};
 
 class TaskForm extends React.Component<Props, State> {
+    static defaultProps = {
+        approverSelectorContacts: [],
+    };
+
     state = this.getInitialFormState();
 
     getInitialFormState() {
@@ -150,7 +154,7 @@ class TaskForm extends React.Component<Props, State> {
     };
 
     render() {
-        const { approverSelectorContacts = [], className, isDisabled, intl } = this.props;
+        const { approverSelectorContacts, className, isDisabled, intl } = this.props;
         const { dueDate, approvers, message, formValidityState, isValid } = this.state;
         const inputContainerClassNames = classNames('bcs-task-input-container', 'bcs-task-input-is-open', className);
 

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -1,0 +1,250 @@
+/**
+ * @flow
+ * @file Component for Approval comment form
+ */
+
+import * as React from 'react';
+import noop from 'lodash/noop';
+import classNames from 'classnames';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import Form from 'box-react-ui/lib/components/form-elements/form/Form';
+import commonMessages from 'box-react-ui/lib/common/messages';
+import ContactDatalistItem from 'box-react-ui/lib/components/contact-datalist-item/ContactDatalistItem';
+import TextArea from 'box-react-ui/lib/components/text-area';
+import DatePicker from 'box-react-ui/lib/components/date-picker/DatePicker';
+import PillSelectorDropdown from 'box-react-ui/lib/components/pill-selector-dropdown/PillSelectorDropdown';
+import Button from 'box-react-ui/lib/components/button/Button';
+import PrimaryButton from 'box-react-ui/lib/components/primary-button/PrimaryButton';
+import type { InjectIntlProvidedProps } from 'react-intl';
+
+import messages from '../../../messages';
+import { ACTIVITY_TARGETS, INTERACTION_TARGET } from '../../../../interactionTargets';
+
+import './TaskForm.scss';
+
+export type TaskFormProps = {|
+    approverSelectorContacts?: SelectorItems,
+    className: string,
+    createTask: (text: string, approvers: SelectorItems, dueDate: ?Date) => any,
+    getApproverWithQuery?: Function,
+    getAvatarUrl: string => Promise<?string>,
+    isDisabled?: boolean,
+    onCancel: () => any,
+    onSubmit: () => any,
+|};
+
+type Props = TaskFormProps & InjectIntlProvidedProps;
+
+type TaskFormFieldName = 'taskName' | 'taskAssignees' | 'taskDueDate';
+
+type State = {|
+    approvers: SelectorItems,
+    dueDate: ?Date,
+    formValidityState: { [key: TaskFormFieldName]: ?{ code: string, message: string } },
+    isValid: ?boolean,
+    message: string,
+|};
+
+class TaskForm extends React.Component<Props, State> {
+    state = this.getInitialFormState();
+
+    getInitialFormState() {
+        return {
+            approvers: [],
+            dueDate: null,
+            formValidityState: {},
+            message: '',
+            isValid: null,
+        };
+    }
+
+    validateForm = (only?: TaskFormFieldName) => {
+        this.setState(state => {
+            const { intl } = this.props;
+            const { approvers, message } = state;
+            const requiredFieldError = {
+                code: 'required',
+                message: intl.formatMessage(commonMessages.requiredFieldError),
+            };
+            const formValidityState = {
+                taskAssignees: approvers.length ? null : requiredFieldError,
+                taskName: message ? null : requiredFieldError,
+                taskDueDate: null,
+            };
+            const isValid = Object.values(formValidityState).every(val => val == null);
+            return {
+                isValid,
+                formValidityState: only
+                    ? { ...state.formValidityState, [only]: formValidityState[only] }
+                    : formValidityState,
+            };
+        });
+    };
+
+    getErrorByFieldname = (fieldName: TaskFormFieldName) => {
+        const { formValidityState } = this.state;
+        return formValidityState[fieldName] ? formValidityState[fieldName].message : null;
+    };
+
+    clearForm = () => this.setState(this.getInitialFormState());
+
+    handleFocusChange = () => {
+        this.validateForm();
+    };
+
+    handleInvalidSubmit = () => {
+        this.validateForm();
+    };
+
+    handleValidSubmit = (): void => {
+        const { createTask, onSubmit } = this.props;
+        const { message, approvers, dueDate, isValid } = this.state;
+
+        if (!isValid) return;
+
+        createTask(message, approvers, dueDate);
+
+        if (onSubmit) {
+            // TODO: could this show server errors? <ApprovalCommentForm /> does not.
+            onSubmit();
+        }
+
+        this.clearForm();
+    };
+
+    handleDueDateChange = (date: ?Date): void => {
+        if (date) {
+            // The date given to us is midnight of the date selected.
+            // Modify date to be the end of day (minus 1 millisecond) for the given due date
+            date.setHours(23, 59, 59, 999);
+        }
+
+        this.setState({ dueDate: date });
+    };
+
+    handleApproverSelectorInput = (value: any): void => {
+        const { getApproverWithQuery = noop } = this.props;
+        getApproverWithQuery(value);
+    };
+
+    handleApproverSelectorSelect = (pills: any): void => {
+        this.setState({ approvers: this.state.approvers.concat(pills) });
+        this.validateForm('taskAssignees');
+    };
+
+    handleApproverSelectorRemove = (option: any, index: number): void => {
+        const approvers = [...this.state.approvers];
+        approvers.splice(index, 1);
+        this.setState({ approvers });
+        this.validateForm('taskAssignees');
+    };
+
+    handleChangeMessage = (e: SyntheticInputEvent<HTMLTextAreaElement>) => {
+        e.persist();
+        this.setState({ message: e.currentTarget.value });
+        this.validateForm('taskName');
+    };
+
+    handleCancelClick = () => {
+        this.props.onCancel();
+    };
+
+    render() {
+        const { approverSelectorContacts = [], className, isDisabled, intl } = this.props;
+        const { dueDate, approvers, message, formValidityState, isValid } = this.state;
+        const inputContainerClassNames = classNames('bcs-task-input-container', 'bcs-task-input-is-open', className);
+
+        // filter out selected approvers
+        // map to datalist item format
+        const approverOptions = approverSelectorContacts
+            .filter(({ id }) => !approvers.find(({ value }) => value === id))
+            .map(({ id, item }) => ({ ...item, text: item.name, value: id }));
+
+        return (
+            <div className={inputContainerClassNames}>
+                <div className="bcs-task-input-form-container">
+                    <Form
+                        onValidSubmit={this.handleValidSubmit}
+                        onInvalidSubmit={this.handleInvalidSubmit}
+                        formValidityState={formValidityState}
+                    >
+                        <PillSelectorDropdown
+                            error={this.getErrorByFieldname('taskAssignees')}
+                            inputProps={{ 'data-testid': 'task-form-assignee-input' }}
+                            isRequired
+                            label={<FormattedMessage {...messages.approvalAssignees} />}
+                            name="taskAssignees"
+                            onBlur={() => this.validateForm('taskAssignees')}
+                            onInput={this.handleApproverSelectorInput}
+                            onRemove={this.handleApproverSelectorRemove}
+                            onSelect={this.handleApproverSelectorSelect}
+                            placeholder={intl.formatMessage(messages.approvalAddAssignee)}
+                            selectedOptions={approvers}
+                            selectorOptions={approverOptions}
+                            validateForError={() => this.validateForm('taskAssignees')}
+                        >
+                            {approverOptions.map(({ id, name, email }) => (
+                                <ContactDatalistItem key={id} name={name} subtitle={email} />
+                            ))}
+                        </PillSelectorDropdown>
+                        <TextArea
+                            className="bcs-task-name-input"
+                            data-testid="task-form-name-input"
+                            disabled={isDisabled}
+                            error={this.getErrorByFieldname('taskName')}
+                            isRequired
+                            label={<FormattedMessage {...messages.tasksAddTaskFormMessageLabel} />}
+                            name="taskName"
+                            onBlur={() => this.validateForm('taskName')}
+                            onChange={this.handleChangeMessage}
+                            placeholder={intl.formatMessage(messages.commentWrite)}
+                            value={message}
+                        />
+                        <DatePicker
+                            className="bcs-task-add-due-date-input"
+                            error={this.getErrorByFieldname('taskDueDate')}
+                            inputProps={{
+                                [INTERACTION_TARGET]: ACTIVITY_TARGETS.TASK_DATE_PICKER,
+                                'data-testid': 'task-form-date-input',
+                            }}
+                            isRequired={false}
+                            label={<FormattedMessage {...messages.approvalDueDate} />}
+                            minDate={new Date()}
+                            name="taskDueDate"
+                            onBlur={() => this.validateForm('taskDueDate')}
+                            onChange={this.handleDueDateChange}
+                            placeholder={intl.formatMessage(messages.approvalSelectDate)}
+                            value={dueDate}
+                        />
+                        <div className="bcs-task-input-controls">
+                            <Button
+                                className="bcs-task-input-cancel-btn"
+                                data-testid="task-form-cancel-button"
+                                data-resin-target={ACTIVITY_TARGETS.APPROVAL_FORM_CANCEL}
+                                onClick={this.handleCancelClick}
+                                type="button"
+                            >
+                                <FormattedMessage {...messages.tasksAddTaskFormCancelLabel} />
+                            </Button>
+                            <PrimaryButton
+                                className="bcs-task-input-submit-btn"
+                                data-testid="task-form-submit-button"
+                                data-resin-target={ACTIVITY_TARGETS.APPROVAL_FORM_POST}
+                                isDisabled={!isValid}
+                                onFocus={this.handleFocusChange}
+                                onMouseEnter={this.handleFocusChange}
+                            >
+                                <FormattedMessage {...messages.tasksAddTaskFormSubmitLabel} />
+                            </PrimaryButton>
+                        </div>
+                    </Form>
+                </div>
+            </div>
+        );
+    }
+}
+
+// For testing only
+export { TaskForm as TaskFormUnwrapped };
+
+export default injectIntl(TaskForm);

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -172,7 +172,7 @@ class TaskForm extends React.Component<Props, State> {
                             error={this.getErrorByFieldname('taskAssignees')}
                             inputProps={{ 'data-testid': 'task-form-assignee-input' }}
                             isRequired
-                            label={<FormattedMessage {...messages.approvalAssignees} />}
+                            label={<FormattedMessage {...messages.tasksAddTaskFormAssigneesLabel} />}
                             name="taskAssignees"
                             onBlur={() => this.validateForm('taskAssignees')}
                             onInput={this.handleApproverSelectorInput}
@@ -184,7 +184,12 @@ class TaskForm extends React.Component<Props, State> {
                             validateForError={() => this.validateForm('taskAssignees')}
                         >
                             {approverOptions.map(({ id, name, email }) => (
-                                <ContactDatalistItem key={id} name={name} subtitle={email} />
+                                <ContactDatalistItem
+                                    key={id}
+                                    name={name}
+                                    subtitle={email}
+                                    data-testid="task-assignee-option"
+                                />
                             ))}
                         </PillSelectorDropdown>
                         <TextArea
@@ -208,7 +213,7 @@ class TaskForm extends React.Component<Props, State> {
                                 'data-testid': 'task-form-date-input',
                             }}
                             isRequired={false}
-                            label={<FormattedMessage {...messages.approvalDueDate} />}
+                            label={<FormattedMessage {...messages.tasksAddTaskFormDueDateLabel} />}
                             minDate={new Date()}
                             name="taskDueDate"
                             onBlur={() => this.validateForm('taskDueDate')}

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -17,8 +17,8 @@ import Button from 'box-react-ui/lib/components/button/Button';
 import PrimaryButton from 'box-react-ui/lib/components/primary-button/PrimaryButton';
 import type { InjectIntlProvidedProps } from 'react-intl';
 
-import messages from '../../../messages';
-import { ACTIVITY_TARGETS, INTERACTION_TARGET } from '../../../../interactionTargets';
+import messages from '../../../common/messages';
+import { ACTIVITY_TARGETS, INTERACTION_TARGET } from '../../../common/interactionTargets';
 
 import './TaskForm.scss';
 

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import '../../../common/variables';
 
 .be .bcs-task-input-container {
     display: flex;

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
@@ -1,0 +1,58 @@
+@import '../../../variables';
+
+.be .bcs-task-input-container {
+    display: flex;
+
+    .bcs-task-input-controls {
+        display: block;
+        text-align: right;
+
+        .btn {
+            margin-bottom: 10px;
+            margin-right: 0;
+            margin-top: 0;
+        }
+
+        .btn:last-child {
+            margin-left: 10px;
+        }
+    }
+
+    .bcs-task-input-form-container {
+        flex: 1;
+        min-width: 0;
+
+        textarea,
+        input {
+            width: 100%;
+        }
+
+        .bcs-task-add-due-date-input {
+            margin-left: 0;
+            margin-right: 0;
+
+            .date-picker-wrapper {
+                width: 166px;
+            }
+        }
+
+        .bcs-task-name-input {
+            margin-bottom: 15px;
+            margin-top: 20px;
+            max-height: 140px;
+        }
+
+        input.pill-selector-hidden-input {
+            width: 1px;
+        }
+
+        .pill-selector-wrapper {
+            margin-left: 0;
+            width: 100%;
+
+            .pill-selector-input-wrapper {
+                width: auto;
+            }
+        }
+    }
+}

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskForm-test.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskForm-test.js
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import DatePicker from 'box-react-ui/lib/components/date-picker/DatePicker'; // eslint-disable-line no-unused-vars
+
+import { TaskFormUnwrapped as TaskForm } from '..';
+
+jest.mock('../../Avatar', () => () => 'Avatar');
+jest.mock('box-react-ui/lib/components/date-picker/DatePicker', () => props => (
+    <input type="date" {...props} {...props.inputProps} />
+));
+
+const mockIntl = {
+    formatMessage: message => message.defaultMessage,
+};
+
+const render = props =>
+    mount(<TaskForm getMentionWithQuery={() => {}} user={{ id: 123, name: 'foo bar' }} intl={mockIntl} {...props} />);
+
+describe('components/ContentSidebar/ActivityFeed/task-form/TaskForm', () => {
+    test('should render form fields', () => {
+        const wrapper = render({ createTask: jest.fn() });
+        const container = wrapper.render();
+
+        expect(container.find('[data-testid="task-form-assignee-input"]').length).toEqual(1);
+        expect(container.find('[data-testid="task-form-name-input"]').length).toEqual(1);
+        expect(container.find('[data-testid="task-form-date-input"]').length).toEqual(1);
+        expect(container.find('.bcs-task-input-controls').length).toEqual(1);
+        expect(container.find('.bcs-task-input-controls').find('button').length).toEqual(2);
+    });
+
+    test('should call createTask prop on submit when form is valid', () => {
+        const createTaskSpy = jest.fn();
+        const wrapper = render({
+            createTask: createTaskSpy,
+        });
+
+        const approvers = [{ text: 'user one', value: '123' }];
+        const message = 'hey';
+        const dueDate = new Date('2019-04-12');
+
+        // Warning: bypass user interactions to populate form
+        wrapper.setState({
+            approvers,
+            message,
+            dueDate,
+            isValid: true,
+        });
+
+        // Clicks should cause form submit but Enzyme doesn't do it
+        const submitButton = wrapper.find('[data-testid="task-form-submit-button"]').hostNodes();
+        submitButton.simulate('submit', {
+            target: {
+                checkValidity: () => true, // not implemented in JSDOM
+            },
+        });
+
+        expect(createTaskSpy).toHaveBeenCalled();
+    });
+
+    test('should call onCancel handler when cancel button is clicked', async () => {
+        const onCancelSpy = jest.fn();
+        const wrapper = render({ onCancel: onCancelSpy });
+
+        // This should be linked to an element but Enzyme won't simulate the event below
+        const cancelButton = wrapper.find('[data-testid="task-form-cancel-button"]').hostNodes();
+        cancelButton.simulate('click');
+
+        expect(onCancelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not call createTask() when inputs are empty', () => {
+        const createTaskSpy = jest.fn();
+        const wrapper = render({ createTask: createTaskSpy });
+
+        const submitButton = wrapper.find('[data-testid="task-form-submit-button"]').hostNodes();
+        submitButton.simulate('click');
+
+        expect(createTaskSpy).not.toHaveBeenCalled();
+        expect(submitButton.props()['aria-disabled']).toBe(true);
+    });
+
+    test('should filter out already-assigned users from assignment dropdown options', () => {
+        const wrapper = render({
+            approverSelectorContacts: [
+                { id: 123, item: { id: 123, name: 'name' }, name: 'name' },
+                { id: 234, item: { id: 234, name: 'test' }, name: 'test' },
+            ],
+            createTask: jest.fn(),
+        });
+        wrapper.setState({
+            approvers: [{ text: 'name', value: 123 }],
+        });
+        expect(wrapper.find('PillSelectorDropdown').prop('selectorOptions').length).toBe(1);
+    });
+
+    describe('handleDueDateChange()', () => {
+        test('should set the approval date to be one millisecond before midnight of the next day', async () => {
+            // Midnight on December 3rd GMT
+            const date = new Date('2018-12-03T00:00:00');
+            // 11:59:59:999 on December 3rd GMT
+            const lastMillisecondOfDate = new Date('2018-12-03T23:59:59.999');
+            const wrapper = render({});
+
+            wrapper.instance().handleDueDateChange(date);
+
+            expect(wrapper.state('dueDate')).toEqual(lastMillisecondOfDate);
+        });
+
+        test('should change a previously set approval date to null if there is no approval date', () => {
+            // Midnight on December 3rd GMT
+            const date = new Date('2018-12-03T00:00:00');
+            // 11:59:59:999 on December 3rd GMT
+            const lastMillisecondOfDate = new Date('2018-12-03T23:59:59.999');
+            const wrapper = render({});
+
+            wrapper.instance().handleDueDateChange(date);
+            expect(wrapper.state('dueDate')).toEqual(lastMillisecondOfDate);
+
+            wrapper.instance().handleDueDateChange(null);
+            expect(wrapper.state('dueDate')).toEqual(null);
+        });
+    });
+
+    describe('handleApproverSelectorInput()', () => {
+        test('should call getApproverWithQuery() when called', () => {
+            const value = 'test';
+            const getApproverWithQuery = jest.fn();
+            const wrapper = render({ getApproverWithQuery });
+            wrapper.instance().handleApproverSelectorInput(value);
+
+            expect(getApproverWithQuery).toHaveBeenCalledWith(value);
+        });
+    });
+
+    describe('handleApproverSelectorSelect()', () => {
+        test('should update approvers when called', () => {
+            const wrapper = render();
+            wrapper.setState({ approvers: [{ value: 123 }] });
+            wrapper.instance().handleApproverSelectorSelect([{ value: 234 }]);
+            expect(wrapper.state('approvers')).toEqual([{ value: 123 }, { value: 234 }]);
+        });
+    });
+
+    describe('handleApproverSelectorRemove()', () => {
+        test('should update approvers when called', () => {
+            const wrapper = render();
+            wrapper.setState({ approvers: [{ value: 123 }, { value: 234 }] });
+            wrapper.instance().handleApproverSelectorRemove({ value: 123 }, 0);
+            expect(wrapper.state('approvers')).toEqual([{ value: 234 }]);
+        });
+    });
+});

--- a/src/elements/content-sidebar/activity-feed/task-form/index.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/index.js
@@ -1,0 +1,3 @@
+// @flow
+export * from './TaskForm';
+export { default } from './TaskForm';

--- a/src/elements/content-sidebar/activity-feed/task/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task/Task.js
@@ -77,6 +77,7 @@ class Task extends React.Component<Props> {
                 className={classNames('bcs-task', {
                     'bcs-is-pending': isPending || error,
                 })}
+                data-testid="task-card"
             >
                 <Comment
                     created_at={created_at}

--- a/src/elements/content-sidebar/activity-feed/task/__tests__/__snapshots__/Task-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task/__tests__/__snapshots__/Task-test.js.snap
@@ -3,6 +3,7 @@
 exports[`elements/content-sidebar/ActivityFeed/task/Task should correctly render task 1`] = `
 <div
   className="bcs-task"
+  data-testid="task-card"
 >
   <mock-comment
     created_at={12345678}
@@ -86,6 +87,7 @@ exports[`elements/content-sidebar/ActivityFeed/task/Task should correctly render
 exports[`elements/content-sidebar/ActivityFeed/task/Task should not render due date when not passed in 1`] = `
 <div
   className="bcs-task"
+  data-testid="task-card"
 >
   <mock-comment
     created_at={12345678}
@@ -154,6 +156,7 @@ exports[`elements/content-sidebar/ActivityFeed/task/Task should not render due d
 exports[`elements/content-sidebar/ActivityFeed/task/Task should show actions for current user and if onAssignmentUpdate is defined 1`] = `
 <div
   className="bcs-task"
+  data-testid="task-card"
 >
   <mock-comment
     created_at={12345678}

--- a/test/integration/content-sidebar/TaskForm.e2e.test.js
+++ b/test/integration/content-sidebar/TaskForm.e2e.test.js
@@ -1,12 +1,12 @@
 // <reference types="Cypress" />
-import { localize as l } from '../../support/i18n';
+import l from '../../support/i18n';
 
 describe('Create Task', () => {
-    const getAssigneeField = opts => cy.getByLabelText(l('be.tasks.addTaskForm.assigneesLabel'), opts);
-    const getMessageField = opts => cy.getByLabelText(l('be.tasks.addTaskForm.messageLabel'), opts);
-    const getSubmitButton = opts => cy.getByTestId('task-form-submit-button', opts);
-    const getCancelButton = opts => cy.getByTestId('task-form-cancel-button', opts);
-    const username = 'Platform ';
+    const getAssigneeField = () => cy.getByTestId('task-form-assignee-input');
+    const getMessageField = () => cy.getByTestId('task-form-name-input');
+    const getSubmitButton = () => cy.getByTestId('task-form-submit-button');
+    const getCancelButton = () => cy.getByTestId('task-form-cancel-button');
+    const username = 'Platform '; // will be used as assignee
 
     beforeEach(() => {
         cy.visit('/ContentSidebar'); // Open sidebar example page
@@ -15,9 +15,9 @@ describe('Create Task', () => {
 
     context('Add Task button', () => {
         it('opens task form', () => {
-            cy.getByText(l('be.tasks.addTask')).click();
+            cy.contains(l('be.tasks.addTask')).click();
             cy.getByTestId('create-task-modal').within(() => {
-                cy.getByText(l('be.tasks.addTaskForm.title')).should('exist');
+                cy.contains(l('be.tasks.addTaskForm.title')).should('exist');
                 getSubmitButton().should('exist');
                 getCancelButton().should('exist');
             });
@@ -26,28 +26,28 @@ describe('Create Task', () => {
 
     context('Task Form', () => {
         beforeEach(() => {
-            cy.getByText(l('be.tasks.addTask')).click();
+            cy.contains(l('be.tasks.addTask')).click();
         });
         it('does not allow submitting form without input', () => {
             getMessageField()
                 .type('...')
                 .clear();
-            cy.getByText('Required Field').should('exist');
+            cy.contains('Required Field').should('exist');
         });
 
         it('creates task if form is filled out', () => {
-            cy.getByTestId('create-task-modal').within(form => {
-                getAssigneeField({ container: form })
+            cy.getByTestId('create-task-modal').within(() => {
+                getAssigneeField()
                     .type(username)
                     .trigger('keydown', { code: 'ArrowDown', which: 40 });
                 cy.getByTestId('task-assignee-option').click();
-                getMessageField({ container: form }).type('valid e2e task');
+                getMessageField().type('valid e2e task');
 
-                getSubmitButton({ container: form }).click();
+                getSubmitButton().click();
             });
 
             // modal should close
-            cy.queryByTestId('create-task-modal').should('be.null');
+            cy.getByTestId('create-task-modal').should('not.exist');
 
             // validate task appears in feed
             // note that in the test environment task create fails with default token
@@ -56,7 +56,7 @@ describe('Create Task', () => {
                 cy.getByTestId('task-card')
                     .last()
                     .within(() => {
-                        cy.getByText('valid e2e task').should('exist');
+                        cy.contains('valid e2e task').should('exist');
                     });
             });
         });

--- a/test/integration/content-sidebar/TaskForm.e2e.test.js
+++ b/test/integration/content-sidebar/TaskForm.e2e.test.js
@@ -1,0 +1,64 @@
+// <reference types="Cypress" />
+import { localize as l } from '../../support/i18n';
+
+describe('Create Task', () => {
+    const getAssigneeField = opts => cy.getByLabelText(l('be.tasks.addTaskForm.assigneesLabel'), opts);
+    const getMessageField = opts => cy.getByLabelText(l('be.tasks.addTaskForm.messageLabel'), opts);
+    const getSubmitButton = opts => cy.getByTestId('task-form-submit-button', opts);
+    const getCancelButton = opts => cy.getByTestId('task-form-cancel-button', opts);
+    const username = 'Platform ';
+
+    beforeEach(() => {
+        cy.visit('/ContentSidebar'); // Open sidebar example page
+        cy.getByTestId('sidebaractivity').click(); // Open activity tab
+    });
+
+    context('Add Task button', () => {
+        it('opens task form', () => {
+            cy.getByText(l('be.tasks.addTask')).click();
+            cy.getByTestId('create-task-modal').within(() => {
+                cy.getByText(l('be.tasks.addTaskForm.title')).should('exist');
+                getSubmitButton().should('exist');
+                getCancelButton().should('exist');
+            });
+        });
+    });
+
+    context('Task Form', () => {
+        beforeEach(() => {
+            cy.getByText(l('be.tasks.addTask')).click();
+        });
+        it('does not allow submitting form without input', () => {
+            getMessageField()
+                .type('...')
+                .clear();
+            cy.getByText('Required Field').should('exist');
+        });
+
+        it('creates task if form is filled out', () => {
+            cy.getByTestId('create-task-modal').within(form => {
+                getAssigneeField({ container: form })
+                    .type(username)
+                    .trigger('keydown', { code: 'ArrowDown', which: 40 });
+                cy.getByTestId('task-assignee-option').click();
+                getMessageField({ container: form }).type('valid e2e task');
+
+                getSubmitButton({ container: form }).click();
+            });
+
+            // modal should close
+            cy.queryByTestId('create-task-modal').should('be.null');
+
+            // validate task appears in feed
+            // note that in the test environment task create fails with default token
+            // but the card temporarily appears
+            cy.getByTestId('activityfeed').within(() => {
+                cy.getByTestId('task-card')
+                    .last()
+                    .within(() => {
+                        cy.getByText('valid e2e task').should('exist');
+                    });
+            });
+        });
+    });
+});

--- a/test/sidebar.html
+++ b/test/sidebar.html
@@ -151,7 +151,11 @@
                     hasActivityFeed: true,
                     hasSkills: true,
                     features: {
-                        tasks: true,
+                        activityFeed: {
+                            tasks: {
+                                createButton: true,
+                            },
+                        },
                     }
                 });
                 if (refreshOnComplete) window.location.reload();

--- a/test/sidebar.html
+++ b/test/sidebar.html
@@ -35,6 +35,8 @@
             <div class="sidebar2"></div>
             <div class="gap">&nbsp;&nbsp;</div>
             <div class="sidebar3"></div>
+            <div class="gap">&nbsp;&nbsp;</div>
+            <div class="sidebar4"></div>
             <div class="inputs">
                 <div>
                     <label>
@@ -46,7 +48,7 @@
                         <input class="token" type="text" placeholder="Enter auth token" />
                     </label>
                 </div>
-                <button type="button" onclick="load()">Submit</button>
+                <button type="button" onclick="load(true)">Submit</button>
             </div>
             </div>
         <link rel="stylesheet" type="text/css" href="../dev/en-US/sidebar.css" />
@@ -55,7 +57,7 @@
     <body>
         <div class="preview sidebar1"></div>
         <script>
-            function load() {
+            function load(refreshOnComplete = false) {
                 const { ContentSidebar } = Box;
                 const token = document.querySelector('.token').value || localStorage.getItem('token');
                 const fileId = document.querySelector('.file').value || localStorage.getItem('file');
@@ -134,8 +136,27 @@
                         getUserProfileUrl: (id) => { return Promise.resolve('#'); }
                     }
                 });
+
+                const sidebar4 = new ContentSidebar();
+                sidebar4.show(fileId, token, {
+                    container: '.sidebar4',
+                    isLarge: true,
+                    detailsSidebarProps: {
+                        hasProperties: true,
+                        hasNotices: true,
+                        hasVersions: true,
+                        hasAccessStats: true,
+                        hasClassification: true
+                    },
+                    hasActivityFeed: true,
+                    hasSkills: true,
+                    features: {
+                        tasks: true,
+                    }
+                });
+                if (refreshOnComplete) window.location.reload();
             }
-            load();
+            load(false);
         </script>
     </body>
 </html>


### PR DESCRIPTION
- [x] Adds new modal-based task create UX behind a feature flag
- [x] Improve validation handling: ported-over ApprovalCommentForm does everything on submit; this could be better
- [x] Refactor components: "Add Task" button + form can probably be pulled out of ActivitySidebar
- [x] Tests for form, button, modal