### PR TITLE
fix(metadata): increase template fetch limit to 1000 max limit

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -143,6 +143,9 @@ class Metadata extends File {
             templates = await this.xhr.get({
                 url: this.getMetadataTemplateUrl(scope),
                 id: getTypedFileId(id),
+                params: {
+                    limit: 1000,
+                },
             });
         } catch (e) {
             const { status } = e;

--- a/src/api/__tests__/Metadata-test.js
+++ b/src/api/__tests__/Metadata-test.js
@@ -207,6 +207,9 @@ describe('api/Metadata', () => {
             expect(metadata.xhr.get).toHaveBeenCalledWith({
                 url: 'template_url',
                 id: 'file_id',
+                params: {
+                    limit: 1000,
+                },
             });
         });
         test('should return empty array of templates when error is 400', async () => {
@@ -225,6 +228,9 @@ describe('api/Metadata', () => {
             expect(metadata.xhr.get).toHaveBeenCalledWith({
                 url: 'template_url',
                 id: 'file_id',
+                params: {
+                    limit: 1000,
+                },
             });
         });
         test('should throw error when error is not 400', async () => {
@@ -243,6 +249,9 @@ describe('api/Metadata', () => {
             expect(metadata.xhr.get).toHaveBeenCalledWith({
                 url: 'template_url',
                 id: 'file_id',
+                params: {
+                    limit: 1000,
+                },
             });
         });
     });


### PR DESCRIPTION
Even though the API request limit is 1000, the template hard limit is 500 while the instance hard limit is 100. Which means you can only have 500 enterprise templates and only 100 of the overall (ent+global) templates can be applied to a file or folder.