### PR TITLE
chore(avatars): Change avatar initials to use approved colors

### DIFF
--- a/src/components/avatar/Avatar.scss
+++ b/src/components/avatar/Avatar.scss
@@ -6,6 +6,7 @@
 
 .avatar {
     display: inline-block;
+    font-weight: bold;
     height: 32px;
     position: relative;
     user-select: none;

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -16,7 +16,7 @@ const AVATAR_COLORS = [
 const getInitials = name => {
     const firstInitial = name.slice(0, 1);
     const lastInitial = name.slice(name.lastIndexOf(' ') + 1, name.lastIndexOf(' ') + 2);
-    return firstInitial + lastInitial;
+    return `${firstInitial}${lastInitial}`.toUpperCase();
 };
 
 type Props = {

--- a/src/components/avatar/AvatarInitials.js
+++ b/src/components/avatar/AvatarInitials.js
@@ -2,15 +2,15 @@
 import React from 'react';
 
 const AVATAR_COLORS = [
-    '#18BBF7',
-    '#0D67C7',
-    '#052E5C',
-    '#747679',
-    '#FDA308',
-    '#98C332',
-    '#159F45',
-    '#B800B2',
-    '#F22C44',
+    '#2486FC',
+    '#0061D5',
+    '#003C84',
+    '#767676',
+    '#F5B31B',
+    '#26C281',
+    '#4826C2',
+    '#9F3FED',
+    '#ED3757',
 ];
 
 const getInitials = name => {

--- a/src/components/avatar/__tests__/AvatarInitials-test.js
+++ b/src/components/avatar/__tests__/AvatarInitials-test.js
@@ -10,16 +10,16 @@ describe('components/avatar/AvatarInitials', () => {
 
     test('should render the initials', () => {
         const wrapper = shallow(<AvatarInitials name="hello world" />);
-        expect(wrapper.text()).toEqual('hw');
+        expect(wrapper.text()).toEqual('HW');
     });
 
     test('should set a backgroundColor based on id', () => {
         const wrapper = shallow(<AvatarInitials id="10" name="hello world" />);
-        expect(wrapper.prop('style').backgroundColor).toEqual('#0D67C7');
+        expect(wrapper.prop('style').backgroundColor).toEqual('#0061D5');
     });
 
     test('should set a default backgroundColor if no id is passed in', () => {
         const wrapper = shallow(<AvatarInitials name="hello world" />);
-        expect(wrapper.prop('style').backgroundColor).toEqual('#18BBF7');
+        expect(wrapper.prop('style').backgroundColor).toEqual('#2486FC');
     });
 });


### PR DESCRIPTION
Per Box Design, the following changes were requested to `<AvatarInitials>`:

Force initials to be uppercase
Change font-weight from default (400) to `bold`
Change colors to use the approved list:
![Avatar Replacement Colors](https://user-images.githubusercontent.com/5079185/55825253-797a8400-5aba-11e9-9885-b8f96780e6a1.png)
