### PR TITLE
build(webpack): Remove devServer option interfering with yarn start:dev

### DIFF
--- a/conf/webpack.config.js
+++ b/conf/webpack.config.js
@@ -72,7 +72,6 @@ function getConfig(isReactExternalized) {
             },
         },
         devServer: {
-            historyApiFallback: true,
             host: '0.0.0.0',
             stats,
         },


### PR DESCRIPTION
We’ll need to look into re-enabling the option if we decide to support deep linking in the future, likely via an environment flag of some kind. It's not needed right now, though.