### PR TITLE
fix(pill-selector-dropdown): update suggested pills filter

### DIFF
--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -213,7 +213,7 @@ class PillSelector extends React.Component<Props, State> {
                     />
                     <SuggestedPillsRow
                         onSuggestedPillAdd={onSuggestedPillAdd}
-                        selectedPillsIDs={this.getPillsByKey('id')}
+                        selectedPillsValues={this.getPillsByKey('value')}
                         suggestedPillsData={suggestedPillsData}
                         title={suggestedPillsTitle}
                     />

--- a/src/components/pill-selector-dropdown/SuggestedPillsRow.js
+++ b/src/components/pill-selector-dropdown/SuggestedPillsRow.js
@@ -9,19 +9,21 @@ import './SuggestedPillsRow.scss';
 
 type Props = {
     onSuggestedPillAdd?: SuggestedPillType => void,
-    selectedPillsIDs?: Array<number>,
+    selectedPillsValues?: Array<number>,
     suggestedPillsData?: SuggestedPills,
     title?: string,
 };
 
 const SuggestedPillsRow = ({
     onSuggestedPillAdd = noop,
-    selectedPillsIDs = [],
+    selectedPillsValues = [],
     suggestedPillsData = [],
     title,
 }: Props) => {
-    // Prevents pills from being rendered that are in the form
-    const filteredSuggestedPillData = suggestedPillsData.filter(item => !selectedPillsIDs.includes(item.id));
+    // Prevents pills from being rendered that are in the form by checking for value which is either an ID or email
+    const filteredSuggestedPillData = suggestedPillsData.filter(
+        item => !(selectedPillsValues.includes(item.email) || selectedPillsValues.includes(item.id)),
+    );
 
     if (filteredSuggestedPillData.length === 0) {
         return null;

--- a/src/components/pill-selector-dropdown/__tests__/SuggestedPillRow-test.js
+++ b/src/components/pill-selector-dropdown/__tests__/SuggestedPillRow-test.js
@@ -49,7 +49,7 @@ describe('components/pill-selector-dropdown/SuggestedPillsRow', () => {
 
         test('should not render anything when all suggestedCollabs are selected', () => {
             const wrapper = getWrapper({
-                selectedPillsIDs: [collabID1, collabID2, collabID3],
+                selectedPillsValues: [collabID1, collabID2, collabID3],
                 suggestedPillsData: [collab1, collab2, collab3],
             });
 
@@ -58,7 +58,7 @@ describe('components/pill-selector-dropdown/SuggestedPillsRow', () => {
 
         test('should not render suggesteCollabs that have been filtered', () => {
             const wrapper = getWrapper({
-                selectedPillsIDs: [collabID1],
+                selectedPillsValues: [collabID1],
                 suggestedPillsData: [collab1, collab2, collab3],
             });
 

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector-test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector-test.js.snap
@@ -33,7 +33,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
       type="text"
     />
     <SuggestedPillsRow
-      selectedPillsIDs={Array []}
+      selectedPillsValues={Array []}
     />
   </span>
 </Tooltip>


### PR DESCRIPTION
Problem: this was build under the assumption that all pills contained an "id" value, which is not true. All pill do have a "value". Value is typically either an "id" or an "email" so we can filter the list of suggested pills by both. 