### PR TITLE
style(links): restore default link outline

### DIFF
--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -81,6 +81,8 @@ type Props = {
     isDisabled: boolean,
     /** Forces the tooltip to be shown or hidden (useful for errors) */
     isShown?: boolean,
+    /** Whether to add tabindex=0.  Defaults to `true` */
+    isTabbable?: boolean,
     /** Function called if the user manually dismisses the tooltip - only applies if showCloseButton is true */
     onDismiss?: () => void,
     /** Where to position the tooltip relative to the wrapped component */
@@ -167,6 +169,7 @@ class Tooltip extends React.Component<Props, State> {
             constrainToWindow,
             isDisabled,
             isShown: isShownProp,
+            isTabbable = true,
             position,
             showCloseButton,
             text,
@@ -208,7 +211,10 @@ class Tooltip extends React.Component<Props, State> {
             componentProps.onKeyDown = this.handleKeyDown;
             componentProps.onMouseEnter = this.handleMouseEnter;
             componentProps.onMouseLeave = this.handleMouseLeave;
-            componentProps.tabIndex = '0';
+
+            if (isTabbable) {
+                componentProps.tabIndex = '0';
+            }
         }
 
         const bodyEl = bodyElement instanceof HTMLElement ? bodyElement : document.body;

--- a/src/components/tooltip/__tests__/Tooltip-test.js
+++ b/src/components/tooltip/__tests__/Tooltip-test.js
@@ -93,6 +93,17 @@ describe('components/tooltip/Tooltip', () => {
             expect(component.prop('tabIndex')).toEqual('0');
         });
 
+        test('should not add tabindex if isTabbable is false', () => {
+            const wrapper = shallow(
+                <Tooltip isShown isTabbable={false} text="hi">
+                    <button />
+                </Tooltip>,
+            );
+            const component = wrapper.find('button');
+
+            expect(component.prop('tabIndex')).toBeFalsy();
+        });
+
         test('should show tooltip when isShown state is true', () => {
             const wrapper = shallow(
                 <Tooltip text="hi">

--- a/src/features/left-sidebar/LeftSidebarLink.js
+++ b/src/features/left-sidebar/LeftSidebarLink.js
@@ -116,6 +116,7 @@ class LeftSidebarLink extends React.Component<Props, State> {
                     className={classNames('nav-link-tooltip', {
                         'is-visible': this.state.isTextOverflowed && !isScrolling,
                     })}
+                    isTabbable={false}
                     position="middle-right"
                     text={message}
                 >

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarLink-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarLink-test.js.snap
@@ -6,6 +6,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render BadgeCountElement 1`
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -29,6 +30,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render BadgeElement 1`] = `
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -58,6 +60,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render RemoveButton 1`] = `
     constrainToScrollParent={false}
     constrainToWindow={true}
     isDisabled={false}
+    isTabbable={false}
     position="middle-right"
     text="Feed"
     theme="default"
@@ -86,6 +89,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render a LinkComponent comp
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -109,6 +113,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render the IconComponent 1`
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -135,6 +140,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render the router link 1`] 
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -172,6 +178,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use a custom className 1`] 
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -195,6 +202,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -222,6 +230,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -245,6 +254,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -272,6 +282,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -295,6 +306,7 @@ exports[`feature/left-sidebar/LeftSidebarLink tooltip should take class from sta
   constrainToScrollParent={false}
   constrainToWindow={true}
   isDisabled={false}
+  isTabbable={false}
   position="middle-right"
   text="Feed"
   theme="default"

--- a/src/features/left-sidebar/styles/LeftSidebar.scss
+++ b/src/features/left-sidebar/styles/LeftSidebar.scss
@@ -230,7 +230,7 @@
     font-size: $lsb-font-size;
     height: 28px;
     letter-spacing: .3px;
-    line-height: 30px;
+    line-height: 28px;
     padding: 0 $lsb-padding-x;
     position: relative;
     width: $lsb-width;

--- a/src/styles/common/_links.scss
+++ b/src/styles/common/_links.scss
@@ -7,7 +7,6 @@
 a,
 .lnk {
     color: $box-blue;
-    outline: none;
     text-decoration: none;
 }
 
@@ -41,7 +40,6 @@ a:focus,
 .lnk:focus,
 a.is-disabled:focus,
 .lnk.is-disabled:focus {
-    outline: none;
     text-decoration: underline;
 }
 


### PR DESCRIPTION
As part of the accessibility push, links should have a blue outline by default

Changes include:
- Removing `outline: none` around links
- Added `makeTabbable` property to tooltip to prevent active state of left sidebar links from showing
- Changing `line-height` of left sidebar link to smooth out outline