### PR TITLE
Smart Views columns should stretch to fill the container width

### DIFF
--- a/src/features/list-view/ListView.js
+++ b/src/features/list-view/ListView.js
@@ -4,10 +4,10 @@ import classNames from 'classnames';
 import noop from 'lodash/noop';
 
 import { MultiGrid } from 'react-virtualized/dist/commonjs/MultiGrid/index';
-import { FIXED_ROW_COUNT, ROW_HEIGHT } from './constants';
 import { SORT_ORDER_ASCENDING, SORT_ORDER_DESCENDING } from '../query-bar/constants';
 import IconSortChevron from '../../icons/general/IconSortChevron';
 
+import { DEFAULT_COLUMN_WIDTH, FIXED_ROW_COUNT, ROW_HEIGHT } from './constants';
 import type { CellRendererArgs, ComputeColumnWidthArgs } from './flowTypes';
 
 import './styles/ListView.scss';
@@ -26,8 +26,6 @@ type Props = {
     rowCount: number,
     width: number,
 };
-
-export const DEFAULT_COLUMN_WIDTH = 300;
 
 class ListView extends React.PureComponent<Props> {
     cellRenderer = ({ columnIndex, key, rowIndex, style }: CellRendererArgs) => {

--- a/src/features/list-view/ListView.js
+++ b/src/features/list-view/ListView.js
@@ -8,6 +8,8 @@ import { FIXED_ROW_COUNT, ROW_HEIGHT } from './constants';
 import { SORT_ORDER_ASCENDING, SORT_ORDER_DESCENDING } from '../query-bar/constants';
 import IconSortChevron from '../../icons/general/IconSortChevron';
 
+import type { CellRendererArgs, ComputeColumnWidthArgs } from './flowTypes';
+
 import './styles/ListView.scss';
 
 type Props = {
@@ -24,17 +26,6 @@ type Props = {
     rowCount: number,
     width: number,
 };
-
-type CellRendererArgs = {|
-    columnIndex: number,
-    key: string,
-    rowIndex: number,
-    style: Object,
-|};
-
-type ComputeColumnWidthArgs = {|
-    index: number,
-|};
 
 export const DEFAULT_COLUMN_WIDTH = 300;
 

--- a/src/features/list-view/README.md
+++ b/src/features/list-view/README.md
@@ -1,5 +1,5 @@
 
-**Skeleton Item List**
+**Skeleton List View**
 ```js
 const SkeletonItemListExample = require('./examples').SkeletonItemListExample;
 
@@ -8,12 +8,20 @@ const SkeletonItemListExample = require('./examples').SkeletonItemListExample;
 </div>
 ```
 
-**Metadata Item List**
+**Metadata List View**
 ```js
 const ListViewExamples = require('./examples').ListViewExamples;
 
 <div>
-    <ListViewExamples />
+    <ListViewExamples columnCount={1000} />
 </div>
 ```
 
+**Metadata List View (stretched columns)**
+```js
+const ListViewExamples = require('./examples').ListViewExamples;
+
+<div>
+    <ListViewExamples columnCount={3} />
+</div>
+```

--- a/src/features/list-view/__tests__/ListView-test.js
+++ b/src/features/list-view/__tests__/ListView-test.js
@@ -1,17 +1,18 @@
 // @flow
 import * as React from 'react';
 
-import ListView from '../ListView';
+import ListView, { DEFAULT_COLUMN_WIDTH } from '../ListView';
 import { SORT_ORDER_ASCENDING } from '../../query-bar/constants';
 // Global Declarations
 
-const rowData = [['A', 'B', 'C'], ['D', 'E', 'F']];
+// Define a matrix with 2 columns and 3 rows.
+const gridData = [['A', 'B', 'C'], ['D', 'E', 'F']];
 
 const getGridHeader = columnIndex => ['h1', 'h2'][columnIndex];
 
 const getGridHeaderSort = columnIndex => [SORT_ORDER_ASCENDING, null][columnIndex];
 
-const getGridCell = ({ columnIndex, rowIndex }) => rowData[columnIndex][rowIndex];
+const getGridCell = ({ columnIndex, rowIndex }) => gridData[columnIndex][rowIndex];
 
 describe('features/list-view/ListView', () => {
     const getWrapper = props => {
@@ -75,7 +76,55 @@ describe('features/list-view/ListView', () => {
         });
     });
 
-    describe('getColumnWidth()', () => {
+    describe('computeColumnWidth()', () => {
+        describe('when props.getColumnWidth is included', () => {
+            test('should delegate to props.getColumnWidth', () => {
+                const getColumnWidth = columnIndex => [150, 250][columnIndex];
+
+                const wrapper = getWrapper({
+                    getColumnWidth,
+                    width: 100,
+                });
+
+                expect(wrapper.instance().computeColumnWidth({ index: 0 })).toBe(150);
+                expect(wrapper.instance().computeColumnWidth({ index: 1 })).toBe(250);
+            });
+
+            test('should ignore props.getColumnWidth and stretch column widths', () => {
+                const getColumnWidth = columnIndex => [150, 250][columnIndex];
+
+                const wrapper = getWrapper({
+                    getColumnWidth,
+                    width: 1000,
+                });
+
+                expect(wrapper.instance().computeColumnWidth({ index: 0 })).toBe(150);
+                expect(wrapper.instance().computeColumnWidth({ index: 1 })).toBe(1000 - 150);
+            });
+        });
+
+        describe('when props.getColumnWidth is excluded', () => {
+            test('should return default column width', () => {
+                const wrapper = getWrapper({
+                    width: 100,
+                });
+
+                expect(wrapper.instance().computeColumnWidth({ index: 0 })).toBe(DEFAULT_COLUMN_WIDTH);
+                expect(wrapper.instance().computeColumnWidth({ index: 1 })).toBe(DEFAULT_COLUMN_WIDTH);
+            });
+
+            test('should stretch column widths', () => {
+                const wrapper = getWrapper({
+                    width: 1000,
+                });
+
+                expect(wrapper.instance().computeColumnWidth({ index: 0 })).toBe(DEFAULT_COLUMN_WIDTH);
+                expect(wrapper.instance().computeColumnWidth({ index: 1 })).toBe(1000 - DEFAULT_COLUMN_WIDTH);
+            });
+        });
+    });
+
+    describe('props.getColumnWidth()', () => {
         const getColumnWidth = columnIndex => [100, 500][columnIndex];
 
         const wrapper = getWrapper({ getColumnWidth });

--- a/src/features/list-view/__tests__/ListView-test.js
+++ b/src/features/list-view/__tests__/ListView-test.js
@@ -1,7 +1,8 @@
 // @flow
 import * as React from 'react';
 
-import ListView, { DEFAULT_COLUMN_WIDTH } from '../ListView';
+import ListView from '../ListView';
+import { DEFAULT_COLUMN_WIDTH } from '../constants';
 import { SORT_ORDER_ASCENDING } from '../../query-bar/constants';
 // Global Declarations
 

--- a/src/features/list-view/constants.js
+++ b/src/features/list-view/constants.js
@@ -1,9 +1,8 @@
-const ROW_HEIGHT = 50;
-const FIXED_ROW_COUNT = 1;
+export const ROW_HEIGHT = 50;
+export const FIXED_ROW_COUNT = 1;
+export const DEFAULT_COLUMN_WIDTH = 300;
 
-const NEED_REFINING = 'needRefining';
-const TOO_MANY_RESULTS = 'tooManyResults';
-const NO_ACCESS_FOR_QUERY = 'noAccessForQuery';
-const NO_ACCESS_FOR_TEMPLATE = 'noAccessForTemplate';
-
-export { FIXED_ROW_COUNT, ROW_HEIGHT, NEED_REFINING, TOO_MANY_RESULTS, NO_ACCESS_FOR_QUERY, NO_ACCESS_FOR_TEMPLATE };
+export const NEED_REFINING = 'needRefining';
+export const TOO_MANY_RESULTS = 'tooManyResults';
+export const NO_ACCESS_FOR_QUERY = 'noAccessForQuery';
+export const NO_ACCESS_FOR_TEMPLATE = 'noAccessForTemplate';

--- a/src/features/list-view/examples/ListViewExamples.js
+++ b/src/features/list-view/examples/ListViewExamples.js
@@ -5,19 +5,23 @@ import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer/index';
 
 import ListView from '../ListView';
 
+type Props = {
+    columnCount: number,
+};
+
 const generateRandomString = value => String.fromCharCode((value % 65) + 65);
 
 const getGridHeader = columnIndex => `Header ${generateRandomString(columnIndex)}`;
 
 const getGridCell = ({ columnIndex, rowIndex }) => `Row ${rowIndex}, Column ${columnIndex}`;
 
-const ListViewExamples = () => {
+const ListViewExamples = ({ columnCount }: Props) => {
     return (
         <div style={{ height: '300px' }}>
             <AutoSizer>
                 {({ height, width }) => (
                     <ListView
-                        columnCount={1000}
+                        columnCount={columnCount}
                         height={height}
                         getGridCell={getGridCell}
                         getGridHeader={getGridHeader}

--- a/src/features/list-view/flowTypes.js
+++ b/src/features/list-view/flowTypes.js
@@ -1,0 +1,12 @@
+// @flow
+
+export type CellRendererArgs = {|
+    columnIndex: number,
+    key: string,
+    rowIndex: number,
+    style: Object,
+|};
+
+export type ComputeColumnWidthArgs = {|
+    index: number,
+|};


### PR DESCRIPTION
Before the fix, the List View displays empty whitespace to the right of the right-most column. 

With the fix...
<img width="1433" alt="Screen Shot 2019-03-28 at 2 11 31 PM" src="https://user-images.githubusercontent.com/380408/55199792-7ad1b580-5178-11e9-8816-105122435891.png">
