### PR TITLE
fix(sidebar): At mentions with no link should render inline

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/UserLink.js
+++ b/src/elements/content-sidebar/activity-feed/comment/UserLink.js
@@ -59,7 +59,7 @@ class UserLink extends React.PureComponent<Props, State> {
                 {name}
             </Link>
         ) : (
-            <div {...rest}>{name}</div>
+            <span {...rest}>{name}</span>
         );
     }
 }


### PR DESCRIPTION
This only affects at mentions that don't have a corresponding link.

Before:
<img width="394" alt="screen shot 2019-02-15 at 2 02 37 pm" src="https://user-images.githubusercontent.com/2474027/52886806-67b7d880-312a-11e9-9be4-ea4ce89e06d1.png">

After:
<img width="401" alt="screen shot 2019-02-15 at 2 01 00 pm" src="https://user-images.githubusercontent.com/2474027/52886819-6d152300-312a-11e9-95bd-bd7a72f72830.png">

