### PR TITLE
chore(query-bar): pass conditions into styleguide

### DIFF
--- a/examples/src/MetadataViewQueryBarExamples.js
+++ b/examples/src/MetadataViewQueryBarExamples.js
@@ -2,11 +2,12 @@
 import * as React from 'react';
 
 import QueryBar from '../../src/features/query-bar/QueryBar';
-import type { ColumnType } from '../../src/features/query-bar/flowTypes';
-import { columns } from '../../src/features/query-bar/components/fixtures';
+import type { ColumnType, ConditionType } from '../../src/features/query-bar/flowTypes';
+import { columns, conditions } from '../../src/features/query-bar/components/fixtures';
 
 type Props = {
     activeTemplate?: MetadataTemplate,
+    conditions: Array<ConditionType>,
     onTemplateChange?: Function,
     templates?: Array<MetadataTemplate>,
     visibleColumns?: Array<ColumnType>,
@@ -16,6 +17,7 @@ const MetadataViewQueryBarExamples = ({ activeTemplate, onTemplateChange, templa
     <QueryBar
         activeTemplate={activeTemplate}
         columns={columns}
+        conditions={conditions}
         onColumnChange={() => {}}
         onTemplateChange={onTemplateChange}
         templates={templates}

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -55,7 +55,7 @@ class Avatar extends React.PureComponent<Props, State> {
     };
 
     render() {
-        const { avatarUrl, className, name, id, size }: Props = this.props;
+        const { avatarUrl, className, name, id, size = '' }: Props = this.props;
         const { hasImageErrored }: State = this.state;
         const classes = classNames(['avatar', className, { [`avatar--${size}`]: SIZES[size] }]);
 


### PR DESCRIPTION
Changes in this PR:
- Pass conditions into styleguide for Query Bar
- Default size to be empty string for Avatar.js
- Resolves two flow errors currently being shown in the console