### PR TITLE
fix(query-bar): user loses name column via column dropdown

### DIFF
--- a/src/features/query-bar/QueryBar.js
+++ b/src/features/query-bar/QueryBar.js
@@ -34,11 +34,18 @@ const QueryBar = ({
 }: Props) => {
     const metadataColumns = columns && columns.filter(column => column.source !== 'item');
     const columnsWithoutItemName = columns && columns.filter(column => !isItemName(column));
+    const nameColumn = columns && columns.find(column => column.source === 'item' && column.property === 'name');
+
     return (
         <section className="metadata-view-query-bar">
             <TemplateButton activeTemplate={activeTemplate} onTemplateChange={onTemplateChange} templates={templates} />
             <FilterButton columns={metadataColumns} conditions={conditions} onFilterChange={onFilterChange} />
-            <ColumnButton columns={columnsWithoutItemName} onColumnChange={onColumnChange} template={activeTemplate} />
+            <ColumnButton
+                columns={columnsWithoutItemName}
+                nameColumn={nameColumn}
+                onColumnChange={onColumnChange}
+                template={activeTemplate}
+            />
         </section>
     );
 };

--- a/src/features/query-bar/__tests__/ColumnButtonOverlay-test.js
+++ b/src/features/query-bar/__tests__/ColumnButtonOverlay-test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { columnForDateType, columnWithFloatType } from '../components/fixtures';
+import { columnForDateType, columnForItemName, columnWithFloatType } from '../components/fixtures';
 import ColumnButtonOverlay from '../components/ColumnButtonOverlay';
 
 const columns = [columnForDateType, columnWithFloatType];
@@ -41,20 +41,30 @@ describe('features/query-bar/components/ColumnButtonOverlay', () => {
     });
 
     describe('applyFilters()', () => {
-        [
-            {
-                description: 'Should apply filters to parent state',
-                pendingColumns: columns,
-            },
-        ].forEach(({ description, pendingColumns }) => {
-            test(`${description}`, () => {
-                const wrapper = getWrapper();
-
-                wrapper.setState({
-                    pendingColumns,
-                });
-                wrapper.instance().applyFilters();
+        test('Should apply filters to parent state and call onColumnChange with columns that include name column', () => {
+            const onColumnChange = jest.fn();
+            const wrapper = getWrapper({
+                nameColumn: columnForItemName,
+                onColumnChange,
             });
+            const updatedColumns = [columnForItemName, ...columns];
+
+            wrapper.setState({
+                pendingColumns: columns,
+            });
+            wrapper.instance().applyFilters();
+            expect(onColumnChange).toBeCalledWith(updatedColumns);
+        });
+
+        test('Should throw error if name column was not passed in', () => {
+            const onColumnChange = jest.fn();
+            const wrapper = getWrapper({
+                onColumnChange,
+            });
+
+            expect(() => {
+                wrapper.instance().applyFilters();
+            }).toThrow('Should have Name Column');
         });
     });
 

--- a/src/features/query-bar/__tests__/QueryBar-test.js
+++ b/src/features/query-bar/__tests__/QueryBar-test.js
@@ -28,6 +28,12 @@ describe('features/query-bar/components/QueryBar', () => {
         expect(ColumnButton.props().columns).toEqual([columnForTemplateFieldName]);
     });
 
+    test('should render ColumnButton with nameColumn', () => {
+        const wrapper = getWrapper({ columns });
+        const ColumnButton = wrapper.find('ColumnButton');
+        expect(ColumnButton.props().nameColumn).toEqual(columnForItemName);
+    });
+
     test('should render FilterButton with metadata columns', () => {
         const wrapper = getWrapper({ columns });
         const FilterButton = wrapper.find('FilterButton');

--- a/src/features/query-bar/components/ColumnButton.js
+++ b/src/features/query-bar/components/ColumnButton.js
@@ -19,6 +19,7 @@ type State = {
 
 type Props = {
     columns?: Array<ColumnType>,
+    nameColumn?: ColumnType,
     onColumnChange?: (columnTypes: Array<ColumnType>) => void,
     template?: MetadataTemplate,
 };
@@ -61,7 +62,7 @@ class ColumnButton extends React.Component<Props, State> {
     };
 
     render() {
-        const { template, columns, onColumnChange } = this.props;
+        const { columns, nameColumn, onColumnChange, template } = this.props;
         const { isColumnMenuOpen } = this.state;
         const numberOfHiddenColumns = this.getNumberOfHiddenColumns();
 
@@ -101,7 +102,11 @@ class ColumnButton extends React.Component<Props, State> {
 
                 <Overlay>
                     {isColumnMenuOpen ? (
-                        <ColumnButtonOverlay columns={columns} onColumnChange={onColumnChange} />
+                        <ColumnButtonOverlay
+                            columns={columns}
+                            nameColumn={nameColumn}
+                            onColumnChange={onColumnChange}
+                        />
                     ) : (
                         <div />
                     )}

--- a/src/features/query-bar/components/ColumnButtonOverlay.js
+++ b/src/features/query-bar/components/ColumnButtonOverlay.js
@@ -21,6 +21,7 @@ type State = {
 
 type Props = {
     columns?: Array<ColumnType>,
+    nameColumn?: ColumnType,
     onColumnChange?: (columnTypes: Array<ColumnType>) => void,
 };
 
@@ -57,10 +58,16 @@ class ColumnButtonOverlay extends React.Component<Props, State> {
     };
 
     applyFilters = () => {
-        const { onColumnChange } = this.props;
+        const { nameColumn, onColumnChange } = this.props;
         const { pendingColumns } = this.state;
+        const pendingColumnsCopy = cloneDeep(pendingColumns);
+        pendingColumnsCopy.unshift(nameColumn);
+        if (!nameColumn) {
+            throw new Error('Should have Name Column');
+        }
+
         if (onColumnChange) {
-            onColumnChange(pendingColumns);
+            onColumnChange(pendingColumnsCopy);
         }
     };
 

--- a/src/features/query-bar/components/ColumnButtonOverlay.js
+++ b/src/features/query-bar/components/ColumnButtonOverlay.js
@@ -60,11 +60,12 @@ class ColumnButtonOverlay extends React.Component<Props, State> {
     applyFilters = () => {
         const { nameColumn, onColumnChange } = this.props;
         const { pendingColumns } = this.state;
+
         const pendingColumnsCopy = cloneDeep(pendingColumns);
-        pendingColumnsCopy.unshift(nameColumn);
         if (!nameColumn) {
             throw new Error('Should have Name Column');
         }
+        pendingColumnsCopy.unshift(nameColumn);
 
         if (onColumnChange) {
             onColumnChange(pendingColumnsCopy);


### PR DESCRIPTION
Changes in this PR:
- Pass down `nameColumn` from QueryBar
- When `onColumnChange` is called in ColumnButtonOverlay, insert `nameColumn` back into the columns array at index 0
<img width="616" alt="Screen Shot 2019-04-12 at 10 55 44 AM" src="https://user-images.githubusercontent.com/7213887/56056607-8cd35c80-5d11-11e9-877b-fa1c7845b37f.png">
