### PR TITLE
fix(shared-link-settings-modal): Update custom URL label

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1027,7 +1027,7 @@ boxui.share.sharedLinkSettings.allowDownloadLabel = Allow users with the Shared 
 # Title for Allow Download section
 boxui.share.sharedLinkSettings.allowDownloadTitle = Allow Download
 # Label for Custom URL text input field
-boxui.share.sharedLinkSettings.customURLLabel = Custom URL
+boxui.share.sharedLinkSettings.customURLLabel = Non-private custom URL
 # Title for Direct Link section
 boxui.share.sharedLinkSettings.directLinkLabel = Direct Link
 # Label for option to enable expiration on a Shared Link
@@ -1061,7 +1061,7 @@ boxui.share.uploadTableHeaderText = Upload
 # Text for Uploader permission level in permissions table
 boxui.share.uploaderLevelText = Uploader
 # Text label for custom URL section
-boxui.share.vanityURLEnableText = Enable custom URL
+boxui.share.vanityURLEnableText = Publish content broadly with a custom, non-private URL
 # Text for Viewer permission level in permissions table
 boxui.share.viewerLevelText = Viewer
 # Text for Viewer Uploader permission level in permissions table

--- a/src/features/shared-link-settings-modal/messages.js
+++ b/src/features/shared-link-settings-modal/messages.js
@@ -28,7 +28,7 @@ const messages = defineMessages({
         id: 'boxui.share.sharedLinkSettings.modalTitle',
     },
     customURLLabel: {
-        defaultMessage: 'Custom URL',
+        defaultMessage: 'Non-private custom URL',
         description: 'Label for Custom URL text input field',
         id: 'boxui.share.sharedLinkSettings.customURLLabel',
     },
@@ -73,7 +73,7 @@ const messages = defineMessages({
         id: 'boxui.share.sharedLinkSettings.vanityURLWarning',
     },
     vanityURLEnableText: {
-        defaultMessage: 'Enable custom URL',
+        defaultMessage: 'Publish content broadly with a custom, non-private URL',
         description: 'Text label for custom URL section',
         id: 'boxui.share.vanityURLEnableText',
     },


### PR DESCRIPTION
Update section heading and form label for custom URLs in shared link settings modal.

<img width="440" alt="Screen Shot 2019-04-08 at 1 15 04 PM" src="https://user-images.githubusercontent.com/1280912/55754345-47591b80-5a01-11e9-9cd9-4681c9c6937c.png">

