### PR TITLE
build: include global flow types, disable react-intl for dev

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,9 @@
-flow/
-es/
+build/
 dist/
-flow-typed/
+es/
+flow/
+flow-typed/npm/
 i18n/
 node_modules/
 reports/
+styleguide/

--- a/.flowconfig
+++ b/.flowconfig
@@ -33,7 +33,6 @@ module.name_mapper.extension='scss' -> '<PROJECT_ROOT>/flow/SCSSFlowStub.js.flow
 module.name_mapper.extension='css' -> '<PROJECT_ROOT>/flow/SCSSFlowStub.js.flow'
 module.name_mapper='react-intl-locale-data' -> '<PROJECT_ROOT>/flow/WebpackI18N.js.flow'
 module.name_mapper='box-ui-elements-locale-data' -> '<PROJECT_ROOT>/flow/WebpackI18N.js.flow'
-module.name_mapper='box-react-ui-locale-data' -> '<PROJECT_ROOT>/flow/WebpackI18N.js.flow'
 module.name_mapper='react-virtualized/dist/es/Table' -> '<PROJECT_ROOT>/flow/ReactVirtualizedStub.js.flow'
 module.name_mapper='react-virtualized/dist/es/AutoSizer' -> '<PROJECT_ROOT>/flow/ReactVirtualizedStub.js.flow'
 module.name_mapper='react-virtualized/dist/es/CellMeasurer' -> '<PROJECT_ROOT>/flow/ReactVirtualizedStub.js.flow'

--- a/.npmignore
+++ b/.npmignore
@@ -33,8 +33,8 @@ coverage
 cypress.json
 desktop.ini
 examples
-flow
-flow-typed
+flow/
+flow-typed/npm/
 jsconfig.json
 npm-debug.log
 npm-error.log

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,13 +16,6 @@ module.exports = {
         '@babel/plugin-proposal-class-properties',
         '@babel/plugin-proposal-object-rest-spread',
         [
-            'react-intl',
-            {
-                enforceDescriptions: true,
-                messagesDir: './i18n/json',
-            },
-        ],
-        [
             'module-resolver',
             {
                 alias: {
@@ -43,7 +36,16 @@ module.exports = {
             plugins: ['flow-react-proptypes'],
         },
         npm: {
-            plugins: [['react-remove-properties', { properties: ['data-testid'] }]],
+            plugins: [
+                ['react-remove-properties', { properties: ['data-testid'] }],
+                [
+                    'react-intl',
+                    {
+                        enforceDescriptions: true,
+                        messagesDir: './i18n/json',
+                    },
+                ],
+            ],
         },
         production: {
             plugins: [['react-remove-properties', { properties: ['data-resin-target', 'data-testid'] }]],

--- a/conf/cut_release.sh
+++ b/conf/cut_release.sh
@@ -125,6 +125,9 @@ build_assets() {
     printf "${blue}Building assets...${end}"
     yarn build:npm || return 1
     printf "${green}Built assets!${end}"
+    printf "${blue}Building locales...${end}"
+    yarn build:i18n || return 1
+    printf "${green}Built locales!${end}"
 }
 
 push_to_npm() {
@@ -202,6 +205,12 @@ push_new_release() {
         return 1
     fi
 
+    # Build npm assets
+    if ! build_assets; then
+        printf "${red}Failed building npm assets!${end}"
+        return 1
+    fi
+
     # Check uncommitted files
     check_uncommitted_files || return 1
 
@@ -228,12 +237,6 @@ push_new_release() {
 
     # Check untracked files
     check_untracked_files || return 1
-
-    # Build npm assets
-    if ! build_assets; then
-        printf "${red}Failed building npm assets!${end}"
-        return 1
-    fi
 
     # Publish to npm
     if ! push_to_npm; then

--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -3,21 +3,21 @@
  * @file Flow types
  * @author Box
  */
-/* eslint-disable no-use-before-define */
+/* eslint-disable no-use-before-define, no-unused-vars */
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import type { MessageDescriptor, InjectIntlProvidedProps } from 'react-intl';
-import type { $AxiosError, Axios, CancelTokenSource } from 'axios';
+import type { $AxiosXHR, $AxiosError, Axios, CancelTokenSource } from 'axios';
 import type FolderAPI from '../src/api/Folder';
 import type FileAPI from '../src/api/File';
 import type WebLinkAPI from '../src/api/WebLink';
 import type MultiputUploadAPI from '../src/api/uploads/MultiputUpload';
 import type PlainUploadAPI from '../src/api/uploads/PlainUpload';
-import type APICache from '../src/util/Cache';
-import type { ContentSidebarProps } from '../src/components/ContentSidebar';
-import type { ContentOpenWithProps } from '../src/components/ContentOpenWithProps';
-import type { ContentPreviewProps } from '../src/components/ContentPreview';
-import type { FeatureConfig } from '../FeatureChecking';
+import type APICache from '../src/utils/Cache';
+import type { ContentSidebarProps } from '../src/elements/content-sidebar';
+import type { ContentOpenWithProps } from '../src/elements/content-open-with';
+import type { ContentPreviewProps } from '../src/elements/content-preview';
+import type { FeatureConfig } from '../src/elements/common/feature-checking';
 import {
     ACCESS_OPEN,
     ACCESS_COLLAB,

--- a/flow-typed/npm/react-intl_v2.x.x.js
+++ b/flow-typed/npm/react-intl_v2.x.x.js
@@ -1,3 +1,6 @@
+// flow-typed signature: c3aa29455eb7f759ba4d433975a4ec02
+// flow-typed version: b14d5b4826/react-intl_v2.x.x/flow_>=v0.63.x
+
 /**
  * Original implementation of this file by @marudor at https://github.com/marudor/flowInterfaces
  * Copied here based on intention to merge with flow-typed expressed here:
@@ -5,255 +8,255 @@
  */
 // Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-api
 declare module "react-intl" {
-    import type { Element, ChildrenArray } from "react";
+  import type { Element, ChildrenArray } from "react";
 
-    declare type $npm$ReactIntl$LocaleData = {
-      locale: string,
-      [key: string]: any
-    };
+  declare type $npm$ReactIntl$LocaleData = {
+    locale: string,
+    [key: string]: any
+  };
 
-    declare type $npm$ReactIntl$MessageDescriptor = {
-      id: string,
-      description?: string,
-      defaultMessage?: string
-    };
+  declare type $npm$ReactIntl$MessageDescriptor = {
+    id: string,
+    description?: string,
+    defaultMessage?: string
+  };
 
-    declare type $npm$ReactIntl$IntlConfig = {
-      locale: string,
-      formats: Object,
-      messages: { [id: string]: string },
+  declare type $npm$ReactIntl$IntlConfig = {
+    locale: string,
+    formats: Object,
+    messages: { [id: string]: string },
 
-      defaultLocale?: string,
-      defaultFormats?: Object
-    };
+    defaultLocale?: string,
+    defaultFormats?: Object
+  };
 
-    declare type $npm$ReactIntl$IntlProviderConfig = {
-      locale?: string,
-      formats?: Object,
-      messages?: { [id: string]: string },
+  declare type $npm$ReactIntl$IntlProviderConfig = {
+    locale?: string,
+    formats?: Object,
+    messages?: { [id: string]: string },
 
-      defaultLocale?: string,
-      defaultFormats?: Object
-    };
+    defaultLocale?: string,
+    defaultFormats?: Object
+  };
 
-    declare type $npm$ReactIntl$IntlFormat = {
-      formatDate: (value: any, options?: Object) => string,
-      formatTime: (value: any, options?: Object) => string,
-      formatRelative: (value: any, options?: Object) => string,
-      formatNumber: (value: any, options?: Object) => string,
-      formatPlural: (value: any, options?: Object) => string,
-      formatMessage: (
-        messageDescriptor: $npm$ReactIntl$MessageDescriptor,
-        values?: Object
-      ) => string,
-      formatHTMLMessage: (
-        messageDescriptor: $npm$ReactIntl$MessageDescriptor,
-        values?: Object
-      ) => string
-    };
-
-    declare type $npm$ReactIntl$IntlShape = $npm$ReactIntl$IntlConfig &
-      $npm$ReactIntl$IntlFormat & { now: () => number };
-
-    declare type $npm$ReactIntl$DateTimeFormatOptions = {
-      localeMatcher?: "best fit" | "lookup",
-      formatMatcher?: "basic" | "best fit",
-
-      timeZone?: string,
-      hour12?: boolean,
-
-      weekday?: "narrow" | "short" | "long",
-      era?: "narrow" | "short" | "long",
-      year?: "numeric" | "2-digit",
-      month?: "numeric" | "2-digit" | "narrow" | "short" | "long",
-      day?: "numeric" | "2-digit",
-      hour?: "numeric" | "2-digit",
-      minute?: "numeric" | "2-digit",
-      second?: "numeric" | "2-digit",
-      timeZoneName?: "short" | "long"
-    };
-
-    declare type $npm$ReactIntl$RelativeFormatOptions = {
-      style?: "best fit" | "numeric",
-      units?: "second" | "minute" | "hour" | "day" | "month" | "year"
-    };
-
-    declare type $npm$ReactIntl$NumberFormatOptions = {
-      localeMatcher?: "best fit" | "lookup",
-
-      style?: "decimal" | "currency" | "percent",
-
-      currency?: string,
-      currencyDisplay?: "symbol" | "code" | "name",
-
-      useGrouping?: boolean,
-
-      minimumIntegerDigits?: number,
-      minimumFractionDigits?: number,
-      maximumFractionDigits?: number,
-      minimumSignificantDigits?: number,
-      maximumSignificantDigits?: number
-    };
-
-    declare type $npm$ReactIntl$PluralFormatOptions = {
-      style?: "cardinal" | "ordinal"
-    };
-
-    declare type $npm$ReactIntl$PluralCategoryString =
-      | "zero"
-      | "one"
-      | "two"
-      | "few"
-      | "many"
-      | "other";
-
-    declare type $npm$ReactIntl$DateParseable = number | string | Date;
-    // PropType checker
-    declare function intlShape(
-      props: Object,
-      propName: string,
-      componentName: string
-    ): void;
-    declare function addLocaleData(
-      data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
-    ): void;
-    declare function defineMessages<
-      T: { [key: string]: $npm$ReactIntl$MessageDescriptor }
-    >(
-      messageDescriptors: T
-    ): T;
-
-    declare type InjectIntlProvidedProps = {
-      intl: $npm$ReactIntl$IntlShape
-    }
-
-    declare type InjectIntlVoidProps = {
-      intl: $npm$ReactIntl$IntlShape | void
-    }
-
-    declare type ComponentWithDefaultProps<DefaultProps: {}, Props: {}> =
-      | React$ComponentType<Props>
-      | React$StatelessFunctionalComponent<Props>
-      | ChildrenArray<void | null | boolean | string | number | Element<any>>;
-
-    declare type InjectIntlOptions = {
-      intlPropName?: string,
-      withRef?: boolean
-    }
-
-    declare class IntlInjectedComponent<TOwnProps, TDefaultProps> extends React$Component<TOwnProps> {
-      static WrappedComponent: Class<React$Component<TOwnProps & InjectIntlProvidedProps>>,
-      static defaultProps: TDefaultProps,
-      props: TOwnProps
-    }
-
-    declare type IntlInjectedComponentClass<TOwnProps, TDefaultProps: {} = {}> = Class<
-      IntlInjectedComponent<TOwnProps, TDefaultProps>
-    >;
-
-    declare function injectIntl<P: {}, Component: React$ComponentType<P>>(
-      WrappedComponent: Component,
-      options?: InjectIntlOptions,
-    ): React$ComponentType<
-      $Diff<React$ElementConfig<Component>, InjectIntlVoidProps>
-    >;
-
-    declare function formatMessage(
+  declare type $npm$ReactIntl$IntlFormat = {
+    formatDate: (value: any, options?: Object) => string,
+    formatTime: (value: any, options?: Object) => string,
+    formatRelative: (value: any, options?: Object) => string,
+    formatNumber: (value: any, options?: Object) => string,
+    formatPlural: (value: any, options?: Object) => string,
+    formatMessage: (
       messageDescriptor: $npm$ReactIntl$MessageDescriptor,
       values?: Object
-    ): string;
-    declare function formatHTMLMessage(
+    ) => string,
+    formatHTMLMessage: (
       messageDescriptor: $npm$ReactIntl$MessageDescriptor,
       values?: Object
-    ): string;
-    declare function formatDate(
-      value: any,
-      options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
-    ): string;
-    declare function formatTime(
-      value: any,
-      options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
-    ): string;
-    declare function formatRelative(
-      value: any,
-      options?: $npm$ReactIntl$RelativeFormatOptions & {
-        format: string,
-        now: any
-      }
-    ): string;
-    declare function formatNumber(
-      value: any,
-      options?: $npm$ReactIntl$NumberFormatOptions & { format: string }
-    ): string;
-    declare function formatPlural(
-      value: any,
-      options?: $npm$ReactIntl$PluralFormatOptions
-    ): $npm$ReactIntl$PluralCategoryString;
+    ) => string
+  };
 
-    declare class FormattedMessage extends React$Component<
-      $npm$ReactIntl$MessageDescriptor & {
-        values?: Object,
-        tagName?: string,
-        children?:
-          | ((...formattedMessage: Array<React$Node>) => React$Node)
-          | (string => React$Node)
-      }
-    > {}
-    declare class FormattedHTMLMessage extends React$Component<
-      $npm$ReactIntl$DateTimeFormatOptions & {
-        values?: Object,
-        tagName?: string,
-        children?: (...formattedMessage: Array<React$Node>) => React$Node
-      }
-    > {}
-    declare class FormattedDate extends React$Component<
-      $npm$ReactIntl$DateTimeFormatOptions & {
-        value: $npm$ReactIntl$DateParseable,
-        format?: string,
-        children?: (formattedDate: string) => React$Node
-      }
-    > {}
-    declare class FormattedTime extends React$Component<
-      $npm$ReactIntl$DateTimeFormatOptions & {
-        value: $npm$ReactIntl$DateParseable,
-        format?: string,
-        children?: (formattedDate: string) => React$Node
-      }
-    > {}
-    declare class FormattedRelative extends React$Component<
-      $npm$ReactIntl$RelativeFormatOptions & {
-        value: $npm$ReactIntl$DateParseable,
-        format?: string,
-        updateInterval?: number,
-        initialNow?: $npm$ReactIntl$DateParseable,
-        children?: (formattedDate: string) => React$Node
-      }
-    > {}
-    declare class FormattedNumber extends React$Component<
-      $npm$ReactIntl$NumberFormatOptions & {
-        value: number | string,
-        format?: string,
-        children?: (formattedNumber: string) => React$Node
-      }
-    > {}
-    declare class FormattedPlural extends React$Component<
-      $npm$ReactIntl$PluralFormatOptions & {
-        value: number | string,
-        other: React$Node,
-        zero?: React$Node,
-        one?: React$Node,
-        two?: React$Node,
-        few?: React$Node,
-        many?: React$Node,
-        children?: (formattedPlural: React$Node) => React$Node
-      }
-    > {}
-    declare class IntlProvider extends React$Component<
-      $npm$ReactIntl$IntlProviderConfig & {
-        children?: React$Node,
-        initialNow?: $npm$ReactIntl$DateParseable
-      }
-    > {}
-    declare type IntlShape = $npm$ReactIntl$IntlShape;
-    declare type MessageDescriptor = $npm$ReactIntl$MessageDescriptor;
+  declare type $npm$ReactIntl$IntlShape = $npm$ReactIntl$IntlConfig &
+    $npm$ReactIntl$IntlFormat & { now: () => number };
+
+  declare type $npm$ReactIntl$DateTimeFormatOptions = {
+    localeMatcher?: "best fit" | "lookup",
+    formatMatcher?: "basic" | "best fit",
+
+    timeZone?: string,
+    hour12?: boolean,
+
+    weekday?: "narrow" | "short" | "long",
+    era?: "narrow" | "short" | "long",
+    year?: "numeric" | "2-digit",
+    month?: "numeric" | "2-digit" | "narrow" | "short" | "long",
+    day?: "numeric" | "2-digit",
+    hour?: "numeric" | "2-digit",
+    minute?: "numeric" | "2-digit",
+    second?: "numeric" | "2-digit",
+    timeZoneName?: "short" | "long"
+  };
+
+  declare type $npm$ReactIntl$RelativeFormatOptions = {
+    style?: "best fit" | "numeric",
+    units?: "second" | "minute" | "hour" | "day" | "month" | "year"
+  };
+
+  declare type $npm$ReactIntl$NumberFormatOptions = {
+    localeMatcher?: "best fit" | "lookup",
+
+    style?: "decimal" | "currency" | "percent",
+
+    currency?: string,
+    currencyDisplay?: "symbol" | "code" | "name",
+
+    useGrouping?: boolean,
+
+    minimumIntegerDigits?: number,
+    minimumFractionDigits?: number,
+    maximumFractionDigits?: number,
+    minimumSignificantDigits?: number,
+    maximumSignificantDigits?: number
+  };
+
+  declare type $npm$ReactIntl$PluralFormatOptions = {
+    style?: "cardinal" | "ordinal"
+  };
+
+  declare type $npm$ReactIntl$PluralCategoryString =
+    | "zero"
+    | "one"
+    | "two"
+    | "few"
+    | "many"
+    | "other";
+
+  declare type $npm$ReactIntl$DateParseable = number | string | Date;
+  // PropType checker
+  declare function intlShape(
+    props: Object,
+    propName: string,
+    componentName: string
+  ): void;
+  declare function addLocaleData(
+    data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
+  ): void;
+  declare function defineMessages<
+    T: { [key: string]: $npm$ReactIntl$MessageDescriptor }
+  >(
+    messageDescriptors: T
+  ): T;
+
+  declare type InjectIntlProvidedProps = {
+    intl: $npm$ReactIntl$IntlShape
   }
+
+  declare type InjectIntlVoidProps = {
+    intl: $npm$ReactIntl$IntlShape | void
+  }
+
+  declare type ComponentWithDefaultProps<DefaultProps: {}, Props: {}> =
+    | React$ComponentType<Props>
+    | React$StatelessFunctionalComponent<Props>
+    | ChildrenArray<void | null | boolean | string | number | Element<any>>;
+
+  declare type InjectIntlOptions = {
+    intlPropName?: string,
+    withRef?: boolean
+  }
+
+  declare class IntlInjectedComponent<TOwnProps, TDefaultProps> extends React$Component<TOwnProps> {
+    static WrappedComponent: Class<React$Component<TOwnProps & InjectIntlProvidedProps>>,
+    static defaultProps: TDefaultProps,
+    props: TOwnProps
+  }
+
+  declare type IntlInjectedComponentClass<TOwnProps, TDefaultProps: {} = {}> = Class<
+    IntlInjectedComponent<TOwnProps, TDefaultProps>
+  >;
+
+  declare function injectIntl<P: {}, Component: React$ComponentType<P>>(
+    WrappedComponent: Component,
+    options?: InjectIntlOptions,
+  ): React$ComponentType<
+    $Diff<React$ElementConfig<Component>, InjectIntlVoidProps>
+  >;
+
+  declare function formatMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatHTMLMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatDate(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatTime(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatRelative(
+    value: any,
+    options?: $npm$ReactIntl$RelativeFormatOptions & {
+      format: string,
+      now: any
+    }
+  ): string;
+  declare function formatNumber(
+    value: any,
+    options?: $npm$ReactIntl$NumberFormatOptions & { format: string }
+  ): string;
+  declare function formatPlural(
+    value: any,
+    options?: $npm$ReactIntl$PluralFormatOptions
+  ): $npm$ReactIntl$PluralCategoryString;
+
+  declare class FormattedMessage extends React$Component<
+    $npm$ReactIntl$MessageDescriptor & {
+      values?: Object,
+      tagName?: string,
+      children?: 
+        | ((...formattedMessage: Array<React$Node>) => React$Node)
+        | (string => React$Node)
+    }
+  > {}
+  declare class FormattedHTMLMessage extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      values?: Object,
+      tagName?: string,
+      children?: (...formattedMessage: Array<React$Node>) => React$Node
+    }
+  > {}
+  declare class FormattedDate extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedTime extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedRelative extends React$Component<
+    $npm$ReactIntl$RelativeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      updateInterval?: number,
+      initialNow?: $npm$ReactIntl$DateParseable,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedNumber extends React$Component<
+    $npm$ReactIntl$NumberFormatOptions & {
+      value: number | string,
+      format?: string,
+      children?: (formattedNumber: string) => React$Node
+    }
+  > {}
+  declare class FormattedPlural extends React$Component<
+    $npm$ReactIntl$PluralFormatOptions & {
+      value: number | string,
+      other: React$Node,
+      zero?: React$Node,
+      one?: React$Node,
+      two?: React$Node,
+      few?: React$Node,
+      many?: React$Node,
+      children?: (formattedPlural: React$Node) => React$Node
+    }
+  > {}
+  declare class IntlProvider extends React$Component<
+    $npm$ReactIntl$IntlProviderConfig & {
+      children?: React$Node,
+      initialNow?: $npm$ReactIntl$DateParseable
+    }
+  > {}
+  declare type IntlShape = $npm$ReactIntl$IntlShape;
+  declare type MessageDescriptor = $npm$ReactIntl$MessageDescriptor;
+}

--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -33,7 +33,6 @@ import SidebarUtils from './SidebarUtils';
 import type { DetailsSidebarProps } from './DetailsSidebar';
 import type { ActivitySidebarProps } from './ActivitySidebar';
 import type { MetadataSidebarProps } from './MetadataSidebar';
-import type { $AxiosXHR } from 'axios'; // eslint-disable-line
 import SidebarNav from './SidebarNav';
 import Sidebar from './Sidebar';
 import 'elements/common/fonts.scss';

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -15,7 +15,6 @@ import DatePicker from 'components/date-picker/DatePicker';
 import PillSelectorDropdown from 'components/pill-selector-dropdown/PillSelectorDropdown';
 import Button from 'components/button/Button';
 import PrimaryButton from 'components/primary-button/PrimaryButton';
-import type { InjectIntlProvidedProps } from 'react-intl';
 
 import messages from '../../../common/messages';
 import { ACTIVITY_TARGETS, INTERACTION_TARGET } from '../../../common/interactionTargets';

--- a/src/elements/content-sidebar/activity-feed/version/Version.js
+++ b/src/elements/content-sidebar/activity-feed/version/Version.js
@@ -20,9 +20,6 @@ import {
     PLACEHOLDER_USER,
 } from '../../../../constants';
 
-// eslint-disable-next-line
-import type { InjectIntlProvidedProps } from 'react-intl';
-
 function getMessageForAction(name: React.Node, action: string, version_number: string): React.Node {
     switch (action) {
         case VERSION_UPLOAD_ACTION:

--- a/src/utils/Xhr.js
+++ b/src/utils/Xhr.js
@@ -18,7 +18,6 @@ import {
     HTTP_OPTIONS,
     HTTP_STATUS_CODE_RATE_LIMIT,
 } from '../constants';
-import type { $AxiosXHR, $AxiosError } from 'axios'; //eslint-disable-line
 
 type PayloadType = StringAnyMap | Array<StringAnyMap>;
 


### PR DESCRIPTION
* Includes global flow types inside the npm package so that parent projects can reference it.
* Also fixes references and eslint issues within the global flow types file.
* Restricts react-intl message extractor plugin to npm (used in prepush and release scripts) builds only so that the properties file is generated based on all JS modules and not just those that are referenced. NPM build touches all JS modules and such suffices to extract any and every message.
* Changes release script to build assets and locales before running semantic release to detect any potential missing locales.