### PR TITLE
fix(sidebar): Maintain toggle state across file navigation

### DIFF
--- a/src/components/ContentSidebar/ContentSidebar.js
+++ b/src/components/ContentSidebar/ContentSidebar.js
@@ -43,7 +43,6 @@ type Props = {
     className: string,
     clientName: string,
     currentUser?: User,
-    defaultView?: SidebarView,
     detailsSidebarProps: DetailsSidebarProps,
     fileId?: string,
     getPreview: Function,
@@ -226,15 +225,9 @@ class ContentSidebar extends React.PureComponent<Props, State> {
      */
     getSidebarView(): ?SidebarView {
         const { file, isOpen, metadataEditors, view }: State = this.state;
-        const { defaultView }: Props = this.props;
 
         if (!isOpen) {
             return undefined;
-        }
-
-        // If there was a default view provided, force use that
-        if (defaultView) {
-            return defaultView;
         }
 
         let newView = view;
@@ -318,11 +311,9 @@ class ContentSidebar extends React.PureComponent<Props, State> {
      * @return {void}
      */
     fetchFileSuccessCallback = (file: BoxItem): void => {
-        const view = this.getSidebarView();
         this.setState(
             {
                 file,
-                view,
                 isLoading: false,
             },
             this.fetchMetadata,
@@ -376,7 +367,8 @@ class ContentSidebar extends React.PureComponent<Props, State> {
             return null;
         }
 
-        const selectedView = isOpen ? this.state.view : undefined;
+        // const selectedView = isOpen ? this.state.view : undefined;
+        const selectedView = this.getSidebarView();
         const hasSkills = SidebarUtils.shouldRenderSkillsSidebar(this.props, file);
         const hasDetails = SidebarUtils.canHaveDetailsSidebar(this.props);
         const hasMetadata = SidebarUtils.shouldRenderMetadataSidebar(this.props, metadataEditors);

--- a/src/components/ContentSidebar/Sidebar.js
+++ b/src/components/ContentSidebar/Sidebar.js
@@ -9,7 +9,6 @@ import DetailsSidebar from './DetailsSidebar';
 import SkillsSidebar from './SkillsSidebar';
 import ActivitySidebar from './ActivitySidebar';
 import MetadataSidebar from './MetadataSidebar';
-import SidebarNav from './SidebarNav';
 import {
     SIDEBAR_VIEW_SKILLS,
     SIDEBAR_VIEW_ACTIVITY,
@@ -22,52 +21,32 @@ import type { MetadataSidebarProps } from './MetadataSidebar';
 import './Sidebar.scss';
 
 type Props = {
-    fileId: string,
-    view?: SidebarView,
+    activitySidebarProps: ActivitySidebarProps,
     currentUser?: User,
+    detailsSidebarProps: DetailsSidebarProps,
     file: BoxItem,
+    fileId: string,
     getPreview: Function,
     getViewer: Function,
-    activitySidebarProps: ActivitySidebarProps,
-    detailsSidebarProps: DetailsSidebarProps,
     metadataSidebarProps: MetadataSidebarProps,
-    hasSkills: boolean,
-    hasMetadata: boolean,
-    hasActivityFeed: boolean,
-    hasSkills: boolean,
-    hasDetails: boolean,
-    translations?: Translations,
-    onToggle: Function,
     onVersionHistoryClick?: Function,
+    selectedView?: SidebarView,
 };
 
 const Sidebar = ({
-    view,
+    activitySidebarProps,
     currentUser,
+    detailsSidebarProps,
     file,
+    fileId,
     getPreview,
     getViewer,
-    hasMetadata,
-    hasActivityFeed,
-    hasSkills,
-    hasDetails,
-    activitySidebarProps,
-    detailsSidebarProps,
     metadataSidebarProps,
-    onToggle,
     onVersionHistoryClick,
-    fileId,
+    selectedView,
 }: Props) => (
     <React.Fragment>
-        <SidebarNav
-            onToggle={onToggle}
-            selectedView={view}
-            hasSkills={hasSkills}
-            hasMetadata={hasMetadata}
-            hasActivityFeed={hasActivityFeed}
-            hasDetails={hasDetails}
-        />
-        {view === SIDEBAR_VIEW_DETAILS && hasDetails && (
+        {selectedView === SIDEBAR_VIEW_DETAILS && (
             <DetailsSidebar
                 key={fileId}
                 fileId={fileId}
@@ -75,21 +54,18 @@ const Sidebar = ({
                 {...detailsSidebarProps}
             />
         )}
-        {view === SIDEBAR_VIEW_SKILLS && hasSkills && (
+        {selectedView === SIDEBAR_VIEW_SKILLS && (
             <SkillsSidebar key={file.id} file={file} getPreview={getPreview} getViewer={getViewer} />
         )}
-        {view === SIDEBAR_VIEW_ACTIVITY && hasActivityFeed && (
+        {selectedView === SIDEBAR_VIEW_ACTIVITY && (
             <ActivitySidebar
-                key={file.id}
                 currentUser={currentUser}
                 file={file}
                 onVersionHistoryClick={onVersionHistoryClick}
                 {...activitySidebarProps}
             />
         )}
-        {view === SIDEBAR_VIEW_METADATA && hasMetadata && (
-            <MetadataSidebar currentUser={currentUser} key={file.id} file={file} {...metadataSidebarProps} />
-        )}
+        {selectedView === SIDEBAR_VIEW_METADATA && <MetadataSidebar file={file} {...metadataSidebarProps} />}
     </React.Fragment>
 );
 

--- a/src/components/ContentSidebar/__tests__/ContentSidebar-test.js
+++ b/src/components/ContentSidebar/__tests__/ContentSidebar-test.js
@@ -11,8 +11,6 @@ const file = {
     id: 'I_AM_A_FILE',
 };
 
-const editors = ['foo'];
-
 describe('components/ContentSidebar/ContentSidebar', () => {
     let rootElement;
     const getWrapper = props => mount(<ContentSidebar {...props} />, { attachTo: rootElement });
@@ -27,122 +25,87 @@ describe('components/ContentSidebar/ContentSidebar', () => {
         document.body.removeChild(rootElement);
     });
 
-    describe('componentWillReceiveProps()', () => {
-        test('should fetch data when file id has changed', () => {
-            const props = {
-                fileId: '123456',
-            };
-            const wrapper = getWrapper(props);
+    describe('componentDidUpdate', () => {
+        test('should fetch the file data when the id changes', () => {
+            const wrapper = getWrapper({ fileId: '123' });
             const instance = wrapper.instance();
-            const newProps = {
-                fileId: 'abcdefg',
-            };
-            instance.fetchData = jest.fn();
-            instance.componentWillReceiveProps(newProps);
-
-            expect(instance.fetchData).toBeCalledWith(newProps);
-        });
-
-        test('should set new view when viewport width may have changed', () => {
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-            const newProps = {
-                isLarge: false,
-            };
-            instance.setState({ file });
+            const newProps = { fileId: '456' };
 
             instance.setState = jest.fn();
-            instance.getDefaultSidebarView = jest.fn().mockReturnValueOnce('view');
-            instance.componentWillReceiveProps(newProps);
+            instance.fetchFile = jest.fn();
 
-            expect(instance.getDefaultSidebarView).toBeCalledWith(newProps, file, undefined);
-            expect(instance.setState).toBeCalledWith({ view: 'view' });
+            instance.componentDidUpdate(newProps);
+
+            expect(instance.fetchFile).toBeCalled();
+            expect(instance.setState).not.toBeCalled();
         });
 
-        test('should not set new view when viewport width may have changed but was manually toggled', () => {
-            const wrapper = getWrapper();
+        test('should set isOpen if view is unset and isLarge prop has changed', () => {
+            const wrapper = getWrapper({ fileId: '123' });
             const instance = wrapper.instance();
-            const newProps = {
-                isLarge: false,
-            };
-            instance.setState({ file, hasBeenToggled: true });
-            instance.setState = jest.fn();
-            instance.getDefaultSidebarView = jest.fn().mockReturnValueOnce('view');
-            instance.componentWillReceiveProps(newProps);
+            const newProps = { fileId: '123', isLarge: false };
 
-            expect(instance.getDefaultSidebarView).not.toBeCalled();
+            instance.setState = jest.fn();
+            instance.fetchFile = jest.fn();
+
+            instance.componentDidUpdate(newProps);
+
+            expect(instance.fetchFile).not.toBeCalled();
+            expect(instance.setState).toBeCalled();
+        });
+
+        test('should do nothing if fileId is the same and view is already set', () => {
+            const wrapper = getWrapper({ fileId: '123' });
+            const instance = wrapper.instance();
+            const newProps = { fileId: '123' };
+
+            instance.setState({ view: 'activityFeed' });
+            instance.setState = jest.fn();
+            instance.fetchFile = jest.fn();
+
+            instance.componentDidUpdate(newProps);
+
+            expect(instance.fetchFile).not.toBeCalled();
             expect(instance.setState).not.toBeCalled();
         });
     });
 
     describe('onToggle()', () => {
-        test('should set new view state but not toggle state', () => {
+        test('should set new view state but not toggle isOpen state', () => {
             const wrapper = getWrapper();
             const instance = wrapper.instance();
 
-            wrapper.setState({ view: 'activity' });
+            wrapper.setState({ view: 'activity', isOpen: true });
             instance.setState = jest.fn();
             instance.onToggle('skills');
 
             expect(instance.setState).toBeCalledWith({
-                hasBeenToggled: false,
+                isOpen: true,
                 view: 'skills',
             });
         });
 
         test('should set new view state and toggle state', () => {
-            const wrapper = getWrapper({ isCollapsed: true });
+            const wrapper = getWrapper();
             const instance = wrapper.instance();
 
+            wrapper.setState({ view: 'skills' });
             instance.setState = jest.fn();
             instance.onToggle('skills');
 
             expect(instance.setState).toBeCalledWith({
-                hasBeenToggled: true,
+                isOpen: false,
                 view: 'skills',
-            });
-        });
-
-        test('should remove view state', () => {
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-
-            wrapper.setState({ view: 'activity' });
-            instance.setState = jest.fn();
-            instance.onToggle('activity');
-
-            expect(instance.setState).toBeCalledWith({
-                hasBeenToggled: true,
-                view: undefined,
             });
         });
     });
 
-    describe('getDefaultSidebarView()', () => {
-        test('should return undefined when no file', () => {
+    describe('getSidebarView()', () => {
+        test('should return undefined when sidebar is not open', () => {
             const wrapper = getWrapper();
+            wrapper.setState({ isOpen: false });
             const instance = wrapper.instance();
-            expect(instance.getDefaultSidebarView({}, null, null)).toBeUndefined();
-        });
-
-        test('should return default view when provided', () => {
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-            expect(instance.getDefaultSidebarView({ defaultView: 'default' }, {})).toBe('default');
-        });
-
-        test('should return undefined when small viewport and not toggled manually', () => {
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-            SidebarUtils.canHaveDetailsSidebar = jest.fn().mockReturnValueOnce(true);
-            expect(instance.getDefaultSidebarView({ isLarge: false }, {})).toBeUndefined();
-        });
-
-        test('should return some view when large viewport and not toggled manually', () => {
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-            SidebarUtils.canHaveDetailsSidebar = jest.fn().mockReturnValueOnce(true);
-            expect(instance.getDefaultSidebarView({ isLarge: true }, {})).toBe('details');
+            expect(instance.getSidebarView({}, null, null)).toBeUndefined();
         });
 
         test('should return skills when no current view is skills and skills exist', () => {
@@ -156,7 +119,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('skills');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('skills');
         });
 
         test('should return activity when current view is activity and skills exist', () => {
@@ -170,7 +133,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('activity');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('activity');
         });
 
         test('should return details when current view is details and skills or activity both exist', () => {
@@ -184,7 +147,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('details');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('details');
         });
 
         test('should return metadata when current view is metadata and skills or activity both exist', () => {
@@ -198,7 +161,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('metadata');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('metadata');
         });
 
         test('should default to skills when no current view and skills exist', () => {
@@ -210,7 +173,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('skills');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('skills');
         });
 
         test('should default to activity when no current view and skills dont exist', () => {
@@ -222,7 +185,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('activity');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('activity');
         });
 
         test('should default to details when no current view and skills or activity dont exist', () => {
@@ -234,7 +197,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(false);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('details');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('details');
         });
 
         test('should default to metadata when no current view and skills or activity or details dont exist', () => {
@@ -246,7 +209,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(false);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('metadata');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('metadata');
         });
 
         test('should default to activity when current view is skills but new view has no skills', () => {
@@ -260,7 +223,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.canHaveMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('activity');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('activity');
         });
 
         test('should default to details when current view is skills but new view has no skills or activity', () => {
@@ -274,7 +237,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(false);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('details');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('details');
         });
 
         test('should default to skills when current view is details but new view has no details', () => {
@@ -288,7 +251,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
             SidebarUtils.canHaveActivitySidebar = jest.fn().mockReturnValueOnce(true);
             SidebarUtils.shouldRenderMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(instance.getDefaultSidebarView({ isLarge: true }, file)).toBe('skills');
+            expect(instance.getSidebarView({ isLarge: true }, file)).toBe('skills');
         });
     });
 
@@ -301,6 +264,7 @@ describe('components/ContentSidebar/ContentSidebar', () => {
         beforeEach(() => {
             wrapper = getWrapper({
                 file,
+                fileId: file.id,
             });
             instance = wrapper.instance();
             fileStub = jest.fn();
@@ -311,18 +275,20 @@ describe('components/ContentSidebar/ContentSidebar', () => {
                 }),
             };
             instance.fetchFileSuccessCallback = fetchFileSuccessCallback;
+            instance.setState = jest.fn();
         });
 
         test('should not fetch the file when sidebar is not configured to show anything', () => {
             SidebarUtils.canHaveSidebar = jest.fn().mockReturnValueOnce(false);
-            instance.fetchFile(file.id);
+            instance.fetchFile();
             expect(SidebarUtils.canHaveSidebar).toBeCalledWith(instance.props);
             expect(fileStub).not.toBeCalled();
+            expect(instance.setState).toBeCalled();
         });
 
         test('should fetch the file with forceFetch', () => {
             SidebarUtils.canHaveSidebar = jest.fn().mockReturnValueOnce(true);
-            instance.fetchFile(file.id, {
+            instance.fetchFile({
                 forceFetch: true,
             });
             expect(SidebarUtils.canHaveSidebar).toBeCalledWith(instance.props);
@@ -330,131 +296,129 @@ describe('components/ContentSidebar/ContentSidebar', () => {
                 forceFetch: true,
                 fields: SIDEBAR_FIELDS_TO_FETCH,
             });
+            expect(instance.setState).toBeCalled();
         });
 
         test('should fetch the file without forceFetch', () => {
             SidebarUtils.canHaveSidebar = jest.fn().mockReturnValueOnce(true);
-            instance.fetchFile(file.id);
+            instance.fetchFile();
             expect(SidebarUtils.canHaveSidebar).toBeCalledWith(instance.props);
             expect(fileStub).toBeCalledWith(file.id, fetchFileSuccessCallback, instance.errorCallback, {
                 fields: SIDEBAR_FIELDS_TO_FETCH,
             });
+            expect(instance.setState).toBeCalled();
         });
     });
 
     describe('fetchMetadataSuccessCallback()', () => {
         let setState;
-        let getDefaultSidebarView;
         let wrapper;
         let instance;
 
         beforeEach(() => {
             setState = jest.fn();
-            getDefaultSidebarView = jest.fn().mockReturnValueOnce('view');
-            wrapper = getWrapper({
-                file,
-            });
+            wrapper = getWrapper();
             instance = wrapper.instance();
-            instance.getDefaultSidebarView = getDefaultSidebarView;
             instance.setState = setState;
         });
 
-        test('should set visibility to false when no data to show', () => {
-            SidebarUtils.shouldRenderSidebar = jest.fn().mockReturnValueOnce(false);
-            instance.fetchMetadataSuccessCallback(file);
+        test('should set metadataEditors', () => {
+            const editorsData = { editors: 'editors' };
+            instance.fetchMetadataSuccessCallback(editorsData);
 
-            expect(getDefaultSidebarView).not.toBeCalled();
-            expect(SidebarUtils.shouldRenderSidebar).toBeCalledWith(instance.props, file, undefined);
             expect(setState).toBeCalledWith({
-                isVisible: false,
-            });
-        });
-
-        test('should set the file and metadata state from responses', () => {
-            SidebarUtils.shouldRenderSidebar = jest.fn().mockReturnValueOnce(true);
-            instance.fetchMetadataSuccessCallback(file, editors);
-
-            expect(getDefaultSidebarView).toBeCalledWith(instance.props, file, editors);
-            expect(SidebarUtils.shouldRenderSidebar).toBeCalledWith(instance.props, file, editors);
-            expect(setState).toBeCalledWith({
-                file,
-                editors,
-                view: 'view',
-                isVisible: true,
+                metadataEditors: 'editors',
             });
         });
     });
 
     describe('fetchFileSuccessCallback()', () => {
         let setState;
-        let getDefaultSidebarView;
         let wrapper;
         let instance;
-        const getMetadata = jest.fn();
 
         beforeEach(() => {
             setState = jest.fn();
-            getDefaultSidebarView = jest.fn().mockReturnValueOnce('view');
-            wrapper = getWrapper({
-                file,
-                metadataSidebarProps: {
-                    getMetadata,
-                    isFeatureEnabled: false,
-                },
-            });
+            wrapper = getWrapper();
             instance = wrapper.instance();
-            instance.getDefaultSidebarView = getDefaultSidebarView;
             instance.setState = setState;
         });
 
-        test('should just call metadata success callback when metadata feature is enabled', () => {
-            wrapper = getWrapper({
-                file,
-                metadataSidebarProps: {
-                    getMetadata,
-                    isFeatureEnabled: true,
-                },
-            });
+        test('should set the state with the file and view and then call fetchMetadata', () => {
+            wrapper = getWrapper();
             instance = wrapper.instance();
-            instance.getDefaultSidebarView = getDefaultSidebarView;
             instance.setState = setState;
 
-            SidebarUtils.canHaveMetadataSidebar = jest.fn().mockReturnValueOnce(true);
-            instance.fetchMetadataSuccessCallback = jest.fn();
+            instance.fetchMetadata = jest.fn();
             instance.fetchFileSuccessCallback(file);
 
-            expect(getDefaultSidebarView).not.toBeCalled();
-            expect(SidebarUtils.canHaveMetadataSidebar).not.toBeCalled();
-            expect(instance.fetchMetadataSuccessCallback).toBeCalledWith(file);
+            expect(instance.setState).toBeCalledWith(
+                {
+                    file,
+                    isLoading: false,
+                },
+                instance.fetchMetadata,
+            );
         });
+    });
 
-        test('should call metadata success callback when no metadata sidebar', () => {
-            SidebarUtils.canHaveMetadataSidebar = jest.fn().mockReturnValueOnce(false);
-            instance.fetchMetadataSuccessCallback = jest.fn();
-            instance.fetchFileSuccessCallback(file);
+    describe('fetchMetadata()', () => {
+        let wrapper;
+        let instance;
+        let getEditorsStub;
 
-            expect(getDefaultSidebarView).not.toBeCalled();
-            expect(SidebarUtils.canHaveMetadataSidebar).toBeCalledWith(instance.props);
-            expect(instance.fetchMetadataSuccessCallback).toBeCalledWith(file);
-        });
-
-        test('should call the fetch metadata when metadata sidebar is allowed', () => {
-            const getEditors = jest.fn();
-            const getMetadataAPI = jest.fn().mockReturnValueOnce({
-                getEditors,
-            });
-
-            SidebarUtils.canHaveMetadataSidebar = jest.fn().mockReturnValueOnce(true);
-
+        test('should fetch metadata if the feature is enabled and can have the sidebar', () => {
+            wrapper = getWrapper({ metadataSidebarProps: { isFeatureEnabled: false } });
+            instance = wrapper.instance();
+            getEditorsStub = jest.fn();
             instance.api = {
-                getMetadataAPI,
+                getMetadataAPI: () => ({
+                    getEditors: getEditorsStub,
+                }),
+                destroy: jest.fn(),
             };
 
-            instance.fetchFileSuccessCallback(file);
+            SidebarUtils.canHaveMetadataSidebar = jest.fn().mockReturnValueOnce(true);
 
-            expect(getEditors).toBeCalledWith(file, expect.any(Function), expect.any(Function), getMetadata, false);
-            expect(SidebarUtils.canHaveMetadataSidebar).toBeCalledWith(instance.props);
-            expect(getMetadataAPI).toBeCalledWith(true);
+            instance.fetchMetadata();
+
+            expect(getEditorsStub).toBeCalled();
+        });
+
+        test('should not fetch metadata if the feature is enabled', () => {
+            wrapper = getWrapper({ metadataSidebarProps: { isFeatureEnabled: true } });
+            instance = wrapper.instance();
+            getEditorsStub = jest.fn();
+            instance.api = {
+                getMetadataAPI: () => ({
+                    getEditors: getEditorsStub,
+                }),
+                destroy: jest.fn(),
+            };
+
+            SidebarUtils.canHaveMetadataSidebar = jest.fn().mockReturnValueOnce(true);
+
+            instance.fetchMetadata();
+
+            expect(getEditorsStub).not.toBeCalled();
+        });
+
+        test('should not fetch the metadata if we cannot have the sidebar', () => {
+            wrapper = getWrapper({ metadataSidebarProps: { isFeatureEnabled: false } });
+            instance = wrapper.instance();
+            getEditorsStub = jest.fn();
+            instance.api = {
+                getMetadataAPI: () => ({
+                    getEditors: getEditorsStub,
+                }),
+                destroy: jest.fn(),
+            };
+
+            SidebarUtils.canHaveMetadataSidebar = jest.fn().mockReturnValueOnce(false);
+
+            instance.fetchMetadata();
+
+            expect(getEditorsStub).not.toBeCalled();
         });
     });
 });

--- a/src/components/ContentSidebar/__tests__/Sidebar-test.js
+++ b/src/components/ContentSidebar/__tests__/Sidebar-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Sidebar from '../Sidebar';
-import SidebarNav from '../SidebarNav';
 
 jest.mock('../ActivitySidebar', () => 'ActivitySidebar');
 jest.mock('../DetailsSidebar', () => 'DetailsSidebar');
@@ -14,34 +13,29 @@ describe('components/ContentSidebar/Sidebar', () => {
 
     test('should render no sidebar', () => {
         const wrapper = getWrapper();
-        expect(wrapper.find(SidebarNav)).toHaveLength(1);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should render skills sidebar', () => {
-        const wrapper = getWrapper({ hasSkills: true, view: 'skills' });
-        expect(wrapper.find(SidebarNav)).toHaveLength(1);
+        const wrapper = getWrapper({ hasSkills: true, selectedView: 'skills' });
         expect(wrapper.find('SkillsSidebar')).toHaveLength(1);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should render activity sidebar', () => {
-        const wrapper = getWrapper({ hasActivityFeed: true, view: 'activity' });
-        expect(wrapper.find(SidebarNav)).toHaveLength(1);
+        const wrapper = getWrapper({ hasActivityFeed: true, selectedView: 'activity' });
         expect(wrapper.find('ActivitySidebar')).toHaveLength(1);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should render details sidebar', () => {
-        const wrapper = getWrapper({ hasDetails: true, view: 'details' });
-        expect(wrapper.find(SidebarNav)).toHaveLength(1);
+        const wrapper = getWrapper({ hasDetails: true, selectedView: 'details' });
         expect(wrapper.find('DetailsSidebar')).toHaveLength(1);
         expect(wrapper).toMatchSnapshot();
     });
 
     test('should render metadata sidebar', () => {
-        const wrapper = getWrapper({ hasMetadata: true, view: 'metadata' });
-        expect(wrapper.find(SidebarNav)).toHaveLength(1);
+        const wrapper = getWrapper({ hasMetadata: true, selectedView: 'metadata' });
         expect(wrapper.find('MetadataSidebar')).toHaveLength(1);
         expect(wrapper).toMatchSnapshot();
     });

--- a/src/components/ContentSidebar/__tests__/__snapshots__/Sidebar-test.js.snap
+++ b/src/components/ContentSidebar/__tests__/__snapshots__/Sidebar-test.js.snap
@@ -2,60 +2,38 @@
 
 exports[`components/ContentSidebar/Sidebar should render activity sidebar 1`] = `
 <Fragment>
-  <SidebarNav
-    hasActivityFeed={true}
-    selectedView="activity"
-  />
   <ActivitySidebar
     file={
       Object {
         "id": "id",
       }
     }
-    key="id"
   />
 </Fragment>
 `;
 
 exports[`components/ContentSidebar/Sidebar should render details sidebar 1`] = `
 <Fragment>
-  <SidebarNav
-    hasDetails={true}
-    selectedView="details"
-  />
   <DetailsSidebar />
 </Fragment>
 `;
 
 exports[`components/ContentSidebar/Sidebar should render metadata sidebar 1`] = `
 <Fragment>
-  <SidebarNav
-    hasMetadata={true}
-    selectedView="metadata"
-  />
   <MetadataSidebar
     file={
       Object {
         "id": "id",
       }
     }
-    key="id"
   />
 </Fragment>
 `;
 
-exports[`components/ContentSidebar/Sidebar should render no sidebar 1`] = `
-<Fragment>
-  <SidebarNav />
-</Fragment>
-`;
+exports[`components/ContentSidebar/Sidebar should render no sidebar 1`] = `<Fragment />`;
 
 exports[`components/ContentSidebar/Sidebar should render skills sidebar 1`] = `
 <Fragment>
-  <SidebarNav
-    hasSkills={true}
-    selectedView="skills"
-  />
   <SkillsSidebar
     file={
       Object {


### PR DESCRIPTION
Introduce `isOpen` state in sidebar in order to persist toggle state when navigating across different files