### PR TITLE
feat(openwith): Expose dropdown alignment prop

### DIFF
--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -630,6 +630,8 @@ type Integration = {
 
 type DisabledReason = ?string | ?Element;
 
+type Alignment = 'left' | 'right';
+
 type JsonPatch = {
     op: 'add' | 'remove' | 'replace' | 'test',
     path: string,

--- a/src/components/ContentOpenWith/ContentOpenWith.js
+++ b/src/components/ContentOpenWith/ContentOpenWith.js
@@ -42,28 +42,30 @@ type ExternalProps = {
 };
 
 type Props = {
-    /** Box File ID. */
-    fileId: string,
-    /** Application client name. */
-    clientName: string,
     /** Box API url. */
     apiHost: string,
-    /** Access token. */
-    token: Token,
     /** Class name applied to base component. */
     className: string,
+    /** Application client name. */
+    clientName: string,
+    /** Box File ID. */
+    fileId: string,
+    /** Determines positioning of menu dropdown */
+    isDropdownRightAligned: boolean,
     /** Language to use for translations. */
     language?: string,
     /** Messages to be translated. */
     messages?: StringMap,
-    /** Axios request interceptor that runs before a network request. */
-    requestInterceptor?: Function,
-    /** Axios response interceptor that runs before a network response is returned. */
-    responseInterceptor?: Function,
     /** Callback that executes when an integration attempts to open the given file */
     onExecute: Function,
     /** Callback that executes when an integration invocation fails. The two most common cases being API failures or blocking of a new window */
     onError: Function,
+    /** Axios request interceptor that runs before a network request. */
+    requestInterceptor?: Function,
+    /** Axios response interceptor that runs before a network response is returned. */
+    responseInterceptor?: Function,
+    /** Access token. */
+    token: Token,
 };
 
 type State = {
@@ -90,9 +92,10 @@ class ContentOpenWith extends PureComponent<Props, State> {
     integrationWindow: ?any;
 
     static defaultProps = {
+        apiHost: DEFAULT_HOSTNAME_API,
         className: '',
         clientName: CLIENT_NAME_OPEN_WITH,
-        apiHost: DEFAULT_HOSTNAME_API,
+        isDropdownRightAligned: true,
         onExecute: noop,
         onError: noop,
     };
@@ -509,7 +512,7 @@ class ContentOpenWith extends PureComponent<Props, State> {
      * @return {Element}
      */
     render() {
-        const { language, messages: intlMessages }: Props = this.props;
+        const { language, messages: intlMessages, isDropdownRightAligned }: Props = this.props;
         const {
             fetchError,
             isLoading,
@@ -534,7 +537,11 @@ class ContentOpenWith extends PureComponent<Props, State> {
                             isLoading={isLoading}
                         />
                     ) : (
-                        <OpenWithDropdownMenu onClick={this.onIntegrationClick} integrations={integrations} />
+                        <OpenWithDropdownMenu
+                            isRightAligned={isDropdownRightAligned}
+                            onClick={this.onIntegrationClick}
+                            integrations={integrations}
+                        />
                     )}
                     {(shouldRenderLoadingIntegrationPortal || shouldRenderErrorIntegrationPortal) && (
                         <IntegrationPortalContainer

--- a/src/components/ContentOpenWith/ContentOpenWith.js
+++ b/src/components/ContentOpenWith/ContentOpenWith.js
@@ -48,11 +48,11 @@ type Props = {
     className: string,
     /** Application client name. */
     clientName: string,
+    /** Determines positioning of menu dropdown */
+    dropdownAlignment: Alignment,
     /** Box File ID. */
     fileId: string,
-    /** Determines positioning of menu dropdown */
-    isDropdownRightAligned: boolean,
-    /** Language to use for translations. */
+    /** Language to use for tra nslations. */
     language?: string,
     /** Messages to be translated. */
     messages?: StringMap,
@@ -95,7 +95,6 @@ class ContentOpenWith extends PureComponent<Props, State> {
         apiHost: DEFAULT_HOSTNAME_API,
         className: '',
         clientName: CLIENT_NAME_OPEN_WITH,
-        isDropdownRightAligned: true,
         onExecute: noop,
         onError: noop,
     };
@@ -512,7 +511,7 @@ class ContentOpenWith extends PureComponent<Props, State> {
      * @return {Element}
      */
     render() {
-        const { language, messages: intlMessages, isDropdownRightAligned }: Props = this.props;
+        const { language, messages: intlMessages, dropdownAlignment }: Props = this.props;
         const {
             fetchError,
             isLoading,
@@ -538,7 +537,7 @@ class ContentOpenWith extends PureComponent<Props, State> {
                         />
                     ) : (
                         <OpenWithDropdownMenu
-                            isRightAligned={isDropdownRightAligned}
+                            dropdownAlignment={dropdownAlignment}
                             onClick={this.onIntegrationClick}
                             integrations={integrations}
                         />

--- a/src/components/ContentOpenWith/OpenWithDropdownMenu.js
+++ b/src/components/ContentOpenWith/OpenWithDropdownMenu.js
@@ -12,12 +12,14 @@ import MultipleIntegrationsOpenWithButton from './MultipleIntegrationsOpenWithBu
 
 type Props = {
     integrations: ?Array<Integration>,
-    isRightAligned: boolean,
+    dropdownAlignment: Alignment,
     onClick: Function,
 };
 
-const OpenWithDropdownMenu = ({ isRightAligned = true, integrations, onClick }: Props) => (
-    <DropdownMenu isRightAligned={isRightAligned}>
+const RIGHT_ALIGNMENT = 'right';
+
+const OpenWithDropdownMenu = ({ dropdownAlignment = RIGHT_ALIGNMENT, integrations, onClick }: Props) => (
+    <DropdownMenu isRightAligned={dropdownAlignment === RIGHT_ALIGNMENT}>
         <MultipleIntegrationsOpenWithButton />
         <Menu className="bcow-menu">
             {integrations &&

--- a/src/components/ContentOpenWith/OpenWithDropdownMenu.js
+++ b/src/components/ContentOpenWith/OpenWithDropdownMenu.js
@@ -12,11 +12,12 @@ import MultipleIntegrationsOpenWithButton from './MultipleIntegrationsOpenWithBu
 
 type Props = {
     integrations: ?Array<Integration>,
+    isRightAligned: boolean,
     onClick: Function,
 };
 
-const OpenWithDropdownMenu = ({ integrations, onClick }: Props) => (
-    <DropdownMenu isRightAligned>
+const OpenWithDropdownMenu = ({ isRightAligned = true, integrations, onClick }: Props) => (
+    <DropdownMenu isRightAligned={isRightAligned}>
         <MultipleIntegrationsOpenWithButton />
         <Menu className="bcow-menu">
             {integrations &&

--- a/src/components/ContentOpenWith/__tests__/__snapshots__/ContentOpenWith-test.js.snap
+++ b/src/components/ContentOpenWith/__tests__/__snapshots__/ContentOpenWith-test.js.snap
@@ -75,7 +75,6 @@ exports[`components/ContentOpenWith/ContentOpenWith render() should render the O
           "Google Suite",
         ]
       }
-      isRightAligned={true}
       onClick={[Function]}
     />
   </div>
@@ -95,7 +94,6 @@ exports[`components/ContentOpenWith/ContentOpenWith render() should render the P
           "Google Suite",
         ]
       }
-      isRightAligned={true}
       onClick={[Function]}
     />
     <IntegrationPortalContainer
@@ -118,7 +116,6 @@ exports[`components/ContentOpenWith/ContentOpenWith render() should render the P
           "Google Suite",
         ]
       }
-      isRightAligned={true}
       onClick={[Function]}
     />
     <IntegrationPortalContainer

--- a/src/components/ContentOpenWith/__tests__/__snapshots__/ContentOpenWith-test.js.snap
+++ b/src/components/ContentOpenWith/__tests__/__snapshots__/ContentOpenWith-test.js.snap
@@ -75,6 +75,7 @@ exports[`components/ContentOpenWith/ContentOpenWith render() should render the O
           "Google Suite",
         ]
       }
+      isRightAligned={true}
       onClick={[Function]}
     />
   </div>
@@ -94,6 +95,7 @@ exports[`components/ContentOpenWith/ContentOpenWith render() should render the P
           "Google Suite",
         ]
       }
+      isRightAligned={true}
       onClick={[Function]}
     />
     <IntegrationPortalContainer
@@ -116,6 +118,7 @@ exports[`components/ContentOpenWith/ContentOpenWith render() should render the P
           "Google Suite",
         ]
       }
+      isRightAligned={true}
       onClick={[Function]}
     />
     <IntegrationPortalContainer

--- a/test/openwith.html
+++ b/test/openwith.html
@@ -99,8 +99,11 @@
                     console.log(error);
                 });
 
+                var isDropdownRightAligned = buttonNum !== 1;
+
                 openwith.show(fileId, token, {
                     container: '.openwith' + buttonNum,
+                    isDropdownRightAligned: isDropdownRightAligned,
                 });
             }
             load(1);

--- a/test/openwith.html
+++ b/test/openwith.html
@@ -99,11 +99,11 @@
                     console.log(error);
                 });
 
-                var isDropdownRightAligned = buttonNum !== 1;
+                var dropdownAlignment = buttonNum !== 1 ? 'right' : 'left';
 
                 openwith.show(fileId, token, {
                     container: '.openwith' + buttonNum,
-                    isDropdownRightAligned: isDropdownRightAligned,
+                    dropdownAlignment: dropdownAlignment,
                 });
             }
             load(1);


### PR DESCRIPTION
Exposing a BRUI prop in Dropdown to avoid the problem of rendering the open with button near the left edge of the screen:
<img width="347" alt="screen shot 2019-01-04 at 10 19 39 am" src="https://user-images.githubusercontent.com/2474027/50704194-619eea00-100b-11e9-8f40-be8530cfc7d4.png">

With `isRightAligned` set to `false`.
<img width="390" alt="screen shot 2019-01-04 at 10 20 02 am" src="https://user-images.githubusercontent.com/2474027/50704218-78454100-100b-11e9-9681-82902cd865bb.png">
