### PR TITLE
style(elements): Fix various style specificity issues; fix modal height

### DIFF
--- a/conf/styleguide.styles.scss
+++ b/conf/styleguide.styles.scss
@@ -1,13 +1,10 @@
 .be {
-    &.bcow {
-        width: 100px;
+    &.bce,
+    &.bcp {
+        height: 600px;
     }
 
-    &.bce,
-    &.bcp,
     &.bcpr {
-        height: 600px;
-
         .bcs {
             box-shadow: initial;
         }
@@ -17,8 +14,11 @@
         height: 400px;
     }
 
+    &.bcow {
+        width: 100px;
+    }
+
     &.bce,
-    &.bcow,
     &.bcp,
     &.bcpr,
     &.bcs,
@@ -34,5 +34,11 @@
 
     .bcs {
         height: 1000px;
+    }
+}
+
+[data-preview='ContentPreview'] {
+    .bcpr {
+        height: 600px;
     }
 }

--- a/src/elements/common/base.scss
+++ b/src/elements/common/base.scss
@@ -12,10 +12,6 @@
     letter-spacing: .3px;
     line-height: 20px;
 
-    .ReactModal__Body--open & {
-        position: relative;
-    }
-
     /* stylelint-disable */
     ::-webkit-input-placeholder {
         @include placeholder;
@@ -73,10 +69,14 @@
     overflow: hidden;
     padding: 0;
     width: 100%;
+
+    .ReactModal__Body--open & {
+        position: relative;
+    }
 }
 
 .be-modal {
-    // This class can be used to applu the base content reset to portalled elements are outside of the .be root
+    // This class can be used to apply the base content reset to portalled elements are outside of the .be root
     // Also add the .be class to the inner content to get the rest of the styles
     @include reset;
     @include be-content;

--- a/src/elements/common/breadcrumbs/Breadcrumb.scss
+++ b/src/elements/common/breadcrumbs/Breadcrumb.scss
@@ -5,7 +5,7 @@
     display: flex;
     min-width: 20px;
 
-    &:first-child {
+    &:only-child {
         min-width: 64px;
     }
 

--- a/src/elements/content-sidebar/activity-feed/approval-comment-form/ApprovalCommentForm.scss
+++ b/src/elements/content-sidebar/activity-feed/approval-comment-form/ApprovalCommentForm.scss
@@ -6,6 +6,7 @@
 
     .bcs-comment-input {
         div[contentEditable='true'].public-DraftEditor-content {
+            cursor: text;
             width: auto;
         }
 

--- a/src/features/access-stats/AccessStatsItem.js
+++ b/src/features/access-stats/AccessStatsItem.js
@@ -58,7 +58,7 @@ const AccessStatsItem = ({
 
     const itemContent = (
         <React.Fragment>
-            <IconComponent color={ICON_COLOR} width={14} />
+            <IconComponent color={ICON_COLOR} height={10} width={14} />
             <span className="access-stats-label">
                 <FormattedMessage {...labelMessage} />
             </span>

--- a/src/features/access-stats/AccessStatsItem.scss
+++ b/src/features/access-stats/AccessStatsItem.scss
@@ -4,28 +4,35 @@
     list-style: none;
 
     .access-stats-item-content {
-        background: $selected-blue-background;
-        border-radius: 2px;
-        color: $koray-ing;
-        display: flex;
-        line-height: 10px;
-        margin: 0 0 5px;
-        padding: 9px;
-        text-align: left;
-        width: 100%;
-    }
+        &,
+        &.btn-plain,
+        &.btn-plain:focus,
+        &.btn-plain:hover {
+            align-items: center;
+            background: $selected-blue-background;
+            border-radius: 2px;
+            color: $koray-ing;
+            display: flex;
+            line-height: 10px;
+            margin: 0 0 5px;
+            padding: 9px;
+            text-align: left;
+            width: 100%;
+        }
 
-    svg {
-        margin-right: 8px;
+        &.btn-plain:focus,
+        &.btn-plain:hover {
+            .access-stats-label {
+                text-decoration: underline;
+            }
+        }
     }
 
     .access-stats-label {
         flex-grow: 1;
     }
 
-    .btn-plain {
-        .access-stats-label:hover {
-            text-decoration: underline;
-        }
+    svg {
+        margin-right: 8px;
     }
 }

--- a/src/features/access-stats/__tests__/__snapshots__/AccessStatsItem-test.js.snap
+++ b/src/features/access-stats/__tests__/__snapshots__/AccessStatsItem-test.js.snap
@@ -11,6 +11,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats of pre
   >
     <IconEye
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span
@@ -37,6 +38,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats of typ
   >
     <IconEye
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span
@@ -63,6 +65,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats of typ
   >
     <IconEye
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span
@@ -89,6 +92,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats of typ
   >
     <IconDownloadSolid
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span
@@ -115,6 +119,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats of typ
   >
     <IconComment
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span
@@ -141,6 +146,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats of typ
   >
     <IconPencilSolid
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span
@@ -169,6 +175,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats with a
   >
     <IconEye
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span
@@ -196,6 +203,7 @@ exports[`features/access-stats/AccessStatsItem should render access stats with a
   >
     <IconEye
       color="#2a62b9"
+      height={10}
       width={14}
     />
     <span

--- a/src/features/item-details/ItemProperties.scss
+++ b/src/features/item-details/ItemProperties.scss
@@ -24,6 +24,10 @@
         transition: background-color .2s, border-color .2s, margin-left .2s, padding .2s;
         width: 100%;
 
+        &:hover {
+            box-shadow: none;
+        }
+
         &:focus {
             background-color: $karl-fog;
             border-color: $off-white;

--- a/src/features/metadata-instance-editor/fields/DateField.scss
+++ b/src/features/metadata-instance-editor/fields/DateField.scss
@@ -1,8 +1,11 @@
 @import '../../../styles/variables';
 
 .metadata-instance-editor-field-date {
-    .date-picker-icon-holder,
-    .date-picker-input {
+    .date-picker-icon-holder {
         width: 100%;
+
+        .date-picker-input {
+            width: 100%;
+        }
     }
 }


### PR DESCRIPTION
This PR addresses the following issues:

- **Critical**: Preview, rename, share, and create folder modals do not show at all in ContentExplorer or ContentPicker
- Access Stats items flash on hover in EUA due to specificity issues with PlainButton
- Access Stats anchor text and icons are not vertically centered
- Access Stats anchor text has its own hover treatment rather than using that of its parent button
- Breadcrumb list show a large gap before subsequent breadcrumbs when viewing a folder with a short name
- Metadata instance editor date fields did not take up the full width of the sidebar in the same way as standard text inputs