### PR TITLE
feat(preview): add thumbnails sidebar

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -16,7 +16,6 @@ import noop from 'lodash/noop';
 import Measure from 'react-measure';
 import { decode } from 'box-react-ui/lib/utils/keys';
 import PreviewLoading from './PreviewLoading';
-import PreviewNavigation from './PreviewNavigation';
 import ContentSidebar from '../content-sidebar';
 import Header from './Header';
 import API from '../../api';
@@ -647,6 +646,24 @@ class ContentPreview extends PureComponent<Props, State> {
     }
 
     /**
+     * Handles the event emitted when Preview SDK navigates to another file
+     *
+     * @return {void}
+     */
+    onPreviewNavigate = (fileId: string) => {
+        const { collection }: Props = this.props;
+        const index = collection.findIndex(item => {
+            if (typeof item === 'string') {
+                return item === fileId;
+            }
+
+            return item.id === fileId;
+        });
+
+        this.navigateToIndex(index);
+    };
+
+    /**
      * Loads preview in the component using the preview library.
      *
      * @return {void}
@@ -673,12 +690,16 @@ class ContentPreview extends PureComponent<Props, State> {
             showDownload: this.canDownload(),
             skipServerUpdate: true,
             useHotkeys: false,
+            enableThumbnailsSidebar: true,
+            disableNavigation: true,
+            collection,
         };
         const { Preview } = global.Box;
         this.preview = new Preview();
         this.preview.addListener('load', this.onPreviewLoad);
         this.preview.addListener('preview_error', this.onPreviewError);
         this.preview.addListener('preview_metric', this.onPreviewMetric);
+        this.preview.addListener('navigate', this.onPreviewNavigate);
         this.preview.updateFileCache([file]);
         this.preview.show(file.id, token, {
             ...previewOptions,
@@ -1067,7 +1088,6 @@ class ContentPreview extends PureComponent<Props, State> {
         }: Props = this.props;
 
         const { file, isFileError, isReloadNotificationVisible, currentFileId }: State = this.state;
-        const { collection }: Props = this.props;
 
         if (!currentFileId) {
             return null;
@@ -1111,12 +1131,6 @@ class ContentPreview extends PureComponent<Props, State> {
                                     />
                                 </div>
                             )}
-                            <PreviewNavigation
-                                collection={collection}
-                                currentIndex={this.getFileIndex()}
-                                onNavigateLeft={this.navigateLeft}
-                                onNavigateRight={this.navigateRight}
-                            />
                         </div>
                         {file && (
                             <ContentSidebar

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -19,43 +19,6 @@
         flex: 1;
     }
 
-    .bp-navigate {
-        /* stylelint-disable declaration-no-important */
-        display: none !important;
-        /* stylelint-enable declaration-no-important */
-    }
-
-    .bcpr-navigate-right {
-        right: 0;
-    }
-
-    .bcpr-navigate-left {
-        left: 0;
-    }
-
-    .bcpr-navigate-left,
-    .bcpr-navigate-right {
-        display: block;
-        height: 64px;
-        opacity: 0;
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        transition-property: opacity;
-        width: 50px;
-
-        &:hover {
-            opacity: 1;
-        }
-    }
-
-    .bcpr-nav-is-visible {
-        .bcpr-navigate-left,
-        .bcpr-navigate-right {
-            opacity: 1;
-        }
-    }
-
     &.be-is-small {
         .bcpr-body {
             position: relative;


### PR DESCRIPTION
Putting this up as more of a RFC than the actual PR to merge in.

The issue I'm trying to solve is that `ContentPreview` provides its own navigation buttons which exist outside of the underlying Preview SDK layout, so when thumbnails sidebar is toggled open, the `ContentPreview` navigation buttons are unaffected and the left navigation overlaps with the thumbnails sidebar.

<img width="980" alt="thumbnail overlap" src="https://user-images.githubusercontent.com/17791289/51284676-36b87c80-19a1-11e9-8fba-d5ac62769e79.png">

The approach here is to:

1. pass the `collection` into PreviewSDK
2. rely on the Preview SDK's native navigation buttons
3. rely on the `navigate` event that is emitted from the Preview SDK to plug back into the `ContentPreview` navigation logic

This requires a corresponding change in Preview SDK to accept an option to disable the native collection navigation which feels a bit awkward.

Another approach to solve this problem is to offset the absolute position of the left navigation arrow whenever the thumbnail sidebar is toggled open, however this solution is not ideal in the case where we support resizing of the thumbnail sidebar (which may not happen).

Thoughts?