### PR TITLE
chore(sidebar): refactor / cleanup of content sidebar

### DIFF
--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -52,6 +52,7 @@ import {
     SKILLS_FACE,
     SKILLS_STATUS,
     SIZE_MEDIUM,
+    SIDEBAR_VIEW_NONE,
     SIDEBAR_VIEW_SKILLS,
     SIDEBAR_VIEW_ACTIVITY,
     SIDEBAR_VIEW_DETAILS,
@@ -608,6 +609,7 @@ type JsonPatch = {
 type JsonPatchData = Array<JsonPatch>;
 
 type SidebarView =
+    | typeof SIDEBAR_VIEW_NONE
     | typeof SIDEBAR_VIEW_SKILLS
     | typeof SIDEBAR_VIEW_DETAILS
     | typeof SIDEBAR_VIEW_METADATA

--- a/src/api/uploads/FolderUploadNode.js
+++ b/src/api/uploads/FolderUploadNode.js
@@ -103,6 +103,9 @@ class FolderUploadNode {
             // @TODO: Handle 429
             if (error.code !== ERROR_CODE_ITEM_NAME_IN_USE) {
                 errorCallback(error);
+                if (isRoot) {
+                    throw new Error('abort');
+                }
                 return;
             }
 

--- a/src/components/ContentSidebar/ContentSidebar.js
+++ b/src/components/ContentSidebar/ContentSidebar.js
@@ -5,12 +5,13 @@
  */
 
 import 'regenerator-runtime/runtime';
-import React, { PureComponent } from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import uniqueid from 'lodash/uniqueId';
 import noop from 'lodash/noop';
 import LoadingIndicator from 'box-react-ui/lib/components/loading-indicator/LoadingIndicator';
 import Sidebar from './Sidebar';
+import SidebarNav from './SidebarNav';
 import API from '../../api';
 import APIContext from '../APIContext';
 import Internationalize from '../Internationalize';
@@ -37,41 +38,41 @@ import '../modal.scss';
 import './ContentSidebar.scss';
 
 type Props = {
-    fileId?: string,
-    isLarge?: boolean,
-    clientName: string,
+    activitySidebarProps: ActivitySidebarProps,
     apiHost: string,
-    token: Token,
+    cache?: APICache,
     className: string,
-    defaultView?: SidebarView,
+    clientName: string,
     currentUser?: User,
+    defaultView?: SidebarView,
+    detailsSidebarProps: DetailsSidebarProps,
+    fileId?: string,
     getPreview: Function,
     getViewer: Function,
-    hasSkills: boolean,
-    activitySidebarProps: ActivitySidebarProps,
-    detailsSidebarProps: DetailsSidebarProps,
-    metadataSidebarProps: MetadataSidebarProps,
-    hasMetadata: boolean,
     hasActivityFeed: boolean,
+    hasMetadata: boolean,
+    hasSkills: boolean,
+    isLarge?: boolean,
     language?: string,
+    metadataSidebarProps: MetadataSidebarProps,
     messages?: StringMap,
-    cache?: APICache,
-    sharedLink?: string,
-    sharedLinkPassword?: string,
+    onVersionHistoryClick?: Function,
     requestInterceptor?: Function,
     responseInterceptor?: Function,
-    onVersionHistoryClick?: Function,
+    sharedLink?: string,
+    sharedLinkPassword?: string,
+    token: Token,
 } & ErrorContextProps;
 
 type State = {
-    view?: SidebarView,
-    editors?: Array<MetadataEditor>,
     file?: BoxItem,
-    isVisible?: boolean,
-    hasBeenToggled?: boolean,
+    isOpen: boolean,
+    isLoading: boolean,
+    metadataEditors?: Array<MetadataEditor>,
+    view?: SidebarView,
 };
 
-class ContentSidebar extends PureComponent<Props, State> {
+class ContentSidebar extends React.PureComponent<Props, State> {
     id: string;
 
     props: Props;
@@ -81,22 +82,18 @@ class ContentSidebar extends PureComponent<Props, State> {
     api: API;
 
     static defaultProps = {
+        activitySidebarProps: {},
+        apiHost: DEFAULT_HOSTNAME_API,
         className: '',
         clientName: CLIENT_NAME_CONTENT_SIDEBAR,
-        apiHost: DEFAULT_HOSTNAME_API,
+        detailsSidebarProps: {},
         getPreview: noop,
         getViewer: noop,
-        isLarge: true,
-        hasSkills: false,
-        hasMetadata: false,
         hasActivityFeed: false,
-        activitySidebarProps: {},
-        detailsSidebarProps: {},
+        hasMetadata: false,
+        hasSkills: false,
+        isLarge: true,
         metadataSidebarProps: {},
-    };
-
-    initialState: State = {
-        file: undefined,
     };
 
     /**
@@ -108,30 +105,30 @@ class ContentSidebar extends PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
         const {
-            cache,
-            token,
-            sharedLink,
-            sharedLinkPassword,
             apiHost,
+            isLarge,
+            cache,
             clientName,
             requestInterceptor,
             responseInterceptor,
+            sharedLink,
+            sharedLinkPassword,
+            token,
         } = props;
 
         this.id = uniqueid('bcs_');
         this.api = new API({
-            cache,
-            token,
-            sharedLink,
-            sharedLinkPassword,
             apiHost,
+            cache,
             clientName,
             requestInterceptor,
             responseInterceptor,
+            sharedLink,
+            sharedLinkPassword,
+            token,
         });
 
-        // Clone initial state to allow for state reset on new files
-        this.state = { ...this.initialState };
+        this.state = { isLoading: true, isOpen: !!isLarge };
     }
 
     /**
@@ -157,36 +154,32 @@ class ContentSidebar extends PureComponent<Props, State> {
     }
 
     /**
-     * Fetches the root folder on load
+     * Fetches the file data on load
      *
      * @private
      * @inheritdoc
      * @return {void}
      */
     componentDidMount() {
-        this.fetchData(this.props);
+        this.fetchFile();
     }
 
     /**
-     * Called when sidebar gets new properties
+     * Fetches new file data on update
      *
      * @private
+     * @inheritdoc
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props): void {
+    componentDidUpdate(prevProps: Props) {
         const { fileId, isLarge }: Props = this.props;
-        const { file, editors, hasBeenToggled }: State = this.state;
-        const hasVisibilityChanged = nextProps.isLarge !== isLarge;
-        const hasFileIdChanged = nextProps.fileId !== fileId;
+        const { fileId: prevFileId, isLarge: prevIsLarge }: Props = prevProps;
+        const { view }: State = this.state;
 
-        if (hasFileIdChanged) {
-            // Clear out existing state
-            this.setState({ ...this.initialState });
-            this.fetchData(nextProps);
-        } else if (!hasBeenToggled && hasVisibilityChanged) {
-            this.setState({
-                view: this.getDefaultSidebarView(nextProps, file, editors),
-            });
+        if (fileId !== prevFileId) {
+            this.fetchFile();
+        } else if (!view && isLarge !== prevIsLarge) {
+            this.setState({ isOpen: isLarge });
         }
     }
 
@@ -197,29 +190,13 @@ class ContentSidebar extends PureComponent<Props, State> {
      * @return {void}
      */
     onToggle = (view: SidebarView): void => {
-        const { view: stateView }: State = this.state;
-        const isTogglingOff = view === stateView;
-        const isTogglingOn = !stateView && !!view;
-        const isToggling = isTogglingOff || isTogglingOn;
+        const { isOpen, view: priorView }: State = this.state;
+        const isClosing = isOpen && (!priorView || view === priorView);
         this.setState({
-            view: isTogglingOff ? undefined : view,
-            hasBeenToggled: isToggling,
+            view,
+            isOpen: !isClosing,
         });
     };
-
-    /**
-     * Fetches the file data for the sidebar
-     *
-     * @param {Object} Props the component props
-     * @return {void}
-     */
-    fetchData(props: Props): void {
-        const { fileId }: Props = props;
-        if (fileId && SidebarUtils.canHaveSidebar(props)) {
-            // Fetch the new file
-            this.fetchFile(fileId);
-        }
-    }
 
     /**
      * Network error callback
@@ -248,12 +225,11 @@ class ContentSidebar extends PureComponent<Props, State> {
      * @param {Object} file - Box file
      * @return {string} Sidebar view to use
      */
-    getDefaultSidebarView(props: Props, file?: BoxItem, editors?: Array<MetadataEditor>): SidebarView {
-        const { view, hasBeenToggled }: State = this.state;
-        const { isLarge, defaultView }: Props = props;
+    getSidebarView(): ?SidebarView {
+        const { file, isOpen, metadataEditors, view }: State = this.state;
+        const { defaultView }: Props = this.props;
 
-        // If no file we don't have a view
-        if (!file) {
+        if (!isOpen) {
             return undefined;
         }
 
@@ -262,28 +238,11 @@ class ContentSidebar extends PureComponent<Props, State> {
             return defaultView;
         }
 
-        // If the user manually toggled the sidebar, respect that.
-        // Otherwise use responsiveness to determine default view.
-        if (!hasBeenToggled && !isLarge) {
-            return undefined;
-        }
-
-        let newView;
+        let newView = view;
         const canDefaultToSkills = SidebarUtils.shouldRenderSkillsSidebar(this.props, file);
         const canDefaultToDetails = SidebarUtils.canHaveDetailsSidebar(this.props);
         const canDefaultToActivity = SidebarUtils.canHaveActivitySidebar(this.props);
-        const canDefaultToMetadata = SidebarUtils.shouldRenderMetadataSidebar(this.props, editors);
-
-        // Calculate the default view with latest props
-        if (canDefaultToSkills) {
-            newView = SIDEBAR_VIEW_SKILLS;
-        } else if (canDefaultToActivity) {
-            newView = SIDEBAR_VIEW_ACTIVITY;
-        } else if (canDefaultToDetails) {
-            newView = SIDEBAR_VIEW_DETAILS;
-        } else if (canDefaultToMetadata) {
-            newView = SIDEBAR_VIEW_METADATA;
-        }
+        const canDefaultToMetadata = SidebarUtils.shouldRenderMetadataSidebar(this.props, metadataEditors);
 
         // Only reset the view if prior view is no longer applicable
         if (
@@ -293,75 +252,92 @@ class ContentSidebar extends PureComponent<Props, State> {
             (view === SIDEBAR_VIEW_DETAILS && !canDefaultToDetails) ||
             (view === SIDEBAR_VIEW_METADATA && !canDefaultToMetadata)
         ) {
-            return newView;
+            if (canDefaultToSkills) {
+                newView = SIDEBAR_VIEW_SKILLS;
+            } else if (canDefaultToActivity) {
+                newView = SIDEBAR_VIEW_ACTIVITY;
+            } else if (canDefaultToDetails) {
+                newView = SIDEBAR_VIEW_DETAILS;
+            } else if (canDefaultToMetadata) {
+                newView = SIDEBAR_VIEW_METADATA;
+            }
         }
 
-        return view;
+        return newView;
     }
 
     /**
-     * File fetch success callback that sets the file and view
-     * Only set file if there is data to show in the sidebar.
-     * Skills sidebar doesn't show when there is no data.
+     * Success callback for fetching metadata editors
      *
      * @private
      * @param {Object} file - Box file
      * @return {void}
      */
-    fetchMetadataSuccessCallback = (file: BoxItem, editors?: Array<MetadataEditor>): void => {
-        let newState = { isVisible: false };
-        if (SidebarUtils.shouldRenderSidebar(this.props, file, editors)) {
-            newState = {
-                file,
-                editors,
-                isVisible: true,
-                view: this.getDefaultSidebarView(this.props, file, editors),
-            };
-        }
-        this.setState(newState);
+    fetchMetadataSuccessCallback = ({ editors }: { editors: Array<MetadataEditor> }): void => {
+        this.setState({ metadataEditors: editors });
     };
 
     /**
-     * File fetch success callback that sets the file and view
-     * Only set file if there is data to show in the sidebar.
-     * Skills sidebar doesn't show when there is no data.
+     * Fetches file metadata editors if required
      *
      * @private
-     * @param {Object} file - Box file
      * @return {void}
      */
-    fetchFileSuccessCallback = (file: BoxItem): void => {
+    fetchMetadata(): void {
+        const { file }: State = this.state;
         const { metadataSidebarProps }: Props = this.props;
         const { getMetadata, isFeatureEnabled = true }: MetadataSidebarProps = metadataSidebarProps;
+
+        // Only fetch metadata if we think that the file may have metadata on it
+        // but currently the metadata feature is turned off. Use case of this would be a free
+        // user who doesn't have the metadata feature but is collabed on a file from a user
+        // who added metadata on the file. If the feature is enabled we always end up showing
+        // the metadata sidebar irrespective of there being any existing metadata or not.
         const canHaveMetadataSidebar = !isFeatureEnabled && SidebarUtils.canHaveMetadataSidebar(this.props);
 
         if (canHaveMetadataSidebar) {
             this.api
                 .getMetadataAPI(true)
                 .getEditors(
-                    file,
-                    ({ editors }: { editors?: Array<MetadataEditor> }) =>
-                        this.fetchMetadataSuccessCallback(file, editors),
-                    () => this.fetchMetadataSuccessCallback(file),
+                    ((file: any): BoxItem),
+                    this.fetchMetadataSuccessCallback,
+                    noop,
                     getMetadata,
                     isFeatureEnabled,
                 );
-        } else {
-            this.fetchMetadataSuccessCallback(file);
         }
+    }
+
+    /**
+     * File fetch success callback that sets the file and sidebar visibility.
+     * Also makes an optional request to fetch metadata editors.
+     *
+     * @private
+     * @param {Object} file - Box file
+     * @return {void}
+     */
+    fetchFileSuccessCallback = (file: BoxItem): void => {
+        this.setState(
+            {
+                file,
+                isLoading: false,
+            },
+            this.fetchMetadata,
+        );
     };
 
     /**
      * Fetches a file
      *
      * @private
-     * @param {string} id - File id
      * @param {Object|void} [fetchOptions] - Fetch options
      * @return {void}
      */
-    fetchFile(id: string, fetchOptions: FetchOptions = {}): void {
-        if (SidebarUtils.canHaveSidebar(this.props)) {
-            this.api.getFileAPI().getFile(id, this.fetchFileSuccessCallback, this.errorCallback, {
+    fetchFile(fetchOptions: FetchOptions = {}): void {
+        const { fileId }: Props = this.props;
+        this.setState({ isLoading: true });
+        if (fileId && SidebarUtils.canHaveSidebar(this.props)) {
+            this.api.getFileAPI().getFile(fileId, this.fetchFileSuccessCallback, this.errorCallback, {
                 ...fetchOptions,
                 fields: SIDEBAR_FIELDS_TO_FETCH,
             });
@@ -377,69 +353,67 @@ class ContentSidebar extends PureComponent<Props, State> {
      */
     render() {
         const {
-            language,
-            messages,
+            activitySidebarProps,
+            className,
+            detailsSidebarProps,
             getPreview,
             getViewer,
             hasActivityFeed,
-            className,
-            activitySidebarProps,
-            detailsSidebarProps,
+            language,
+            messages,
             metadataSidebarProps,
             onVersionHistoryClick,
         }: Props = this.props;
-        const { editors, file, view, isVisible }: State = this.state;
+        const { file, isLoading, isOpen, metadataEditors }: State = this.state;
+        const hasSidebar = SidebarUtils.shouldRenderSidebar(this.props, file, metadataEditors);
 
-        // By default sidebar is always visible if there is something configured
-        // to show via props. At least one of the sidebars is needed for visibility.
-        // However we may turn the visibility off if there is no data to show
-        // in the sidebar. This can only happen if skills sidebar was showing
-        // however there is no skills data to show. For all other sidebars
-        // we show them by default even if there is no data in them.
-        if (!isVisible || !SidebarUtils.canHaveSidebar(this.props)) {
+        if (!file || !hasSidebar) {
             return null;
         }
 
+        const selectedView = this.getSidebarView();
+        const hasSkills = SidebarUtils.shouldRenderSkillsSidebar(this.props, file);
+        const hasDetails = SidebarUtils.canHaveDetailsSidebar(this.props);
+        const hasMetadata = SidebarUtils.shouldRenderMetadataSidebar(this.props, metadataEditors);
         const styleClassName = classNames(
             'be bcs',
             {
-                [`bcs-${((view: any): string)}`]: !!view,
-                'bcs-is-open': !!view,
+                [`bcs-${((selectedView: any): string)}`]: isOpen,
+                'bcs-is-open': isOpen,
             },
             className,
         );
-
-        const hasSkills = SidebarUtils.shouldRenderSkillsSidebar(this.props, file);
-        const hasDetails = SidebarUtils.canHaveDetailsSidebar(this.props);
-        const hasMetadata = SidebarUtils.shouldRenderMetadataSidebar(this.props, editors);
-        const hasSidebar = SidebarUtils.shouldRenderSidebar(this.props, file, editors);
 
         return (
             <Internationalize language={language} messages={messages}>
                 <aside id={this.id} className={styleClassName}>
                     <div className="be-app-element">
-                        {hasSidebar ? (
-                            <APIContext.Provider value={(this.api: any)}>
-                                <Sidebar
-                                    file={((file: any): BoxItem)}
-                                    view={view}
-                                    detailsSidebarProps={detailsSidebarProps}
-                                    activitySidebarProps={activitySidebarProps}
-                                    metadataSidebarProps={metadataSidebarProps}
-                                    getPreview={getPreview}
-                                    getViewer={getViewer}
-                                    hasSkills={hasSkills}
-                                    hasDetails={hasDetails}
-                                    hasMetadata={hasMetadata}
-                                    hasActivityFeed={hasActivityFeed}
-                                    onToggle={this.onToggle}
-                                    onVersionHistoryClick={onVersionHistoryClick}
-                                />
-                            </APIContext.Provider>
-                        ) : (
+                        {isLoading ? (
                             <div className="bcs-loading">
                                 <LoadingIndicator />
                             </div>
+                        ) : (
+                            <APIContext.Provider value={(this.api: any)}>
+                                <SidebarNav
+                                    hasSkills={hasSkills}
+                                    hasMetadata={hasMetadata}
+                                    hasActivityFeed={hasActivityFeed}
+                                    hasDetails={hasDetails}
+                                    onToggle={this.onToggle}
+                                    selectedView={selectedView}
+                                />
+                                <Sidebar
+                                    activitySidebarProps={activitySidebarProps}
+                                    detailsSidebarProps={detailsSidebarProps}
+                                    file={file}
+                                    getPreview={getPreview}
+                                    getViewer={getViewer}
+                                    key={file.id}
+                                    metadataSidebarProps={metadataSidebarProps}
+                                    onVersionHistoryClick={onVersionHistoryClick}
+                                    selectedView={selectedView}
+                                />
+                            </APIContext.Provider>
                         )}
                     </div>
                 </aside>

--- a/src/components/ContentSidebar/Sidebar.js
+++ b/src/components/ContentSidebar/Sidebar.js
@@ -9,7 +9,6 @@ import DetailsSidebar from './DetailsSidebar';
 import SkillsSidebar from './SkillsSidebar';
 import ActivitySidebar from './ActivitySidebar';
 import MetadataSidebar from './MetadataSidebar';
-import SidebarNav from './SidebarNav';
 import {
     SIDEBAR_VIEW_SKILLS,
     SIDEBAR_VIEW_ACTIVITY,
@@ -22,72 +21,44 @@ import type { MetadataSidebarProps } from './MetadataSidebar';
 import './Sidebar.scss';
 
 type Props = {
-    view?: SidebarView,
+    activitySidebarProps: ActivitySidebarProps,
     currentUser?: User,
+    detailsSidebarProps: DetailsSidebarProps,
     file: BoxItem,
     getPreview: Function,
     getViewer: Function,
-    activitySidebarProps: ActivitySidebarProps,
-    detailsSidebarProps: DetailsSidebarProps,
     metadataSidebarProps: MetadataSidebarProps,
-    hasSkills: boolean,
-    hasMetadata: boolean,
-    hasActivityFeed: boolean,
-    hasSkills: boolean,
-    hasDetails: boolean,
-    translations?: Translations,
-    onToggle: Function,
     onVersionHistoryClick?: Function,
+    selectedView: SidebarView,
 };
 
 const Sidebar = ({
-    view,
+    activitySidebarProps,
     currentUser,
+    detailsSidebarProps,
     file,
     getPreview,
     getViewer,
-    hasMetadata,
-    hasActivityFeed,
-    hasSkills,
-    hasDetails,
-    activitySidebarProps,
-    detailsSidebarProps,
     metadataSidebarProps,
-    onToggle,
     onVersionHistoryClick,
+    selectedView,
 }: Props) => (
     <React.Fragment>
-        <SidebarNav
-            onToggle={onToggle}
-            selectedView={view}
-            hasSkills={hasSkills}
-            hasMetadata={hasMetadata}
-            hasActivityFeed={hasActivityFeed}
-            hasDetails={hasDetails}
-        />
-        {view === SIDEBAR_VIEW_DETAILS && hasDetails && (
-            <DetailsSidebar
-                key={file.id}
-                file={file}
-                onVersionHistoryClick={onVersionHistoryClick}
-                {...detailsSidebarProps}
-            />
+        {selectedView === SIDEBAR_VIEW_DETAILS && (
+            <DetailsSidebar file={file} onVersionHistoryClick={onVersionHistoryClick} {...detailsSidebarProps} />
         )}
-        {view === SIDEBAR_VIEW_SKILLS && hasSkills && (
-            <SkillsSidebar key={file.id} file={file} getPreview={getPreview} getViewer={getViewer} />
+        {selectedView === SIDEBAR_VIEW_SKILLS && (
+            <SkillsSidebar file={file} getPreview={getPreview} getViewer={getViewer} />
         )}
-        {view === SIDEBAR_VIEW_ACTIVITY && hasActivityFeed && (
+        {selectedView === SIDEBAR_VIEW_ACTIVITY && (
             <ActivitySidebar
-                key={file.id}
                 currentUser={currentUser}
                 file={file}
                 onVersionHistoryClick={onVersionHistoryClick}
                 {...activitySidebarProps}
             />
         )}
-        {view === SIDEBAR_VIEW_METADATA && hasMetadata && (
-            <MetadataSidebar currentUser={currentUser} key={file.id} file={file} {...metadataSidebarProps} />
-        )}
+        {selectedView === SIDEBAR_VIEW_METADATA && <MetadataSidebar file={file} {...metadataSidebarProps} />}
     </React.Fragment>
 );
 

--- a/src/components/ContentSidebar/SidebarUtils.js
+++ b/src/components/ContentSidebar/SidebarUtils.js
@@ -88,17 +88,17 @@ class SidebarUtils {
      *
      * @private
      * @param {ContentSidebarProps} props - User passed in props
-     * @param {Array<MetadataEditor>} editors - metadata editors
+     * @param {Array<MetadataEditor>} metadataEditors - metadata metadataEditors
      * @param {Boolean} isMetadataEnabled - metadata feature
      * @return {Boolean} true if we should render
      */
-    static shouldRenderMetadataSidebar(props: ContentSidebarProps, editors?: Array<MetadataEditor>): boolean {
+    static shouldRenderMetadataSidebar(props: ContentSidebarProps, metadataEditors?: Array<MetadataEditor>): boolean {
         const { metadataSidebarProps = {} }: ContentSidebarProps = props;
         const { isFeatureEnabled = true }: MetadataSidebarProps = metadataSidebarProps;
 
         return (
             SidebarUtils.canHaveMetadataSidebar(props) &&
-            (isFeatureEnabled || (Array.isArray(editors) && editors.length > 0))
+            (isFeatureEnabled || (Array.isArray(metadataEditors) && metadataEditors.length > 0))
         );
     }
 
@@ -110,13 +110,17 @@ class SidebarUtils {
      * @param {BoxItem} file - box file
      * @return {Boolean} true if we should fetch or render
      */
-    static shouldRenderSidebar(props: ContentSidebarProps, file?: BoxItem, editors?: Array<MetadataEditor>): boolean {
+    static shouldRenderSidebar(
+        props: ContentSidebarProps,
+        file?: BoxItem,
+        metadataEditors?: Array<MetadataEditor>,
+    ): boolean {
         return (
             !!file &&
             (SidebarUtils.canHaveDetailsSidebar(props) ||
                 SidebarUtils.shouldRenderSkillsSidebar(props, file) ||
                 SidebarUtils.canHaveActivitySidebar(props) ||
-                SidebarUtils.shouldRenderMetadataSidebar(props, editors))
+                SidebarUtils.shouldRenderMetadataSidebar(props, metadataEditors))
         );
     }
 }


### PR DESCRIPTION
- make object attributes in ascending order
- remove cwrp
- default state properties
- break up file fetch and metadata fetch

Use Cases
- When the user has not interfered with the sidebar
  - The sidebar should open when viewport is large enough (current threshold 1000)
  - The sidebar should close when viewport is small
  - When navigating from file to file, tabs should switch based on this order of precedence: skills > activity > details > metadata

- When the user has interfered with the sidebar
  - Sidebar should remain closed if the user closed it when navigating between files
  - Sidebar should stick to prior chosen tab if it exists

- When navigating between files sidebar should show loading indicator
- When opening file for 1st time, then sidebar should only show up after file load, so that we dont have two loading indicators
- Sidebar should not show on shared file page unless skills exist
- Sidebar should show for shared folder page with details and optionally skills