### PR TITLE
fix(flow): type issues

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -16,19 +16,10 @@
 .*/node_modules/config-chain*
 .*/__tests__/.*
 
-[untyped]
-
-[include]
-./src
-
-[libs]
-
 [options]
 esproposal.export_star_as=enable
 module.file_ext=.js
 module.file_ext=.scss
-module.system.node.resolve_dirname=node_modules
-module.system.node.resolve_dirname=src
 module.name_mapper.extension='scss' -> '<PROJECT_ROOT>/flow/SCSSFlowStub.js.flow'
 module.name_mapper.extension='css' -> '<PROJECT_ROOT>/flow/SCSSFlowStub.js.flow'
 module.name_mapper='react-intl-locale-data' -> '<PROJECT_ROOT>/flow/WebpackI18N.js.flow'


### PR DESCRIPTION
First, in version 0.57 of Flow, [the feature](https://github.com/facebook/flow/releases/tag/v0.57.1) as described below added

New Features:
Flow will now only check the files in node_modules/ which are direct or transitive dependencies of the non-node_modules code.

Also, [the document ](https://flow.org/en/docs/config/options/#toc-module-system-node-resolve-dirname-string)explains about setting module.system.node.resolve_dirname as below.

module.system.node.resolve_dirname (string)
By default, Flow will look in directories named node_modules for node modules. You can configure this behavior with this option.

from https://github.com/facebook/flow/issues/5180#issuecomment-341887514