### PR TITLE
 refactor(versions): Move history logic from version item to container

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -362,6 +362,7 @@ export const KEYS = {
     arrowUp: 'ArrowUp',
     backspace: 'Backspace',
     enter: 'Enter',
+    space: ' ',
 };
 
 /* ----------------- Other ----------------------- */

--- a/src/elements/content-sidebar/versions/Versions.js
+++ b/src/elements/content-sidebar/versions/Versions.js
@@ -1,0 +1,2 @@
+// @flow
+export type VersionActionCallback = (versionId: string) => void;

--- a/src/elements/content-sidebar/versions/VersionsItem.js
+++ b/src/elements/content-sidebar/versions/VersionsItem.js
@@ -81,7 +81,7 @@ const VersionsItem = ({
             className="bcs-VersionsItem"
             isDisabled={isDisabled}
             isSelected={isSelected}
-            onClick={handleAction(onPreview)}
+            onActivate={handleAction(onPreview)}
         >
             <div className="bcs-VersionsItem-badge">
                 <VersionsItemBadge isDisabled={isDeleted} versionNumber={versionNumber} />

--- a/src/elements/content-sidebar/versions/VersionsItem.js
+++ b/src/elements/content-sidebar/versions/VersionsItem.js
@@ -5,16 +5,14 @@
  */
 
 import React from 'react';
-import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
-import { generatePath, withRouter } from 'react-router-dom';
-import type { Match } from 'react-router-dom';
 import messages from './messages';
-import NavButton from '../../common/nav-button';
 import sizeUtil from '../../../utils/size';
 import VersionsItemActions from './VersionsItemActions';
+import VersionsItemButton from './VersionsItemButton';
 import VersionsItemBadge from './VersionsItemBadge';
 import { ReadableTime } from '../../../components/time';
+import type { VersionActionCallback } from './Versions';
 import {
     PLACEHOLDER_USER,
     VERSION_DELETE_ACTION,
@@ -25,7 +23,12 @@ import './VersionsItem.scss';
 
 type Props = {
     isCurrent: boolean,
-    match: Match,
+    isSelected: boolean,
+    onDelete?: VersionActionCallback,
+    onDownload?: VersionActionCallback,
+    onPreview?: VersionActionCallback,
+    onPromote?: VersionActionCallback,
+    onRestore?: VersionActionCallback,
     permissions: BoxItemPermission,
     version: BoxItemVersion,
 };
@@ -39,7 +42,17 @@ const FIVE_MINUTES_MS = 5 * 60 * 1000;
 
 const getActionMessage = action => ACTION_MAP[action] || ACTION_MAP[VERSION_UPLOAD_ACTION];
 
-const VersionsItem = ({ isCurrent, match, permissions, version }: Props) => {
+const VersionsItem = ({
+    isCurrent,
+    isSelected,
+    onDelete,
+    onDownload,
+    onPreview,
+    onPromote,
+    onRestore,
+    permissions,
+    version,
+}: Props) => {
     const {
         action = VERSION_UPLOAD_ACTION,
         created_at: createdAt,
@@ -49,24 +62,26 @@ const VersionsItem = ({ isCurrent, match, permissions, version }: Props) => {
         version_number: versionNumber,
     } = version;
     const isDeleted = action === VERSION_DELETE_ACTION;
-    const className = classNames('bcs-VersionsItem', {
-        'bcs-is-disabled': isDeleted,
-    });
-    const handler = () => {}; // TODO: Add actual event handling logic
-    const versionPath = generatePath(match.path, { ...match.params, versionId });
-    const versionUser = modifiedBy.name || <FormattedMessage {...messages.versionUserUnknown} />;
+    const isDisabled = isDeleted || !permissions.can_preview;
+
+    // Version info helpers
+    const versionSize = sizeUtil(size);
     const versionTimestamp = createdAt && new Date(createdAt).getTime();
+    const versionUser = modifiedBy.name || <FormattedMessage {...messages.versionUserUnknown} />;
+
+    // Version action helper
+    const handleAction = (handler?: VersionActionCallback) => (): void => {
+        if (handler) {
+            handler(versionId);
+        }
+    };
 
     return (
-        <NavButton
-            activeClassName="bcs-is-selected"
-            aria-disabled={isDeleted}
-            className={className}
-            component="div"
-            data-resin-target="versions-item"
-            data-testid="versions-item"
-            tabIndex="0"
-            to={versionPath}
+        <VersionsItemButton
+            className="bcs-VersionsItem"
+            isDisabled={isDisabled}
+            isSelected={isSelected}
+            onClick={handleAction(onPreview)}
         >
             <div className="bcs-VersionsItem-badge">
                 <VersionsItemBadge isDisabled={isDeleted} versionNumber={versionNumber} />
@@ -91,22 +106,26 @@ const VersionsItem = ({ isCurrent, match, permissions, version }: Props) => {
                             />
                         </time>
                     )}
-                    {size && <span className="bcs-VersionsItem-size">{sizeUtil(size)}</span>}
+                    {!!size && (
+                        <span className="bcs-VersionsItem-size" title={versionSize}>
+                            {versionSize}
+                        </span>
+                    )}
                 </div>
             </div>
 
             <VersionsItemActions
                 isCurrent={isCurrent}
                 isDeleted={isDeleted}
-                onDelete={handler}
-                onDownload={handler}
-                onPreview={handler}
-                onPromote={handler}
-                onRestore={handler}
+                onDelete={handleAction(onDelete)}
+                onDownload={handleAction(onDownload)}
+                onPreview={handleAction(onPreview)}
+                onPromote={handleAction(onPromote)}
+                onRestore={handleAction(onRestore)}
                 permissions={permissions}
             />
-        </NavButton>
+        </VersionsItemButton>
     );
 };
 
-export default withRouter(VersionsItem);
+export default VersionsItem;

--- a/src/elements/content-sidebar/versions/VersionsItemButton.js
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.js
@@ -1,0 +1,61 @@
+/**
+ * @flow
+ * @file Versions Item Button component
+ * @author Box
+ */
+
+import * as React from 'react';
+import classNames from 'classnames';
+import { KEYS } from '../../../constants';
+
+type Props = {
+    children: React.Node,
+    className: string,
+    isDisabled: boolean,
+    isSelected: boolean,
+    onClick: (event: SyntheticEvent<any>) => void,
+};
+
+const isClickEvent = event => {
+    return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
+};
+
+const isKeyPressEvent = event => {
+    return event.key === KEYS.enter || event.key === KEYS.space;
+};
+
+const VersionsItemButton = ({ children, className, isDisabled, isSelected, onClick }: Props) => {
+    const buttonClassName = classNames(className, {
+        'bcs-is-disabled': isDisabled,
+        'bcs-is-selected': isSelected,
+    });
+
+    return (
+        <div
+            aria-disabled={isDisabled}
+            className={buttonClassName}
+            data-resin-target="versions-item-button"
+            data-testid="versions-item-button"
+            onClick={event => {
+                if (isClickEvent(event)) {
+                    onClick(event);
+                }
+            }}
+            onKeyPress={event => {
+                if (isKeyPressEvent(event)) {
+                    if (event.key === KEYS.space) {
+                        event.preventDefault(); // Prevent scroll on space key press
+                    }
+
+                    onClick(event);
+                }
+            }}
+            role="button"
+            tabIndex="0"
+        >
+            {children}
+        </div>
+    );
+};
+
+export default VersionsItemButton;

--- a/src/elements/content-sidebar/versions/VersionsItemButton.js
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.js
@@ -6,6 +6,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
+import { isActivateKey, isLeftClick } from '../../../utils/dom';
 import { KEYS } from '../../../constants';
 
 type Props = {
@@ -13,49 +14,59 @@ type Props = {
     className: string,
     isDisabled: boolean,
     isSelected: boolean,
-    onClick: (event: SyntheticEvent<any>) => void,
+    onActivate: (event: SyntheticMouseEvent<HTMLDivElement> | SyntheticKeyboardEvent<HTMLDivElement>) => void,
 };
 
-const isClickEvent = event => {
-    return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey;
-};
+class VersionsItemButton extends React.Component<Props> {
+    buttonRef: ?HTMLDivElement;
 
-const isKeyPressEvent = event => {
-    return event.key === KEYS.enter || event.key === KEYS.space;
-};
+    componentDidUpdate({ isSelected: prevIsSelected }: Props) {
+        const { isSelected } = this.props;
 
-const VersionsItemButton = ({ children, className, isDisabled, isSelected, onClick }: Props) => {
-    const buttonClassName = classNames(className, {
-        'bcs-is-disabled': isDisabled,
-        'bcs-is-selected': isSelected,
-    });
+        if (this.buttonRef && isSelected && isSelected !== prevIsSelected) {
+            this.buttonRef.focus();
+        }
+    }
 
-    return (
-        <div
-            aria-disabled={isDisabled}
-            className={buttonClassName}
-            data-resin-target="versions-item-button"
-            data-testid="versions-item-button"
-            onClick={event => {
-                if (isClickEvent(event)) {
-                    onClick(event);
-                }
-            }}
-            onKeyPress={event => {
-                if (isKeyPressEvent(event)) {
-                    if (event.key === KEYS.space) {
-                        event.preventDefault(); // Prevent scroll on space key press
+    setButtonRef = (buttonRef: ?HTMLDivElement): void => {
+        this.buttonRef = buttonRef;
+    };
+
+    render() {
+        const { children, className, isDisabled, isSelected, onActivate } = this.props;
+        const buttonClassName = classNames(className, {
+            'bcs-is-disabled': isDisabled,
+            'bcs-is-selected': isSelected,
+        });
+
+        return (
+            <div
+                aria-disabled={isDisabled}
+                className={buttonClassName}
+                data-resin-target="versions-item-button"
+                data-testid="versions-item-button"
+                onClick={event => {
+                    if (isLeftClick(event)) {
+                        onActivate(event);
                     }
+                }}
+                onKeyPress={event => {
+                    if (isActivateKey(event)) {
+                        if (event.key === KEYS.space) {
+                            event.preventDefault(); // Prevent scroll on space key press
+                        }
 
-                    onClick(event);
-                }
-            }}
-            role="button"
-            tabIndex="0"
-        >
-            {children}
-        </div>
-    );
-};
+                        onActivate(event);
+                    }
+                }}
+                ref={this.setButtonRef}
+                role="button"
+                tabIndex="0"
+            >
+                {children}
+            </div>
+        );
+    }
+}
 
 export default VersionsItemButton;

--- a/src/elements/content-sidebar/versions/VersionsList.js
+++ b/src/elements/content-sidebar/versions/VersionsList.js
@@ -5,17 +5,20 @@
  */
 
 import React from 'react';
+import { Route } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 import VersionsItem from './VersionsItem';
+import type { VersionActionCallback } from './Versions';
 import './VersionsList.scss';
 
 type Props = {
+    onPreview: VersionActionCallback,
     permissions: BoxItemPermission,
     versions: Array<BoxItemVersion>,
 };
 
-const VersionsList = ({ permissions, versions = [] }: Props) => {
+const VersionsList = ({ onPreview, permissions, versions }: Props) => {
     if (!versions.length) {
         return (
             <div className="bcs-VersionsList bcs-is-empty">
@@ -28,7 +31,17 @@ const VersionsList = ({ permissions, versions = [] }: Props) => {
         <ul className="bcs-VersionsList">
             {versions.map((version, index) => (
                 <li className="bcs-VersionsList-item" key={version.id}>
-                    <VersionsItem isCurrent={index === 0} permissions={permissions} version={version} />
+                    <Route
+                        render={({ match }) => (
+                            <VersionsItem
+                                isCurrent={index === 0}
+                                isSelected={match.params.versionId === version.id}
+                                onPreview={onPreview}
+                                permissions={permissions}
+                                version={version}
+                            />
+                        )}
+                    />
                 </li>
             ))}
         </ul>

--- a/src/elements/content-sidebar/versions/VersionsSidebar.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebar.js
@@ -11,6 +11,7 @@ import messages from './messages';
 import messagesCommon from '../../common/messages';
 import SidebarContent from '../SidebarContent';
 import SidebarSection from '../SidebarSection';
+import type { VersionActionCallback } from './Versions';
 import VersionsList from './VersionsList';
 import { BackButton } from '../../common/nav-button';
 import { LoadingIndicatorWrapper } from '../../../components/loading-indicator';
@@ -19,12 +20,13 @@ import './VersionsSidebar.scss';
 type Props = {
     error?: string,
     isLoading: boolean,
+    onPreview: VersionActionCallback,
     parentName: string,
     permissions: BoxItemPermission,
     versions: Array<BoxItemVersion>,
 };
 
-const VersionsSidebar = ({ error, isLoading, parentName, permissions, versions }: Props) => (
+const VersionsSidebar = ({ error, isLoading, onPreview, parentName, permissions, versions }: Props) => (
     <SidebarContent
         className="bcs-Versions"
         title={
@@ -40,7 +42,12 @@ const VersionsSidebar = ({ error, isLoading, parentName, permissions, versions }
                     {error ? (
                         <InlineError title={<FormattedMessage {...messagesCommon.error} />}>{error}</InlineError>
                     ) : (
-                        <VersionsList permissions={permissions} versions={versions} />
+                        <VersionsList
+                            isLoading={isLoading}
+                            onPreview={onPreview}
+                            permissions={permissions}
+                            versions={versions}
+                        />
                     )}
                 </SidebarSection>
             )}

--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -5,7 +5,10 @@
  */
 
 import React from 'react';
+import flow from 'lodash/flow';
 import noop from 'lodash/noop';
+import { generatePath, withRouter } from 'react-router-dom';
+import type { Match, RouterHistory } from 'react-router-dom';
 import API from '../../../api';
 import VersionsSidebar from './VersionsSidebar';
 import { withAPIContext } from '../../common/api-context';
@@ -13,6 +16,8 @@ import { withAPIContext } from '../../common/api-context';
 type Props = {
     api: API,
     fileId: string,
+    history: RouterHistory,
+    match: Match,
     onVersionChange: (versionId?: string) => void,
     parentName: string,
     versionId?: string,
@@ -73,6 +78,10 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
         );
     };
 
+    handleActionPreview = (versionId: string): void => {
+        this.updateVersion(versionId);
+    };
+
     handleFetchError = ({ message }: ElementsXhrError) => {
         this.setState({
             error: message,
@@ -94,10 +103,15 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
         });
     };
 
+    updateVersion = (versionId?: string): void => {
+        const { history, match } = this.props;
+        return history.push(generatePath(match.path, { ...match.params, versionId }));
+    };
+
     render() {
         const { parentName } = this.props;
-        return <VersionsSidebar parentName={parentName} {...this.state} />;
+        return <VersionsSidebar onPreview={this.handleActionPreview} parentName={parentName} {...this.state} />;
     }
 }
 
-export default withAPIContext(VersionsSidebarContainer);
+export default flow([withRouter, withAPIContext])(VersionsSidebarContainer);

--- a/src/elements/content-sidebar/versions/__tests__/VersionsItem-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsItem-test.js
@@ -1,13 +1,8 @@
 import * as React from 'react';
 import { shallow } from 'enzyme/build';
-import NavButton from '../../../common/nav-button';
 import VersionsItem from '../VersionsItem';
+import VersionsItemButton from '../VersionsItemButton';
 import { ReadableTime } from '../../../../components/time';
-
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    withRouter: Component => Component,
-}));
 
 describe('elements/content-sidebar/versions/VersionsItem', () => {
     const defaults = {
@@ -18,23 +13,25 @@ describe('elements/content-sidebar/versions/VersionsItem', () => {
         size: 10240,
         version_number: 1,
     };
-    const getMatch = () => ({ path: '/:versionId', params: {} });
-    const getWrapper = (props = {}) => shallow(<VersionsItem match={getMatch()} {...props} />);
+    const defaultPermissions = {
+        can_delete: true,
+        can_preview: true,
+    };
     const getVersion = (overrides = {}) => ({
         ...defaults,
         ...overrides,
     });
+    const getWrapper = ({ permissions = defaultPermissions, ...props } = {}) =>
+        shallow(<VersionsItem permissions={permissions} {...props} />);
 
     describe('render', () => {
         test('should render an uploaded version correctly', () => {
             const wrapper = getWrapper({
                 version: getVersion({ action: 'upload' }),
             });
-            const navButton = wrapper.closest(NavButton);
+            const button = wrapper.closest(VersionsItemButton);
 
-            expect(navButton.prop('aria-disabled')).toBe(false);
-            expect(navButton.prop('className')).not.toContain('bcs-is-disabled');
-            expect(navButton.prop('to')).toBe('/12345');
+            expect(button.prop('isDisabled')).toBe(false);
             expect(wrapper.closest(ReadableTime)).toBeTruthy();
             expect(wrapper).toMatchSnapshot();
         });
@@ -43,10 +40,9 @@ describe('elements/content-sidebar/versions/VersionsItem', () => {
             const wrapper = getWrapper({
                 version: getVersion({ action: 'delete' }),
             });
-            const navButton = wrapper.closest(NavButton);
+            const button = wrapper.closest(VersionsItemButton);
 
-            expect(navButton.prop('aria-disabled')).toBe(true);
-            expect(navButton.prop('className')).toContain('bcs-is-disabled');
+            expect(button.prop('isDisabled')).toBe(true);
             expect(wrapper.closest(ReadableTime)).toBeTruthy();
             expect(wrapper).toMatchSnapshot();
         });

--- a/src/elements/content-sidebar/versions/__tests__/VersionsItem-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsItem-test.js
@@ -47,6 +47,16 @@ describe('elements/content-sidebar/versions/VersionsItem', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
+        test('should render a selected version correctly', () => {
+            const wrapper = getWrapper({
+                isSelected: true,
+                version: getVersion({ action: 'upload' }),
+            });
+            const button = wrapper.closest(VersionsItemButton);
+
+            expect(button.prop('isSelected')).toBe(true);
+        });
+
         test('should default to an unknown user if none is provided', () => {
             const wrapper = getWrapper({
                 version: getVersion({ modified_by: undefined }),

--- a/src/elements/content-sidebar/versions/__tests__/VersionsItemButton-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsItemButton-test.js
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { shallow } from 'enzyme/build';
+import VersionsItemButton from '../VersionsItemButton';
+
+describe('elements/content-sidebar/versions/VersionsItemButton', () => {
+    const getMount = (props = {}) => mount(<VersionsItemButton {...props}>Test</VersionsItemButton>);
+    const getShallow = (props = {}) => shallow(<VersionsItemButton {...props}>Test</VersionsItemButton>);
+
+    describe('render', () => {
+        test('should render in enabled state correctly', () => {
+            const wrapper = getShallow({
+                isDisabled: false,
+                isSelected: false,
+            });
+
+            expect(wrapper.prop('aria-disabled')).toBe(false);
+            expect(wrapper.prop('className')).not.toContain('bcs-is-disabled');
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should render in disabled state correctly', () => {
+            const wrapper = getShallow({
+                isDisabled: true,
+                isSelected: false,
+            });
+
+            expect(wrapper.prop('aria-disabled')).toBe(true);
+            expect(wrapper.prop('className')).toContain('bcs-is-disabled');
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should render in enabled state correctly', () => {
+            const wrapper = getShallow({
+                isDisabled: false,
+                isSelected: true,
+            });
+
+            expect(wrapper.prop('className')).toContain('bcs-is-selected');
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+
+    describe('onKeyPress', () => {
+        test('calls onClick event handler', () => {
+            const clickHandler = jest.fn();
+            const preventDefault = jest.fn();
+            const button = getMount({ onClick: clickHandler });
+
+            button.simulate('keyPress', {
+                key: 'Enter',
+            });
+
+            button.simulate('keyPress', {
+                key: ' ',
+                preventDefault,
+            });
+
+            expect(clickHandler).toBeCalledTimes(2);
+            expect(preventDefault).toBeCalledTimes(1);
+        });
+
+        test('does not call onClick event handler on invalid keypress', () => {
+            const clickHandler = jest.fn();
+            const button = getMount({ onClick: clickHandler });
+
+            button.simulate('keyPress', {
+                key: 'Ctrl',
+            });
+
+            expect(clickHandler).not.toBeCalled();
+        });
+    });
+});

--- a/src/elements/content-sidebar/versions/__tests__/VersionsItemButton-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsItemButton-test.js
@@ -41,10 +41,10 @@ describe('elements/content-sidebar/versions/VersionsItemButton', () => {
     });
 
     describe('onKeyPress', () => {
-        test('calls onClick event handler', () => {
-            const clickHandler = jest.fn();
+        test('calls onActivate event handler', () => {
+            const activateHandler = jest.fn();
             const preventDefault = jest.fn();
-            const button = getMount({ onClick: clickHandler });
+            const button = getMount({ onActivate: activateHandler });
 
             button.simulate('keyPress', {
                 key: 'Enter',
@@ -55,19 +55,19 @@ describe('elements/content-sidebar/versions/VersionsItemButton', () => {
                 preventDefault,
             });
 
-            expect(clickHandler).toBeCalledTimes(2);
+            expect(activateHandler).toBeCalledTimes(2);
             expect(preventDefault).toBeCalledTimes(1);
         });
 
-        test('does not call onClick event handler on invalid keypress', () => {
-            const clickHandler = jest.fn();
-            const button = getMount({ onClick: clickHandler });
+        test('does not call onActivate event handler on invalid keypress', () => {
+            const activateHandler = jest.fn();
+            const button = getMount({ onActivate: activateHandler });
 
             button.simulate('keyPress', {
                 key: 'Ctrl',
             });
 
-            expect(clickHandler).not.toBeCalled();
+            expect(activateHandler).not.toBeCalled();
         });
     });
 });

--- a/src/elements/content-sidebar/versions/__tests__/VersionsList-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsList-test.js
@@ -8,12 +8,15 @@ describe('elements/content-sidebar/versions/VersionsList', () => {
     describe('render', () => {
         test.each`
             versions
-            ${undefined}
             ${[]}
             ${[{ id: '12345' }]}
             ${[{ id: '12345' }, { id: '45678' }]}
         `('should match its snapshot', ({ versions }) => {
-            const wrapper = getWrapper({ versions });
+            const match = {
+                params: { versionId: '12345' },
+                path: '/versions/:versionId',
+            };
+            const wrapper = getWrapper({ match, versions });
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
@@ -2,6 +2,11 @@ import * as React from 'react';
 import { shallow } from 'enzyme/build';
 import VersionsSidebar from '../VersionsSidebarContainer';
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    withRouter: Component => Component,
+}));
+
 jest.mock('../../../common/api-context', () => ({
     withAPIContext: Component => Component,
 }));

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItem-test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItem-test.js.snap
@@ -4,7 +4,7 @@ exports[`elements/content-sidebar/versions/VersionsItem render should default to
 <VersionsItemButton
   className="bcs-VersionsItem"
   isDisabled={false}
-  onClick={[Function]}
+  onActivate={[Function]}
 >
   <div
     className="bcs-VersionsItem-badge"
@@ -75,7 +75,7 @@ exports[`elements/content-sidebar/versions/VersionsItem render should render a d
 <VersionsItemButton
   className="bcs-VersionsItem"
   isDisabled={true}
-  onClick={[Function]}
+  onActivate={[Function]}
 >
   <div
     className="bcs-VersionsItem-badge"
@@ -143,7 +143,7 @@ exports[`elements/content-sidebar/versions/VersionsItem render should render an 
 <VersionsItemButton
   className="bcs-VersionsItem"
   isDisabled={false}
-  onClick={[Function]}
+  onActivate={[Function]}
 >
   <div
     className="bcs-VersionsItem-badge"

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItem-test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItem-test.js.snap
@@ -1,15 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`elements/content-sidebar/versions/VersionsItem render should default to an unknown user if none is provided 1`] = `
-<ForwardRef
-  activeClassName="bcs-is-selected"
-  aria-disabled={false}
+<VersionsItemButton
   className="bcs-VersionsItem"
-  component="div"
-  data-resin-target="versions-item"
-  data-testid="versions-item"
-  tabIndex="0"
-  to="/12345"
+  isDisabled={false}
+  onClick={[Function]}
 >
   <div
     className="bcs-VersionsItem-badge"
@@ -53,6 +48,7 @@ exports[`elements/content-sidebar/versions/VersionsItem render should default to
       </time>
       <span
         className="bcs-VersionsItem-size"
+        title="10 KB"
       >
         10 KB
       </span>
@@ -65,20 +61,21 @@ exports[`elements/content-sidebar/versions/VersionsItem render should default to
     onPreview={[Function]}
     onPromote={[Function]}
     onRestore={[Function]}
+    permissions={
+      Object {
+        "can_delete": true,
+        "can_preview": true,
+      }
+    }
   />
-</ForwardRef>
+</VersionsItemButton>
 `;
 
 exports[`elements/content-sidebar/versions/VersionsItem render should render a deleted version correctly 1`] = `
-<ForwardRef
-  activeClassName="bcs-is-selected"
-  aria-disabled={true}
-  className="bcs-VersionsItem bcs-is-disabled"
-  component="div"
-  data-resin-target="versions-item"
-  data-testid="versions-item"
-  tabIndex="0"
-  to="/12345"
+<VersionsItemButton
+  className="bcs-VersionsItem"
+  isDisabled={true}
+  onClick={[Function]}
 >
   <div
     className="bcs-VersionsItem-badge"
@@ -119,6 +116,7 @@ exports[`elements/content-sidebar/versions/VersionsItem render should render a d
       </time>
       <span
         className="bcs-VersionsItem-size"
+        title="10 KB"
       >
         10 KB
       </span>
@@ -131,20 +129,21 @@ exports[`elements/content-sidebar/versions/VersionsItem render should render a d
     onPreview={[Function]}
     onPromote={[Function]}
     onRestore={[Function]}
+    permissions={
+      Object {
+        "can_delete": true,
+        "can_preview": true,
+      }
+    }
   />
-</ForwardRef>
+</VersionsItemButton>
 `;
 
 exports[`elements/content-sidebar/versions/VersionsItem render should render an uploaded version correctly 1`] = `
-<ForwardRef
-  activeClassName="bcs-is-selected"
-  aria-disabled={false}
+<VersionsItemButton
   className="bcs-VersionsItem"
-  component="div"
-  data-resin-target="versions-item"
-  data-testid="versions-item"
-  tabIndex="0"
-  to="/12345"
+  isDisabled={false}
+  onClick={[Function]}
 >
   <div
     className="bcs-VersionsItem-badge"
@@ -185,6 +184,7 @@ exports[`elements/content-sidebar/versions/VersionsItem render should render an 
       </time>
       <span
         className="bcs-VersionsItem-size"
+        title="10 KB"
       >
         10 KB
       </span>
@@ -197,6 +197,12 @@ exports[`elements/content-sidebar/versions/VersionsItem render should render an 
     onPreview={[Function]}
     onPromote={[Function]}
     onRestore={[Function]}
+    permissions={
+      Object {
+        "can_delete": true,
+        "can_preview": true,
+      }
+    }
   />
-</ForwardRef>
+</VersionsItemButton>
 `;

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton-test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton-test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`elements/content-sidebar/versions/VersionsItemButton render should render in disabled state correctly 1`] = `
+<div
+  aria-disabled={true}
+  className="bcs-is-disabled"
+  data-resin-target="versions-item-button"
+  data-testid="versions-item-button"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  Test
+</div>
+`;
+
+exports[`elements/content-sidebar/versions/VersionsItemButton render should render in enabled state correctly 1`] = `
+<div
+  aria-disabled={false}
+  className=""
+  data-resin-target="versions-item-button"
+  data-testid="versions-item-button"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  Test
+</div>
+`;
+
+exports[`elements/content-sidebar/versions/VersionsItemButton render should render in enabled state correctly 2`] = `
+<div
+  aria-disabled={false}
+  className="bcs-is-selected"
+  data-resin-target="versions-item-button"
+  data-testid="versions-item-button"
+  onClick={[Function]}
+  onKeyPress={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  Test
+</div>
+`;

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsList-test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsList-test.js.snap
@@ -12,14 +12,18 @@ exports[`elements/content-sidebar/versions/VersionsList render should match its 
 `;
 
 exports[`elements/content-sidebar/versions/VersionsList render should match its snapshot 2`] = `
-<div
-  className="bcs-VersionsList bcs-is-empty"
+<ul
+  className="bcs-VersionsList"
 >
-  <FormattedMessage
-    defaultMessage="No prior versions are available for this file."
-    id="be.sidebarVersions.empty"
-  />
-</div>
+  <li
+    className="bcs-VersionsList-item"
+    key="12345"
+  >
+    <Route
+      render={[Function]}
+    />
+  </li>
+</ul>
 `;
 
 exports[`elements/content-sidebar/versions/VersionsList render should match its snapshot 3`] = `
@@ -30,46 +34,16 @@ exports[`elements/content-sidebar/versions/VersionsList render should match its 
     className="bcs-VersionsList-item"
     key="12345"
   >
-    <withRouter(VersionsItem)
-      isCurrent={true}
-      version={
-        Object {
-          "id": "12345",
-        }
-      }
-    />
-  </li>
-</ul>
-`;
-
-exports[`elements/content-sidebar/versions/VersionsList render should match its snapshot 4`] = `
-<ul
-  className="bcs-VersionsList"
->
-  <li
-    className="bcs-VersionsList-item"
-    key="12345"
-  >
-    <withRouter(VersionsItem)
-      isCurrent={true}
-      version={
-        Object {
-          "id": "12345",
-        }
-      }
+    <Route
+      render={[Function]}
     />
   </li>
   <li
     className="bcs-VersionsList-item"
     key="45678"
   >
-    <withRouter(VersionsItem)
-      isCurrent={false}
-      version={
-        Object {
-          "id": "45678",
-        }
-      }
+    <Route
+      render={[Function]}
     />
   </li>
 </ul>

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsSidebarContainer-test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsSidebarContainer-test.js.snap
@@ -3,6 +3,7 @@
 exports[`elements/content-sidebar/versions/VersionsSidebarContainer render should match its snapshot 1`] = `
 <VersionsSidebar
   isLoading={true}
+  onPreview={[Function]}
   parentName="activity"
   permissions={Object {}}
   versions={Array []}

--- a/src/utils/__tests__/dom-test.js
+++ b/src/utils/__tests__/dom-test.js
@@ -1,9 +1,21 @@
 import scrollIntoViewIfNeeded from 'scroll-into-view-if-needed';
-import { isLeftClick, scrollIntoView } from '../dom';
+import { isActivateKey, isLeftClick, scrollIntoView } from '../dom';
 
 jest.mock('scroll-into-view-if-needed');
 
 describe('util/dom', () => {
+    describe('isActivateKey', () => {
+        test('should return true for enter and space keys', () => {
+            expect(isActivateKey({ key: 'Enter' })).toBe(true);
+            expect(isActivateKey({ key: ' ' })).toBe(true);
+        });
+
+        test('should return false for all other keys', () => {
+            expect(isActivateKey({ key: 'Ctrl' })).toBe(false);
+            expect(isActivateKey({ key: 'Tab' })).toBe(false);
+        });
+    });
+
     describe('isLeftClick', () => {
         test('should return true for unmodified left click events', () => {
             expect(isLeftClick({ button: 0 })).toBe(true);

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -4,7 +4,7 @@
  * @author Box
  */
 import scrollIntoViewIfNeeded from 'scroll-into-view-if-needed';
-import { OVERLAY_WRAPPER_CLASS } from '../constants';
+import { KEYS, OVERLAY_WRAPPER_CLASS } from '../constants';
 import './domPolyfill';
 
 /**
@@ -54,6 +54,16 @@ export function isFocusableElement(element: HTMLElement | EventTarget | null): b
         (element.parentElement instanceof HTMLElement ? element.parentElement.classList.contains('btn') : false);
 
     return isInputElement(element) || tag === 'button' || tag === 'a' || tag === 'option' || isCheckbox || isButton;
+}
+
+/**
+ * Checks if a keyboard event is intended to activate an element.
+ *
+ * @param {SyntheticKeyboardEvent<HTMLElement>} event - The keyboard event
+ * @returns {boolean} true if the event is intended to activate the element
+ */
+export function isActivateKey(event: SyntheticKeyboardEvent<HTMLElement>) {
+    return event.key === KEYS.enter || event.key === KEYS.space;
 }
 
 /**

--- a/test/integration/content-sidebar/ContentSidebar.e2e.test.js
+++ b/test/integration/content-sidebar/ContentSidebar.e2e.test.js
@@ -54,7 +54,7 @@ describe('ContentSidebar', () => {
             cy.getByTestId('versionhistory').click();
             cy.contains('[data-testid="bcs-content"]', 'Version History').as('versionHistory');
 
-            cy.getByTestId('versions-item').within($versionsItem => {
+            cy.getByTestId('versions-item-button').within($versionsItem => {
                 cy.wrap($versionsItem)
                     .contains('V2')
                     .click();


### PR DESCRIPTION
This change ended up being fairly large, so I wanted to break it into its own pull request. It should be merged before #1035. The new delete and promote actions will require programatic access to set the currently-selected version. Managing this state in the container centralizes the navigation logic nicely.