### PR TITLE
feat(tooltip): render children when disabled or text is missing

### DIFF
--- a/src/components/footer-indicator/__tests__/__snapshots__/FooterIndicator-test.js.snap
+++ b/src/components/footer-indicator/__tests__/__snapshots__/FooterIndicator-test.js.snap
@@ -7,6 +7,7 @@ exports[`feature/footer-indicator/FooterIndicator should render a FooterIndicato
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="middle-right"
     text="abcdefghijklmnopqrstuvwxyz"
     theme="default"

--- a/src/components/form-elements/text-area/__tests__/TextArea-test.js
+++ b/src/components/form-elements/text-area/__tests__/TextArea-test.js
@@ -88,10 +88,13 @@ describe('components/form-elements/text-area/TextArea', () => {
         stub.onCall(1).returns();
 
         const wrapper = mount(<TextArea label="label" name="textarea" type="custom" validation={stub} value="yes" />);
-        const textarea = wrapper.find('textarea');
+        let textarea = wrapper.find('textarea');
 
         textarea.simulate('blur');
         expect(textarea.instance().validity.valid).toBeFalsy();
+
+        // Get the re-rendered textarea again
+        textarea = wrapper.find('textarea');
 
         textarea.simulate('blur');
         expect(textarea.instance().validity.valid).toBeTruthy();

--- a/src/components/form-elements/text-input/__tests__/TextInput-test.js
+++ b/src/components/form-elements/text-input/__tests__/TextInput-test.js
@@ -124,11 +124,15 @@ describe('components/form-elements/text-input/TextInput', () => {
         stub.onCall(1).returns();
 
         const wrapper = mount(<TextInput label="label" name="input" type="custom" validation={stub} value="yes" />);
-        const input = wrapper.find('input');
-        const setCustomValiditySpy = jest.spyOn(input.getDOMNode(), 'setCustomValidity');
+        let input = wrapper.find('input');
+        let setCustomValiditySpy = jest.spyOn(input.getDOMNode(), 'setCustomValidity');
 
         input.simulate('blur');
         expect(setCustomValiditySpy).toHaveBeenCalledWith('errCode');
+
+        // Get the re-rendered input again
+        input = wrapper.find('input');
+        setCustomValiditySpy = jest.spyOn(input.getDOMNode(), 'setCustomValidity');
 
         input.simulate('blur');
         expect(setCustomValiditySpy).toHaveBeenCalledWith('');

--- a/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip-test.js.snap
+++ b/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip-test.js.snap
@@ -8,6 +8,7 @@ exports[`components/label/InfoIconWithTooltip should render correctly 1`] = `
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-center"
     text="I am a tooltip"
     theme="default"

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector-test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector-test.js.snap
@@ -4,6 +4,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
 <Tooltip
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   isShown={false}
   position="middle-right"
   text=""

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/SuggestedPill-test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/SuggestedPill-test.js.snap
@@ -4,6 +4,7 @@ exports[`components/pill-selector-dropdown/SuggestedPill render() should render 
 <Tooltip
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="bottom-center"
   text="foo@bar.com"
   theme="default"

--- a/src/components/select/__tests__/__snapshots__/Select-test.js.snap
+++ b/src/components/select/__tests__/__snapshots__/Select-test.js.snap
@@ -11,6 +11,7 @@ exports[`components/select/Select should not show Tooltip when no error exists 1
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       position="middle-right"
       text=""
@@ -44,6 +45,7 @@ exports[`components/select/Select should not show error outline if not specified
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       position="middle-right"
       text=""
@@ -77,6 +79,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       position="middle-right"
       text=""
@@ -98,6 +101,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
+          isDisabled={false}
           position="middle-right"
           text="hello!!!"
           theme="default"
@@ -129,6 +133,7 @@ exports[`components/select/Select should show Tooltip when error exists 1`] = `
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       text="error"
@@ -162,6 +167,7 @@ exports[`components/select/Select should show error outline if specified 1`] = `
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       position="middle-right"
       text=""

--- a/src/components/text-input/__tests__/__snapshots__/TextInput-test.js.snap
+++ b/src/components/text-input/__tests__/__snapshots__/TextInput-test.js.snap
@@ -15,6 +15,7 @@ exports[`components/text-input/TextInput should render text input with descripti
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       position="middle-right"
       text=""

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -77,6 +77,8 @@ type Props = {
     constrainToScrollParent: boolean,
     /** Whether to constrain the tooltip to window. Defaults to `true` */
     constrainToWindow: boolean,
+    /** Forces the tooltip to be disabled irrespecitve of it's shown state. Defaults to `false` */
+    isDisabled: boolean,
     /** Forces the tooltip to be shown or hidden (useful for errors) */
     isShown?: boolean,
     /** Function called if the user manually dismisses the tooltip - only applies if showCloseButton is true */
@@ -85,8 +87,9 @@ type Props = {
     position: Position,
     /** Shows an X button to close the tooltip. Useful when tooltips are force shown with the isShown prop. */
     showCloseButton?: boolean,
-    text: React.Node,
     /** Text to show in the tooltip */
+    text?: React.Node,
+    /** Tooltip theme */
     theme: 'callout' | 'default' | 'error',
 };
 
@@ -99,6 +102,7 @@ class Tooltip extends React.Component<Props, State> {
     static defaultProps = {
         constrainToScrollParent: false,
         constrainToWindow: true,
+        isDisabled: false,
         position: TOP_CENTER,
         theme: DEFAULT_THEME,
     };
@@ -161,12 +165,19 @@ class Tooltip extends React.Component<Props, State> {
             className,
             constrainToScrollParent,
             constrainToWindow,
+            isDisabled,
             isShown: isShownProp,
             position,
             showCloseButton,
             text,
             theme,
         } = this.props;
+
+        // If the tooltip is disabled or if the text is missing, just render the children
+        if (isDisabled || !text) {
+            return React.Children.only(children);
+        }
+
         const isControlled = typeof isShownProp !== 'undefined';
         const isShown = isControlled ? isShownProp : this.state.isShown;
         const showTooltip = isShown && !this.state.wasClosedByUser;
@@ -207,6 +218,7 @@ class Tooltip extends React.Component<Props, State> {
             'is-error': theme === ERROR_THEME,
             'with-close-button': withCloseButton,
         });
+
         return (
             <TetherComponent
                 attachment={tetherPosition.attachment}

--- a/src/components/tooltip/__tests__/Tooltip-test.js
+++ b/src/components/tooltip/__tests__/Tooltip-test.js
@@ -203,6 +203,22 @@ describe('components/tooltip/Tooltip', () => {
 
             expect(wrapper.find('[role="tooltip"]').hasClass('is-error')).toBe(true);
         });
+
+        test('should render children only when tooltip is disabled', () => {
+            expect(
+                getWrapper({
+                    isDisabled: true,
+                }),
+            ).toMatchSnapshot();
+        });
+
+        test('should render children only when tooltip text is missing', () => {
+            expect(
+                getWrapper({
+                    text: null,
+                }),
+            ).toMatchSnapshot();
+        });
     });
 
     describe('closeTooltip()', () => {

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip-test.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip-test.js.snap
@@ -81,6 +81,18 @@ exports[`components/tooltip/Tooltip render() should not render with close button
 </TetherComponent>
 `;
 
+exports[`components/tooltip/Tooltip render() should render children only when tooltip is disabled 1`] = `
+<div>
+  Hello
+</div>
+`;
+
+exports[`components/tooltip/Tooltip render() should render children only when tooltip text is missing 1`] = `
+<div>
+  Hello
+</div>
+`;
+
 exports[`components/tooltip/Tooltip render() should render correctly with callout theme 1`] = `
 <TetherComponent
   attachment="bottom center"

--- a/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties-test.js.snap
@@ -443,6 +443,7 @@ exports[`elements/content-sidebar/SidebarFileProperties render() should render c
                   <Tooltip
                     constrainToScrollParent={false}
                     constrainToWindow={true}
+                    isDisabled={false}
                     position="middle-left"
                     text="tooltip value"
                     theme="default"
@@ -595,6 +596,7 @@ exports[`elements/content-sidebar/SidebarFileProperties render() should render c
                   <Tooltip
                     constrainToScrollParent={false}
                     constrainToWindow={true}
+                    isDisabled={false}
                     position="middle-left"
                     text="tooltip value"
                     theme="default"

--- a/src/elements/content-sidebar/activity-feed/app-activity/__tests__/__snapshots__/AppActivity-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/app-activity/__tests__/__snapshots__/AppActivity-test.js.snap
@@ -45,6 +45,7 @@ exports[`elements/content-sidebar/ActivityFeed/app-activity/AppActivity should c
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
+          isDisabled={false}
           position="top-center"
           text={
             <FormattedMessage

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
@@ -35,6 +35,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
+          isDisabled={false}
           position="top-center"
           text={
             <FormattedMessage
@@ -105,6 +106,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
+          isDisabled={false}
           position="top-center"
           text={
             <FormattedMessage
@@ -176,6 +178,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render an 
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
+          isDisabled={false}
           position="top-center"
           text={
             <FormattedMessage
@@ -250,6 +253,7 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render com
         <Tooltip
           constrainToScrollParent={false}
           constrainToWindow={true}
+          isDisabled={false}
           position="top-center"
           text={
             <FormattedMessage

--- a/src/elements/content-sidebar/activity-feed/keywords/__tests__/__snapshots__/Keywords-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/keywords/__tests__/__snapshots__/Keywords-test.js.snap
@@ -8,6 +8,7 @@ exports[`elements/content-sidebar/ActivityFeed/keywords/Keywords should correctl
     className="bcs-keywords-actions-tooltip"
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="bottom-left"
     text={
       <FormattedMessage

--- a/src/elements/content-sidebar/activity-feed/task/__tests__/__snapshots__/Task-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task/__tests__/__snapshots__/Task-test.js.snap
@@ -251,6 +251,7 @@ exports[`elements/content-sidebar/ActivityFeed/task/Task should show tooltips wh
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -275,6 +276,7 @@ exports[`elements/content-sidebar/ActivityFeed/task/Task should show tooltips wh
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage

--- a/src/elements/content-sidebar/skills/faces/__tests__/__snapshots__/Faces-test.js.snap
+++ b/src/elements/content-sidebar/skills/faces/__tests__/__snapshots__/Faces-test.js.snap
@@ -8,6 +8,7 @@ exports[`elements/content-sidebar/Skills/Faces/Faces should correctly render edi
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-center"
     text={
       <FormattedMessage
@@ -115,6 +116,7 @@ exports[`elements/content-sidebar/Skills/Faces/Faces should correctly render sav
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-center"
     text={
       <FormattedMessage

--- a/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/Keywords-test.js.snap
+++ b/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/Keywords-test.js.snap
@@ -8,6 +8,7 @@ exports[`elements/content-sidebar/Skills/Keywords/Keywords should correctly rend
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-center"
     text={
       <FormattedMessage
@@ -50,6 +51,7 @@ exports[`elements/content-sidebar/Skills/Keywords/Keywords should correctly rend
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-center"
     text={
       <FormattedMessage

--- a/src/elements/content-sidebar/skills/transcript/__tests__/__snapshots__/Transcript-test.js.snap
+++ b/src/elements/content-sidebar/skills/transcript/__tests__/__snapshots__/Transcript-test.js.snap
@@ -11,6 +11,7 @@ exports[`elements/content-sidebar/Skills/Transcript/Transcript should correctly 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-center"
       text={
         <FormattedMessage
@@ -35,6 +36,7 @@ exports[`elements/content-sidebar/Skills/Transcript/Transcript should correctly 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-center"
       text={
         <FormattedMessage
@@ -104,6 +106,7 @@ exports[`elements/content-sidebar/Skills/Transcript/Transcript should correctly 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-center"
       text={
         <FormattedMessage
@@ -128,6 +131,7 @@ exports[`elements/content-sidebar/Skills/Transcript/Transcript should correctly 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-center"
       text={
         <FormattedMessage
@@ -151,6 +155,7 @@ exports[`elements/content-sidebar/Skills/Transcript/Transcript should correctly 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-center"
       text={
         <FormattedMessage
@@ -248,6 +253,7 @@ exports[`elements/content-sidebar/Skills/Transcript/Transcript should correctly 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-center"
       text={
         <FormattedMessage

--- a/src/elements/content-uploader/__tests__/__snapshots__/ItemAction-test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/ItemAction-test.js.snap
@@ -7,6 +7,7 @@ exports[`elements/content-uploader/ItemAction should render correctly with STATU
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-left"
     text={
       <span
@@ -35,6 +36,7 @@ exports[`elements/content-uploader/ItemAction should render correctly with STATU
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-left"
     text={
       <span
@@ -63,6 +65,7 @@ exports[`elements/content-uploader/ItemAction should render correctly with STATU
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-left"
     text={
       <span
@@ -89,6 +92,7 @@ exports[`elements/content-uploader/ItemAction should render correctly with STATU
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="top-left"
     text={
       <span

--- a/src/features/beta-feedback/__tests__/__snapshots__/BetaFeedbackBadge-test.js.snap
+++ b/src/features/beta-feedback/__tests__/__snapshots__/BetaFeedbackBadge-test.js.snap
@@ -22,6 +22,7 @@ exports[`features/beta-feedback/BetaFeedbackBadge should render component with t
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="middle-right"
       text={
         <FormattedMessage

--- a/src/features/classification/__tests__/__snapshots__/ClassificationBadge-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/ClassificationBadge-test.js.snap
@@ -13,6 +13,7 @@ exports[`features/classification/ClassificationBadge should render tooltip when 
 <Tooltip
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="top-center"
   text="Sensitive"
   theme="default"
@@ -30,6 +31,7 @@ exports[`features/classification/ClassificationBadge should render tooltip with 
 <Tooltip
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-left"
   text="Sensitive"
   theme="default"

--- a/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorAvatarItem-test.js.snap
+++ b/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorAvatarItem-test.js.snap
@@ -67,6 +67,7 @@ exports[`features/collaborator-avatars/CollaboratorAvatarItem render() should re
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="middle-right"
       text={
         <FormattedMessage
@@ -104,6 +105,7 @@ exports[`features/collaborator-avatars/CollaboratorAvatarItem render() should re
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="middle-right"
       text={
         <FormattedMessage

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarLink-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarLink-test.js.snap
@@ -5,6 +5,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render BadgeCountElement 1`
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -27,6 +28,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render BadgeElement 1`] = `
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -55,6 +57,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render RemoveButton 1`] = `
     className="nav-link-tooltip"
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="middle-right"
     text="Feed"
     theme="default"
@@ -82,6 +85,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render a LinkComponent comp
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -104,6 +108,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render the IconComponent 1`
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -129,6 +134,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should render the router link 1`] 
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -165,6 +171,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use a custom className 1`] 
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -187,6 +194,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -213,6 +221,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -235,6 +244,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -261,6 +271,7 @@ exports[`feature/left-sidebar/LeftSidebarLink should use custom theme based on s
   className="nav-link-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"
@@ -283,6 +294,7 @@ exports[`feature/left-sidebar/LeftSidebarLink tooltip should take class from sta
   className="nav-link-tooltip is-visible"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="middle-right"
   text="Feed"
   theme="default"

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance-test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance-test.js.snap
@@ -15,6 +15,7 @@ exports[`features/metadata-instance-editor/fields/Instance collapsible isOpen pr
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         position="top-left"
         text={
           <FormattedMessage
@@ -726,6 +727,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         position="top-left"
         text={
           <FormattedMessage
@@ -920,6 +922,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         position="top-left"
         text={
           <FormattedMessage
@@ -1023,6 +1026,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         position="top-left"
         text={
           <FormattedMessage

--- a/src/features/presence/__tests__/__snapshots__/Presence-test.js.snap
+++ b/src/features/presence/__tests__/__snapshots__/Presence-test.js.snap
@@ -23,6 +23,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="1"
       position="bottom-center"
@@ -72,6 +73,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="2"
       position="bottom-center"
@@ -121,6 +123,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="3"
       position="bottom-center"
@@ -253,6 +256,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="1"
       position="bottom-center"
@@ -302,6 +306,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="2"
       position="bottom-center"
@@ -351,6 +356,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="3"
       position="bottom-center"
@@ -525,6 +531,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="1"
       position="bottom-center"
@@ -574,6 +581,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="2"
       position="bottom-center"
@@ -623,6 +631,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="3"
       position="bottom-center"
@@ -764,6 +773,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="1"
       position="bottom-center"
@@ -813,6 +823,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="2"
       position="bottom-center"
@@ -862,6 +873,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       key="3"
       position="bottom-center"

--- a/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm-test.js.snap
@@ -12,6 +12,7 @@ exports[`features/unified-share-modal/EmailForm render() should not show inline 
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       showCloseButton={true}
@@ -56,6 +57,7 @@ exports[`features/unified-share-modal/EmailForm render() should not show inline 
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       showCloseButton={true}
@@ -105,6 +107,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       showCloseButton={true}
@@ -145,6 +148,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
   <Tooltip
     constrainToScrollParent={false}
     constrainToWindow={true}
+    isDisabled={false}
     position="bottom-center"
     text="You do not have permission to invite collaborators."
     theme="default"
@@ -156,6 +160,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={true}
         position="middle-right"
         showCloseButton={true}
@@ -234,6 +239,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       showCloseButton={true}
@@ -311,6 +317,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       showCloseButton={true}
@@ -360,6 +367,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       showCloseButton={true}
@@ -442,6 +450,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={true}
       position="middle-right"
       showCloseButton={true}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu-test.js.snap
@@ -12,6 +12,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -243,6 +244,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -474,6 +476,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -705,6 +708,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -936,6 +940,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -1167,6 +1172,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -1505,6 +1511,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="bottom-center"
       text={
         <FormattedMessage
@@ -1621,6 +1628,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() should ren
 <Tooltip
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="bottom-center"
   text={
     <FormattedMessage
@@ -1653,6 +1661,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() should ren
 <Tooltip
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   position="bottom-center"
   text={
     <FormattedMessage

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu-test.js.snap
@@ -5,6 +5,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
   className="usm-ftux-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   isShown={false}
   onDismiss={[Function]}
   position="middle-left"
@@ -38,6 +39,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleWithTheLink"
         position="top-center"
         text={
@@ -70,6 +72,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleInYourCompany"
         position="top-center"
         text={
@@ -102,6 +105,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleInThisItem"
         position="top-center"
         text={
@@ -141,6 +145,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
   className="usm-ftux-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   isShown={false}
   onDismiss={[Function]}
   position="middle-left"
@@ -174,6 +179,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleWithTheLink"
         position="top-center"
         text={
@@ -206,6 +212,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleInYourCompany"
         position="top-center"
         text={
@@ -238,6 +245,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleInThisItem"
         position="top-center"
         text={
@@ -277,6 +285,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
   className="usm-ftux-tooltip"
   constrainToScrollParent={false}
   constrainToWindow={true}
+  isDisabled={false}
   isShown={true}
   onDismiss={[Function]}
   position="middle-left"
@@ -310,6 +319,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleWithTheLink"
         position="top-center"
         text={
@@ -342,6 +352,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleInYourCompany"
         position="top-center"
         text={
@@ -374,6 +385,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         key="tooltip-peopleInThisItem"
         position="top-center"
         text={

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection-test.js.snap
@@ -31,6 +31,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
             <Tooltip
               constrainToScrollParent={false}
               constrainToWindow={true}
+              isDisabled={false}
               position="top-center"
               text={
                 <FormattedMessage
@@ -66,6 +67,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       onDismiss={[Function]}
       position="middle-right"
@@ -99,6 +101,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-left"
       text={
         <FormattedMessage
@@ -173,6 +176,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-right"
       text={
         <FormattedMessage
@@ -206,6 +210,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       onDismiss={[Function]}
       position="middle-right"
@@ -239,6 +244,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-left"
       text={
         <FormattedMessage
@@ -309,6 +315,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-right"
       text={
         <FormattedMessage
@@ -377,6 +384,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       onDismiss={[Function]}
       position="middle-right"
@@ -410,6 +418,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-left"
       text={
         <FormattedMessage
@@ -519,6 +528,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-right"
       text={
         <FormattedMessage
@@ -552,6 +562,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       onDismiss={[Function]}
       position="middle-right"
@@ -585,6 +596,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-left"
       text={
         <FormattedMessage
@@ -622,6 +634,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-center"
       text={
         <FormattedMessage
@@ -684,6 +697,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       onDismiss={[Function]}
       position="middle-right"
@@ -717,6 +731,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-left"
       text={
         <FormattedMessage
@@ -812,6 +827,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       onDismiss={[Function]}
       position="middle-right"
@@ -845,6 +861,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-left"
       text={
         <FormattedMessage
@@ -965,6 +982,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
       className="usm-ftux-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       isShown={false}
       onDismiss={[Function]}
       position="middle-right"
@@ -998,6 +1016,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}
+      isDisabled={false}
       position="top-left"
       text={
         <FormattedMessage

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal-test.js.snap
@@ -33,6 +33,7 @@ exports[`features/unified-share-modal/UnifiedShareModal closeEmailSharedLinkForm
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -262,6 +263,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -436,6 +438,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -610,6 +613,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -788,6 +792,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={true}
         position="middle-left"
         showCloseButton={true}
@@ -962,6 +967,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -1136,6 +1142,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -1281,6 +1288,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -1456,6 +1464,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -1631,6 +1640,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -1806,6 +1816,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -2016,6 +2027,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -2194,6 +2206,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -2372,6 +2385,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -2546,6 +2560,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -2719,6 +2734,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}
@@ -2867,6 +2883,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         className="usm-ftux-tooltip"
         constrainToScrollParent={false}
         constrainToWindow={true}
+        isDisabled={false}
         isShown={false}
         position="middle-left"
         showCloseButton={true}


### PR DESCRIPTION
The tooltip will not show and just render its children when `text` is missing or if `isDisabled` is `true`.