### PR TITLE
feat(upload-manager): Add error case to upload manager name conflict

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -404,6 +404,8 @@ be.uploadsCancelButtonTooltip = Cancel this upload
 be.uploadsDefaultErrorMessage = Something went wrong with the upload. Please try again.
 # Error message shown when file size exceeds the limit
 be.uploadsFileSizeLimitExceededErrorMessage = File size exceeds the folder owner’s file size limit
+# Error message shown when attempting to upload a file which name already exists
+be.uploadsItemNameInUseErrorMessage = A file with this name already exists.
 # Text shown when uploads are completed
 be.uploadsManagerUploadComplete = Completed
 # Text shown when uploads failed

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -652,6 +652,11 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
         description: 'Error message shown when pending app folder size exceeds the limit',
         defaultMessage: 'Pending app folder size limit exceeded',
     },
+    uploadsItemNameInUseErrorMessage: {
+        id: 'be.uploadsItemNameInUseErrorMessage',
+        description: 'Error message shown when attempting to upload a file which name already exists',
+        defaultMessage: 'File name already exists for the attempted upload.',
+    },
     uploadsProvidedFolderNameInvalidMessage: {
         id: 'be.uploadsProvidedFolderNameInvalidMessage',
         description: 'Error message shown when pending folder upload contains invalid characters',

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -655,7 +655,7 @@ const messages: { [string]: MessageDescriptor } = defineMessages({
     uploadsItemNameInUseErrorMessage: {
         id: 'be.uploadsItemNameInUseErrorMessage',
         description: 'Error message shown when attempting to upload a file which name already exists',
-        defaultMessage: 'File name already exists for the attempted upload.',
+        defaultMessage: 'A file with this name already exists.',
     },
     uploadsProvidedFolderNameInvalidMessage: {
         id: 'be.uploadsProvidedFolderNameInvalidMessage',

--- a/src/elements/content-uploader/progressCellRenderer.js
+++ b/src/elements/content-uploader/progressCellRenderer.js
@@ -9,6 +9,7 @@ import messages from '../common/messages';
 import ItemProgress from './ItemProgress';
 import {
     ERROR_CODE_UPLOAD_FILE_SIZE_LIMIT_EXCEEDED,
+    ERROR_CODE_ITEM_NAME_IN_USE,
     ERROR_CODE_ITEM_NAME_INVALID,
     ERROR_CODE_UPLOAD_PENDING_APP_FOLDER_SIZE_LIMIT,
     ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED,
@@ -34,6 +35,8 @@ const getErrorMessage = (errorCode: ?string, itemName: ?string) => {
             return <FormattedMessage {...messages.uploadsOneOrMoreChildFoldersFailedToUploadMessage} />;
         case ERROR_CODE_UPLOAD_FILE_SIZE_LIMIT_EXCEEDED:
             return <FormattedMessage {...messages.uploadsFileSizeLimitExceededErrorMessage} />;
+        case ERROR_CODE_ITEM_NAME_IN_USE:
+            return <FormattedMessage {...messages.uploadsItemNameInUseErrorMessage} />;
         case ERROR_CODE_ITEM_NAME_INVALID:
             return (
                 <FormattedMessage {...messages.uploadsProvidedFolderNameInvalidMessage} values={{ name: itemName }} />


### PR DESCRIPTION
<img width="1675" alt="Screen Shot 2019-03-12 at 2 45 51 PM" src="https://user-images.githubusercontent.com/7213887/54238382-8f098780-44d5-11e9-95e4-28bf1b73e7b4.png">

Changes in this PR:
- Add error case for uploading a file with a name that already exists
