### PR TITLE
feat(tasks): new comment layout

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/Comment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.js
@@ -139,6 +139,17 @@ class Comment extends React.Component<Props, State> {
                                 name={createdByUser.name}
                                 getUserProfileUrl={getUserProfileUrl}
                             />
+                        </div>
+                        <div className="bcs-comment-meta">
+                            {!!onEdit && !!canEdit && !isPending && <InlineEdit id={id} toEdit={toEdit} />}
+                            {!!onDelete && !!canDelete && !isPending && (
+                                <InlineDelete
+                                    id={id}
+                                    permissions={permissions}
+                                    message={<FormattedMessage {...inlineDeleteMessage} />}
+                                    onDelete={onDelete}
+                                />
+                            )}
                             <Tooltip
                                 text={
                                     <FormattedMessage
@@ -151,15 +162,6 @@ class Comment extends React.Component<Props, State> {
                                     <ReadableTime timestamp={createdAtTimestamp} relativeThreshold={ONE_HOUR_MS} />
                                 </small>
                             </Tooltip>
-                            {onEdit && canEdit && !isPending ? <InlineEdit id={id} toEdit={toEdit} /> : null}
-                            {onDelete && canDelete && !isPending ? (
-                                <InlineDelete
-                                    id={id}
-                                    permissions={permissions}
-                                    message={<FormattedMessage {...inlineDeleteMessage} />}
-                                    onDelete={onDelete}
-                                />
-                            ) : null}
                         </div>
                         {isEditing ? (
                             <ApprovalCommentForm

--- a/src/elements/content-sidebar/activity-feed/comment/Comment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.js
@@ -139,8 +139,6 @@ class Comment extends React.Component<Props, State> {
                                 name={createdByUser.name}
                                 getUserProfileUrl={getUserProfileUrl}
                             />
-                        </div>
-                        <div className="bcs-comment-meta">
                             {!!onEdit && !!canEdit && !isPending && <InlineEdit id={id} toEdit={toEdit} />}
                             {!!onDelete && !!canDelete && !isPending && (
                                 <InlineDelete
@@ -150,6 +148,8 @@ class Comment extends React.Component<Props, State> {
                                     onDelete={onDelete}
                                 />
                             )}
+                        </div>
+                        <div>
                             <Tooltip
                                 text={
                                     <FormattedMessage

--- a/src/elements/content-sidebar/activity-feed/comment/Comment.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.scss
@@ -127,20 +127,20 @@
             color: $fours;
             flex: 1;
             min-width: 0;
+        }
 
-            .bcs-comment-user-name {
-                color: $twos;
-                font-weight: bold;
-                line-height: 19.5px;
-                margin-right: 10px;
-            }
+        .bcs-comment-user-name {
+            color: $twos;
+            font-weight: bold;
+            line-height: 19.5px;
+            margin-right: 10px;
+        }
 
-            .bcs-comment-created-at {
-                color: $sevens;
-                cursor: default;
-                font-size: 11px;
-                line-height: 20px;
-            }
+        .bcs-comment-created-at {
+            color: $sevens;
+            cursor: default;
+            font-size: 11px;
+            line-height: 20px;
         }
 
         .bcs-comment-headline {

--- a/src/elements/content-sidebar/activity-feed/comment/Comment.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.scss
@@ -139,7 +139,7 @@
         .bcs-comment-created-at {
             color: $sevens;
             cursor: default;
-            font-size: 11px;
+            font-size: 12px;
             line-height: 20px;
         }
 

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
@@ -31,9 +31,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
           name="50 Cent"
         />
       </div>
-      <div
-        className="bcs-comment-meta"
-      >
+      <div>
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
@@ -103,9 +101,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
           name="50 Cent"
         />
       </div>
-      <div
-        className="bcs-comment-meta"
-      >
+      <div>
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
@@ -176,9 +172,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render an 
           name="50 Cent"
         />
       </div>
-      <div
-        className="bcs-comment-meta"
-      >
+      <div>
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
@@ -252,9 +246,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render com
           name="50 Cent"
         />
       </div>
-      <div
-        className="bcs-comment-meta"
-      >
+      <div>
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
@@ -30,6 +30,10 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
           id={10}
           name="50 Cent"
         />
+      </div>
+      <div
+        className="bcs-comment-meta"
+      >
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
@@ -98,6 +102,10 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
           id={10}
           name="50 Cent"
         />
+      </div>
+      <div
+        className="bcs-comment-meta"
+      >
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
@@ -167,6 +175,10 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render an 
           id={10}
           name="50 Cent"
         />
+      </div>
+      <div
+        className="bcs-comment-meta"
+      >
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
@@ -239,6 +251,10 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render com
           id={10}
           name="50 Cent"
         />
+      </div>
+      <div
+        className="bcs-comment-meta"
+      >
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}


### PR DESCRIPTION
- this moves the timestamp to its own line following latest design
- cleans up conditional with explicit booleans

<img width="320" alt="screen shot 2019-02-04 at 3 05 45 pm" src="https://user-images.githubusercontent.com/1571667/52243411-64049600-288e-11e9-8f7c-e708fc907aa3.png">

