### PR TITLE
chore(ide): fix vscode intellisense

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,5 +4,6 @@
         "paths": {
             "*": ["src/*"]
         }
-    }
+    },
+    "exclude": ["node_modules", "dist", "es", "flow", "flow-typed", "i18n", "reports"]
 }


### PR DESCRIPTION
https://code.visualstudio.com/docs/languages/jsconfig#_best-practices

Intellisense is currently disabled because the TS server detects too many files with the new settings