### PR TITLE
 chore(unified-share-modal): Update shared link call to action strings

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1056,10 +1056,10 @@ boxui.unifiedShare.inviteDisabledTooltip = You do not have permission to invite 
 boxui.unifiedShare.inviteDisabledWeblinkTooltip = Collaborators cannot be added to bookmarks.
 # Label of the field where a user designates who to invite to collaborate on an item
 boxui.unifiedShare.inviteFieldLabel = Invite People
-# Link sharing is off
-boxui.unifiedShare.linkShareOff = Link sharing is off
+# Enable shared link
+boxui.unifiedShare.linkShareOff = Enable shared link
 # Link sharing is on
-boxui.unifiedShare.linkShareOn = Link sharing is on
+boxui.unifiedShare.linkShareOn = Shared link is enabled
 # Label for "Message" text box to email the Shared Link
 boxui.unifiedShare.message = Message
 # Title of the Unified Share Modal. {itemName} is the name of the file / folder being shared

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -159,6 +159,7 @@
 
             .toggle-simple-label {
                 color: $twos;
+                cursor: pointer;
             }
         }
 

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection-test.js.snap
@@ -25,7 +25,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
         label={
           <span>
             <FormattedMessage
-              defaultMessage="Link sharing is on"
+              defaultMessage="Shared link is enabled"
               id="boxui.unifiedShare.linkShareOn"
             />
             <Tooltip
@@ -176,7 +176,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
           isOn={true}
           label={
             <FormattedMessage
-              defaultMessage="Link sharing is on"
+              defaultMessage="Shared link is enabled"
               id="boxui.unifiedShare.linkShareOn"
             />
           }
@@ -298,7 +298,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
           isOn={false}
           label={
             <FormattedMessage
-              defaultMessage="Link sharing is off"
+              defaultMessage="Enable shared link"
               id="boxui.unifiedShare.linkShareOff"
             />
           }
@@ -334,7 +334,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Link sharing is on"
+            defaultMessage="Shared link is enabled"
             id="boxui.unifiedShare.linkShareOn"
           />
         }
@@ -447,7 +447,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         isOn={false}
         label={
           <FormattedMessage
-            defaultMessage="Link sharing is off"
+            defaultMessage="Enable shared link"
             id="boxui.unifiedShare.linkShareOff"
           />
         }
@@ -482,7 +482,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Link sharing is on"
+            defaultMessage="Shared link is enabled"
             id="boxui.unifiedShare.linkShareOn"
           />
         }
@@ -596,7 +596,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Link sharing is on"
+            defaultMessage="Shared link is enabled"
             id="boxui.unifiedShare.linkShareOn"
           />
         }
@@ -735,7 +735,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Link sharing is on"
+            defaultMessage="Shared link is enabled"
             id="boxui.unifiedShare.linkShareOn"
           />
         }

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -91,12 +91,12 @@ const messages = defineMessages({
         id: 'boxui.unifiedShare.settingsButtonLabel',
     },
     linkShareOff: {
-        defaultMessage: 'Link sharing is off',
-        description: 'Link sharing is off',
+        defaultMessage: 'Enable shared link',
+        description: 'Enable shared link',
         id: 'boxui.unifiedShare.linkShareOff',
     },
     linkShareOn: {
-        defaultMessage: 'Link sharing is on',
+        defaultMessage: 'Shared link is enabled',
         description: 'Link sharing is on',
         id: 'boxui.unifiedShare.linkShareOn',
     },


### PR DESCRIPTION
Changes in this PR include: 
- Update `linkShareOn` and `linkShareOff` strings for shared link toggle in unified share modal. 
- Add CSS to show pointer cursor on shared link toggle label. 
