### PR TITLE
chore(accessibility): Increase the contrast of modal close button to 3:1

### DIFF
--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -72,7 +72,7 @@ class ModalDialog extends React.Component<Props> {
                 className="modal-close-button"
                 onClick={this.onCloseButtonClick}
             >
-                <IconClose color="#999EA4" height={18} width={18} />
+                <IconClose color="#909090" height={18} width={18} />
             </button>
         );
     }


### PR DESCRIPTION
Increases the contrast ratio of the icon to >3:1 which is the WCAG AA standard for non-text UI.