### PR TITLE
fix(uploader): Handle errors with calling logging endpoint

### DIFF
--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -378,10 +378,14 @@ class MultiputUpload extends BaseMultiput {
             this.sha1Worker.terminate();
         }
 
-        if (this.sessionEndpoints.abort) {
-            this.xhr.delete({
-                url: this.sessionEndpoints.abort,
-            });
+        if (this.sessionEndpoints.abort && this.sessionId) {
+            this.xhr
+                .delete({
+                    url: this.sessionEndpoints.abort,
+                })
+                .then(() => {
+                    this.sessionId = '';
+                });
         }
     }
 

--- a/src/api/uploads/__tests__/MultiputPart-test.js
+++ b/src/api/uploads/__tests__/MultiputPart-test.js
@@ -116,10 +116,9 @@ describe('api/uploads/MultiputPart', () => {
             MultiputPartTest.destroyed = false;
             MultiputPartTest.numUploadRetriesPerformed = 100;
             MultiputPartTest.config.retries = 1;
-            MultiputPartTest.logEvent = jest.fn();
+            MultiputPartTest.logEvent = jest.fn().mockResolvedValue();
             MultiputPartTest.onError = jest.fn();
             MultiputPartTest.uploadErrorHandler(error);
-            expect(MultiputPartTest.logEvent).toHaveBeenCalled();
             expect(MultiputPartTest.onError).toHaveBeenCalled();
         });
 
@@ -130,13 +129,12 @@ describe('api/uploads/MultiputPart', () => {
             MultiputPartTest.destroyed = false;
             MultiputPartTest.numUploadRetriesPerformed = 100;
             MultiputPartTest.config.retries = 1000;
-            MultiputPartTest.logEvent = jest.fn();
+            MultiputPartTest.logEvent = jest.fn().mockResolvedValue();
             MultiputPartTest.onError = jest.fn();
             MultiputPartTest.retryUpload = jest.fn();
             MultiputPartTest.uploadErrorHandler(error);
             jest.runOnlyPendingTimers();
             expect(MultiputPartTest.numUploadRetriesPerformed).toBe(101);
-            expect(MultiputPartTest.logEvent).toHaveBeenCalled();
             expect(MultiputPartTest.onError).not.toHaveBeenCalled();
             jest.clearAllTimers();
         });

--- a/src/api/uploads/__tests__/MultiputUpload-test.js
+++ b/src/api/uploads/__tests__/MultiputUpload-test.js
@@ -496,8 +496,9 @@ describe('api/uploads/MultiputUpload', () => {
             multiputUploadTest.sha1Worker = {
                 terminate: jest.fn(),
             };
-            multiputUploadTest.xhr.delete = jest.fn();
+            multiputUploadTest.xhr.delete = jest.fn().mockResolvedValue();
             multiputUploadTest.sessionEndpoints.abort = 'foo';
+            multiputUploadTest.sessionId = '123';
 
             multiputUploadTest.abortSession(null, '123', '123');
             expect(multiputUploadTest.xhr.delete).toHaveBeenCalled();

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -834,13 +834,17 @@ class ContentUploader extends Component<Props, State> {
     handleUploadError = (item: UploadItem, error: Error) => {
         const { onError, useUploadsManager } = this.props;
         const { file } = item;
+        const { items } = this.state;
 
         item.status = STATUS_ERROR;
         item.error = error;
         this.numItemsUploading -= 1;
 
-        const { items } = this.state;
-        items[items.indexOf(item)] = item;
+        const newItems = [...items];
+        const index = newItems.findIndex(singleItem => singleItem === item);
+        if (index !== -1) {
+            newItems[index] = item;
+        }
 
         // Broadcast that there was an error uploading a file
         const errorData = useUploadsManager
@@ -855,7 +859,7 @@ class ContentUploader extends Component<Props, State> {
 
         onError(errorData);
 
-        this.updateViewAndCollection(items);
+        this.updateViewAndCollection(newItems);
 
         if (useUploadsManager) {
             this.isAutoExpanded = true;


### PR DESCRIPTION
Fixes 2 issues that occur in error handling:

1) If the original part failure is due to 401, the logEvent will also fail with an uncaught promise.
2) Aborting a session can cause multiple DELETE calls to the session endpoint which will result in 404s.

Additionally the start of some tech debt cleanup for cases when state is modified directly.

