### PR TITLE
fix: Add dimension to make icon sizes consistent

### DIFF
--- a/src/components/ContentOpenWith/MultipleIntegrationsOpenWithButton.js
+++ b/src/components/ContentOpenWith/MultipleIntegrationsOpenWithButton.js
@@ -23,7 +23,7 @@ const MultipleIntegrationsOpenWithButton = (buttonProps: Props) => (
         <Button {...buttonProps}>
             <MenuToggle>
                 <OpenWithButtonContents>
-                    <IconOpenWith height={26} width={26} className={CLASS_INTEGRATION_ICON} />
+                    <IconOpenWith className={CLASS_INTEGRATION_ICON} dimension={26} height={26} width={26} />
                 </OpenWithButtonContents>
             </MenuToggle>
         </Button>

--- a/src/components/ContentOpenWith/OpenWithButton.js
+++ b/src/components/ContentOpenWith/OpenWithButton.js
@@ -63,7 +63,13 @@ const OpenWithButton = ({ error, onClick, displayIntegration, isLoading }: Props
         <Tooltip text={getTooltip(displayDescription, isLoading, error, disabledReasons)} position="bottom-center">
             <Button isDisabled={isDisabled} onClick={() => onClick(displayIntegration)}>
                 <OpenWithButtonContents>
-                    <Icon extension={extension} className={CLASS_INTEGRATION_ICON} height={26} width={26} />
+                    <Icon
+                        className={CLASS_INTEGRATION_ICON}
+                        dimension={26}
+                        extension={extension}
+                        height={26}
+                        width={26}
+                    />
                 </OpenWithButtonContents>
             </Button>
         </Tooltip>

--- a/src/components/ContentOpenWith/__tests__/__snapshots__/MultipleIntegrationsOpenWithButton-test.js.snap
+++ b/src/components/ContentOpenWith/__tests__/__snapshots__/MultipleIntegrationsOpenWithButton-test.js.snap
@@ -17,6 +17,7 @@ exports[`components/ContentOpenWith/MultipleIntegrationsOpenWithButton should pa
       <OpenWithButtonContents>
         <IconOpenWith
           className="bcow-integration-icon"
+          dimension={26}
           height={26}
           width={26}
         />
@@ -41,6 +42,7 @@ exports[`components/ContentOpenWith/MultipleIntegrationsOpenWithButton should re
       <OpenWithButtonContents>
         <IconOpenWith
           className="bcow-integration-icon"
+          dimension={26}
           height={26}
           width={26}
         />

--- a/src/components/ContentOpenWith/__tests__/__snapshots__/OpenWithButton-test.js.snap
+++ b/src/components/ContentOpenWith/__tests__/__snapshots__/OpenWithButton-test.js.snap
@@ -17,6 +17,7 @@ exports[`components/ContentOpenWith/OpenWithButton should render as disabled if 
     <OpenWithButtonContents>
       <IconAdobeSign
         className="bcow-integration-icon"
+        dimension={26}
         height={26}
         width={26}
       />
@@ -42,6 +43,7 @@ exports[`components/ContentOpenWith/OpenWithButton should render as disabled if 
     <OpenWithButtonContents>
       <IconOpenWith
         className="bcow-integration-icon"
+        dimension={26}
         height={26}
         width={26}
       />
@@ -67,6 +69,7 @@ exports[`components/ContentOpenWith/OpenWithButton should render with the correc
     <OpenWithButtonContents>
       <IconGoogleDocs
         className="bcow-integration-icon"
+        dimension={26}
         height={26}
         width={26}
       />


### PR DESCRIPTION
FileIcon takes a different prop `dimension` from other icons.