### PR TITLE
feat(avatar): add size prop to avatars

### DIFF
--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import classNames from 'classnames';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
 import UnknownUserAvatar from '../../icons/avatars/UnknownUserAvatar';
@@ -54,10 +55,9 @@ class Avatar extends React.PureComponent<Props, State> {
     };
 
     render() {
-        const { avatarUrl, className = '', name, id, size }: Props = this.props;
+        const { avatarUrl, className, name, id, size }: Props = this.props;
         const { hasImageErrored }: State = this.state;
-        // restrict CSS classnames to known sizes
-        const sizeClass = SIZES[size] ? size : '';
+        const classes = classNames(['avatar', className, { [`avatar--${size}`]: SIZES[size] }]);
 
         let avatar;
         if (avatarUrl && !hasImageErrored) {
@@ -69,7 +69,7 @@ class Avatar extends React.PureComponent<Props, State> {
         }
 
         return (
-            <span className={`avatar ${className} ${sizeClass}`} role="presentation">
+            <span className={classes} role="presentation">
                 {avatar}
             </span>
         );

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -6,6 +6,8 @@ import UnknownUserAvatar from '../../icons/avatars/UnknownUserAvatar';
 
 import './Avatar.scss';
 
+const SIZES = { large: true };
+
 type Props = {
     /**
      * Url to avatar image.  If passed in, component will render the avatar image instead of the initials
@@ -23,6 +25,8 @@ type Props = {
      * Required if "avatarUrl" is not specified.
      */
     name?: string,
+    /* avatar size (enum) */
+    size?: $Keys<typeof SIZES>,
 };
 
 type State = {
@@ -50,8 +54,10 @@ class Avatar extends React.PureComponent<Props, State> {
     };
 
     render() {
-        const { avatarUrl, className = '', name, id }: Props = this.props;
+        const { avatarUrl, className = '', name, id, size }: Props = this.props;
         const { hasImageErrored }: State = this.state;
+        // restrict CSS classnames to known sizes
+        const sizeClass = SIZES[size] ? size : '';
 
         let avatar;
         if (avatarUrl && !hasImageErrored) {
@@ -63,7 +69,7 @@ class Avatar extends React.PureComponent<Props, State> {
         }
 
         return (
-            <span className={`avatar ${className}`} role="presentation">
+            <span className={`avatar ${className} ${sizeClass}`} role="presentation">
                 {avatar}
             </span>
         );

--- a/src/components/avatar/Avatar.scss
+++ b/src/components/avatar/Avatar.scss
@@ -36,7 +36,7 @@
         justify-content: center;
     }
 
-    &.large {
+    &.avatar--large {
         height: 44px;
         width: 44px;
 

--- a/src/components/avatar/Avatar.scss
+++ b/src/components/avatar/Avatar.scss
@@ -35,4 +35,14 @@
         display: flex;
         justify-content: center;
     }
+
+    &.large {
+        height: 44px;
+        width: 44px;
+
+        .avatar-initials {
+            font-size: 14px;
+            font-weight: bold;
+        }
+    }
 }

--- a/src/components/avatar/__tests__/Avatar-test.js
+++ b/src/components/avatar/__tests__/Avatar-test.js
@@ -12,12 +12,12 @@ describe('components/avatar/Avatar', () => {
 
     test('should add size class based on prop', () => {
         const wrapper = shallow(<Avatar name="hello" size="large" />);
-        expect(wrapper.is('span.avatar.large')).toBe(true);
+        expect(wrapper.is('span.avatar.avatar--large')).toBe(true);
     });
 
     test('should not allow unknown sizes', () => {
         const wrapper = shallow(<Avatar name="hello" size="WRONG" />);
-        expect(wrapper.is('span.avatar.WRONG')).toBe(false);
+        expect(wrapper.is('span.avatar.avatar--WRONG')).toBe(false);
     });
 
     test('should render an AvatarImage when avatarUrl is passed in', () => {

--- a/src/components/avatar/__tests__/Avatar-test.js
+++ b/src/components/avatar/__tests__/Avatar-test.js
@@ -7,7 +7,17 @@ const testDataURI = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAAL
 describe('components/avatar/Avatar', () => {
     test('should render an avatar container', () => {
         const wrapper = shallow(<Avatar className="test-avatar" name="hello" />);
-        expect(wrapper.is('span.avatar.test-avatar')).toBeTruthy();
+        expect(wrapper.is('span.avatar.test-avatar')).toBe(true);
+    });
+
+    test('should add size class based on prop', () => {
+        const wrapper = shallow(<Avatar name="hello" size="large" />);
+        expect(wrapper.is('span.avatar.large')).toBe(true);
+    });
+
+    test('should not allow unknown sizes', () => {
+        const wrapper = shallow(<Avatar name="hello" size="WRONG" />);
+        expect(wrapper.is('span.avatar.WRONG')).toBe(false);
     });
 
     test('should render an AvatarImage when avatarUrl is passed in', () => {

--- a/src/elements/content-sidebar/activity-feed/__tests__/__snapshots__/Avatar-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/__tests__/__snapshots__/Avatar-test.js.snap
@@ -10,7 +10,7 @@ exports[`elements/content-sidebar/ActivityFeed/Avatar should render the avatar w
 
 exports[`elements/content-sidebar/ActivityFeed/Avatar should set the avatarUrl state from user prop 1`] = `
 <span
-  className="avatar  "
+  className="avatar"
   role="presentation"
 >
   <AvatarInitials

--- a/src/elements/content-sidebar/activity-feed/__tests__/__snapshots__/Avatar-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/__tests__/__snapshots__/Avatar-test.js.snap
@@ -10,7 +10,7 @@ exports[`elements/content-sidebar/ActivityFeed/Avatar should render the avatar w
 
 exports[`elements/content-sidebar/ActivityFeed/Avatar should set the avatarUrl state from user prop 1`] = `
 <span
-  className="avatar "
+  className="avatar  "
   role="presentation"
 >
   <AvatarInitials

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
@@ -257,7 +257,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should show assignm
               name="Jake Thomas"
             >
               <span
-                className="avatar bcs-task-assignment-avatar"
+                className="avatar bcs-task-assignment-avatar "
                 role="presentation"
               >
                 <AvatarInitials
@@ -320,7 +320,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should show assignm
               name="Patrick Paul"
             >
               <span
-                className="avatar bcs-task-assignment-avatar"
+                className="avatar bcs-task-assignment-avatar "
                 role="presentation"
               >
                 <AvatarInitials

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
@@ -257,7 +257,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should show assignm
               name="Jake Thomas"
             >
               <span
-                className="avatar bcs-task-assignment-avatar "
+                className="avatar bcs-task-assignment-avatar"
                 role="presentation"
               >
                 <AvatarInitials
@@ -320,7 +320,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should show assignm
               name="Patrick Paul"
             >
               <span
-                className="avatar bcs-task-assignment-avatar "
+                className="avatar bcs-task-assignment-avatar"
                 role="presentation"
               >
                 <AvatarInitials


### PR DESCRIPTION
Adds a size prop (currently restricted to "large") for avatars. The default CSS matches the design for the components using HeaderFlyout (44px width, 14px font size).