### PR TITLE
Modifier dropdown gets closed datepicker

### DIFF
--- a/src/features/query-bar/__tests__/__snapshots__/FilterButton-test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/FilterButton-test.js.snap
@@ -15,7 +15,11 @@ exports[`feature/query-bar/components/filter/FilterButton render should disable 
   openOnHover={false}
   openOnHoverDelayTimeout={300}
   overlayIsVisible={false}
-  portaledClasses={Array []}
+  portaledClasses={
+    Array [
+      "pika-single",
+    ]
+  }
   position="bottom-right"
   shouldDefaultFocus={true}
 >
@@ -60,7 +64,11 @@ exports[`feature/query-bar/components/filter/FilterButton render should enable F
   openOnHover={false}
   openOnHoverDelayTimeout={300}
   overlayIsVisible={false}
-  portaledClasses={Array []}
+  portaledClasses={
+    Array [
+      "pika-single",
+    ]
+  }
   position="bottom-right"
   shouldDefaultFocus={true}
 >

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -264,6 +264,7 @@ class FilterButton extends React.Component<Props, State> {
                 onClose={this.onClose}
                 onOpen={this.onOpen}
                 overlayIsVisible={isMenuOpen}
+                portaledClasses={['pika-single']} /* Element in DatePicker package  */
                 position="bottom-right"
                 shouldDefaultFocus
             >


### PR DESCRIPTION
Changes in this PR:
- Pass portaledClasses so that clicking on the Month/Day button will no longer close the entire Flyout