### PR TITLE
fix(details-sidebar): classification for collaborators

### DIFF
--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -926,8 +926,9 @@ type ErrorContextProps = {
 type ElementsErrorCallback = (e: ElementsXhrError, code: string, contextInfo?: Object) => void;
 
 type ClassificationInfo = {
-    Box__Security__Classification__Key?: string,
-} & MetadataInstance;
+    description: ?string,
+    type: ?string,
+};
 
 type MetricType =
     | typeof METRIC_TYPE_PREVIEW

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -10,7 +10,6 @@ import { getBadItemError, getBadPermissionsError, isUserCorrectableError } from 
 import { getTypedFileId } from '../utils/file';
 import File from './File';
 import {
-    ERROR_CODE_FETCH_CLASSIFICATION,
     HEADER_CONTENT_TYPE,
     METADATA_SCOPE_ENTERPRISE,
     METADATA_SCOPE_GLOBAL,
@@ -502,62 +501,6 @@ class Metadata extends File {
                 this.merge(this.getCacheKey(id), FIELD_METADATA_SKILLS, metadata.data);
                 this.getCache().set(this.getSkillsCacheKey(id), cards);
                 this.successHandler(cards);
-            }
-        } catch (e) {
-            this.errorHandler(e);
-        }
-    }
-
-    /**
-     * Gets classification for a file.
-     *
-     * @param {string} fileId - The file id
-     * @param {Function} successCallback - Success callback
-     * @param {Function} errorCallback - Error callback
-     * @param {boolean|void} [options.forceFetch] - Optionally Bypasses the cache
-     * @param {boolean|void} [options.refreshCache] - Optionally Updates the cache
-     * @return {Promise}
-     */
-    async getClassification(
-        fileId: string,
-        successCallback: Function,
-        errorCallback: Function,
-        options: FetchOptions = {},
-    ): Promise<void> {
-        this.successCallback = successCallback;
-        this.errorCallback = errorCallback;
-        this.errorCode = ERROR_CODE_FETCH_CLASSIFICATION;
-
-        if (!fileId) {
-            this.errorHandler(getBadItemError());
-            return;
-        }
-
-        const cache: APICache = this.getCache();
-        const key = this.getClassificationCacheKey(fileId);
-
-        // Clear the cache if needed
-        if (options.forceFetch) {
-            cache.unset(key);
-        }
-
-        // Return the Cache value if it exists
-        if (cache.has(key)) {
-            this.successHandler(cache.get(key));
-            if (!options.refreshCache) {
-                return;
-            }
-        }
-
-        try {
-            const classification = await this.xhr.get({
-                url: this.getMetadataUrl(fileId, METADATA_SCOPE_ENTERPRISE, METADATA_TEMPLATE_CLASSIFICATION),
-                id: getTypedFileId(fileId),
-            });
-
-            if (!this.isDestroyed()) {
-                cache.set(key, classification.data);
-                this.successHandler(cache.get(key));
             }
         } catch (e) {
             this.errorHandler(e);

--- a/src/elements/content-sidebar/DetailsSidebar.js
+++ b/src/elements/content-sidebar/DetailsSidebar.js
@@ -18,7 +18,7 @@ import { withLogger } from '../common/logger';
 import { EVENT_JS_READY } from '../common/logger/constants';
 import { SIDEBAR_FIELDS_TO_FETCH } from '../../utils/fields';
 import { mark } from '../../utils/performance';
-import { isUserCorrectableError, getBadItemError } from '../../utils/error';
+import { getBadItemError } from '../../utils/error';
 import SidebarAccessStats from './SidebarAccessStats';
 import SidebarSection from './SidebarSection';
 import SidebarContent from './SidebarContent';
@@ -35,7 +35,7 @@ import {
 import './DetailsSidebar.scss';
 
 type ExternalProps = {
-    bannerPolicy?: Object, // TODO: add fileVersionId
+    classification?: ClassificationInfo,
     fileId: string,
     hasAccessStats?: boolean,
     hasClassification?: boolean,
@@ -59,12 +59,9 @@ type Props = {
 type State = {
     accessStats?: FileAccessStats,
     accessStatsError?: Errors,
-    classification?: ClassificationInfo,
-    classificationError?: Errors,
     file?: BoxItem,
     fileError?: Errors,
     isLoadingAccessStats: boolean,
-    isLoadingClassification: boolean,
 };
 
 const MARK_NAME_JS_READY = `${ORIGIN_DETAILS_SIDEBAR}_${EVENT_JS_READY}`;
@@ -87,7 +84,6 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
         super(props);
         this.state = {
             isLoadingAccessStats: false,
-            isLoadingClassification: false,
         };
         const { logger } = this.props;
         logger.onReadyMetric({
@@ -100,16 +96,12 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
         if (this.props.hasAccessStats) {
             this.fetchAccessStats();
         }
-        if (this.props.hasClassification) {
-            this.fetchClassification();
-        }
     }
 
     componentDidUpdate(prevProps: Props) {
-        const { hasAccessStats, hasClassification } = this.props;
+        const { hasAccessStats } = this.props;
         // Component visibility props such as hasAccessStats can sometimes be flipped after an async call
         const hasAccessStatsChanged = prevProps.hasAccessStats !== hasAccessStats;
-        const hasClassificationChanged = prevProps.hasClassification !== hasClassification;
         if (hasAccessStatsChanged) {
             if (hasAccessStats) {
                 this.fetchAccessStats();
@@ -118,18 +110,6 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
                     isLoadingAccessStats: false,
                     accessStats: undefined,
                     accessStatsError: undefined,
-                });
-            }
-        }
-
-        if (hasClassificationChanged) {
-            if (hasClassification) {
-                this.fetchClassification();
-            } else {
-                this.setState({
-                    classification: undefined,
-                    classificationError: undefined,
-                    isLoadingClassification: false,
                 });
             }
         }
@@ -324,99 +304,9 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
         );
     }
 
-    /**
-     * File classification fetch success callback.
-     *
-     * @param {ClassificationInfo} classification - Info about the file's classification
-     * @return {void}
-     */
-    fetchClassificationSuccessCallback = (classification: ClassificationInfo): void => {
-        if (!this.props.hasClassification) {
-            return;
-        }
-
-        this.setState({
-            classification,
-            classificationError: undefined,
-            isLoadingClassification: false,
-        });
-    };
-
-    /**
-     * Handles a failed file classification fetch
-     *
-     * @private
-     * @param {ElementsXhrError} error - API error
-     * @param {string} code - Error code
-     * @return {void}
-     */
-    fetchClassificationErrorCallback = (error: ElementsXhrError, code: string): void => {
-        if (!this.props.hasClassification) {
-            return;
-        }
-
-        const isValidError = isUserCorrectableError(error.status);
-        let classificationError;
-
-        if (isValidError) {
-            classificationError = {
-                inlineError: {
-                    title: messages.fileClassificationErrorHeaderMessage,
-                    content: messages.defaultErrorMaskSubHeaderMessage,
-                },
-            };
-        }
-
-        this.setState({
-            classification: undefined,
-            classificationError,
-            isLoadingClassification: false,
-        });
-
-        this.props.onError(error, code, {
-            error,
-            [IS_ERROR_DISPLAYED]: isValidError,
-        });
-    };
-
-    /**
-     * Fetches the classification for a file
-     *
-     * @private
-     * @return {void}
-     */
-    fetchClassification = (): void => {
-        const { api, fileId }: Props = this.props;
-        const { isLoadingClassification } = this.state;
-
-        if (isLoadingClassification) {
-            return;
-        }
-
-        this.setState({ isLoadingClassification: true });
-        api.getMetadataAPI(false).getClassification(
-            fileId,
-            this.fetchClassificationSuccessCallback,
-            this.fetchClassificationErrorCallback,
-            {
-                refreshCache: true,
-            },
-        );
-    };
-
-    /**
-     * Add classification click handler
-     *
-     * @private
-     * @return {void}
-     */
-    onClassificationClick = (): void => {
-        const { onClassificationClick }: Props = this.props;
-        onClassificationClick(this.fetchClassification);
-    };
-
     render() {
         const {
+            classification,
             hasProperties,
             hasNotices,
             hasAccessStats,
@@ -425,21 +315,12 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
             hasVersions,
             onAccessStatsClick,
             onVersionHistoryClick,
+            onClassificationClick,
             onRetentionPolicyExtendClick,
             retentionPolicy,
-            bannerPolicy,
         }: Props = this.props;
 
-        const {
-            accessStats,
-            accessStatsError,
-            classification,
-            classificationError,
-            file,
-            fileError,
-            isLoadingAccessStats,
-            isLoadingClassification,
-        }: State = this.state;
+        const { accessStats, accessStatsError, file, fileError, isLoadingAccessStats }: State = this.state;
 
         // TODO: Add loading indicator and handle errors once file call is split out
         return (
@@ -471,15 +352,13 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
                             file={file}
                             onDescriptionChange={this.onDescriptionChange}
                             {...fileError}
-                            bannerPolicy={bannerPolicy}
                             classification={classification}
                             hasClassification={hasClassification}
                             hasRetentionPolicy={hasRetentionPolicy}
-                            isLoading={isLoadingAccessStats && isLoadingClassification}
-                            onClassificationClick={this.onClassificationClick}
+                            isLoading={isLoadingAccessStats}
+                            onClassificationClick={onClassificationClick}
                             onRetentionPolicyExtendClick={onRetentionPolicyExtendClick}
                             retentionPolicy={retentionPolicy}
-                            {...classificationError}
                         />
                     </SidebarSection>
                 )}

--- a/src/elements/content-sidebar/SidebarFileProperties.js
+++ b/src/elements/content-sidebar/SidebarFileProperties.js
@@ -12,10 +12,9 @@ import LoadingIndicatorWrapper from '../../components/loading-indicator/LoadingI
 import getFileSize from '../../utils/getFileSize';
 import { INTERACTION_TARGET, DETAILS_TARGETS } from '../common/interactionTargets';
 import withErrorHandling from './withErrorHandling';
-import { FIELD_PERMISSIONS_CAN_UPLOAD, KEY_CLASSIFICATION_TYPE } from '../../constants';
+import { FIELD_PERMISSIONS_CAN_UPLOAD } from '../../constants';
 
 type Props = {
-    bannerPolicy?: Object,
     classification?: ClassificationInfo,
     file: BoxItem,
     hasClassification: boolean,
@@ -44,19 +43,18 @@ export const getClassificationModal = (file: BoxItem, onClassificationClick: ?Fu
 };
 
 const SidebarFileProperties = ({
-    classification,
     file,
     onDescriptionChange,
     hasClassification,
     onClassificationClick,
     hasRetentionPolicy,
     retentionPolicy,
-    bannerPolicy,
+    classification,
     onRetentionPolicyExtendClick,
     isLoading,
     intl,
 }: Props) => {
-    const classificationType = getProp(classification, KEY_CLASSIFICATION_TYPE);
+    const classificationType = getProp(classification, 'type');
 
     return (
         <LoadingIndicatorWrapper isLoading={isLoading}>
@@ -65,7 +63,7 @@ const SidebarFileProperties = ({
                     hasClassification
                         ? {
                               openModal: getClassificationModal(file, onClassificationClick),
-                              tooltip: getProp(bannerPolicy, 'body'),
+                              tooltip: getProp(classification, 'description'),
                               value: classificationType,
                               [INTERACTION_TARGET]: classificationType
                                   ? DETAILS_TARGETS.CLASSIFICATION_EDIT

--- a/src/elements/content-sidebar/__tests__/SidebarFileProperties-test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarFileProperties-test.js
@@ -6,7 +6,6 @@ import SidebarFileProperties, {
     SidebarFilePropertiesComponent,
     getClassificationModal,
 } from '../SidebarFileProperties';
-import { KEY_CLASSIFICATION_TYPE } from '../../../constants';
 
 describe('elements/content-sidebar/SidebarFileProperties', () => {
     const getWrapper = props => shallow(<SidebarFilePropertiesComponent {...props} />);
@@ -36,8 +35,9 @@ describe('elements/content-sidebar/SidebarFileProperties', () => {
     const classificationProps = {
         hasClassification: true,
         onClassificationClick: jest.fn(),
-        bannerPolicy: {
-            body: 'tooltip value',
+        classification: {
+            type: 'Public',
+            description: 'tooltip value',
         },
         file: {
             size: '1',
@@ -47,9 +47,6 @@ describe('elements/content-sidebar/SidebarFileProperties', () => {
         },
         intl: {
             locale: 'en',
-        },
-        classification: {
-            [KEY_CLASSIFICATION_TYPE]: 'Public',
         },
     };
 
@@ -125,10 +122,10 @@ describe('elements/content-sidebar/SidebarFileProperties', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should not render a tooltip if no banner policy body is provided', () => {
+        test('should not render a tooltip if no classification description is provided', () => {
             const wrapper = getMountWrapper({
                 ...classificationProps,
-                bannerPolicy: undefined,
+                classification: { type: 'Public' },
                 file: {
                     ...classificationProps.file,
                     permissions: {

--- a/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties-test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`elements/content-sidebar/SidebarFileProperties render() should not render a tooltip if no banner policy body is provided 1`] = `
+exports[`elements/content-sidebar/SidebarFileProperties render() should not render a tooltip if no classification description is provided 1`] = `
 <SidebarFileProperties
   classification={
     Object {
-      "Box__Security__Classification__Key": "Public",
+      "type": "Public",
     }
   }
   file={
@@ -358,14 +358,10 @@ exports[`elements/content-sidebar/SidebarFileProperties render() should render a
 
 exports[`elements/content-sidebar/SidebarFileProperties render() should render classification information and not link when given proper metadata 1`] = `
 <SidebarFileProperties
-  bannerPolicy={
-    Object {
-      "body": "tooltip value",
-    }
-  }
   classification={
     Object {
-      "Box__Security__Classification__Key": "Public",
+      "description": "tooltip value",
+      "type": "Public",
     }
   }
   file={
@@ -509,14 +505,10 @@ exports[`elements/content-sidebar/SidebarFileProperties render() should render c
 
 exports[`elements/content-sidebar/SidebarFileProperties render() should render classification link only when given callback and has_upload permission is true 1`] = `
 <SidebarFileProperties
-  bannerPolicy={
-    Object {
-      "body": "tooltip value",
-    }
-  }
   classification={
     Object {
-      "Box__Security__Classification__Key": "Public",
+      "description": "tooltip value",
+      "type": "Public",
     }
   }
   file={


### PR DESCRIPTION
Removes fetching of classification from within the details sidebar and relies on the value passed in.
Classification value was being passed in via the `bannerPolicy` prop which is now renamed to `classification` with a more descriptive object structure.