### PR TITLE
refactor(text-input): remove tag styles for inputs

### DIFF
--- a/conf/styleguide.config.js
+++ b/conf/styleguide.config.js
@@ -28,6 +28,7 @@ const allSections = [
     {
         name: 'Components',
         components: () => [
+            '../src/components/heading/Heading.js',
             '../src/components/avatar/Avatar.js',
             '../src/components/badge/Badge.js',
             '../src/components/badgeable/Badgeable.js',

--- a/src/components/heading/Heading.js
+++ b/src/components/heading/Heading.js
@@ -1,0 +1,25 @@
+// @flow
+import * as React from 'react';
+import classNames from 'classnames';
+import './Heading.scss';
+
+type Props = {
+    /** Heading contents */
+    children: React.Node,
+    /** Heading contents */
+    className?: string,
+    /** Header tag type */
+    type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+};
+
+const Heading = ({ children, className = '', type, ...rest }: Props) =>
+    React.createElement(
+        type,
+        {
+            className: classNames(`bdl-${type}`, className),
+            ...rest,
+        },
+        ...children,
+    );
+
+export default Heading;

--- a/src/components/heading/Heading.scss
+++ b/src/components/heading/Heading.scss
@@ -1,0 +1,44 @@
+@import '../../styles/variables';
+
+.bdl-h1,
+.bdl-h2,
+.bdl-h3,
+.bdl-h4,
+.bdl-h5,
+.bdl-h6 {
+    color: inherit;
+    font-family: inherit;
+    font-size: 100%;
+    font-weight: 400;
+    line-height: 20px;
+    margin: 8px 0;
+    padding: 0;
+    text-rendering: optimizeLegibility;
+}
+
+.bdl-h1 {
+    font-size: 30px;
+    line-height: 36px;
+}
+
+.bdl-h2 {
+    font-size: 24px;
+    line-height: 30px;
+}
+
+.bdl-h3 {
+    font-size: 20px;
+    line-height: 24px;
+}
+
+.bdl-h4 {
+    font-size: 16px;
+}
+
+.bdl-h5 {
+    font-size: 14px;
+}
+
+.bdl-h6 {
+    font-size: 12px;
+}

--- a/src/components/heading/README.md
+++ b/src/components/heading/README.md
@@ -1,0 +1,42 @@
+### Examples
+**H1**
+```
+<Heading type='h1'>
+    Box Design Language
+</Heading>
+```
+
+**H2**
+```
+<Heading type='h2'>
+    Box Design Language
+</Heading>
+```
+
+**H3**
+```
+<Heading type='h3'>
+    Box Design Language
+</Heading>
+```
+
+**H4**
+```
+<Heading type='h4'>
+    Box Design Language
+</Heading>
+```
+
+**H5**
+```
+<Heading type='h5'>
+    Box Design Language
+</Heading>
+```
+
+**H6**
+```
+<Heading type='h6'>
+    Box Design Language
+</Heading>
+```

--- a/src/components/heading/__tests__/Heading-test.js
+++ b/src/components/heading/__tests__/Heading-test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import Heading from '..';
+
+describe('components/heading/Heading', () => {
+    test('should correctly render h1', () => {
+        const wrapper = shallow(<Heading type="h1">BDL</Heading>);
+        expect(wrapper.type()).toEqual('h1');
+        expect(wrapper.hasClass('bdl-h1')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h2', () => {
+        const wrapper = shallow(<Heading type="h2">BDL</Heading>);
+        expect(wrapper.type()).toEqual('h2');
+        expect(wrapper.hasClass('bdl-h2')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h3', () => {
+        const wrapper = shallow(<Heading type="h3">BDL</Heading>);
+        expect(wrapper.type()).toEqual('h3');
+        expect(wrapper.hasClass('bdl-h3')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h4', () => {
+        const wrapper = shallow(<Heading type="h4">BDL</Heading>);
+        expect(wrapper.type()).toEqual('h4');
+        expect(wrapper.hasClass('bdl-h4')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h5', () => {
+        const wrapper = shallow(<Heading type="h5">BDL</Heading>);
+        expect(wrapper.type()).toEqual('h5');
+        expect(wrapper.hasClass('bdl-h5')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h6', () => {
+        const wrapper = shallow(<Heading type="h6">BDL</Heading>);
+        expect(wrapper.type()).toEqual('h6');
+        expect(wrapper.hasClass('bdl-h6')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/components/heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/components/heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/heading/Heading should correctly render h1 1`] = `
+<h1
+  className="bdl-h1"
+>
+  B
+  D
+  L
+</h1>
+`;
+
+exports[`components/heading/Heading should correctly render h2 1`] = `
+<h2
+  className="bdl-h2"
+>
+  B
+  D
+  L
+</h2>
+`;
+
+exports[`components/heading/Heading should correctly render h3 1`] = `
+<h3
+  className="bdl-h3"
+>
+  B
+  D
+  L
+</h3>
+`;
+
+exports[`components/heading/Heading should correctly render h4 1`] = `
+<h4
+  className="bdl-h4"
+>
+  B
+  D
+  L
+</h4>
+`;
+
+exports[`components/heading/Heading should correctly render h5 1`] = `
+<h5
+  className="bdl-h5"
+>
+  B
+  D
+  L
+</h5>
+`;
+
+exports[`components/heading/Heading should correctly render h6 1`] = `
+<h6
+  className="bdl-h6"
+>
+  B
+  D
+  L
+</h6>
+`;

--- a/src/components/heading/index.js
+++ b/src/components/heading/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './Heading';

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -26,12 +26,6 @@ dd,
 ul,
 ol,
 li,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
 pre,
 code,
 form,
@@ -81,16 +75,6 @@ ul {
 caption,
 th {
     text-align: left;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    font-size: 100%;
-    font-weight: normal;
 }
 
 q::before,

--- a/src/styles/common/_typography.scss
+++ b/src/styles/common/_typography.scss
@@ -23,47 +23,6 @@ p {
     margin: 0 0 20px;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    color: inherit;
-    font-family: inherit;
-    font-weight: 400;
-    line-height: 20px;
-    margin: 8px 0;
-    text-rendering: optimizeLegibility;
-}
-
-h1 {
-    font-size: 30px;
-    line-height: 36px;
-}
-
-h2 {
-    font-size: 24px;
-    line-height: 30px;
-}
-
-h3 {
-    font-size: 20px;
-    line-height: 24px;
-}
-
-h4 {
-    font-size: 16px;
-}
-
-h5 {
-    font-size: 14px;
-}
-
-h6 {
-    font-size: 12px;
-}
-
 .strong,
 strong {
     font-weight: 700;


### PR DESCRIPTION
Does not fix other components using text-inputs or text-areas

BREAKING CHANGE: The styling classes for text inputs have changed.