### PR TITLE
fix(unified-share-modal): reduce default text box height

### DIFF
--- a/src/features/unified-share-modal/EmailForm.js
+++ b/src/features/unified-share-modal/EmailForm.js
@@ -289,7 +289,7 @@ class EmailForm extends React.Component<Props, State> {
                         label={<FormattedMessage {...messages.messageTitle} />}
                         onChange={this.handleMessageChange}
                         placeholder={intl.formatMessage(commonMessages.messageSelectorPlaceholder)}
-                        rows={4}
+                        rows={3}
                         value={message}
                         {...messageProps}
                     />

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -113,12 +113,15 @@
         .text-area-container textarea::placeholder {
             color: $nines;
         }
+
+        .pill-selector-input-wrapper {
+            min-height: 68px;
+        }
     }
 
     .pill-selector-input-wrapper {
         border: 1px solid $seesee;
         margin-top: 10px;
-        min-height: $bdl-line-height * 4;
 
         .pill-selector-input::placeholder {
             color: $nines;

--- a/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm-test.js.snap
@@ -194,7 +194,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
-    rows={4}
+    rows={3}
     value=""
   />
   <ModalActions>
@@ -271,7 +271,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
-    rows={4}
+    rows={3}
     value=""
   />
   <ModalActions>
@@ -397,7 +397,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
-    rows={4}
+    rows={3}
     value=""
   />
   <ModalActions>
@@ -479,7 +479,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
-    rows={4}
+    rows={3}
     value=""
   />
   <ModalActions>


### PR DESCRIPTION
Reverting back to original sizes because the extra height is no longer necessary. This will also help USM to better support smaller screen sizes. 

![image](https://user-images.githubusercontent.com/9208519/54710316-a283a680-4b04-11e9-9fb1-dd8ae88843ad.png)


![image](https://user-images.githubusercontent.com/9208519/54710281-8e3fa980-4b04-11e9-9e35-f33fe512b96d.png)
