### PR TITLE
build(examples): add gitignore for gh-pages branch

### DIFF
--- a/conf/cut_release.sh
+++ b/conf/cut_release.sh
@@ -145,6 +145,7 @@ push_to_gh_pages() {
     git checkout -b gh-pages || return 1
     rm -rf build
     cp -R styleguide/. ./ || return 1
+    cp examples/gitignore .gitignore || return 1
     git add -A || return 1
     git commit --no-verify -am "build(examples): v$VERSION" || return 1
     git push release gh-pages --force --no-verify || return 1

--- a/examples/gitignore
+++ b/examples/gitignore
@@ -1,0 +1,10 @@
+/*
+!LICENSE
+!index.html
+!main.css
+!package.json
+!THIRD_PARTY_LICENSES
+!.gitignore
+!build
+!conf
+!i18n


### PR DESCRIPTION
gh-pages branch does not need anything except the `build` folder, the `index.html` and `main.css` files. Github has a problem parsing `{{ }}` from React within .md files that results in errors like

```
The variable `{{ retentionPolicyDescription: 'Retention', policyType: 'finite', openModal: () => { alert('Retention Modal'); }` on line 51 in `src/features/item-details/ItemProperties.md` was not properly closed with `}}`.
```