### PR TITLE
chore(content-preview): Trigger callback when a new version is previewed

### DIFF
--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -966,4 +966,9 @@ type NavigateOptions = {
     isToggle?: boolean,
 };
 
-type OnVersionChange = (version: ?BoxItemVersion, additionalVersionInfo: ?Object) => void;
+type AdditionalVersionInfo = {
+    isCurrentVersion: boolean,
+    updateVersionToCurrent: () => void,
+};
+
+type OnVersionChange = (version: ?BoxItemVersion, additionalVersionInfo: ?AdditionalVersionInfo) => void;

--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -965,3 +965,5 @@ type ContentSidebarFeatures = {
 type NavigateOptions = {
     isToggle?: boolean,
 };
+
+type OnVersionChange = (version: ?BoxItemVersion, additionalVersionInfo: ?Object) => void;

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -75,6 +75,7 @@ type Props = {
     onDownload: Function,
     onLoad: Function,
     onNavigate: Function,
+    onVersionChange: (versionId?: string, isCurrentVersion?: boolean) => void,
     previewLibraryVersion: string,
     requestInterceptor?: Function,
     responseInterceptor?: Function,
@@ -187,6 +188,7 @@ class ContentPreview extends PureComponent<Props, State> {
         onError: noop,
         onLoad: noop,
         onNavigate: noop,
+        onVersionChange: noop,
         previewLibraryVersion: DEFAULT_PREVIEW_VERSION,
         showAnnotations: false,
         staticHost: DEFAULT_HOSTNAME_STATIC,
@@ -1048,7 +1050,9 @@ class ContentPreview extends PureComponent<Props, State> {
      *
      * @param {string} versionId - The version id to set as current
      */
-    onVersionChange = (versionId?: string) => {
+    onVersionChange = (versionId?: string, isCurrentVersion?: boolean) => {
+        const { onVersionChange }: Props = this.props;
+        onVersionChange(versionId, isCurrentVersion);
         this.setState({ selectedVersionId: versionId });
     };
 

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -75,7 +75,7 @@ type Props = {
     onDownload: Function,
     onLoad: Function,
     onNavigate: Function,
-    onVersionChange: (versionId?: string, isCurrentVersion?: boolean) => void,
+    onVersionChange: OnVersionChange,
     previewLibraryVersion: string,
     requestInterceptor?: Function,
     responseInterceptor?: Function,
@@ -1050,10 +1050,10 @@ class ContentPreview extends PureComponent<Props, State> {
      *
      * @param {string} versionId - The version id to set as current
      */
-    onVersionChange = (versionId?: string, isCurrentVersion?: boolean) => {
+    onVersionChange = (version?: BoxItemVersion, additionalVersionInfo?: Object) => {
         const { onVersionChange }: Props = this.props;
-        onVersionChange(versionId, isCurrentVersion);
-        this.setState({ selectedVersionId: versionId });
+        onVersionChange(version, additionalVersionInfo);
+        this.setState({ selectedVersionId: getProp(version, 'id') });
     };
 
     /**

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1048,9 +1048,10 @@ class ContentPreview extends PureComponent<Props, State> {
     /**
      * Handles version change events
      *
-     * @param {string} versionId - The version id to set as current
+     * @param {string} [version] - The version that is now previewed
+     * @param {object} [additionalVersionInfo] - extra info about the version
      */
-    onVersionChange = (version?: BoxItemVersion, additionalVersionInfo?: Object) => {
+    onVersionChange = (version?: BoxItemVersion, additionalVersionInfo?: Object): void => {
         const { onVersionChange }: Props = this.props;
         onVersionChange(version, additionalVersionInfo);
         this.setState({ selectedVersionId: getProp(version, 'id') });

--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -19,7 +19,7 @@ type Props = {
     fileId: string,
     history: RouterHistory,
     match: Match,
-    onVersionChange: (versionId?: string) => void,
+    onVersionChange: (versionId?: string, isCurrentVersion?: boolean) => void,
     parentName: string,
     versionId?: string,
 };
@@ -54,7 +54,9 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
 
         // Forward the current version id that is passed in via the wrapping route
         if (prevVersionId !== versionId) {
-            onVersionChange(versionId);
+            const { versions } = this.state;
+            const isCurrentVersion = versionId === versions[0].id;
+            onVersionChange(versionId, isCurrentVersion);
         }
     }
 

--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -19,7 +19,7 @@ type Props = {
     fileId: string,
     history: RouterHistory,
     match: Match,
-    onVersionChange: (versionId?: string, isCurrentVersion?: boolean) => void,
+    onVersionChange: OnVersionChange,
     parentName: string,
     versionId?: string,
 };
@@ -55,8 +55,11 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
         // Forward the current version id that is passed in via the wrapping route
         if (prevVersionId !== versionId) {
             const { versions } = this.state;
-            const isCurrentVersion = versionId === versions[0].id;
-            onVersionChange(versionId, isCurrentVersion);
+            const previewedVersion = versions.find(version => version.id === versionId);
+            const isCurrentVersion = previewedVersion === versions[0];
+            onVersionChange(previewedVersion, {
+                isCurrentVersion,
+            });
         }
     }
 

--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -59,6 +59,7 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
             const isCurrentVersion = previewedVersion === versions[0];
             onVersionChange(previewedVersion, {
                 isCurrentVersion,
+                updateVersionToCurrent: this.updateVersionToCurrent,
             });
         }
     }
@@ -102,9 +103,7 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
 
         // Bump the user to the current version if they deleted their selected version
         if (versionId === selectedVersionId) {
-            const { versions } = this.state;
-            const { id: currentVersionId } = versions[0] || {};
-            this.updateVersion(currentVersionId);
+            this.updateVersionToCurrent();
         }
     };
 
@@ -193,14 +192,15 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
         );
     };
 
-    updateVersion = (versionId?: string): void => {
+    updateVersion = (versionId?: ?string): void => {
         const { history, match } = this.props;
         return history.push(generatePath(match.path, { ...match.params, versionId }));
     };
 
-    updateVersion = (versionId?: string): void => {
-        const { history, match } = this.props;
-        return history.push(generatePath(match.path, { ...match.params, versionId }));
+    updateVersionToCurrent = (): void => {
+        const { versions } = this.state;
+        const versionId = versions[0] ? versions[0].id : null;
+        this.updateVersion(versionId);
     };
 
     render() {

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
@@ -43,14 +43,15 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
         test('should forward version id changes to the parent component', () => {
             const onVersionChange = jest.fn();
             const wrapper = getWrapper({ onVersionChange });
+            const version = { id: '12345' };
 
             wrapper.setState({
-                versions: [{ id: '54321' }],
+                versions: [{ id: '54321' }, version],
             });
 
             wrapper.setProps({ versionId: '12345' });
 
-            expect(onVersionChange).toHaveBeenCalledWith('12345', false);
+            expect(onVersionChange).toHaveBeenCalledWith(version, { isCurrentVersion: false });
         });
     });
 

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
@@ -44,9 +44,13 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
             const onVersionChange = jest.fn();
             const wrapper = getWrapper({ onVersionChange });
 
+            wrapper.setState({
+                versions: [{ id: '54321' }],
+            });
+
             wrapper.setProps({ versionId: '12345' });
 
-            expect(onVersionChange).toHaveBeenCalledWith('12345');
+            expect(onVersionChange).toHaveBeenCalledWith('12345', false);
         });
     });
 

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
@@ -51,7 +51,10 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
 
             wrapper.setProps({ versionId: '12345' });
 
-            expect(onVersionChange).toHaveBeenCalledWith(version, { isCurrentVersion: false });
+            expect(onVersionChange).toHaveBeenCalledWith(version, {
+                isCurrentVersion: false,
+                updateVersionToCurrent: expect.any(Function),
+            });
         });
     });
 


### PR DESCRIPTION
This callback will allow ContentPreview/ContentExplorer or other consumers to control the header when a version is previewed.

Open Questions:
1. Should we send the whole version info back in the callback? This will allow consumers to skip additional network calls and directly add the new version info into their redux store/state.
2. Can we always assume that the current version will be at the beginning of the versions array?