### PR TITLE
feat(typography): heading component

### DIFF
--- a/conf/styleguide.config.js
+++ b/conf/styleguide.config.js
@@ -28,6 +28,7 @@ const allSections = [
     {
         name: 'Components',
         components: () => [
+            '../src/components/heading/Heading.js',
             '../src/components/avatar/Avatar.js',
             '../src/components/badge/Badge.js',
             '../src/components/badgeable/Badgeable.js',

--- a/src/components/heading/Heading.js
+++ b/src/components/heading/Heading.js
@@ -1,0 +1,39 @@
+// @flow
+import * as React from 'react';
+import isFinite from 'lodash/isFinite';
+import classNames from 'classnames';
+import HeadingConsumer from './HeadingConsumer';
+import './Heading.scss';
+
+type Props = {
+    /** Heading contents */
+    children: React.Node,
+    /** Heading contents */
+    className?: string,
+    /** Header tag level */
+    level?: number,
+};
+
+const Heading = ({ children, className = '', level, ...rest }: Props) => {
+    return (
+        <HeadingConsumer>
+            {value => {
+                const headingLevel = parseInt(level || value, 10);
+                if (isFinite(headingLevel) && (headingLevel < 1 || headingLevel > 6)) {
+                    throw new Error('Heading level can only be 1, 2, 3, 4, 5 or 6');
+                }
+                const type = `h${headingLevel}`;
+                return React.createElement(
+                    type,
+                    {
+                        className: classNames(`bdl-Heading--${type}`, className),
+                        ...rest,
+                    },
+                    ...children,
+                );
+            }}
+        </HeadingConsumer>
+    );
+};
+
+export default Heading;

--- a/src/components/heading/Heading.scss
+++ b/src/components/heading/Heading.scss
@@ -1,0 +1,44 @@
+@import '../../styles/variables';
+
+.bdl-Heading--h1,
+.bdl-Heading--h2,
+.bdl-Heading--h3,
+.bdl-Heading--h4,
+.bdl-Heading--h5,
+.bdl-Heading--h6 {
+    color: inherit;
+    font-family: inherit;
+    font-size: 100%;
+    font-weight: 400;
+    line-height: 20px;
+    margin: 8px 0;
+    padding: 0;
+    text-rendering: optimizeLegibility;
+}
+
+.bdl-Heading--h1 {
+    font-size: 30px;
+    line-height: 36px;
+}
+
+.bdl-Heading--h2 {
+    font-size: 24px;
+    line-height: 30px;
+}
+
+.bdl-Heading--h3 {
+    font-size: 20px;
+    line-height: 24px;
+}
+
+.bdl-Heading--h4 {
+    font-size: 16px;
+}
+
+.bdl-Heading--h5 {
+    font-size: 14px;
+}
+
+.bdl-Heading--h6 {
+    font-size: 12px;
+}

--- a/src/components/heading/HeadingConsumer.js
+++ b/src/components/heading/HeadingConsumer.js
@@ -1,0 +1,6 @@
+// @flow
+import HeadingContext from './HeadingContext';
+
+const HeadingConsumer = HeadingContext.Consumer;
+
+export default HeadingConsumer;

--- a/src/components/heading/HeadingContext.js
+++ b/src/components/heading/HeadingContext.js
@@ -1,0 +1,8 @@
+/**
+ * @flow
+ * @file Creates an API Context
+ * @author Box
+ */
+import React from 'react';
+
+export default React.createContext<?number>();

--- a/src/components/heading/HeadingProvider.js
+++ b/src/components/heading/HeadingProvider.js
@@ -1,0 +1,6 @@
+// @flow
+import HeadingContext from './HeadingContext';
+
+const HeadingProvider = HeadingContext.Provider;
+
+export default HeadingProvider;

--- a/src/components/heading/README.md
+++ b/src/components/heading/README.md
@@ -1,0 +1,62 @@
+### Examples
+**H1**
+```
+<Heading level={1}>
+    Box Design Language
+</Heading>
+```
+
+**H2**
+```
+<Heading level={2}>
+    Box Design Language
+</Heading>
+```
+
+**H3**
+```
+<Heading level={3}>
+    Box Design Language
+</Heading>
+```
+
+**H4**
+```
+<Heading level={4}>
+    Box Design Language
+</Heading>
+```
+
+**H5**
+```
+<Heading level={5}>
+    Box Design Language
+</Heading>
+```
+
+**H6**
+```
+<Heading level={6}>
+    Box Design Language
+</Heading>
+```
+
+**H3 via context with some overrides**
+```js
+const HeadingProvider = require('./HeadingProvider').default;
+
+<HeadingProvider value={3}>
+    <Heading>
+        H3 - Box Design Language
+    </Heading>
+    <Heading>
+        H3 - Box Design Language
+    </Heading>
+    <Heading level={1}>
+        H1 - Box Design Language
+    </Heading>
+    <Heading level={6}>
+        H6 - Box Design Language
+    </Heading>
+</HeadingProvider>
+```

--- a/src/components/heading/__tests__/Heading-test.js
+++ b/src/components/heading/__tests__/Heading-test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import Heading from '..';
+
+describe('components/heading/Heading', () => {
+    test('should correctly render h1', () => {
+        const wrapper = shallow(<Heading level={1}>BDL</Heading>);
+        expect(wrapper.type()).toEqual('h1');
+        expect(wrapper.hasClass('bdl-h1')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h2', () => {
+        const wrapper = shallow(<Heading level={2}>BDL</Heading>);
+        expect(wrapper.type()).toEqual('h2');
+        expect(wrapper.hasClass('bdl-h2')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h3', () => {
+        const wrapper = shallow(<Heading level={3}>BDL</Heading>);
+        expect(wrapper.type()).toEqual('h3');
+        expect(wrapper.hasClass('bdl-h3')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h4', () => {
+        const wrapper = shallow(<Heading level={4}>BDL</Heading>);
+        expect(wrapper.type()).toEqual('h4');
+        expect(wrapper.hasClass('bdl-h4')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h5', () => {
+        const wrapper = shallow(<Heading level={5}>BDL</Heading>);
+        expect(wrapper.type()).toEqual('h5');
+        expect(wrapper.hasClass('bdl-h5')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+    test('should correctly render h6', () => {
+        const wrapper = shallow(<Heading level={6}>BDL</Heading>);
+        expect(wrapper.type()).toEqual('h6');
+        expect(wrapper.hasClass('bdl-h6')).toBe(true);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/components/heading/__tests__/__snapshots__/Heading-test.js.snap
+++ b/src/components/heading/__tests__/__snapshots__/Heading-test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/heading/Heading should correctly render h1 1`] = `
+<h1
+  className="bdl-h1"
+>
+  B
+  D
+  L
+</h1>
+`;
+
+exports[`components/heading/Heading should correctly render h2 1`] = `
+<h2
+  className="bdl-h2"
+>
+  B
+  D
+  L
+</h2>
+`;
+
+exports[`components/heading/Heading should correctly render h3 1`] = `
+<h3
+  className="bdl-h3"
+>
+  B
+  D
+  L
+</h3>
+`;
+
+exports[`components/heading/Heading should correctly render h4 1`] = `
+<h4
+  className="bdl-h4"
+>
+  B
+  D
+  L
+</h4>
+`;
+
+exports[`components/heading/Heading should correctly render h5 1`] = `
+<h5
+  className="bdl-h5"
+>
+  B
+  D
+  L
+</h5>
+`;
+
+exports[`components/heading/Heading should correctly render h6 1`] = `
+<h6
+  className="bdl-h6"
+>
+  B
+  D
+  L
+</h6>
+`;

--- a/src/components/heading/index.js
+++ b/src/components/heading/index.js
@@ -1,0 +1,4 @@
+// @flow
+export { default } from './Heading';
+export { default as HeadingProvider } from './HeadingProvider';
+export { default as HeadingConsumer } from './HeadingConsumer';

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -26,12 +26,6 @@ dd,
 ul,
 ol,
 li,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
 pre,
 code,
 form,
@@ -81,16 +75,6 @@ ul {
 caption,
 th {
     text-align: left;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    font-size: 100%;
-    font-weight: normal;
 }
 
 q::before,

--- a/src/styles/common/_typography.scss
+++ b/src/styles/common/_typography.scss
@@ -23,47 +23,6 @@ p {
     margin: 0 0 20px;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    color: inherit;
-    font-family: inherit;
-    font-weight: 400;
-    line-height: 20px;
-    margin: 8px 0;
-    text-rendering: optimizeLegibility;
-}
-
-h1 {
-    font-size: 30px;
-    line-height: 36px;
-}
-
-h2 {
-    font-size: 24px;
-    line-height: 30px;
-}
-
-h3 {
-    font-size: 20px;
-    line-height: 24px;
-}
-
-h4 {
-    font-size: 16px;
-}
-
-h5 {
-    font-size: 14px;
-}
-
-h6 {
-    font-size: 12px;
-}
-
 .strong,
 strong {
     font-weight: 700;


### PR DESCRIPTION
1. Adds h1, h2, h3, h4, h5, h6 support
2. remove tag styles and reset related to header elements

<img width="399" alt="screen shot 2019-03-05 at 6 46 42 pm" src="https://user-images.githubusercontent.com/1075325/53852490-10619700-3f77-11e9-8736-0a84eb16683d.png">

- Alternatively we can create a `<Typography>` element that takes in more than just hX. Similar to material-ui.
- Alternatively we can create components for each.
- Alternatively we don't style any of these and let the parent components deal with it.

BREAKING CHANGE: The styling classes for h1-h6 have changed.