### PR TITLE
fix(uploader): ContentUploader did not properly handle multiput errors

### DIFF
--- a/src/api/uploads/MultiputPart.js
+++ b/src/api/uploads/MultiputPart.js
@@ -4,6 +4,7 @@
  * @author Box
  */
 import noop from 'lodash/noop';
+import getProp from 'lodash/get';
 import BaseMultiput from './BaseMultiput';
 import { updateQueryParameters } from '../../util/url';
 import { HTTP_PUT } from '../../constants';
@@ -237,9 +238,11 @@ class MultiputPart extends BaseMultiput {
             return;
         }
 
-        this.consoleLog(
-            `Upload failure ${error.message} for part ${this.toJSON()}. XHR state: ${this.xhr.xhr.readyState}.`,
-        );
+        const xhr_ready_state = getProp(this.xhr, 'xhr.readyState', null);
+        const xhr_status_text = getProp(this.xhr, 'xhr.statusText', '');
+
+        this.consoleLog(`Upload failure ${error.message} for part ${this.toJSON()}. XHR state: ${xhr_ready_state}.`);
+
         const eventInfo = {
             message: error.message,
             part: {
@@ -248,9 +251,10 @@ class MultiputPart extends BaseMultiput {
                 index: this.index,
                 offset: this.offset,
             },
-            xhr_ready_state: this.xhr.xhr.readyState,
-            xhr_status_text: this.xhr.xhr.statusText,
+            xhr_ready_state,
+            xhr_status_text,
         };
+
         const eventInfoString = JSON.stringify(eventInfo);
         this.logEvent('part_failure', eventInfoString);
 


### PR DESCRIPTION
The `uploadErrorHandler` would frequently attempt to check properties on an undefined XHR object leading an exception and the part not being properly retried. This PR fixes that.