### PR TITLE
feat(unified-share-modal): add contextual callout tooltips

### DIFF
--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -79,6 +79,8 @@ type Props = {
     constrainToWindow: boolean,
     /** Forces the tooltip to be shown or hidden (useful for errors) */
     isShown?: boolean,
+    /** Function called if the user manually dismisses the tooltip - only applies if showCloseButton is true */
+    onDismiss?: () => void,
     /** Where to position the tooltip relative to the wrapped component */
     position: Position,
     /** Shows an X button to close the tooltip. Useful when tooltips are force shown with the isShown prop. */
@@ -110,7 +112,11 @@ class Tooltip extends React.Component<Props, State> {
     tooltipID = uniqueId('tooltip');
 
     closeTooltip = () => {
+        const { onDismiss } = this.props;
         this.setState({ wasClosedByUser: true });
+        if (onDismiss) {
+            onDismiss();
+        }
     };
 
     fireChildEvent = (type: string, event: SyntheticEvent<>) => {

--- a/src/components/tooltip/__tests__/Tooltip-test.js
+++ b/src/components/tooltip/__tests__/Tooltip-test.js
@@ -205,6 +205,32 @@ describe('components/tooltip/Tooltip', () => {
         });
     });
 
+    describe('closeTooltip()', () => {
+        test('should update the wasClosedByUser state', () => {
+            const wrapper = shallow(
+                <Tooltip text="hi">
+                    <button />
+                </Tooltip>,
+            );
+
+            expect(wrapper.state('wasClosedByUser')).toBe(false);
+            wrapper.instance().closeTooltip();
+            expect(wrapper.state('wasClosedByUser')).toBe(true);
+        });
+
+        test('should call onDismiss if provided', () => {
+            const onDismissMock = jest.fn();
+            const wrapper = shallow(
+                <Tooltip text="hi" onDismiss={onDismissMock}>
+                    <button />
+                </Tooltip>,
+            );
+
+            wrapper.instance().closeTooltip();
+            expect(onDismissMock).toHaveBeenCalled();
+        });
+    });
+
     describe('handleMouseEnter()', () => {
         test('should correctly handle mouseenter events', () => {
             const onMouseEnter = sinon.spy();

--- a/src/features/unified-share-modal/EmailForm.js
+++ b/src/features/unified-share-modal/EmailForm.js
@@ -235,6 +235,7 @@ class EmailForm extends React.Component<Props, State> {
         const contactsField = (
             <div className="tooltip-target">
                 <Tooltip
+                    className="usm-ftux-tooltip"
                     isShown={showEnterEmailsCallout}
                     position="middle-right"
                     showCloseButton

--- a/src/features/unified-share-modal/SharedLinkAccessMenu.js
+++ b/src/features/unified-share-modal/SharedLinkAccessMenu.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
@@ -23,14 +23,16 @@ type Props = {
     classificationName?: string,
     enterpriseName?: string,
     itemType: ItemType,
+    onDismissTooltip: () => void,
     submitting: boolean,
+    tooltipContent: React.Node,
     trackingProps: {
         onChangeSharedLinkAccessLevel?: Function,
         sharedLinkAccessMenuButtonProps?: Object,
     },
 };
 
-class SharedLinkAccessMenu extends Component<Props> {
+class SharedLinkAccessMenu extends React.Component<Props> {
     static defaultProps = {
         allowedAccessLevels: {},
         trackingProps: {},
@@ -100,27 +102,45 @@ class SharedLinkAccessMenu extends Component<Props> {
     }
 
     render() {
-        const { accessLevel, enterpriseName, itemType, submitting, trackingProps } = this.props;
+        const {
+            accessLevel,
+            enterpriseName,
+            itemType,
+            onDismissTooltip,
+            submitting,
+            tooltipContent,
+            trackingProps,
+        } = this.props;
         const { sharedLinkAccessMenuButtonProps } = trackingProps;
 
         return (
             <DropdownMenu>
-                <PlainButton
-                    className={classNames('lnk', {
-                        'is-disabled': submitting,
-                    })}
-                    disabled={submitting}
-                    {...sharedLinkAccessMenuButtonProps}
+                <Tooltip
+                    className="usm-ftux-tooltip"
+                    isShown={!!tooltipContent}
+                    onDismiss={onDismissTooltip}
+                    position="bottom-center"
+                    showCloseButton
+                    text={tooltipContent}
+                    theme="callout"
                 >
-                    <MenuToggle>
-                        <SharedLinkAccessLabel
-                            accessLevel={accessLevel}
-                            enterpriseName={enterpriseName}
-                            hasDescription={false}
-                            itemType={itemType}
-                        />
-                    </MenuToggle>
-                </PlainButton>
+                    <PlainButton
+                        className={classNames('lnk', {
+                            'is-disabled': submitting,
+                        })}
+                        disabled={submitting}
+                        {...sharedLinkAccessMenuButtonProps}
+                    >
+                        <MenuToggle>
+                            <SharedLinkAccessLabel
+                                accessLevel={accessLevel}
+                                enterpriseName={enterpriseName}
+                                hasDescription={false}
+                                itemType={itemType}
+                            />
+                        </MenuToggle>
+                    </PlainButton>
+                </Tooltip>
                 {this.renderMenu()}
             </DropdownMenu>
         );

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -28,6 +28,7 @@ import type {
     inviteePermissionType as InviteePermissions,
     item as ItemType,
     contactType as Contact,
+    tooltipComponentIdentifierType,
     trackingPropsType,
     sharedLinkType,
 } from './flowTypes';
@@ -71,6 +72,8 @@ type Props = {
     item: ItemType,
     /** Handler function that adds the shared link */
     onAddLink: () => void,
+    /** Handler function that gets called whenever the user dismisses a tooltip on the given component identifier */
+    onDismissTooltip?: (componentIdentifier: tooltipComponentIdentifierType) => void,
     /** Handler function that removes the shared link */
     onRemoveLink: () => void,
     /** Handler function for when modal is closed */
@@ -110,6 +113,8 @@ type Props = {
     submitting: boolean,
     /** Data for suggested collaborators shown at bottom of input box. UI doesn't render when this has length of 0. */
     suggestedCollaborators?: Array<Object>,
+    /** Mapping of components to the content that should be rendered in their tooltips */
+    tooltips?: { [componentIdentifier: tooltipComponentIdentifierType]: React.Node },
     /** Object with props and handlers for tracking interactions in unified share modal */
     trackingProps: trackingPropsType,
 };
@@ -619,9 +624,11 @@ class UnifiedShareModal extends React.Component<Props, State> {
             onSettingsClick,
             sharedLink,
             intl,
+            onDismissTooltip = () => {},
             showEnterEmailsCallout = false,
             showSharedLinkSettingsCallout = false,
             submitting,
+            tooltips = {},
             ...rest
         } = this.props;
         const {
@@ -678,6 +685,7 @@ class UnifiedShareModal extends React.Component<Props, State> {
                                 intl={intl}
                                 item={item}
                                 itemType={item.type}
+                                onDismissTooltip={onDismissTooltip}
                                 onEmailSharedLinkClick={this.openEmailSharedLinkForm}
                                 onSettingsClick={onSettingsClick}
                                 onToggleSharedLink={this.onToggleSharedLink}
@@ -685,6 +693,7 @@ class UnifiedShareModal extends React.Component<Props, State> {
                                 showSharedLinkSettingsCallout={showSharedLinkSettingsCallout}
                                 submitting={submitting || isFetching}
                                 trackingProps={sharedLinkTracking}
+                                tooltips={tooltips}
                             />
                         )}
 

--- a/src/features/unified-share-modal/__tests__/SharedLinkAccessMenu-test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkAccessMenu-test.js
@@ -4,6 +4,24 @@ import { ANYONE_WITH_LINK, ANYONE_IN_COMPANY } from '../constants';
 import SharedLinkAccessMenu from '../SharedLinkAccessMenu';
 
 describe('features/unified-share-modal/SharedLinkAccessMenu', () => {
+    const getWrapper = props =>
+        shallow(
+            <SharedLinkAccessMenu
+                accessLevel={ANYONE_IN_COMPANY}
+                changeAccessLevel={() => {}}
+                classificationName="Internal"
+                enterpriseName="Box"
+                isDownloadAllowed
+                isEditAllowed
+                isPreviewAllowed
+                itemType="folder"
+                onDismissTooltip={() => {}}
+                submitting={false}
+                tooltipContent={null}
+                {...props}
+            />,
+        );
+
     describe('render()', () => {
         [
             {
@@ -14,22 +32,14 @@ describe('features/unified-share-modal/SharedLinkAccessMenu', () => {
             },
         ].forEach(({ submitting }) => {
             test('should render correct menu', () => {
-                const sharedLinkAccessMenu = shallow(
-                    <SharedLinkAccessMenu
-                        accessLevel={ANYONE_WITH_LINK}
-                        changeAccessLevel={() => {}}
-                        classificationName="Internal"
-                        enterpriseName="Box"
-                        isDownloadAllowed
-                        isEditAllowed
-                        isPreviewAllowed
-                        itemType="folder"
-                        submitting={submitting}
-                    />,
-                );
-
+                const sharedLinkAccessMenu = getWrapper({ submitting });
                 expect(sharedLinkAccessMenu).toMatchSnapshot();
             });
+        });
+
+        test('should render tooltipContent if provided', () => {
+            const sharedLinkAccessMenu = getWrapper({ tooltipContent: 'Hello, world!' });
+            expect(sharedLinkAccessMenu).toMatchSnapshot();
         });
     });
 
@@ -37,22 +47,12 @@ describe('features/unified-share-modal/SharedLinkAccessMenu', () => {
         test('should call tracking function on menu change if it is set', () => {
             const changeMenuMock = jest.fn();
             const accessLevelSpy = jest.fn();
-            const sharedLinkPermissionMenu = shallow(
-                <SharedLinkAccessMenu
-                    accessLevel={ANYONE_IN_COMPANY}
-                    changeAccessLevel={accessLevelSpy}
-                    classificationName="Internal"
-                    enterpriseName="Box"
-                    isDownloadAllowed
-                    isEditAllowed
-                    isPreviewAllowed
-                    itemType="folder"
-                    submitting={false}
-                    trackingProps={{
-                        onChangeSharedLinkAccessLevel: changeMenuMock,
-                    }}
-                />,
-            );
+            const sharedLinkPermissionMenu = getWrapper({
+                changeAccessLevel: accessLevelSpy,
+                trackingProps: {
+                    onChangeSharedLinkAccessLevel: changeMenuMock,
+                },
+            });
             sharedLinkPermissionMenu.instance().onChangeAccessLevel(ANYONE_WITH_LINK);
 
             expect(changeMenuMock).toBeCalled();
@@ -62,22 +62,12 @@ describe('features/unified-share-modal/SharedLinkAccessMenu', () => {
         test('should not call tracking function on menu change if it is set (when accessLevel is the same value)', () => {
             const changeMenuMock = jest.fn();
             const accessLevelSpy = jest.fn();
-            const sharedLinkPermissionMenu = shallow(
-                <SharedLinkAccessMenu
-                    accessLevel={ANYONE_IN_COMPANY}
-                    changeAccessLevel={accessLevelSpy}
-                    classificationName="Internal"
-                    enterpriseName="Box"
-                    isDownloadAllowed
-                    isEditAllowed
-                    isPreviewAllowed
-                    itemType="folder"
-                    submitting={false}
-                    trackingProps={{
-                        onChangeSharedLinkAccessLevel: changeMenuMock,
-                    }}
-                />,
-            );
+            const sharedLinkPermissionMenu = getWrapper({
+                changeAccessLevel: accessLevelSpy,
+                trackingProps: {
+                    onChangeSharedLinkAccessLevel: changeMenuMock,
+                },
+            });
             sharedLinkPermissionMenu.instance().onChangeAccessLevel(ANYONE_IN_COMPANY);
 
             expect(changeMenuMock).not.toBeCalled();

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection-test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection-test.js
@@ -22,7 +22,9 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
                 intl={intl}
                 item={defaultItem}
                 itemType="file"
+                onDismissTooltip={() => {}}
                 showSharedLinkSettingsCallout
+                tooltips={{}}
                 {...props}
             />,
         );

--- a/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm-test.js.snap
@@ -9,6 +9,7 @@ exports[`features/unified-share-modal/EmailForm render() should not show inline 
     className="tooltip-target"
   >
     <Tooltip
+      className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isShown={true}
@@ -53,6 +54,7 @@ exports[`features/unified-share-modal/EmailForm render() should not show inline 
     className="tooltip-target"
   >
     <Tooltip
+      className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isShown={true}
@@ -102,6 +104,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
     className="tooltip-target"
   >
     <Tooltip
+      className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isShown={true}
@@ -153,6 +156,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className="tooltip-target"
     >
       <Tooltip
+        className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
         isShown={true}
@@ -231,6 +235,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
     className="tooltip-target"
   >
     <Tooltip
+      className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isShown={true}
@@ -308,6 +313,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
     className="tooltip-target"
   >
     <Tooltip
+      className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isShown={true}
@@ -357,6 +363,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
     className="tooltip-target"
   >
     <Tooltip
+      className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isShown={true}
@@ -439,6 +446,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
     className="tooltip-target"
   >
     <Tooltip
+      className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isShown={true}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu-test.js.snap
@@ -6,19 +6,31 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
   constrainToWindow={false}
   isRightAligned={false}
 >
-  <PlainButton
-    className="lnk is-disabled"
-    disabled={true}
+  <Tooltip
+    className="usm-ftux-tooltip"
+    constrainToScrollParent={false}
+    constrainToWindow={true}
+    isShown={false}
+    onDismiss={[Function]}
+    position="bottom-center"
+    showCloseButton={true}
+    text={null}
+    theme="callout"
   >
-    <MenuToggle>
-      <SharedLinkAccessLabel
-        accessLevel="peopleWithTheLink"
-        enterpriseName="Box"
-        hasDescription={false}
-        itemType="folder"
-      />
-    </MenuToggle>
-  </PlainButton>
+    <PlainButton
+      className="lnk is-disabled"
+      disabled={true}
+    >
+      <MenuToggle>
+        <SharedLinkAccessLabel
+          accessLevel="peopleInYourCompany"
+          enterpriseName="Box"
+          hasDescription={false}
+          itemType="folder"
+        />
+      </MenuToggle>
+    </PlainButton>
+  </Tooltip>
   <Menu
     className="usm-share-access-menu"
     isHidden={false}
@@ -44,7 +56,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
     >
       <SelectMenuItem
         isDisabled={true}
-        isSelected={true}
+        isSelected={false}
         key="peopleWithTheLink"
         onClick={[Function]}
       >
@@ -76,7 +88,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
     >
       <SelectMenuItem
         isDisabled={true}
-        isSelected={false}
+        isSelected={true}
         key="peopleInYourCompany"
         onClick={[Function]}
       >
@@ -130,19 +142,31 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
   constrainToWindow={false}
   isRightAligned={false}
 >
-  <PlainButton
-    className="lnk"
-    disabled={false}
+  <Tooltip
+    className="usm-ftux-tooltip"
+    constrainToScrollParent={false}
+    constrainToWindow={true}
+    isShown={false}
+    onDismiss={[Function]}
+    position="bottom-center"
+    showCloseButton={true}
+    text={null}
+    theme="callout"
   >
-    <MenuToggle>
-      <SharedLinkAccessLabel
-        accessLevel="peopleWithTheLink"
-        enterpriseName="Box"
-        hasDescription={false}
-        itemType="folder"
-      />
-    </MenuToggle>
-  </PlainButton>
+    <PlainButton
+      className="lnk"
+      disabled={false}
+    >
+      <MenuToggle>
+        <SharedLinkAccessLabel
+          accessLevel="peopleInYourCompany"
+          enterpriseName="Box"
+          hasDescription={false}
+          itemType="folder"
+        />
+      </MenuToggle>
+    </PlainButton>
+  </Tooltip>
   <Menu
     className="usm-share-access-menu"
     isHidden={false}
@@ -168,7 +192,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
     >
       <SelectMenuItem
         isDisabled={true}
-        isSelected={true}
+        isSelected={false}
         key="peopleWithTheLink"
         onClick={[Function]}
       >
@@ -200,7 +224,143 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
     >
       <SelectMenuItem
         isDisabled={true}
+        isSelected={true}
+        key="peopleInYourCompany"
+        onClick={[Function]}
+      >
+        <SharedLinkAccessLabel
+          accessLevel="peopleInYourCompany"
+          enterpriseName="Box"
+          hasDescription={true}
+          itemType="folder"
+        />
+      </SelectMenuItem>
+    </Tooltip>
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      key="tooltip-peopleInThisItem"
+      position="top-center"
+      text={
+        <FormattedMessage
+          defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+          id="boxui.unifiedShare.disabledShareLinkPermission"
+          values={
+            Object {
+              "classification": "Internal",
+            }
+          }
+        />
+      }
+      theme="default"
+    >
+      <SelectMenuItem
+        isDisabled={true}
         isSelected={false}
+        key="peopleInThisItem"
+        onClick={[Function]}
+      >
+        <SharedLinkAccessLabel
+          accessLevel="peopleInThisItem"
+          enterpriseName="Box"
+          hasDescription={true}
+          itemType="folder"
+        />
+      </SelectMenuItem>
+    </Tooltip>
+  </Menu>
+</DropdownMenu>
+`;
+
+exports[`features/unified-share-modal/SharedLinkAccessMenu render() should render tooltipContent if provided 1`] = `
+<DropdownMenu
+  constrainToScrollParent={false}
+  constrainToWindow={false}
+  isRightAligned={false}
+>
+  <Tooltip
+    className="usm-ftux-tooltip"
+    constrainToScrollParent={false}
+    constrainToWindow={true}
+    isShown={true}
+    onDismiss={[Function]}
+    position="bottom-center"
+    showCloseButton={true}
+    text="Hello, world!"
+    theme="callout"
+  >
+    <PlainButton
+      className="lnk"
+      disabled={false}
+    >
+      <MenuToggle>
+        <SharedLinkAccessLabel
+          accessLevel="peopleInYourCompany"
+          enterpriseName="Box"
+          hasDescription={false}
+          itemType="folder"
+        />
+      </MenuToggle>
+    </PlainButton>
+  </Tooltip>
+  <Menu
+    className="usm-share-access-menu"
+    isHidden={false}
+    isSubmenu={false}
+  >
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      key="tooltip-peopleWithTheLink"
+      position="top-center"
+      text={
+        <FormattedMessage
+          defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+          id="boxui.unifiedShare.disabledShareLinkPermission"
+          values={
+            Object {
+              "classification": "Internal",
+            }
+          }
+        />
+      }
+      theme="default"
+    >
+      <SelectMenuItem
+        isDisabled={true}
+        isSelected={false}
+        key="peopleWithTheLink"
+        onClick={[Function]}
+      >
+        <SharedLinkAccessLabel
+          accessLevel="peopleWithTheLink"
+          enterpriseName="Box"
+          hasDescription={true}
+          itemType="folder"
+        />
+      </SelectMenuItem>
+    </Tooltip>
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      key="tooltip-peopleInYourCompany"
+      position="top-center"
+      text={
+        <FormattedMessage
+          defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+          id="boxui.unifiedShare.disabledShareLinkPermission"
+          values={
+            Object {
+              "classification": "Internal",
+            }
+          }
+        />
+      }
+      theme="default"
+    >
+      <SelectMenuItem
+        isDisabled={true}
+        isSelected={true}
         key="peopleInYourCompany"
         onClick={[Function]}
       >

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection-test.js.snap
@@ -62,29 +62,40 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
   <div
     className="shared-link-field-row"
   >
-    <TextInputWithCopyButton
-      autofocus={false}
-      buttonDefaultText={
-        <FormattedMessage
-          defaultMessage="Copy"
-          id="boxui.core.copy"
-        />
-      }
-      buttonProps={Object {}}
-      buttonSuccessText={
-        <FormattedMessage
-          defaultMessage="Copied"
-          id="boxui.core.copied"
-        />
-      }
-      className="shared-link-field-container"
-      hideOptionalLabel={true}
-      label=""
-      readOnly={true}
-      successStateDuration={3000}
-      type="url"
-      value="https://example.com/shared-link"
-    />
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
@@ -114,6 +125,8 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
       changeAccessLevel={[Function]}
       enterpriseName="Box"
       itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
       trackingProps={
         Object {
           "onChangeSharedLinkAccessLevel": undefined,
@@ -188,29 +201,40 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
   <div
     className="shared-link-field-row"
   >
-    <TextInputWithCopyButton
-      autofocus={false}
-      buttonDefaultText={
-        <FormattedMessage
-          defaultMessage="Copy"
-          id="boxui.core.copy"
-        />
-      }
-      buttonProps={Object {}}
-      buttonSuccessText={
-        <FormattedMessage
-          defaultMessage="Copied"
-          id="boxui.core.copied"
-        />
-      }
-      className="shared-link-field-container"
-      hideOptionalLabel={true}
-      label=""
-      readOnly={true}
-      successStateDuration={3000}
-      type="url"
-      value="https://example.com/shared-link"
-    />
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
@@ -240,6 +264,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
       changeAccessLevel={[Function]}
       enterpriseName="Box"
       itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
       trackingProps={
         Object {
           "onChangeSharedLinkAccessLevel": undefined,
@@ -345,29 +371,40 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
   <div
     className="shared-link-field-row"
   >
-    <TextInputWithCopyButton
-      autofocus={false}
-      buttonDefaultText={
-        <FormattedMessage
-          defaultMessage="Copy"
-          id="boxui.core.copy"
-        />
-      }
-      buttonProps={Object {}}
-      buttonSuccessText={
-        <FormattedMessage
-          defaultMessage="Copied"
-          id="boxui.core.copied"
-        />
-      }
-      className="shared-link-field-container"
-      hideOptionalLabel={true}
-      label=""
-      readOnly={true}
-      successStateDuration={3000}
-      type="url"
-      value="https://example.com/shared-link"
-    />
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
@@ -397,6 +434,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       changeAccessLevel={[Function]}
       enterpriseName="Box"
       itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
       trackingProps={
         Object {
           "onChangeSharedLinkAccessLevel": undefined,
@@ -506,29 +545,40 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
   <div
     className="shared-link-field-row"
   >
-    <TextInputWithCopyButton
-      autofocus={false}
-      buttonDefaultText={
-        <FormattedMessage
-          defaultMessage="Copy"
-          id="boxui.core.copy"
-        />
-      }
-      buttonProps={Object {}}
-      buttonSuccessText={
-        <FormattedMessage
-          defaultMessage="Copied"
-          id="boxui.core.copied"
-        />
-      }
-      className="shared-link-field-container"
-      hideOptionalLabel={true}
-      label=""
-      readOnly={true}
-      successStateDuration={3000}
-      type="url"
-      value="http://example.com/s/abc"
-    />
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="http://example.com/s/abc"
+      />
+    </Tooltip>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
@@ -556,6 +606,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
       trackingProps={
         Object {
           "onChangeSharedLinkAccessLevel": undefined,
@@ -624,29 +676,40 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <div
     className="shared-link-field-row"
   >
-    <TextInputWithCopyButton
-      autofocus={false}
-      buttonDefaultText={
-        <FormattedMessage
-          defaultMessage="Copy"
-          id="boxui.core.copy"
-        />
-      }
-      buttonProps={Object {}}
-      buttonSuccessText={
-        <FormattedMessage
-          defaultMessage="Copied"
-          id="boxui.core.copied"
-        />
-      }
-      className="shared-link-field-container"
-      hideOptionalLabel={true}
-      label=""
-      readOnly={true}
-      successStateDuration={3000}
-      type="url"
-      value="https://example.com/shared-link"
-    />
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
@@ -676,6 +739,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       changeAccessLevel={[Function]}
       enterpriseName="Box"
       itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
       trackingProps={
         Object {
           "onChangeSharedLinkAccessLevel": undefined,
@@ -738,29 +803,40 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <div
     className="shared-link-field-row"
   >
-    <TextInputWithCopyButton
-      autofocus={false}
-      buttonDefaultText={
-        <FormattedMessage
-          defaultMessage="Copy"
-          id="boxui.core.copy"
-        />
-      }
-      buttonProps={Object {}}
-      buttonSuccessText={
-        <FormattedMessage
-          defaultMessage="Copied"
-          id="boxui.core.copied"
-        />
-      }
-      className="shared-link-field-container"
-      hideOptionalLabel={true}
-      label=""
-      readOnly={true}
-      successStateDuration={3000}
-      type="url"
-      value="https://example.com/shared-link"
-    />
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
@@ -790,6 +866,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       changeAccessLevel={[Function]}
       enterpriseName="Box"
       itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
       trackingProps={
         Object {
           "onChangeSharedLinkAccessLevel": undefined,
@@ -877,29 +955,40 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
   <div
     className="shared-link-field-row"
   >
-    <TextInputWithCopyButton
-      autofocus={false}
-      buttonDefaultText={
-        <FormattedMessage
-          defaultMessage="Copy"
-          id="boxui.core.copy"
-        />
-      }
-      buttonProps={Object {}}
-      buttonSuccessText={
-        <FormattedMessage
-          defaultMessage="Copied"
-          id="boxui.core.copied"
-        />
-      }
-      className="shared-link-field-container"
-      hideOptionalLabel={true}
-      label=""
-      readOnly={true}
-      successStateDuration={3000}
-      type="url"
-      value="https://example.com/shared-link"
-    />
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
@@ -929,6 +1018,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
       changeAccessLevel={[Function]}
       enterpriseName="Box"
       itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
       trackingProps={
         Object {
           "onChangeSharedLinkAccessLevel": undefined,

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal-test.js.snap
@@ -159,11 +159,13 @@ exports[`features/unified-share-modal/UnifiedShareModal closeEmailSharedLinkForm
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={false}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -386,11 +388,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={true}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -558,11 +562,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={true}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -730,6 +736,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={
@@ -739,6 +746,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         }
         showSharedLinkSettingsCallout={false}
         submitting={true}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={true}
       />
@@ -906,11 +914,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={true}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -1078,11 +1088,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={true}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -1396,11 +1408,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="web_link"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={false}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -1569,11 +1583,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="folder"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={true}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -1742,11 +1758,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={false}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -2124,11 +2142,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={false}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -2300,6 +2320,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={
@@ -2309,6 +2330,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         }
         showSharedLinkSettingsCallout={false}
         submitting={true}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={true}
       />
@@ -2476,11 +2498,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={false}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />
@@ -2647,11 +2671,13 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           }
         }
         itemType="file"
+        onDismissTooltip={[Function]}
         onEmailSharedLinkClick={[Function]}
         onToggleSharedLink={[Function]}
         sharedLink={Object {}}
         showSharedLinkSettingsCallout={false}
         submitting={false}
+        tooltips={Object {}}
         trackingProps={Object {}}
         triggerCopyOnLoad={false}
       />

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -140,3 +140,9 @@ export type collaboratorType = {
 export type collaboratorsListType = {
     collaborators: Array<collaboratorType>,
 };
+
+export type tooltipComponentIdentifierType =
+    | 'shared-link-access-menu'
+    | 'shared-link-copy-button'
+    | 'shared-link-settings'
+    | 'shared-link-toggle';


### PR DESCRIPTION
### `shared-link-toggle`
<img width="537" alt="Screen Shot 2019-03-19 at 4 07 40 PM" src="https://user-images.githubusercontent.com/12469495/54647879-7236fc00-4a61-11e9-8251-f79df67fd0ca.png">

### `shared-link-access-menu`
<img width="535" alt="Screen Shot 2019-03-19 at 4 06 36 PM" src="https://user-images.githubusercontent.com/12469495/54647889-7d8a2780-4a61-11e9-8396-853eec3c132a.png">

### `shared-link-settings`
<img width="600" alt="Screen Shot 2019-03-19 at 4 07 25 PM" src="https://user-images.githubusercontent.com/12469495/54647913-8ed33400-4a61-11e9-96e7-95acec2e3443.png">

### `shared-link-copy-button`
<img width="583" alt="Screen Shot 2019-03-19 at 4 07 00 PM" src="https://user-images.githubusercontent.com/12469495/54647930-9c88b980-4a61-11e9-8260-f1ab409f69f9.png">

### Multiple at once
<img width="630" alt="Screen Shot 2019-03-19 at 4 08 11 PM" src="https://user-images.githubusercontent.com/12469495/54647942-a3afc780-4a61-11e9-9e9b-bc7d4036b6ec.png">
