### PR TITLE
feat(query-bar): Implement multi enum in filter button

### DIFF
--- a/src/features/query-bar/__tests__/Condition-test.js
+++ b/src/features/query-bar/__tests__/Condition-test.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 
 import { columnOptions, columns, initialCondition } from '../components/fixtures';
-import { OPERATOR, VALUES } from '../constants';
 import Condition from '../components/filter/Condition';
 
 describe('features/query-bar/components/filter/Condition', () => {
@@ -61,18 +60,16 @@ describe('features/query-bar/components/filter/Condition', () => {
         };
 
         test('should select an operator', () => {
-            const onColumnChange = jest.fn();
-            const onFieldChange = jest.fn();
+            const onOperatorChange = jest.fn();
             const wrapper = getWrapper({
-                onFieldChange,
-                onColumnChange,
+                onOperatorChange,
             });
 
             wrapper
                 .find('SingleSelectField')
                 .at(1)
                 .simulate('change', option);
-            expect(onFieldChange).toHaveBeenCalledWith(condition, value, OPERATOR);
+            expect(onOperatorChange).toHaveBeenCalledWith(condition, value);
         });
     });
 
@@ -81,20 +78,19 @@ describe('features/query-bar/components/filter/Condition', () => {
         const textInputValue = 'string';
         const selectFieldValue = '1';
         const dateFieldValue = new Date(2018, 11, 24, 10, 33, 30, 0);
-        const keyType = VALUES;
 
         test.each`
             description                                            | option              | value
-            ${'should invoke onFieldChange with "string"'}         | ${textInputValue}   | ${textInputValue}
-            ${'should invoke onFieldChange with selectFieldValue'} | ${selectFieldValue} | ${selectFieldValue}
-            ${'should invoke onFieldChange with Date'}             | ${dateFieldValue}   | ${dateFieldValue}
+            ${'should invoke onValueChange with "string"'}         | ${textInputValue}   | ${textInputValue}
+            ${'should invoke onValueChange with selectFieldValue'} | ${selectFieldValue} | ${selectFieldValue}
+            ${'should invoke onValueChange with Date'}             | ${dateFieldValue}   | ${dateFieldValue}
         `('$description', ({ option, value }) => {
-            const onFieldChange = jest.fn();
-            const wrapper = getWrapper({ onFieldChange });
+            const onValueChange = jest.fn();
+            const wrapper = getWrapper({ onValueChange });
 
             wrapper.find('ValueField').prop('onChange')(option);
 
-            expect(onFieldChange).toHaveBeenCalledWith(condition, value, keyType);
+            expect(onValueChange).toHaveBeenCalledWith(condition, value);
         });
     });
 

--- a/src/features/query-bar/__tests__/Condition-test.js
+++ b/src/features/query-bar/__tests__/Condition-test.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 
 import { columnOptions, columns, initialCondition } from '../components/fixtures';
-import { OPERATOR, VALUE } from '../constants';
+import { OPERATOR, VALUES } from '../constants';
 import Condition from '../components/filter/Condition';
 
 describe('features/query-bar/components/filter/Condition', () => {
@@ -72,7 +72,7 @@ describe('features/query-bar/components/filter/Condition', () => {
                 .find('SingleSelectField')
                 .at(1)
                 .simulate('change', option);
-            expect(onFieldChange).toHaveBeenCalledWith(condition, [value], OPERATOR);
+            expect(onFieldChange).toHaveBeenCalledWith(condition, value, OPERATOR);
         });
     });
 
@@ -81,7 +81,7 @@ describe('features/query-bar/components/filter/Condition', () => {
         const textInputValue = 'string';
         const selectFieldValue = '1';
         const dateFieldValue = new Date(2018, 11, 24, 10, 33, 30, 0);
-        const keyType = VALUE;
+        const keyType = VALUES;
 
         test.each`
             description                                            | option              | value

--- a/src/features/query-bar/__tests__/Condition-test.js
+++ b/src/features/query-bar/__tests__/Condition-test.js
@@ -54,7 +54,7 @@ describe('features/query-bar/components/filter/Condition', () => {
     describe('handleOperatorChange()', () => {
         const displayText = 'Vendor Name';
         const condition = initialCondition;
-        const value = 0;
+        const value = '0';
         const option = {
             displayText,
             value,
@@ -72,7 +72,7 @@ describe('features/query-bar/components/filter/Condition', () => {
                 .find('SingleSelectField')
                 .at(1)
                 .simulate('change', option);
-            expect(onFieldChange).toHaveBeenCalledWith(condition, value, OPERATOR);
+            expect(onFieldChange).toHaveBeenCalledWith(condition, [value], OPERATOR);
         });
     });
 

--- a/src/features/query-bar/__tests__/Condition-test.js
+++ b/src/features/query-bar/__tests__/Condition-test.js
@@ -69,7 +69,7 @@ describe('features/query-bar/components/filter/Condition', () => {
                 .find('SingleSelectField')
                 .at(1)
                 .simulate('change', option);
-            expect(onOperatorChange).toHaveBeenCalledWith(condition, value);
+            expect(onOperatorChange).toHaveBeenCalledWith(condition.id, value);
         });
     });
 
@@ -90,7 +90,7 @@ describe('features/query-bar/components/filter/Condition', () => {
 
             wrapper.find('ValueField').prop('onChange')(option);
 
-            expect(onValueChange).toHaveBeenCalledWith(condition, value);
+            expect(onValueChange).toHaveBeenCalledWith(condition.id, value);
         });
     });
 

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 
-import { columns } from '../components/fixtures';
+import { columns, initialCondition } from '../components/fixtures';
 import FilterButton from '../components/filter/FilterButton';
 import { EQUALS, LESS_THAN, OPERATOR, VALUES } from '../constants';
 
@@ -81,7 +81,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                         values: [],
                     },
                 ],
-                value: LESS_THAN,
+                values: LESS_THAN,
                 property: OPERATOR,
                 newCondition: [
                     {
@@ -109,7 +109,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                         values: [],
                     },
                 ],
-                value: ['0'],
+                values: ['0'],
                 property: VALUES,
                 newCondition: [
                     {
@@ -120,13 +120,13 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     },
                 ],
             },
-        ].forEach(({ description, condition, conditions, value, property, newCondition }) => {
+        ].forEach(({ description, condition, conditions, values, property, newCondition }) => {
             test(`${description}`, () => {
                 const wrapper = getWrapper();
                 wrapper.setState({
                     conditions,
                 });
-                wrapper.instance().handleFieldChange(condition, value, property);
+                wrapper.instance().handleFieldChange(condition, values, property);
 
                 expect(wrapper.state('conditions')).toEqual(newCondition);
             });
@@ -257,18 +257,13 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
     });
 
     describe('closeOnClickPredicate()', () => {
-        const condition = {
-            columnId: '1',
-            id: '3',
-            operator: EQUALS,
-        };
         const conditionsWithValues = [
             {
-                ...condition,
+                ...initialCondition,
                 values: ['1'],
             },
         ];
-        const conditionsWithEmptyValues = [{ ...condition, values: [] }];
+        const conditionsWithEmptyValues = [{ ...initialCondition, values: [] }];
 
         test.each`
             description                                                                | conditions                   | shouldCloseResult

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { columns, initialCondition } from '../components/fixtures';
 import FilterButton from '../components/filter/FilterButton';
-import { EQUALS, LESS_THAN, OPERATOR, VALUES } from '../constants';
+import { EQUALS, LESS_THAN } from '../constants';
 
 describe('feature/query-bar/components/filter/FilterButton', () => {
     const getWrapper = (props = {}) => {
@@ -82,7 +82,6 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     },
                 ],
                 value: LESS_THAN,
-                property: OPERATOR,
                 expectedConditions: [
                     {
                         columnId: '1',
@@ -92,13 +91,13 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     },
                 ],
             },
-        ].forEach(({ description, condition, conditions, value, property, expectedConditions }) => {
+        ].forEach(({ description, condition, conditions, value, expectedConditions }) => {
             test(`${description}`, () => {
                 const wrapper = getWrapper();
                 wrapper.setState({
                     conditions,
                 });
-                wrapper.instance().handleOperatorChange(condition, value, property);
+                wrapper.instance().handleOperatorChange(condition, value);
 
                 expect(wrapper.state('conditions')).toEqual(expectedConditions);
             });
@@ -125,7 +124,6 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     },
                 ],
                 values: ['0'],
-                property: VALUES,
                 expectedConditions: [
                     {
                         columnId: '1',
@@ -135,13 +133,13 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     },
                 ],
             },
-        ].forEach(({ description, condition, conditions, values, property, expectedConditions }) => {
+        ].forEach(({ description, condition, conditions, values, expectedConditions }) => {
             test(`${description}`, () => {
                 const wrapper = getWrapper();
                 wrapper.setState({
                     conditions,
                 });
-                wrapper.instance().handleValueChange(condition, values, property);
+                wrapper.instance().handleValueChange(condition, values);
 
                 expect(wrapper.state('conditions')).toEqual(expectedConditions);
             });

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -31,14 +31,14 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     columnId: '1',
                     id: '3',
                     operator: EQUALS,
-                    value: null,
+                    value: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '3',
                         operator: EQUALS,
-                        value: null,
+                        value: [],
                     },
                 ],
                 expectedConditions: [
@@ -46,7 +46,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                         columnId: '2',
                         id: '3',
                         operator: EQUALS,
-                        value: null,
+                        value: [],
                     },
                 ],
             },
@@ -71,14 +71,14 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     columnId: '1',
                     id: '4',
                     operator: EQUALS,
-                    value: null,
+                    value: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '4',
                         operator: EQUALS,
-                        value: null,
+                        value: [],
                     },
                 ],
                 property: LESS_THAN,
@@ -88,7 +88,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                         columnId: '1',
                         id: '4',
                         operator: LESS_THAN,
-                        value: null,
+                        value: [],
                     },
                 ],
             },
@@ -99,24 +99,24 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     columnId: '1',
                     id: '5',
                     operator: EQUALS,
-                    value: null,
+                    value: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '5',
                         operator: EQUALS,
-                        value: null,
+                        value: [],
                     },
                 ],
-                property: 0,
+                property: ['0'],
                 conditionProperty: 'value',
                 newCondition: [
                     {
                         columnId: '1',
                         id: '5',
                         operator: EQUALS,
-                        value: 0,
+                        value: ['0'],
                     },
                 ],
             },
@@ -141,26 +141,20 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 conditions: [
                     {
                         id: '2',
-                        operatorDisplayText: '',
                         operator: null,
-                        valueDisplayText: null,
-                        value: null,
+                        value: [],
                     },
                     {
                         id: '3',
-                        operatorDisplayText: '',
                         operator: null,
-                        valueDisplayText: null,
-                        value: null,
+                        value: [],
                     },
                 ],
                 expectedConditions: [
                     {
                         id: '3',
-                        operatorDisplayText: '',
                         operator: null,
-                        valueDisplayText: null,
-                        value: null,
+                        value: [],
                     },
                 ],
             },
@@ -238,8 +232,8 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
             const expected = {
                 columnId: '1',
                 id: conditionID,
-                operator: EQUALS,
-                value: null,
+                operator: [EQUALS],
+                value: [],
             };
             wrapper.instance().setState({
                 conditions: [],
@@ -263,16 +257,50 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
     });
 
     describe('closeOnClickPredicate()', () => {
-        test('Should return true if Apply button was clicked', () => {
+        test('Should return true if Apply button was clicked and value is not empty', () => {
+            const conditions = [
+                {
+                    columnId: '1',
+                    id: '3',
+                    operator: EQUALS,
+                    value: ['1'],
+                },
+            ];
             const wrapper = getWrapper();
             const targetWithClassName = {
                 target: document.createElement('button'),
             };
+            wrapper.instance().setState({
+                conditions,
+            });
             targetWithClassName.target.className = 'apply-filters-button';
             const closeOnClickPredicateResult = wrapper.instance().shouldClose(targetWithClassName);
 
             wrapper.update();
             expect(closeOnClickPredicateResult).toEqual(true);
+        });
+
+        test('Should return false if Apply button was clicked and value is empty', () => {
+            const conditions = [
+                {
+                    columnId: '1',
+                    id: '3',
+                    operator: EQUALS,
+                    value: [],
+                },
+            ];
+            const wrapper = getWrapper();
+            const targetWithClassName = {
+                target: document.createElement('button'),
+            };
+            wrapper.instance().setState({
+                conditions,
+            });
+            targetWithClassName.target.className = 'apply-filters-button';
+            const closeOnClickPredicateResult = wrapper.instance().shouldClose(targetWithClassName);
+
+            wrapper.update();
+            expect(closeOnClickPredicateResult).toEqual(false);
         });
     });
 });

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -30,14 +30,14 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 condition: {
                     columnId: '1',
                     id: '3',
-                    operator: EQUALS,
+                    operator: [EQUALS],
                     value: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '3',
-                        operator: EQUALS,
+                        operator: [EQUALS],
                         value: [],
                     },
                 ],
@@ -45,7 +45,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     {
                         columnId: '2',
                         id: '3',
-                        operator: EQUALS,
+                        operator: [EQUALS],
                         value: [],
                     },
                 ],
@@ -70,24 +70,24 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 condition: {
                     columnId: '1',
                     id: '4',
-                    operator: EQUALS,
+                    operator: [EQUALS],
                     value: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '4',
-                        operator: EQUALS,
+                        operator: [EQUALS],
                         value: [],
                     },
                 ],
-                property: LESS_THAN,
+                property: [LESS_THAN],
                 conditionProperty: 'operator',
                 newCondition: [
                     {
                         columnId: '1',
                         id: '4',
-                        operator: LESS_THAN,
+                        operator: [LESS_THAN],
                         value: [],
                     },
                 ],

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -257,15 +257,24 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
     });
 
     describe('closeOnClickPredicate()', () => {
-        test('Should return true if Apply button was clicked and value is not empty', () => {
-            const conditions = [
-                {
-                    columnId: '1',
-                    id: '3',
-                    operator: EQUALS,
-                    values: ['1'],
-                },
-            ];
+        const condition = {
+            columnId: '1',
+            id: '3',
+            operator: EQUALS,
+        };
+        const conditionsWithValues = [
+            {
+                ...condition,
+                values: ['1'],
+            },
+        ];
+        const conditionsWithEmptyValues = [{ ...condition, values: [] }];
+
+        test.each`
+            description                                                                | conditions                   | shouldCloseResult
+            ${'Should return true if Apply button was clicked and value is not empty'} | ${conditionsWithValues}      | ${true}
+            ${'Should return false if Apply button was clicked and value is empty'}    | ${conditionsWithEmptyValues} | ${false}
+        `('$description', ({ conditions, shouldCloseResult }) => {
             const wrapper = getWrapper();
             const targetWithClassName = {
                 target: document.createElement('button'),
@@ -277,30 +286,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
             const closeOnClickPredicateResult = wrapper.instance().shouldClose(targetWithClassName);
 
             wrapper.update();
-            expect(closeOnClickPredicateResult).toEqual(true);
-        });
-
-        test('Should return false if Apply button was clicked and value is empty', () => {
-            const conditions = [
-                {
-                    columnId: '1',
-                    id: '3',
-                    operator: EQUALS,
-                    values: [],
-                },
-            ];
-            const wrapper = getWrapper();
-            const targetWithClassName = {
-                target: document.createElement('button'),
-            };
-            wrapper.instance().setState({
-                conditions,
-            });
-            targetWithClassName.target.className = 'apply-filters-button';
-            const closeOnClickPredicateResult = wrapper.instance().shouldClose(targetWithClassName);
-
-            wrapper.update();
-            expect(closeOnClickPredicateResult).toEqual(false);
+            expect(closeOnClickPredicateResult).toEqual(shouldCloseResult);
         });
     });
 });

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { columns } from '../components/fixtures';
 import FilterButton from '../components/filter/FilterButton';
-import { EQUALS, LESS_THAN, OPERATOR, VALUE } from '../constants';
+import { EQUALS, LESS_THAN, OPERATOR, VALUES } from '../constants';
 
 describe('feature/query-bar/components/filter/FilterButton', () => {
     const getWrapper = (props = {}) => {
@@ -30,23 +30,23 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 condition: {
                     columnId: '1',
                     id: '3',
-                    operator: [EQUALS],
-                    value: [],
+                    operator: EQUALS,
+                    values: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '3',
-                        operator: [EQUALS],
-                        value: [],
+                        operator: EQUALS,
+                        values: [],
                     },
                 ],
                 expectedConditions: [
                     {
                         columnId: '2',
                         id: '3',
-                        operator: [EQUALS],
-                        value: [],
+                        operator: EQUALS,
+                        values: [],
                     },
                 ],
             },
@@ -70,25 +70,25 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 condition: {
                     columnId: '1',
                     id: '4',
-                    operator: [EQUALS],
-                    value: [],
+                    operator: EQUALS,
+                    values: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '4',
-                        operator: [EQUALS],
-                        value: [],
+                        operator: EQUALS,
+                        values: [],
                     },
                 ],
-                value: [LESS_THAN],
+                value: LESS_THAN,
                 property: OPERATOR,
                 newCondition: [
                     {
                         columnId: '1',
                         id: '4',
-                        operator: [LESS_THAN],
-                        value: [],
+                        operator: LESS_THAN,
+                        values: [],
                     },
                 ],
             },
@@ -98,25 +98,25 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 condition: {
                     columnId: '1',
                     id: '5',
-                    operator: [EQUALS],
-                    value: [],
+                    operator: EQUALS,
+                    values: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '5',
-                        operator: [EQUALS],
-                        value: [],
+                        operator: EQUALS,
+                        values: [],
                     },
                 ],
                 value: ['0'],
-                property: VALUE,
+                property: VALUES,
                 newCondition: [
                     {
                         columnId: '1',
                         id: '5',
-                        operator: [EQUALS],
-                        value: ['0'],
+                        operator: EQUALS,
+                        values: ['0'],
                     },
                 ],
             },
@@ -141,20 +141,20 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 conditions: [
                     {
                         id: '2',
-                        operator: [EQUALS],
-                        value: [],
+                        operator: EQUALS,
+                        values: [],
                     },
                     {
                         id: '3',
-                        operator: [EQUALS],
-                        value: [],
+                        operator: EQUALS,
+                        values: [],
                     },
                 ],
                 expectedConditions: [
                     {
                         id: '3',
-                        operator: [EQUALS],
-                        value: [],
+                        operator: EQUALS,
+                        values: [],
                     },
                 ],
             },
@@ -232,8 +232,8 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
             const expected = {
                 columnId: '1',
                 id: conditionID,
-                operator: [EQUALS],
-                value: [],
+                operator: EQUALS,
+                values: [],
             };
             wrapper.instance().setState({
                 conditions: [],
@@ -263,7 +263,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     columnId: '1',
                     id: '3',
                     operator: EQUALS,
-                    value: ['1'],
+                    values: ['1'],
                 },
             ];
             const wrapper = getWrapper();
@@ -286,7 +286,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     columnId: '1',
                     id: '3',
                     operator: EQUALS,
-                    value: [],
+                    values: [],
                 },
             ];
             const wrapper = getWrapper();

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -67,16 +67,11 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
         [
             {
                 description: 'should set conditions with an object with operator',
-                condition: {
-                    columnId: '1',
-                    id: '4',
-                    operator: EQUALS,
-                    values: [],
-                },
+                conditionId: 4,
                 conditions: [
                     {
                         columnId: '1',
-                        id: '4',
+                        id: 4,
                         operator: EQUALS,
                         values: [],
                     },
@@ -85,19 +80,19 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 expectedConditions: [
                     {
                         columnId: '1',
-                        id: '4',
+                        id: 4,
                         operator: LESS_THAN,
                         values: [],
                     },
                 ],
             },
-        ].forEach(({ description, condition, conditions, value, expectedConditions }) => {
+        ].forEach(({ description, conditionId, conditions, value, expectedConditions }) => {
             test(`${description}`, () => {
                 const wrapper = getWrapper();
                 wrapper.setState({
                     conditions,
                 });
-                wrapper.instance().handleOperatorChange(condition, value);
+                wrapper.instance().handleOperatorChange(conditionId, value);
 
                 expect(wrapper.state('conditions')).toEqual(expectedConditions);
             });
@@ -109,16 +104,11 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
             {
                 description: 'should set conditions with an object with value',
                 index: 0,
-                condition: {
-                    columnId: '1',
-                    id: '5',
-                    operator: EQUALS,
-                    values: [],
-                },
+                conditionId: 5,
                 conditions: [
                     {
                         columnId: '1',
-                        id: '5',
+                        id: 5,
                         operator: EQUALS,
                         values: [],
                     },
@@ -127,19 +117,19 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 expectedConditions: [
                     {
                         columnId: '1',
-                        id: '5',
+                        id: 5,
                         operator: EQUALS,
                         values: ['0'],
                     },
                 ],
             },
-        ].forEach(({ description, condition, conditions, values, expectedConditions }) => {
+        ].forEach(({ description, conditionId, conditions, values, expectedConditions }) => {
             test(`${description}`, () => {
                 const wrapper = getWrapper();
                 wrapper.setState({
                     conditions,
                 });
-                wrapper.instance().handleValueChange(condition, values);
+                wrapper.instance().handleValueChange(conditionId, values);
 
                 expect(wrapper.state('conditions')).toEqual(expectedConditions);
             });

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -63,7 +63,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
         });
     });
 
-    describe('handleFieldChange()', () => {
+    describe('handleOperatorChange()', () => {
         [
             {
                 description: 'should set conditions with an object with operator',
@@ -81,9 +81,9 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                         values: [],
                     },
                 ],
-                values: LESS_THAN,
+                value: LESS_THAN,
                 property: OPERATOR,
-                newCondition: [
+                expectedConditions: [
                     {
                         columnId: '1',
                         id: '4',
@@ -92,6 +92,21 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     },
                 ],
             },
+        ].forEach(({ description, condition, conditions, value, property, expectedConditions }) => {
+            test(`${description}`, () => {
+                const wrapper = getWrapper();
+                wrapper.setState({
+                    conditions,
+                });
+                wrapper.instance().handleOperatorChange(condition, value, property);
+
+                expect(wrapper.state('conditions')).toEqual(expectedConditions);
+            });
+        });
+    });
+
+    describe('handleValueChange()', () => {
+        [
             {
                 description: 'should set conditions with an object with value',
                 index: 0,
@@ -111,7 +126,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 ],
                 values: ['0'],
                 property: VALUES,
-                newCondition: [
+                expectedConditions: [
                     {
                         columnId: '1',
                         id: '5',
@@ -120,15 +135,15 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                     },
                 ],
             },
-        ].forEach(({ description, condition, conditions, values, property, newCondition }) => {
+        ].forEach(({ description, condition, conditions, values, property, expectedConditions }) => {
             test(`${description}`, () => {
                 const wrapper = getWrapper();
                 wrapper.setState({
                     conditions,
                 });
-                wrapper.instance().handleFieldChange(condition, values, property);
+                wrapper.instance().handleValueChange(condition, values, property);
 
-                expect(wrapper.state('conditions')).toEqual(newCondition);
+                expect(wrapper.state('conditions')).toEqual(expectedConditions);
             });
         });
     });

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { columns } from '../components/fixtures';
 import FilterButton from '../components/filter/FilterButton';
-import { EQUALS, LESS_THAN } from '../constants';
+import { EQUALS, LESS_THAN, OPERATOR, VALUE } from '../constants';
 
 describe('feature/query-bar/components/filter/FilterButton', () => {
     const getWrapper = (props = {}) => {
@@ -81,8 +81,8 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                         value: [],
                     },
                 ],
-                property: [LESS_THAN],
-                conditionProperty: 'operator',
+                value: [LESS_THAN],
+                property: OPERATOR,
                 newCondition: [
                     {
                         columnId: '1',
@@ -98,35 +98,35 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 condition: {
                     columnId: '1',
                     id: '5',
-                    operator: EQUALS,
+                    operator: [EQUALS],
                     value: [],
                 },
                 conditions: [
                     {
                         columnId: '1',
                         id: '5',
-                        operator: EQUALS,
+                        operator: [EQUALS],
                         value: [],
                     },
                 ],
-                property: ['0'],
-                conditionProperty: 'value',
+                value: ['0'],
+                property: VALUE,
                 newCondition: [
                     {
                         columnId: '1',
                         id: '5',
-                        operator: EQUALS,
+                        operator: [EQUALS],
                         value: ['0'],
                     },
                 ],
             },
-        ].forEach(({ description, condition, conditions, property, conditionProperty, newCondition }) => {
+        ].forEach(({ description, condition, conditions, value, property, newCondition }) => {
             test(`${description}`, () => {
                 const wrapper = getWrapper();
                 wrapper.setState({
                     conditions,
                 });
-                wrapper.instance().handleFieldChange(condition, property, conditionProperty);
+                wrapper.instance().handleFieldChange(condition, value, property);
 
                 expect(wrapper.state('conditions')).toEqual(newCondition);
             });
@@ -141,19 +141,19 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
                 conditions: [
                     {
                         id: '2',
-                        operator: null,
+                        operator: [EQUALS],
                         value: [],
                     },
                     {
                         id: '3',
-                        operator: null,
+                        operator: [EQUALS],
                         value: [],
                     },
                 ],
                 expectedConditions: [
                     {
                         id: '3',
-                        operator: null,
+                        operator: [EQUALS],
                         value: [],
                     },
                 ],

--- a/src/features/query-bar/__tests__/ValueField-test.js
+++ b/src/features/query-bar/__tests__/ValueField-test.js
@@ -28,15 +28,15 @@ describe('features/query-bar/components/filter/ValueField', () => {
     describe('render value fields', () => {
         const emptyArray = [];
         test.each`
-            description                                                                   | valueType       | renderedComponent      | selectedValue
+            description                                                                   | valueType       | renderedComponent      | selectedValues
             ${'should correctly render a MultiSelectField for a valueType of multi-enum'} | ${'multi-enum'} | ${'MultiSelectField'}  | ${emptyArray}
             ${'should correctly render a SingleSelectField for a valueType of enum'}      | ${'enum'}       | ${'SingleSelectField'} | ${emptyArray}
             ${'should correctly render a DatePicker for a valueType of date'}             | ${'date'}       | ${'DatePicker'}        | ${new Date(1995, 11, 25, 9, 30, 0)}
             ${'should correctly render a TextInput for a valueType of string'}            | ${'string'}     | ${'TextInput'}         | ${emptyArray}
             ${'should correctly render a TextInput for a valueType of float'}             | ${'float'}      | ${'TextInput'}         | ${emptyArray}
             ${'should correctly render a TextInput for a valueType of number'}            | ${'number'}     | ${'TextInput'}         | ${emptyArray}
-        `('$description', ({ valueType, renderedComponent, selectedValue }) => {
-            const wrapper = getWrapper({ valueType, selectedValue });
+        `('$description', ({ valueType, renderedComponent, selectedValues }) => {
+            const wrapper = getWrapper({ valueType, selectedValues });
             expect(wrapper).toMatchSnapshot();
             expect(wrapper.find(renderedComponent)).toHaveLength(1);
         });

--- a/src/features/query-bar/__tests__/ValueField-test.js
+++ b/src/features/query-bar/__tests__/ValueField-test.js
@@ -26,14 +26,15 @@ describe('features/query-bar/components/filter/ValueField', () => {
     };
 
     describe('render value fields', () => {
+        const emptyArray = [];
         test.each`
             description                                                                   | valueType       | renderedComponent      | selectedValue
-            ${'should correctly render a MultiSelectField for a valueType of multi-enum'} | ${'multi-enum'} | ${'MultiSelectField'}  | ${['']}
-            ${'should correctly render a SingleSelectField for a valueType of enum'}      | ${'enum'}       | ${'SingleSelectField'} | ${['']}
+            ${'should correctly render a MultiSelectField for a valueType of multi-enum'} | ${'multi-enum'} | ${'MultiSelectField'}  | ${emptyArray}
+            ${'should correctly render a SingleSelectField for a valueType of enum'}      | ${'enum'}       | ${'SingleSelectField'} | ${emptyArray}
             ${'should correctly render a DatePicker for a valueType of date'}             | ${'date'}       | ${'DatePicker'}        | ${new Date(1995, 11, 25, 9, 30, 0)}
-            ${'should correctly render a TextInput for a valueType of string'}            | ${'string'}     | ${'TextInput'}         | ${['']}
-            ${'should correctly render a TextInput for a valueType of float'}             | ${'float'}      | ${'TextInput'}         | ${['']}
-            ${'should correctly render a TextInput for a valueType of number'}            | ${'number'}     | ${'TextInput'}         | ${['']}
+            ${'should correctly render a TextInput for a valueType of string'}            | ${'string'}     | ${'TextInput'}         | ${emptyArray}
+            ${'should correctly render a TextInput for a valueType of float'}             | ${'float'}      | ${'TextInput'}         | ${emptyArray}
+            ${'should correctly render a TextInput for a valueType of number'}            | ${'number'}     | ${'TextInput'}         | ${emptyArray}
         `('$description', ({ valueType, renderedComponent, selectedValue }) => {
             const wrapper = getWrapper({ valueType, selectedValue });
             expect(wrapper).toMatchSnapshot();

--- a/src/features/query-bar/__tests__/ValueField-test.js
+++ b/src/features/query-bar/__tests__/ValueField-test.js
@@ -27,12 +27,13 @@ describe('features/query-bar/components/filter/ValueField', () => {
 
     describe('render value fields', () => {
         test.each`
-            description                                                              | valueType   | renderedComponent      | selectedValue
-            ${'should correctly render a SingleSelectField for a valueType of enum'} | ${'enum'}   | ${'SingleSelectField'} | ${''}
-            ${'should correctly render a DatePicker for a valueType of date'}        | ${'date'}   | ${'DatePicker'}        | ${new Date(1995, 11, 25, 9, 30, 0)}
-            ${'should correctly render a TextInput for a valueType of string'}       | ${'string'} | ${'TextInput'}         | ${''}
-            ${'should correctly render a TextInput for a valueType of float'}        | ${'float'}  | ${'TextInput'}         | ${''}
-            ${'should correctly render a TextInput for a valueType of number'}       | ${'number'} | ${'TextInput'}         | ${''}
+            description                                                                   | valueType       | renderedComponent      | selectedValue
+            ${'should correctly render a MultiSelectField for a valueType of multi-enum'} | ${'multi-enum'} | ${'MultiSelectField'}  | ${['']}
+            ${'should correctly render a SingleSelectField for a valueType of enum'}      | ${'enum'}       | ${'SingleSelectField'} | ${['']}
+            ${'should correctly render a DatePicker for a valueType of date'}             | ${'date'}       | ${'DatePicker'}        | ${new Date(1995, 11, 25, 9, 30, 0)}
+            ${'should correctly render a TextInput for a valueType of string'}            | ${'string'}     | ${'TextInput'}         | ${['']}
+            ${'should correctly render a TextInput for a valueType of float'}             | ${'float'}      | ${'TextInput'}         | ${['']}
+            ${'should correctly render a TextInput for a valueType of number'}            | ${'number'}     | ${'TextInput'}         | ${['']}
         `('$description', ({ valueType, renderedComponent, selectedValue }) => {
             const wrapper = getWrapper({ valueType, selectedValue });
             expect(wrapper).toMatchSnapshot();

--- a/src/features/query-bar/__tests__/__snapshots__/ColumnButton-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/ColumnButton-test.js.snap
@@ -110,6 +110,24 @@ exports[`features/query-bar/components/ColumnButton render should render ColumnB
             "source": "metadata",
             "type": "enum",
           },
+          Object {
+            "displayName": "Offices",
+            "id": "4",
+            "isShown": true,
+            "options": Array [
+              Object {
+                "id": "",
+                "key": "Office A",
+              },
+              Object {
+                "id": "1",
+                "key": "Office B",
+              },
+            ],
+            "property": "offices",
+            "source": "metadata",
+            "type": "multi-enum",
+          },
         ]
       }
       onColumnChange={[MockFunction]}

--- a/src/features/query-bar/__tests__/__snapshots__/ColumnButtonOverlay-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/ColumnButtonOverlay-test.js.snap
@@ -51,6 +51,19 @@ exports[`features/query-bar/components/ColumnButtonOverlay render should render 
           onChange={[Function]}
         />
       </PortaledDraggableListItem>
+      <PortaledDraggableListItem
+        id="4"
+        index={3}
+        isDraggableViaHandle={true}
+        key="3"
+      >
+        <Checkbox
+          isChecked={true}
+          label="Offices"
+          name="Offices"
+          onChange={[Function]}
+        />
+      </PortaledDraggableListItem>
     </DraggableList>
   </div>
   <div

--- a/src/features/query-bar/__tests__/__snapshots__/Condition-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/Condition-test.js.snap
@@ -108,7 +108,7 @@ exports[`features/query-bar/components/filter/Condition render() should render C
   >
     <ValueField
       onChange={[Function]}
-      selectedValue={Array []}
+      selectedValues={Array []}
       valueOptions={
         Array [
           Object {

--- a/src/features/query-bar/__tests__/__snapshots__/Condition-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/Condition-test.js.snap
@@ -58,6 +58,11 @@ exports[`features/query-bar/components/filter/Condition render() should render C
               "type": "enum",
               "value": "3",
             },
+            Object {
+              "displayText": "Offices",
+              "type": "multi-enum",
+              "value": "4",
+            },
           ]
         }
         selectedValue="3"
@@ -103,7 +108,7 @@ exports[`features/query-bar/components/filter/Condition render() should render C
   >
     <ValueField
       onChange={[Function]}
-      selectedValue={null}
+      selectedValue={Array []}
       valueOptions={
         Array [
           Object {

--- a/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
@@ -40,11 +40,7 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
       id="boxui.queryBar.selectValuePlaceholderText"
     />
   }
-  selectedValues={
-    Array [
-      "",
-    ]
-  }
+  selectedValues={Array []}
 />
 `;
 
@@ -67,7 +63,7 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
       id="boxui.queryBar.selectValuePlaceholderText"
     />
   }
-  selectedValue=""
+  selectedValue={null}
 />
 `;
 
@@ -81,7 +77,7 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
     name="float field"
     onChange={[Function]}
     placeholder="Enter a float"
-    value=""
+    value={null}
   />
 </div>
 `;
@@ -96,7 +92,7 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
     name="number field"
     onChange={[Function]}
     placeholder="Enter a number"
-    value=""
+    value={null}
   />
 </div>
 `;
@@ -111,7 +107,7 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
     name="string field"
     onChange={[Function]}
     placeholder="Enter a string"
-    value=""
+    value={null}
   />
 </div>
 `;

--- a/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
@@ -21,6 +21,33 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
 </div>
 `;
 
+exports[`features/query-bar/components/filter/ValueField render value fields "should correctly render a MultiSelectField for a valueType of multi-enum" 1`] = `
+<MultiSelectField
+  fieldType="value"
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "displayText": "Hello",
+        "type": "enum",
+        "value": 0,
+      },
+    ]
+  }
+  placeholder={
+    <FormattedMessage
+      defaultMessage="Select value"
+      id="boxui.queryBar.selectValuePlaceholderText"
+    />
+  }
+  selectedValues={
+    Array [
+      "",
+    ]
+  }
+/>
+`;
+
 exports[`features/query-bar/components/filter/ValueField render value fields "should correctly render a SingleSelectField for a valueType of enum" 1`] = `
 <SingleSelectField
   fieldType="value"

--- a/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
@@ -17,7 +17,6 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
     name="datepicker"
     onChange={[Function]}
     placeholder="Date"
-    value={1995-12-25T17:30:00.000Z}
   />
 </div>
 `;

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -11,19 +11,19 @@ import ValueField from './ValueField';
 
 import messages from '../../messages';
 import { AND, COLUMN, COLUMN_OPERATORS, DATE, OPERATOR, OR, VALUE } from '../../constants';
-import type { ColumnType, ConnectorType, OptionType } from '../../flowTypes';
+import type { ColumnType, ConditionType, ConnectorType, OptionType } from '../../flowTypes';
 
 import '../../styles/Condition.scss';
 
 type Props = {
     areErrorsEnabled: boolean,
     columns?: Array<ColumnType>,
-    condition: Object,
+    condition: ConditionType,
     deleteCondition: (index: number) => void,
     index: number,
-    onColumnChange: (condition: Object, columnId: string) => void,
+    onColumnChange: (condition: ConditionType, columnId: string) => void,
     onConnectorChange: (option: OptionType) => void,
-    onFieldChange: (condition: Object, value: Array<string>, property: string) => void,
+    onFieldChange: (condition: ConditionType, value: Array<string>, property: string) => void,
     selectedConnector: ConnectorType,
 };
 
@@ -90,7 +90,7 @@ const Condition = ({
         const column = columns && columns.find(c => c.id === columnId);
         const type = column && column.type;
 
-        const isValueSet = value !== null && value !== '' && value.length !== 0;
+        const isValueSet = value.length !== 0;
         const message = (
             <FormattedMessage
                 {...(type === DATE ? messages.tooltipSelectDateError : messages.tooltipSelectValueError)}

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -23,7 +23,7 @@ type Props = {
     index: number,
     onColumnChange: (condition: Object, columnId: string) => void,
     onConnectorChange: (option: OptionType) => void,
-    onFieldChange: (condition: Object, value: string, property: string) => void,
+    onFieldChange: (condition: Object, value: Array<string>, property: string) => void,
     selectedConnector: ConnectorType,
 };
 
@@ -52,10 +52,10 @@ const Condition = ({
 
     const handleOperatorChange = (option: OptionType) => {
         const { value } = option;
-        onFieldChange(condition, value, OPERATOR);
+        onFieldChange(condition, ([value]: Array<string>), OPERATOR);
     };
 
-    const handleValueChange = (value: string) => {
+    const handleValueChange = (value: Array<string>) => {
         onFieldChange(condition, value, VALUE);
     };
 
@@ -90,7 +90,7 @@ const Condition = ({
         const column = columns && columns.find(c => c.id === columnId);
         const type = column && column.type;
 
-        const isValueSet = value !== null && value !== '';
+        const isValueSet = value !== null && value !== '' && value.length !== 0;
         const message = (
             <FormattedMessage
                 {...(type === DATE ? messages.tooltipSelectDateError : messages.tooltipSelectValueError)}
@@ -183,7 +183,7 @@ const Condition = ({
                         isDisabled={false}
                         onChange={handleOperatorChange}
                         options={operatorOptions}
-                        selectedValue={operator}
+                        selectedValue={operator[0]}
                     />
                 </div>
             </div>

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -10,8 +10,15 @@ import SingleSelectField from '../../../../components/select-field/SingleSelectF
 import ValueField from './ValueField';
 
 import messages from '../../messages';
-import { AND, COLUMN, COLUMN_OPERATORS, DATE, OPERATOR, OR, VALUES } from '../../constants';
-import type { ColumnType, ConditionType, ConnectorType, OptionType } from '../../flowTypes';
+import { AND, COLUMN, COLUMN_OPERATORS, DATE, OPERATOR, OR } from '../../constants';
+import type {
+    ColumnType,
+    ConditionType,
+    ConnectorType,
+    OperatorOptionType,
+    OperatorType,
+    OptionType,
+} from '../../flowTypes';
 
 import '../../styles/Condition.scss';
 
@@ -23,7 +30,8 @@ type Props = {
     index: number,
     onColumnChange: (condition: ConditionType, columnId: string) => void,
     onConnectorChange: (option: OptionType) => void,
-    onFieldChange: (condition: ConditionType, value: string | Array<string>, property: string) => void,
+    onOperatorChange: (condition: ConditionType, value: OperatorType) => void,
+    onValueChange: (condition: ConditionType, values: Array<string>) => void,
     selectedConnector: ConnectorType,
 };
 
@@ -36,7 +44,8 @@ const Condition = ({
     condition,
     deleteCondition,
     onColumnChange,
-    onFieldChange,
+    onOperatorChange,
+    onValueChange,
     index,
     selectedConnector,
     onConnectorChange,
@@ -50,13 +59,13 @@ const Condition = ({
         onColumnChange(condition, columnId);
     };
 
-    const handleOperatorChange = (option: OptionType) => {
+    const handleOperatorChange = (option: OperatorOptionType) => {
         const { value } = option;
-        onFieldChange(condition, value, OPERATOR);
+        onOperatorChange(condition, value);
     };
 
-    const handleValueChange = (value: Array<string>) => {
-        onFieldChange(condition, value, VALUES);
+    const handleValueChange = (values: Array<string>) => {
+        onValueChange(condition, values);
     };
 
     const getColumnOperators = () => {

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -30,8 +30,8 @@ type Props = {
     index: number,
     onColumnChange: (condition: ConditionType, columnId: string) => void,
     onConnectorChange: (option: OptionType) => void,
-    onOperatorChange: (condition: ConditionType, value: OperatorType) => void,
-    onValueChange: (condition: ConditionType, values: Array<string>) => void,
+    onOperatorChange: (conditionId: number, value: OperatorType) => void,
+    onValueChange: (conditionId: number, values: Array<string>) => void,
     selectedConnector: ConnectorType,
 };
 
@@ -60,12 +60,14 @@ const Condition = ({
     };
 
     const handleOperatorChange = (option: OperatorOptionType) => {
+        const { id } = condition;
         const { value } = option;
-        onOperatorChange(condition, value);
+        onOperatorChange(id, value);
     };
 
     const handleValueChange = (values: Array<string>) => {
-        onValueChange(condition, values);
+        const { id } = condition;
+        onValueChange(id, values);
     };
 
     const getColumnOperators = () => {

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -10,7 +10,7 @@ import SingleSelectField from '../../../../components/select-field/SingleSelectF
 import ValueField from './ValueField';
 
 import messages from '../../messages';
-import { AND, COLUMN, COLUMN_OPERATORS, DATE, OPERATOR, OR, VALUE } from '../../constants';
+import { AND, COLUMN, COLUMN_OPERATORS, DATE, OPERATOR, OR, VALUES } from '../../constants';
 import type { ColumnType, ConditionType, ConnectorType, OptionType } from '../../flowTypes';
 
 import '../../styles/Condition.scss';
@@ -23,7 +23,7 @@ type Props = {
     index: number,
     onColumnChange: (condition: ConditionType, columnId: string) => void,
     onConnectorChange: (option: OptionType) => void,
-    onFieldChange: (condition: ConditionType, value: Array<string>, property: string) => void,
+    onFieldChange: (condition: ConditionType, value: string | Array<string>, property: string) => void,
     selectedConnector: ConnectorType,
 };
 
@@ -52,11 +52,11 @@ const Condition = ({
 
     const handleOperatorChange = (option: OptionType) => {
         const { value } = option;
-        onFieldChange(condition, ([value]: Array<string>), OPERATOR);
+        onFieldChange(condition, value, OPERATOR);
     };
 
     const handleValueChange = (value: Array<string>) => {
-        onFieldChange(condition, value, VALUE);
+        onFieldChange(condition, value, VALUES);
     };
 
     const getColumnOperators = () => {
@@ -86,11 +86,11 @@ const Condition = ({
     };
 
     const getErrorMessage = () => {
-        const { value, columnId } = condition;
+        const { values, columnId } = condition;
         const column = columns && columns.find(c => c.id === columnId);
         const type = column && column.type;
 
-        const isValueSet = value.length !== 0;
+        const isValueSet = values.length !== 0;
         const message = (
             <FormattedMessage
                 {...(type === DATE ? messages.tooltipSelectDateError : messages.tooltipSelectValueError)}
@@ -183,7 +183,7 @@ const Condition = ({
                         isDisabled={false}
                         onChange={handleOperatorChange}
                         options={operatorOptions}
-                        selectedValue={operator[0]}
+                        selectedValue={operator}
                     />
                 </div>
             </div>
@@ -191,7 +191,7 @@ const Condition = ({
     };
 
     const renderValueField = () => {
-        const { columnId, value } = condition;
+        const { columnId, values } = condition;
 
         const column = columns && columns.find(c => c.id === columnId);
         const type = column && column.type;
@@ -208,7 +208,7 @@ const Condition = ({
                 <div className={classnames}>
                     <ValueField
                         onChange={handleValueChange}
-                        selectedValue={value}
+                        selectedValues={values}
                         valueOptions={valueOptions}
                         valueType={type}
                     />

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -10,11 +10,11 @@ import Button from '../../../../components/button/Button';
 import PrimaryButton from '../../../../components/primary-button/PrimaryButton';
 import MenuToggle from '../../../../components/dropdown-menu/MenuToggle';
 import { Flyout, Overlay } from '../../../../components/flyout';
-import { AND, OR, COLUMN_OPERATORS } from '../../constants';
+import { AND, OR, COLUMN_OPERATORS, OPERATOR, VALUES } from '../../constants';
 
 import messages from '../../messages';
 
-import type { ColumnType, ConditionType, ConnectorType, OptionType } from '../../flowTypes';
+import type { ColumnType, ConditionType, ConnectorType, OperatorType, OptionType } from '../../flowTypes';
 
 type State = {
     appliedConditions: Array<Object>,
@@ -141,7 +141,7 @@ class FilterButton extends React.Component<Props, State> {
         }
     };
 
-    handleFieldChange = (condition: ConditionType, value: string | Array<string>, property: string) => {
+    handleOperatorChange = (condition: ConditionType, value: OperatorType) => {
         const { conditions } = this.state;
         let newConditionIndex = 0;
         const conditionToUpdate = conditions.find((currentCondition, index) => {
@@ -151,7 +151,28 @@ class FilterButton extends React.Component<Props, State> {
 
         const newCondition = {
             ...conditionToUpdate,
-            [property]: value,
+            [OPERATOR]: value,
+        };
+
+        const newConditions = conditions.slice(0);
+        newConditions[newConditionIndex] = newCondition;
+
+        this.setState({
+            conditions: newConditions,
+        });
+    };
+
+    handleValueChange = (condition: ConditionType, values: Array<string>) => {
+        const { conditions } = this.state;
+        let newConditionIndex = 0;
+        const conditionToUpdate = conditions.find((currentCondition, index) => {
+            newConditionIndex = index;
+            return currentCondition.id === condition.id;
+        });
+
+        const newCondition = {
+            ...conditionToUpdate,
+            [VALUES]: values,
         };
 
         const newConditions = conditions.slice(0);
@@ -280,7 +301,8 @@ class FilterButton extends React.Component<Props, State> {
                                             index={index}
                                             columns={columns}
                                             selectedConnector={selectedConnector}
-                                            onFieldChange={this.handleFieldChange}
+                                            onOperatorChange={this.handleOperatorChange}
+                                            onValueChange={this.handleValueChange}
                                             onColumnChange={this.handleColumnChange}
                                             onConnectorChange={this.handleConnectorChange}
                                         />

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -69,13 +69,13 @@ class FilterButton extends React.Component<Props, State> {
         const { columns } = this.props;
         if (columns) {
             const firstColumn = columns[0];
-            const operator = [COLUMN_OPERATORS[firstColumn.type][0].key];
+            const operator = COLUMN_OPERATORS[firstColumn.type][0].key;
 
             return {
                 columnId: firstColumn.id,
                 id: conditionID,
                 operator,
-                value: [],
+                values: [],
             };
         }
         return {};
@@ -123,13 +123,13 @@ class FilterButton extends React.Component<Props, State> {
         if (column) {
             const type = column && column.type;
 
-            const operator = [COLUMN_OPERATORS[type][0].key];
+            const operator = COLUMN_OPERATORS[type][0].key;
 
             const newCondition = {
                 ...conditionToUpdate,
                 columnId,
                 operator,
-                value: [],
+                values: [],
             };
 
             const newConditions = conditions.slice(0);
@@ -141,7 +141,7 @@ class FilterButton extends React.Component<Props, State> {
         }
     };
 
-    handleFieldChange = (condition: ConditionType, value: Array<string>, property: string) => {
+    handleFieldChange = (condition: ConditionType, value: string | Array<string>, property: string) => {
         const { conditions } = this.state;
         let newConditionIndex = 0;
         const conditionToUpdate = conditions.find((currentCondition, index) => {
@@ -195,7 +195,7 @@ class FilterButton extends React.Component<Props, State> {
         const { conditions } = this.state;
         let areAllValid = true;
         conditions.forEach(condition => {
-            if (condition.value.length === 0) {
+            if (condition.values.length === 0) {
                 areAllValid = false;
             }
         });

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -14,7 +14,7 @@ import { AND, OR, COLUMN_OPERATORS } from '../../constants';
 
 import messages from '../../messages';
 
-import type { ColumnType, OptionType, ConnectorType } from '../../flowTypes';
+import type { ColumnType, ConditionType, ConnectorType, OptionType } from '../../flowTypes';
 
 type State = {
     appliedConditions: Array<Object>,
@@ -109,7 +109,7 @@ class FilterButton extends React.Component<Props, State> {
         }
     };
 
-    handleColumnChange = (condition: Object, columnId: string) => {
+    handleColumnChange = (condition: ConditionType, columnId: string) => {
         const { columns } = this.props;
         const { conditions } = this.state;
         let newConditionIndex = 0;
@@ -141,7 +141,7 @@ class FilterButton extends React.Component<Props, State> {
         }
     };
 
-    handleFieldChange = (condition: Object, value: Array<string>, property: string) => {
+    handleFieldChange = (condition: ConditionType, value: Array<string>, property: string) => {
         const { conditions } = this.state;
         let newConditionIndex = 0;
         const conditionToUpdate = conditions.find((currentCondition, index) => {

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -109,6 +109,24 @@ class FilterButton extends React.Component<Props, State> {
         }
     };
 
+    updateConditionState = (conditionId: number, updateCondition: Function) => {
+        const { conditions } = this.state;
+        let newConditionIndex = 0;
+        const conditionToUpdate = conditions.find((currentCondition, index) => {
+            newConditionIndex = index;
+            return currentCondition.id === conditionId;
+        });
+
+        const newCondition = updateCondition(conditionToUpdate);
+
+        const newConditions = conditions.slice(0);
+        newConditions[newConditionIndex] = newCondition;
+
+        this.setState({
+            conditions: newConditions,
+        });
+    };
+
     handleColumnChange = (condition: ConditionType, columnId: string) => {
         const { columns } = this.props;
         const { conditions } = this.state;
@@ -141,45 +159,17 @@ class FilterButton extends React.Component<Props, State> {
         }
     };
 
-    handleOperatorChange = (condition: ConditionType, value: OperatorType) => {
-        const { conditions } = this.state;
-        let newConditionIndex = 0;
-        const conditionToUpdate = conditions.find((currentCondition, index) => {
-            newConditionIndex = index;
-            return currentCondition.id === condition.id;
-        });
-
-        const newCondition = {
-            ...conditionToUpdate,
-            [OPERATOR]: value,
-        };
-
-        const newConditions = conditions.slice(0);
-        newConditions[newConditionIndex] = newCondition;
-
-        this.setState({
-            conditions: newConditions,
+    handleOperatorChange = (conditionId: number, value: OperatorType) => {
+        this.updateConditionState(conditionId, condition => {
+            condition[OPERATOR] = value;
+            return condition;
         });
     };
 
-    handleValueChange = (condition: ConditionType, values: Array<string>) => {
-        const { conditions } = this.state;
-        let newConditionIndex = 0;
-        const conditionToUpdate = conditions.find((currentCondition, index) => {
-            newConditionIndex = index;
-            return currentCondition.id === condition.id;
-        });
-
-        const newCondition = {
-            ...conditionToUpdate,
-            [VALUES]: values,
-        };
-
-        const newConditions = conditions.slice(0);
-        newConditions[newConditionIndex] = newCondition;
-
-        this.setState({
-            conditions: newConditions,
+    handleValueChange = (conditionId: number, values: Array<string>) => {
+        this.updateConditionState(conditionId, condition => {
+            condition[VALUES] = values;
+            return condition;
         });
     };
 

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -117,7 +117,8 @@ class FilterButton extends React.Component<Props, State> {
             return currentCondition.id === conditionId;
         });
 
-        const newCondition = updateCondition(conditionToUpdate);
+        let newCondition = { ...conditionToUpdate };
+        newCondition = updateCondition(newCondition);
 
         const newConditions = conditions.slice(0);
         newConditions[newConditionIndex] = newCondition;

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -69,13 +69,13 @@ class FilterButton extends React.Component<Props, State> {
         const { columns } = this.props;
         if (columns) {
             const firstColumn = columns[0];
-            const operator = COLUMN_OPERATORS[firstColumn.type][0].key;
+            const operator = [COLUMN_OPERATORS[firstColumn.type][0].key];
 
             return {
                 columnId: firstColumn.id,
                 id: conditionID,
                 operator,
-                value: null,
+                value: [],
             };
         }
         return {};
@@ -123,13 +123,13 @@ class FilterButton extends React.Component<Props, State> {
         if (column) {
             const type = column && column.type;
 
-            const operator = COLUMN_OPERATORS[type][0].key;
+            const operator = [COLUMN_OPERATORS[type][0].key];
 
             const newCondition = {
                 ...conditionToUpdate,
                 columnId,
                 operator,
-                value: null,
+                value: [],
             };
 
             const newConditions = conditions.slice(0);
@@ -141,7 +141,7 @@ class FilterButton extends React.Component<Props, State> {
         }
     };
 
-    handleFieldChange = (condition: Object, value: string, property: string) => {
+    handleFieldChange = (condition: Object, value: Array<string>, property: string) => {
         const { conditions } = this.state;
         let newConditionIndex = 0;
         const conditionToUpdate = conditions.find((currentCondition, index) => {
@@ -195,7 +195,7 @@ class FilterButton extends React.Component<Props, State> {
         const { conditions } = this.state;
         let areAllValid = true;
         conditions.forEach(condition => {
-            if (condition.value === null || condition.value === '') {
+            if (condition.value.length === 0) {
                 areAllValid = false;
             }
         });

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -295,16 +295,16 @@ class FilterButton extends React.Component<Props, State> {
                                     return (
                                         <Condition
                                             key={`metadata-view-filter-item-${condition.id}`}
+                                            areErrorsEnabled={areErrorsEnabled}
+                                            columns={columns}
                                             condition={condition}
                                             deleteCondition={this.deleteCondition}
-                                            areErrorsEnabled={areErrorsEnabled}
                                             index={index}
-                                            columns={columns}
-                                            selectedConnector={selectedConnector}
-                                            onOperatorChange={this.handleOperatorChange}
-                                            onValueChange={this.handleValueChange}
                                             onColumnChange={this.handleColumnChange}
                                             onConnectorChange={this.handleConnectorChange}
+                                            onOperatorChange={this.handleOperatorChange}
+                                            onValueChange={this.handleValueChange}
+                                            selectedConnector={selectedConnector}
                                         />
                                     );
                                 })}

--- a/src/features/query-bar/components/filter/ValueField.js
+++ b/src/features/query-bar/components/filter/ValueField.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import DatePicker from '../../../../components/date-picker';
 import SingleSelectField from '../../../../components/select-field/SingleSelectField';
+import MultiSelectField from '../../../../components/select-field/MultiSelectField';
 import TextInput from '../../../../components/text-input';
 import { VALUE } from '../../constants';
 import messages from '../../messages';
@@ -11,13 +12,15 @@ import messages from '../../messages';
 import '../../styles/Condition.scss';
 
 type Props = {
-    onChange: (value: String) => void,
-    selectedValue?: string | number,
+    onChange: (value: Array<string>) => void,
+    selectedValue: Array<string> | Array<number>,
     valueOptions: Array<Object>,
     valueType: string,
 };
 
 const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props) => {
+    const isValueSet = selectedValue && selectedValue.length > 0;
+
     switch (valueType) {
         case 'string':
             return (
@@ -26,9 +29,9 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         hideLabel
                         label="String input"
                         name="string field"
-                        onChange={e => onChange(e.target.value)}
+                        onChange={e => onChange([e.target.value])}
                         placeholder="Enter a string"
-                        value={selectedValue || ''}
+                        value={isValueSet ? selectedValue[0] : null}
                     />
                 </div>
             );
@@ -39,9 +42,9 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         hideLabel
                         label="Number input"
                         name="number field"
-                        onChange={e => onChange(e.target.value)}
+                        onChange={e => onChange([e.target.value])}
                         placeholder="Enter a number"
-                        value={selectedValue || ''}
+                        value={isValueSet ? selectedValue[0] : null}
                     />
                 </div>
             );
@@ -52,9 +55,9 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         hideLabel
                         label="Float input"
                         name="float field"
-                        onChange={e => onChange(e.target.value)}
+                        onChange={e => onChange([e.target.value])}
                         placeholder="Enter a float"
-                        value={selectedValue || ''}
+                        value={isValueSet ? selectedValue[0] : null}
                     />
                 </div>
             );
@@ -70,9 +73,9 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         hideLabel
                         label="Date"
                         name="datepicker"
-                        onChange={e => onChange(e.toString())}
+                        onChange={e => onChange([e.toString()])}
                         placeholder="Date"
-                        value={selectedValue ? new Date(selectedValue) : undefined}
+                        value={isValueSet && selectedValue[0] !== '' ? new Date(selectedValue[0]) : undefined}
                     />
                 </div>
             );
@@ -80,10 +83,20 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
             return (
                 <SingleSelectField
                     fieldType={VALUE}
-                    onChange={e => onChange(e.value)}
+                    onChange={e => onChange([e.value])}
                     options={valueOptions}
                     placeholder={<FormattedMessage {...messages.selectValuePlaceholderText} />}
-                    selectedValue={selectedValue}
+                    selectedValue={isValueSet ? selectedValue[0] : null}
+                />
+            );
+        case 'multi-enum':
+            return (
+                <MultiSelectField
+                    fieldType={VALUE}
+                    onChange={e => onChange(e.map(option => option.value))}
+                    options={valueOptions}
+                    placeholder={<FormattedMessage {...messages.selectValuePlaceholderText} />}
+                    selectedValues={selectedValue}
                 />
             );
         default:

--- a/src/features/query-bar/components/filter/ValueField.js
+++ b/src/features/query-bar/components/filter/ValueField.js
@@ -20,6 +20,7 @@ type Props = {
 
 const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props) => {
     const isValueSet = selectedValues.length > 0;
+    const value = isValueSet ? selectedValues[0] : null;
 
     switch (valueType) {
         case 'string':
@@ -31,7 +32,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                         name="string field"
                         onChange={e => onChange([e.target.value])}
                         placeholder="Enter a string"
-                        value={isValueSet ? selectedValues[0] : null}
+                        value={value}
                     />
                 </div>
             );
@@ -44,7 +45,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                         name="number field"
                         onChange={e => onChange([e.target.value])}
                         placeholder="Enter a number"
-                        value={isValueSet ? selectedValues[0] : null}
+                        value={value}
                     />
                 </div>
             );
@@ -57,7 +58,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                         name="float field"
                         onChange={e => onChange([e.target.value])}
                         placeholder="Enter a float"
-                        value={isValueSet ? selectedValues[0] : null}
+                        value={value}
                     />
                 </div>
             );
@@ -88,7 +89,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                     onChange={e => onChange([e.value])}
                     options={valueOptions}
                     placeholder={<FormattedMessage {...messages.selectValuePlaceholderText} />}
-                    selectedValue={isValueSet ? selectedValues[0] : null}
+                    selectedValue={value}
                 />
             );
         case 'multi-enum':

--- a/src/features/query-bar/components/filter/ValueField.js
+++ b/src/features/query-bar/components/filter/ValueField.js
@@ -13,13 +13,13 @@ import '../../styles/Condition.scss';
 
 type Props = {
     onChange: (value: Array<string>) => void,
-    selectedValue: Array<string> | Array<number>,
+    selectedValue: Array<string>,
     valueOptions: Array<Object>,
     valueType: string,
 };
 
 const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props) => {
-    const isValueSet = selectedValue && selectedValue.length > 0;
+    const isValueSet = selectedValue.length > 0;
 
     switch (valueType) {
         case 'string':
@@ -73,7 +73,9 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         hideLabel
                         label="Date"
                         name="datepicker"
-                        onChange={e => onChange([e.toString()])}
+                        onChange={e => {
+                            return e ? onChange([e.toString()]) : onChange([]);
+                        }}
                         placeholder="Date"
                         value={isValueSet && selectedValue[0] !== '' ? new Date(selectedValue[0]) : undefined}
                     />

--- a/src/features/query-bar/components/filter/ValueField.js
+++ b/src/features/query-bar/components/filter/ValueField.js
@@ -13,13 +13,13 @@ import '../../styles/Condition.scss';
 
 type Props = {
     onChange: (value: Array<string>) => void,
-    selectedValue: Array<string>,
+    selectedValues: Array<string>,
     valueOptions: Array<Object>,
     valueType: string,
 };
 
-const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props) => {
-    const isValueSet = selectedValue.length > 0;
+const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props) => {
+    const isValueSet = selectedValues.length > 0;
 
     switch (valueType) {
         case 'string':
@@ -31,7 +31,7 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         name="string field"
                         onChange={e => onChange([e.target.value])}
                         placeholder="Enter a string"
-                        value={isValueSet ? selectedValue[0] : null}
+                        value={isValueSet ? selectedValues[0] : null}
                     />
                 </div>
             );
@@ -44,7 +44,7 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         name="number field"
                         onChange={e => onChange([e.target.value])}
                         placeholder="Enter a number"
-                        value={isValueSet ? selectedValue[0] : null}
+                        value={isValueSet ? selectedValues[0] : null}
                     />
                 </div>
             );
@@ -57,7 +57,7 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                         name="float field"
                         onChange={e => onChange([e.target.value])}
                         placeholder="Enter a float"
-                        value={isValueSet ? selectedValue[0] : null}
+                        value={isValueSet ? selectedValues[0] : null}
                     />
                 </div>
             );
@@ -77,7 +77,7 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                             return e ? onChange([e.toString()]) : onChange([]);
                         }}
                         placeholder="Date"
-                        value={isValueSet && selectedValue[0] !== '' ? new Date(selectedValue[0]) : undefined}
+                        value={isValueSet && selectedValues[0] !== '' ? new Date(selectedValues[0]) : undefined}
                     />
                 </div>
             );
@@ -88,7 +88,7 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                     onChange={e => onChange([e.value])}
                     options={valueOptions}
                     placeholder={<FormattedMessage {...messages.selectValuePlaceholderText} />}
-                    selectedValue={isValueSet ? selectedValue[0] : null}
+                    selectedValue={isValueSet ? selectedValues[0] : null}
                 />
             );
         case 'multi-enum':
@@ -98,7 +98,7 @@ const ValueField = ({ onChange, selectedValue, valueOptions, valueType }: Props)
                     onChange={e => onChange(e.map(option => option.value))}
                     options={valueOptions}
                     placeholder={<FormattedMessage {...messages.selectValuePlaceholderText} />}
-                    selectedValues={selectedValue}
+                    selectedValues={selectedValues}
                 />
             );
         default:

--- a/src/features/query-bar/components/fixtures.js
+++ b/src/features/query-bar/components/fixtures.js
@@ -5,8 +5,8 @@ import { EQUALS } from '../constants';
 const initialCondition: ConditionType = {
     columnId: '3',
     id: 0,
-    operator: EQUALS,
-    value: null,
+    operator: [EQUALS],
+    value: [],
 };
 
 const columnOptions = [
@@ -51,6 +51,24 @@ const columns: Array<ColumnType> = [
             },
         ],
     },
+    {
+        displayName: 'Offices',
+        id: '4',
+        isShown: true,
+        property: 'offices',
+        source: 'metadata',
+        type: 'multi-enum',
+        options: [
+            {
+                id: '',
+                key: 'Office A',
+            },
+            {
+                id: '1',
+                key: 'Office B',
+            },
+        ],
+    },
 ];
 
 const columnsWithNewOrder: Array<ColumnType> = [
@@ -81,6 +99,24 @@ const columnsWithNewOrder: Array<ColumnType> = [
         source: 'metadata',
         type: 'enum',
     },
+    {
+        displayName: 'Offices',
+        id: '4',
+        isShown: true,
+        property: 'offices',
+        source: 'metadata',
+        type: 'multi-enum',
+        options: [
+            {
+                id: '',
+                key: 'Office A',
+            },
+            {
+                id: '1',
+                key: 'Office B',
+            },
+        ],
+    },
 ];
 
 const columnsWithOneColumnNotShown: Array<ColumnType> = [
@@ -110,6 +146,24 @@ const columnsWithOneColumnNotShown: Array<ColumnType> = [
         property: 'contractValue',
         source: 'metadata',
         type: 'enum',
+    },
+    {
+        displayName: 'Offices',
+        id: '4',
+        isShown: true,
+        property: 'offices',
+        source: 'metadata',
+        type: 'multi-enum',
+        options: [
+            {
+                id: '',
+                key: 'Office A',
+            },
+            {
+                id: '1',
+                key: 'Office B',
+            },
+        ],
     },
 ];
 

--- a/src/features/query-bar/components/fixtures.js
+++ b/src/features/query-bar/components/fixtures.js
@@ -18,153 +18,79 @@ const columnOptions = [
 
 const conditions: Array<ConditionType> = [initialCondition];
 
+const columnWithStringType = {
+    displayName: 'Hullo Thar',
+    id: '1',
+    isShown: true,
+    options: null,
+    property: 'name',
+    source: 'item',
+    type: 'string',
+};
+
+const columnWithDateType = {
+    displayName: 'Last Updated',
+    id: '2',
+    isShown: true,
+    options: null,
+    property: 'lastUpdatedByName',
+    source: 'item',
+    type: 'date',
+};
+
+const columnWithEnumType = {
+    displayName: 'Contract Value',
+    id: '3',
+    isShown: true,
+    property: 'contractValue',
+    source: 'metadata',
+    type: 'enum',
+    options: [
+        {
+            id: '',
+            key: '$100',
+        },
+    ],
+};
+
+const columnWithMultiEnumType = {
+    displayName: 'Offices',
+    id: '4',
+    isShown: true,
+    property: 'offices',
+    source: 'metadata',
+    type: 'multi-enum',
+    options: [
+        {
+            id: '',
+            key: 'Office A',
+        },
+        {
+            id: '1',
+            key: 'Office B',
+        },
+    ],
+};
+
 const columns: Array<ColumnType> = [
-    {
-        displayName: 'Hullo Thar',
-        id: '1',
-        isShown: true,
-        options: null,
-        property: 'name',
-        source: 'item',
-        type: 'string',
-    },
-    {
-        displayName: 'Last Updated',
-        id: '2',
-        isShown: true,
-        options: null,
-        property: 'lastUpdatedByName',
-        source: 'item',
-        type: 'date',
-    },
-    {
-        displayName: 'Contract Value',
-        id: '3',
-        isShown: true,
-        property: 'contractValue',
-        source: 'metadata',
-        type: 'enum',
-        options: [
-            {
-                id: '',
-                key: '$100',
-            },
-        ],
-    },
-    {
-        displayName: 'Offices',
-        id: '4',
-        isShown: true,
-        property: 'offices',
-        source: 'metadata',
-        type: 'multi-enum',
-        options: [
-            {
-                id: '',
-                key: 'Office A',
-            },
-            {
-                id: '1',
-                key: 'Office B',
-            },
-        ],
-    },
+    columnWithStringType,
+    columnWithDateType,
+    columnWithEnumType,
+    columnWithMultiEnumType,
 ];
 
 const columnsWithNewOrder: Array<ColumnType> = [
-    {
-        displayName: 'Last Updated',
-        id: '2',
-        isShown: true,
-        options: null,
-        property: 'lastUpdatedByName',
-        source: 'item',
-        type: 'date',
-    },
-    {
-        displayName: 'Hullo Thar',
-        id: '1',
-        isShown: true,
-        options: null,
-        property: 'name',
-        source: 'item',
-        type: 'string',
-    },
-    {
-        displayName: 'Contract Value',
-        id: '3',
-        isShown: true,
-        options: [{ id: '', key: '$100' }],
-        property: 'contractValue',
-        source: 'metadata',
-        type: 'enum',
-    },
-    {
-        displayName: 'Offices',
-        id: '4',
-        isShown: true,
-        property: 'offices',
-        source: 'metadata',
-        type: 'multi-enum',
-        options: [
-            {
-                id: '',
-                key: 'Office A',
-            },
-            {
-                id: '1',
-                key: 'Office B',
-            },
-        ],
-    },
+    columnWithDateType,
+    columnWithStringType,
+    columnWithEnumType,
+    columnWithMultiEnumType,
 ];
 
 const columnsWithOneColumnNotShown: Array<ColumnType> = [
-    {
-        displayName: 'Hullo Thar',
-        id: '1',
-        isShown: false,
-        options: null,
-        property: 'name',
-        source: 'item',
-        type: 'string',
-    },
-    {
-        displayName: 'Last Updated',
-        id: '2',
-        isShown: true,
-        options: null,
-        property: 'lastUpdatedByName',
-        source: 'item',
-        type: 'date',
-    },
-    {
-        displayName: 'Contract Value',
-        id: '3',
-        isShown: true,
-        options: [{ id: '', key: '$100' }],
-        property: 'contractValue',
-        source: 'metadata',
-        type: 'enum',
-    },
-    {
-        displayName: 'Offices',
-        id: '4',
-        isShown: true,
-        property: 'offices',
-        source: 'metadata',
-        type: 'multi-enum',
-        options: [
-            {
-                id: '',
-                key: 'Office A',
-            },
-            {
-                id: '1',
-                key: 'Office B',
-            },
-        ],
-    },
+    { ...columnWithStringType, isShown: false },
+    columnWithDateType,
+    columnWithEnumType,
+    columnWithMultiEnumType,
 ];
 
 const expectedVisibleColumns = {

--- a/src/features/query-bar/components/fixtures.js
+++ b/src/features/query-bar/components/fixtures.js
@@ -5,8 +5,8 @@ import { EQUALS } from '../constants';
 const initialCondition: ConditionType = {
     columnId: '3',
     id: 0,
-    operator: [EQUALS],
-    value: [],
+    operator: EQUALS,
+    values: [],
 };
 
 const columnOptions = [

--- a/src/features/query-bar/constants.js
+++ b/src/features/query-bar/constants.js
@@ -9,6 +9,7 @@ export const OPERATOR: 'operator' = 'operator';
 export const OPERATOR_DISPLAY_TEXT: 'operatorDisplayText' = 'operatorDisplayText';
 export const OPERATOR_KEY: 'operatorKey' = 'operatorKey';
 export const VALUE: 'value' = 'value';
+export const VALUES: 'values' = 'values';
 export const VALUE_DISPLAY_TEXT: 'valueDisplayText' = 'valueDisplayText';
 export const VALUE_KEY: 'valueKey' = 'valueKey';
 export const WHERE: 'WHERE' = 'WHERE';

--- a/src/features/query-bar/constants.js
+++ b/src/features/query-bar/constants.js
@@ -39,4 +39,5 @@ export const COLUMN_OPERATORS = {
     float: ALL_OPERATORS,
     enum: ALL_OPERATORS,
     date: ALL_OPERATORS,
+    'multi-enum': ALL_OPERATORS,
 };

--- a/src/features/query-bar/flowTypes.js
+++ b/src/features/query-bar/flowTypes.js
@@ -1,13 +1,20 @@
 // @flow
-import { AND, OR, EMPTY_CONNECTOR } from './constants';
+import { AND, EQUALS, GREATER_THAN, LESS_THAN, NOT_EQUALS, OR, EMPTY_CONNECTOR } from './constants';
 
 export type ConnectorType = typeof AND | typeof OR | typeof EMPTY_CONNECTOR;
+
+export type OperatorType = typeof EQUALS | typeof NOT_EQUALS | typeof GREATER_THAN | typeof LESS_THAN;
 
 export type OptionType = {
     displayText: string,
     id: string,
     type?: string,
     value: string,
+};
+
+export type OperatorOptionType = {
+    displayText: string,
+    value: OperatorType,
 };
 
 export type ColumnType = {
@@ -24,6 +31,6 @@ export type ColumnType = {
 export type ConditionType = {
     columnId: string,
     id: number,
-    operator: string,
+    operator: OperatorType,
     values: Array<string>,
 };

--- a/src/features/query-bar/flowTypes.js
+++ b/src/features/query-bar/flowTypes.js
@@ -24,6 +24,6 @@ export type ColumnType = {
 export type ConditionType = {
     columnId: string,
     id: number,
-    operator: string,
-    value: string | null,
+    operator: Array<string>,
+    value: Array<string>,
 };

--- a/src/features/query-bar/flowTypes.js
+++ b/src/features/query-bar/flowTypes.js
@@ -24,6 +24,6 @@ export type ColumnType = {
 export type ConditionType = {
     columnId: string,
     id: number,
-    operator: Array<string>,
-    value: Array<string>,
+    operator: string,
+    values: Array<string>,
 };

--- a/src/features/query-bar/styles/Condition.scss
+++ b/src/features/query-bar/styles/Condition.scss
@@ -94,22 +94,6 @@
         }
     }
 
-    .condition-value-dropdown-container.show-error {
-        .filter-dropdown-text-field-container {
-            .text-input-container input {
-                @include error-border();
-            }
-        }
-
-        .date-picker-wrapper input {
-            @include error-border();
-        }
-
-        .select-button.placeholder {
-            @include error-border();
-        }
-    }
-
     .condition-value-dropdown-container {
         align-items: center;
         height: 100%;
@@ -162,6 +146,28 @@
             .select-button.placeholder {
                 color: $seventy-sixers;
             }
+        }
+    }
+
+    .condition-value-dropdown-container.show-error {
+        .select-container {
+            button.select-button {
+                @include error-border();
+            }
+        }
+
+        .filter-dropdown-text-field-container {
+            .text-input-container input {
+                @include error-border();
+            }
+        }
+
+        .date-picker-wrapper input {
+            @include error-border();
+        }
+
+        .select-button.placeholder {
+            @include error-border();
         }
     }
 


### PR DESCRIPTION
Changes in this PR:
- Update Condition flowtype `value` and `operator` property to be `Array<string>` instead of `string`
- Use `MultiSelectField` in ValueField.js
- Add multi-enum object into columns array in `fixtures.js` for use in the styleguide
- Cleaned up `fixtures.js` by moving copy/pasted column objects to a constant and share that with other constants
- Update Condition.scss to include error state for MultiSelectField
- Handle handler logic when deleting a date from the DatePicker, ran into a bug earlier where there was an error that said `cannot toString null`
<img width="533" alt="screen shot 2019-03-01 at 2 25 21 pm" src="https://user-images.githubusercontent.com/7213887/53669988-dff3c300-3c2d-11e9-8c7a-31da2956de05.png">

