### PR TITLE
build: include scss imports within babel compiled output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Create a branch with a descriptive name, such as `add-search`.
 
 ### Step 4: Push your feature branch to your fork
 
-We use [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format) and the [conventional commit message format](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional). Keep a separate feature branch for each issue you want to address. As you develop code, continue to push code to your remote feature branch. If applicable, please make sure to include the issue number you're addressing in your commit message, such as:
+We use [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format) and the [conventional commit message format](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional). Keep a separate feature branch for each issue you want to address. As you develop code, continue to push code to your remote feature branch. If applicable, please make sure to include the issue number you're addressing in your commit message, such as:
 
 ```
 tag(optional scope): short description
@@ -48,7 +48,7 @@ longer description here if necessary.
 include BREAKING CHANGE keyword for breaking changes.
 ```
 
-The message summary should be a one-sentence description of the change, and it must be 72 characters in length or shorter. For a list of tags, please [click here](https://github.com/marionebl/commitlint/tree/master/%40commitlint/config-conventional#type-enum). We use the angular style for tags. See the [default release rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js) based on the commit tag. Shown below is an example of the release type that will be done based on a commit message.
+The message summary should be a one-sentence description of the change, and it must be 72 characters in length or shorter. For a list of tags, please [click here](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum). We use the angular style for tags. See the [default release rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js) based on the commit tag. Shown below is an example of the release type that will be done based on a commit message.
 
 | Commit message                                                                                                                                          | Release type               |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -53,11 +53,12 @@ Install the following plugins in your preferred editor
 
 ## Common script commands
 
--   `yarn start` to launch a local styleguide examples server. Uses demo data.
--   `yarn start:dev` to launch a local webpack server. Uses your own data.
--   `yarn start:npm` to symlink via `yarn link` to a parent project.
+-   `yarn start` to launch a local styleguide examples server. Uses demo live data for Elements.
+-   `yarn start:npm` to symlink Elements via `yarn link` to a parent project.
+-   `yarn start:dev` to launch a local webpack dev server. Uses your own data for Elements.
 -   `yarn lint` to lint js and css.
--   `yarn lint --fix` to lint js and fix issues.
+-   `yarn lint:js --fix` to lint js and fix issues.
+-   `yarn lint:css --fix` to lint styles and fix issues.
 -   `yarn test` to launch tests with jest.
 -   `yarn test --watch` to launch tests with jest in watch mode.
 -   `yarn test --coverage` to launch tests with jest with coverage.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Box UI Elements are pre-built UI components that allow developers to add feature
 To prevent library duplication, the UI Elements require certain peer dependencies to be installed manually. For a list of required peer dependencies, see [package.json](package.json).
 
 # Usage
-This documentation describes how to use UI Elements in a [React](https://facebook.github.io/react) application. If instead you require a framework-agnostic solution, please refer to our [developer documentation](https://developer.box.com/docs/box-ui-elements). You can also reference our [Elements Demo App](https://github.com/box/box-ui-elements-demo) and [Preview Demo App](https://github.com/box/box-content-preview-demo) for examples of minimal React applications using ContentExplorer and ContentPreview, respectively.
+This documentation describes how to use UI Elements in a [React](https://facebook.github.io/react) application using [webpack](https://webpack.js.org/). If instead you require a framework-agnostic solution, please refer to our [developer documentation](https://developer.box.com/docs/box-ui-elements). You can also reference our [Elements Demo App](https://github.com/box/box-ui-elements-demo) and [Preview Demo App](https://github.com/box/box-content-preview-demo) for examples of minimal React applications using ContentExplorer and ContentPreview, respectively.
 
 ### Common
 * [Authentication](src/elements/README.md#authentication)
@@ -34,10 +34,10 @@ This documentation describes how to use UI Elements in a [React](https://faceboo
 \* _These components utilize code splitting. See the [Code Splitting](#code-splitting) section for more information._
 
 ### Code Splitting
-[Code splitting](https://webpack.js.org/guides/code-splitting/) is currently supported for some UI Elements. In order to use an Element with code splitting, you will need to build the Element with webpack by importing it from the `es` folder in our npm package.
+[Code splitting](https://webpack.js.org/guides/code-splitting/) is currently supported for some UI Elements. In order to use an Element with code splitting, you need to set it up in webpack.
 
 ### Stylesheets
-Each Box UI Elements requires its corresponding stylesheet to render properly. To import these stylesheets as modules (e.g. `import 'box-ui-elements/dist/sidebar.css';`), your project must integrate with Webpack's style-loader and css-loader. Alternatively, you can include the stylesheets in your application's HTML via `<style>` tags.
+Box UI Elements use [SCSS stylesheets](https://sass-lang.com/guide). Each of the Elements include their corresponding SCSS stylesheet to render properly. Once you `import` an Element within your React app, the corresponding stylesheet will automatically get included. However, you will need to [setup webpack](https://github.com/webpack-contrib/mini-css-extract-plugin#minimal-example) to handle `.scss` files by using the sass-loader / css-loader. This will direct webpack to properly include our SCSS files in your final CSS output. A sample configuration is [shown here](https://github.com/box/box-ui-elements-demo/blob/master/webpack.config.js) under the rules section.
 
 ### Browser Support
 * Desktop Chrome, Firefox, Safari, Edge (latest 2 versions)

--- a/babel.config.js
+++ b/babel.config.js
@@ -43,15 +43,7 @@ module.exports = {
             plugins: ['flow-react-proptypes'],
         },
         npm: {
-            plugins: [
-                [
-                    'babel-plugin-transform-require-ignore',
-                    {
-                        extensions: ['.scss', '.css'],
-                    },
-                ],
-                ['react-remove-properties', { properties: ['data-testid'] }],
-            ],
+            plugins: [['react-remove-properties', { properties: ['data-testid'] }]],
         },
         production: {
             plugins: [['react-remove-properties', { properties: ['data-resin-target', 'data-testid'] }]],
@@ -64,12 +56,6 @@ module.exports = {
                     'react-intl',
                     {
                         enforceDescriptions: false,
-                    },
-                ],
-                [
-                    'babel-plugin-transform-require-ignore',
-                    {
-                        extensions: ['.scss', '.css'],
                     },
                 ],
             ],

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "start": "yarn start:examples",
         "start:dev": "yarn setup; LANGUAGE=en-US BABEL_ENV=dev NODE_ENV=dev node --max_old_space_size=8192 node_modules/webpack-dev-server/bin/webpack-dev-server.js --config conf/webpack.config.js --mode development",
         "start:examples": "yarn setup; EXAMPLES=true LANGUAGE=en-US REACT=true BABEL_ENV=dev NODE_ENV=dev node --max_old_space_size=8192 node_modules/react-styleguidist/bin/styleguidist.js server --config conf/styleguide.config.js --mode development",
-        "start:npm": "yarn setup; npm-run-all build:prod:npm build:dev:es",
+        "start:npm": "yarn setup; yarn build:dev:es",
         "test": "BABEL_ENV=test NODE_ENV=test yarn jest",
         "test:e2e": "npm-run-all -p -r start:examples cy:run",
         "test:e2e:open": "npm-run-all -p -r start:examples cy:open"
@@ -105,7 +105,7 @@
             "react-intl-locale-data": "<rootDir>/node_modules/react-intl/locale-data/en.js",
             "box-ui-elements-locale-data": "<rootDir>/i18n/en-US.js",
             "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/conf/jest/fileMock.js",
-            "\\.(css|less)$": "<rootDir>/conf/jest/mocks/styleMock.js",
+            "\\.(css|less|scss)$": "<rootDir>/conf/jest/mocks/styleMock.js",
             "react-virtualized/dist/es": "react-virtualized/dist/commonjs"
         },
         "transformIgnorePatterns": ["node_modules/(?!(react-virtualized/dist/es))"],
@@ -151,7 +151,6 @@
         "babel-plugin-react-intl": "^2.4.0",
         "babel-plugin-react-remove-properties": "^0.2.5",
         "babel-plugin-rewire": "^1.0.0",
-        "babel-plugin-transform-require-ignore": "^0.1.1",
         "circular-dependency-plugin": "^5.0.2",
         "classnames": "^2.2.6",
         "color": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,11 +2410,6 @@ babel-plugin-syntax-object-rest-spread@^6.13.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
 
-babel-plugin-transform-require-ignore@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-require-ignore/-/babel-plugin-transform-require-ignore-0.1.1.tgz#1abb0f803cc29646dd0057f538fdb4a98d6cb8b2"
-  integrity sha512-A7EmlVd3ZYWJI3eg3dklAXn1yfq8Y5omHMQgAUo0FwGLYRuL5daLR6+LtCVHi4f9+fStr7HuPkW9rmKtcmY67w==
-
 babel-polyfill@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"


### PR DESCRIPTION
BREAKING CHANGE: The babel compiled output will now include SCSS imports. This commit removes the `babel-plugin-transform-require-ignore` which was responsible for removing lines such as `import './ContentPreview.scss'` from the babel compiled version of `ContentPreview.js`. This forced customers to manually include styles via `import 'box-ui-elements/dist/preview.css'`. With this change, the babel compiled output will now include `import './ContentPreview.scss'` and no manual import of `preview.css` will be required. This change however requires that [webpack is configured properly](https://github.com/box/box-ui-elements#stylesheets) to handle `.scss` files. As a customer, you will notice the change as shown below:

**Before**
-----------
Notice the import of `preview.css`.
```jsx
import React from 'react';	
import { render } from 'react-dom';	
import { ContentPreview } from 'box-ui-elements';	
import messages from 'box-ui-elements/i18n/en-US';	
import 'box-ui-elements/dist/preview.css';

render(	
    <ContentPreview	
        fileId='FILE_ID'	
        token='ACCESS_TOKEN'	
        language='en-US'	
        messages={messages}	
    />,	
    document.querySelector('.container')	
);	
```

**After**
--------
Notice no import of `preview.css`.

```jsx
import React from 'react';	
import { render } from 'react-dom';	
import { ContentPreview } from 'box-ui-elements';	
import messages from 'box-ui-elements/i18n/en-US';

render(	
    <ContentPreview	
        fileId='FILE_ID'	
        token='ACCESS_TOKEN'	
        language='en-US'	
        messages={messages}	
    />,	
    document.querySelector('.container')	
);	
```
