### PR TITLE
fix(query-bar): fix tooltip text for Condition

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -800,6 +800,8 @@ boxui.queryBar.selectValuePlaceholderText = Select value
 boxui.queryBar.templatesButtonText = Select Metadata
 # Text on the templates button when templates are still being loaded
 boxui.queryBar.templatesLoadingButtonText = Template Name
+# Text displayed on the Tooltip for an input field
+boxui.queryBar.tooltipEnterValueError = Please Enter a Value
 # Text displayed on the Tooltip for a date field
 boxui.queryBar.tooltipSelectDateError = Please Select a Date
 # Text displayed on the Tooltip for a value field

--- a/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/ValueField-test.js.snap
@@ -63,7 +63,7 @@ exports[`features/query-bar/components/filter/ValueField render value fields "sh
       id="boxui.queryBar.selectValuePlaceholderText"
     />
   }
-  selectedValue=""
+  selectedValue={null}
 />
 `;
 

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -10,7 +10,19 @@ import SingleSelectField from '../../../../components/select-field/SingleSelectF
 import ValueField from './ValueField';
 
 import messages from '../../messages';
-import { AND, COLUMN, COLUMN_OPERATORS, DATE, OPERATOR, OR } from '../../constants';
+import {
+    AND,
+    COLUMN,
+    COLUMN_OPERATORS,
+    DATE,
+    ENUM,
+    FLOAT,
+    MULTI_ENUM,
+    NUMBER,
+    OPERATOR,
+    OR,
+    STRING,
+} from '../../constants';
 import type {
     ColumnType,
     ConditionType,
@@ -102,11 +114,30 @@ const Condition = ({
         const type = column && column.type;
 
         const isValueSet = values.length !== 0;
-        const message = (
-            <FormattedMessage
-                {...(type === DATE ? messages.tooltipSelectDateError : messages.tooltipSelectValueError)}
-            />
-        );
+        let message;
+        switch (type) {
+            case STRING:
+                message = <FormattedMessage {...messages.tooltipEnterValueError} />;
+                break;
+            case NUMBER:
+                message = <FormattedMessage {...messages.tooltipEnterValueError} />;
+                break;
+            case FLOAT:
+                message = <FormattedMessage {...messages.tooltipEnterValueError} />;
+                break;
+            case DATE:
+                message = <FormattedMessage {...messages.tooltipSelectDateError} />;
+                break;
+            case ENUM:
+                message = <FormattedMessage {...messages.tooltipSelectValueError} />;
+                break;
+            case MULTI_ENUM:
+                message = <FormattedMessage {...messages.tooltipSelectValueError} />;
+                break;
+            default:
+                break;
+        }
+
         const error = areErrorsEnabled && !isValueSet ? message : null;
 
         return error;

--- a/src/features/query-bar/components/filter/ValueField.js
+++ b/src/features/query-bar/components/filter/ValueField.js
@@ -6,7 +6,7 @@ import DatePicker from '../../../../components/date-picker';
 import SingleSelectField from '../../../../components/select-field/SingleSelectField';
 import MultiSelectField from '../../../../components/select-field/MultiSelectField';
 import TextInput from '../../../../components/text-input';
-import { VALUE } from '../../constants';
+import { DATE, ENUM, FLOAT, MULTI_ENUM, NUMBER, STRING, VALUE } from '../../constants';
 import messages from '../../messages';
 
 import '../../styles/Condition.scss';
@@ -26,7 +26,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
     };
 
     switch (valueType) {
-        case 'string':
+        case STRING:
             return (
                 <div className="filter-dropdown-text-field-container">
                     <TextInput
@@ -39,7 +39,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                     />
                 </div>
             );
-        case 'number':
+        case NUMBER:
             return (
                 <div className="filter-dropdown-text-field-container">
                     <TextInput
@@ -52,7 +52,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                     />
                 </div>
             );
-        case 'float':
+        case FLOAT:
             return (
                 <div className="filter-dropdown-text-field-container">
                     <TextInput
@@ -65,7 +65,7 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                     />
                 </div>
             );
-        case 'date':
+        case DATE:
             return (
                 <div className="filter-dropdown-date-field-container">
                     <DatePicker
@@ -85,17 +85,17 @@ const ValueField = ({ onChange, selectedValues, valueOptions, valueType }: Props
                     />
                 </div>
             );
-        case 'enum':
+        case ENUM:
             return (
                 <SingleSelectField
                     fieldType={VALUE}
                     onChange={e => onChange([e.value])}
                     options={valueOptions}
                     placeholder={<FormattedMessage {...messages.selectValuePlaceholderText} />}
-                    selectedValue={value}
+                    selectedValue={value === '' ? null : value}
                 />
             );
-        case 'multi-enum':
+        case MULTI_ENUM:
             return (
                 <MultiSelectField
                     fieldType={VALUE}

--- a/src/features/query-bar/constants.js
+++ b/src/features/query-bar/constants.js
@@ -18,6 +18,7 @@ export const STRING: 'string' = 'string';
 export const NUMBER: 'number' = 'number';
 export const FLOAT: 'float' = 'float';
 export const ENUM: 'enum' = 'enum';
+export const MULTI_ENUM: 'multi-enum' = 'multi-enum';
 export const DATE: 'date' = 'date';
 
 export const EQUALS: '=' = '=';
@@ -40,5 +41,5 @@ export const COLUMN_OPERATORS = {
     float: ALL_OPERATORS,
     enum: ALL_OPERATORS,
     date: ALL_OPERATORS,
-    'multi-enum': ALL_OPERATORS,
+    MULTI_ENUM: ALL_OPERATORS,
 };

--- a/src/features/query-bar/messages.js
+++ b/src/features/query-bar/messages.js
@@ -2,6 +2,11 @@
 import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
+    tooltipEnterValueError: {
+        defaultMessage: 'Please Enter a Value',
+        description: 'Text displayed on the Tooltip for an input field',
+        id: 'boxui.queryBar.tooltipEnterValueError',
+    },
     tooltipSelectValueError: {
         defaultMessage: 'Please Select a Value',
         description: 'Text displayed on the Tooltip for a value field',


### PR DESCRIPTION
Changes in this PR:
- `TextInput` fields now have an error tooltip that says `Please enter a value`
- Use constants instead of hardcoded strings in Condition.js and ValueField.js
- Fix UI issue with single select enum where the placeholder isn't shown when empty string is passed in

<img width="569" alt="Screen Shot 2019-03-15 at 2 42 14 PM" src="https://user-images.githubusercontent.com/7213887/54465076-954a6e80-4736-11e9-9001-598ef3573370.png">

