### PR TITLE
chore(query-bar): Reference conditions from parent app

### DIFF
--- a/src/features/query-bar/QueryBar.js
+++ b/src/features/query-bar/QueryBar.js
@@ -5,23 +5,32 @@ import TemplateButton from './components/TemplateButton';
 import FilterButton from './components/filter/FilterButton';
 import ColumnButton from './components/ColumnButton';
 
-import type { ColumnType } from './flowTypes';
+import type { ColumnType, ConditionType } from './flowTypes';
 
 import './styles/QueryBarButtons.scss';
 
 type Props = {
     activeTemplate?: MetadataTemplate,
     columns?: Array<ColumnType>,
+    conditions: Array<ConditionType>,
     onColumnChange?: Function,
     onFilterChange?: Function,
     onTemplateChange?: Function,
     templates?: Array<MetadataTemplate>,
 };
 
-const QueryBar = ({ activeTemplate, columns, onColumnChange, onFilterChange, onTemplateChange, templates }: Props) => (
+const QueryBar = ({
+    activeTemplate,
+    columns,
+    conditions,
+    onColumnChange,
+    onFilterChange,
+    onTemplateChange,
+    templates,
+}: Props) => (
     <section className="metadata-view-query-bar">
         <TemplateButton activeTemplate={activeTemplate} onTemplateChange={onTemplateChange} templates={templates} />
-        <FilterButton onFilterChange={onFilterChange} columns={columns} />
+        <FilterButton columns={columns} conditions={conditions} onFilterChange={onFilterChange} />
         <ColumnButton columns={columns} onColumnChange={onColumnChange} template={activeTemplate} />
     </section>
 );


### PR DESCRIPTION
Changes in this PR:
- FilterButton now accepts ```conditions``` prop passed down from EUA
- FilterButton's original state called ```conditions``` is now called ```transientConditions```
- Upon closing the FilterButton dropdown, ```this.state.transientConditions``` will get set to an empty Array
- Upon any changes between ```this.props.condition``` in FilterButton and ```this.state.transientConditions```, ```componentDidUpdate``` will handle hydrating local state with Redux state