### PR TITLE
fix(tasks): correct task type enum

### DIFF
--- a/conf/jest/enzyme-adapter.js
+++ b/conf/jest/enzyme-adapter.js
@@ -13,4 +13,6 @@ global.shallow = shallow;
 global.mount = mount;
 
 // testing utility functions
-global.queryAllByTestId = (wrapper, testid) => wrapper.find(`[data-testid="${testid}"]`).hostNodes();
+
+// accepts a Cheerio jQuery-style wrapper or Enzyme mount wrapper
+global.queryAllByTestId = (wrapper, testid) => wrapper.find(`[data-testid="${testid}"]`);

--- a/conf/jest/enzyme-adapter.js
+++ b/conf/jest/enzyme-adapter.js
@@ -11,3 +11,6 @@ Enzyme.configure({ adapter: new Adapter() });
 // make Enzyme functions available in all test files without importing
 global.shallow = shallow;
 global.mount = mount;
+
+// testing utility functions
+global.queryAllByTestId = (wrapper, testid) => wrapper.find(`[data-testid="${testid}"]`).hostNodes();

--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -702,7 +702,7 @@ type MarkerPaginatedCollection<T> = {
 // See https://github.com/facebook/flow/issues/7574
 // This is currently *not* enforcing the constant types
 // type TaskType = typeof TASK_TYPE_GENERAL | typeof TASK_TYPE_APPROVAL;
-type TaskType = 'general' | 'approval';
+type TaskType = 'GENERAL' | 'APPROVAL';
 
 type TaskNew = {|
     assigned_to: MarkerPaginatedCollection<TaskCollabAssignee>,
@@ -724,7 +724,7 @@ type TaskNew = {|
     progress_at?: ?ISODate,
     status: TaskStatus,
     task_links: MarkerPaginatedCollection<TaskLink>,
-    task_type?: TaskType,
+    task_type: TaskType,
     type: 'task',
 |};
 

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -748,6 +748,7 @@ class Feed extends Base {
                 limit: 1,
                 next_marker: null,
             },
+            task_type: 'GENERAL',
             status: TASK_NEW_INCOMPLETE,
         };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -351,8 +351,8 @@ export const TASK_NEW_INCOMPLETE: 'NOT_STARTED' = 'NOT_STARTED';
 export const TASK_NEW_REJECTED: 'REJECTED' = 'REJECTED';
 
 /* ------------------ New Task types ----------------- */
-export const TASK_TYPE_GENERAL: 'general' = 'general';
-export const TASK_TYPE_APPROVAL: 'approval' = 'approval';
+export const TASK_TYPE_GENERAL: 'GENERAL' = 'GENERAL';
+export const TASK_TYPE_APPROVAL: 'APPROVAL' = 'APPROVAL';
 
 /* ------------------ Keyboard Events ----------------- */
 export const KEYS = {

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskActions.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskActions.js
@@ -5,21 +5,23 @@ import { FormattedMessage } from 'react-intl';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 import messages from '../../../common/messages';
 import Button from '../../../../components/button';
-import { TASK_TYPE_APPROVAL } from '../../../../constants';
+import { TASK_TYPE_APPROVAL, TASK_TYPE_GENERAL } from '../../../../constants';
 
 type Props = {|
     onTaskApproval: Function,
     onTaskComplete: Function,
     onTaskReject: Function,
-    taskType?: TaskType,
+    taskType: TaskType,
 |};
 
-const TaskActions = ({ onTaskApproval, onTaskReject, onTaskComplete, taskType }: Props): React.Node => (
-    <div className="bcs-task-pending-assignment bcs-task-assignment-actions">
-        {taskType === TASK_TYPE_APPROVAL ? (
+const TaskActions = ({ onTaskApproval, onTaskReject, onTaskComplete, taskType }: Props): React.Node => {
+    let action = null;
+    if (taskType === TASK_TYPE_APPROVAL) {
+        action = (
             <React.Fragment>
                 <Button
                     className="bcs-task-action-button bcs-task-check-btn"
+                    data-testid="approve-task"
                     onClick={onTaskApproval}
                     data-resin-target={ACTIVITY_TARGETS.TASK_APPROVE}
                 >
@@ -27,22 +29,27 @@ const TaskActions = ({ onTaskApproval, onTaskReject, onTaskComplete, taskType }:
                 </Button>
                 <Button
                     className="bcs-task-action-button bcs-task-x-btn"
+                    data-testid="reject-task"
                     onClick={onTaskReject}
                     data-resin-target={ACTIVITY_TARGETS.TASK_REJECT}
                 >
                     <FormattedMessage {...messages.tasksFeedRejectAction} />
                 </Button>
             </React.Fragment>
-        ) : (
+        );
+    } else if (taskType === TASK_TYPE_GENERAL) {
+        action = (
             <Button
                 className="bcs-task-action-button bcs-task-check-btn"
+                data-testid="complete-task"
                 onClick={onTaskComplete}
                 data-resin-target={ACTIVITY_TARGETS.TASK_COMPLETE}
             >
                 <FormattedMessage {...messages.tasksFeedCompleteAction} />
             </Button>
-        )}
-    </div>
-);
+        );
+    }
+    return <div className="bcs-task-pending-assignment bcs-task-assignment-actions">{action}</div>;
+};
 
 export default TaskActions;

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task-test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task-test.js
@@ -173,13 +173,13 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
     });
 
     test('should show actions for task type', () => {
-        const approvalTask = mount(<Task {...task} task_type="APPROVAL" currentUser={currentUser} />);
+        const approvalTask = mount(<Task {...task} task_type="APPROVAL" currentUser={currentUser} />).render();
         const approvalBtns = global.queryAllByTestId(approvalTask, 'approve-task');
         const rejectBtns = global.queryAllByTestId(approvalTask, 'reject-task');
         expect(approvalBtns).toHaveLength(1);
         expect(rejectBtns).toHaveLength(1);
 
-        const generalTask = mount(<Task {...task} task_type="GENERAL" currentUser={currentUser} />);
+        const generalTask = mount(<Task {...task} task_type="GENERAL" currentUser={currentUser} />).render();
         const completeBtns = global.queryAllByTestId(generalTask, 'complete-task');
         expect(completeBtns).toHaveLength(1);
     });

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task-test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task-test.js
@@ -67,6 +67,7 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
             limit: 1000,
             next_marker: null,
         },
+        task_type: 'GENERAL',
         type: 'task',
     };
 
@@ -169,6 +170,18 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
         );
 
         expect(wrapper.find('TaskActions')).toHaveLength(0);
+    });
+
+    test('should show actions for task type', () => {
+        const approvalTask = mount(<Task {...task} task_type="APPROVAL" currentUser={currentUser} />);
+        const approvalBtns = global.queryAllByTestId(approvalTask, 'approve-task');
+        const rejectBtns = global.queryAllByTestId(approvalTask, 'reject-task');
+        expect(approvalBtns).toHaveLength(1);
+        expect(rejectBtns).toHaveLength(1);
+
+        const generalTask = mount(<Task {...task} task_type="GENERAL" currentUser={currentUser} />);
+        const completeBtns = global.queryAllByTestId(generalTask, 'complete-task');
+        expect(completeBtns).toHaveLength(1);
     });
 
     test('should call onAssignmentUpdate with completed status when task action complete is clicked', () => {

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
@@ -76,6 +76,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
       onTaskApproval={[Function]}
       onTaskComplete={[Function]}
       onTaskReject={[Function]}
+      taskType="GENERAL"
     />
   </div>
 </div>
@@ -163,6 +164,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should show assignm
       "next_marker": null,
     }
   }
+  task_type="GENERAL"
   type="task"
 >
   <div
@@ -395,6 +397,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should show assignm
         onTaskApproval={[Function]}
         onTaskComplete={[Function]}
         onTaskReject={[Function]}
+        taskType="GENERAL"
       >
         <div
           className="bcs-task-pending-assignment bcs-task-assignment-actions"
@@ -402,11 +405,13 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should show assignm
           <Button
             className="bcs-task-action-button bcs-task-check-btn"
             data-resin-target="activityfeed-taskcomplete"
+            data-testid="complete-task"
             onClick={[Function]}
           >
             <button
               className="btn bcs-task-action-button bcs-task-check-btn"
               data-resin-target="activityfeed-taskcomplete"
+              data-testid="complete-task"
               onClick={[Function]}
               type="submit"
             >


### PR DESCRIPTION
- Fixes the task API to use the new enum format for task_types
- Removes the possibility to "fall through" to general task since the field is non-nullable and the update PUT payload must match the task type