### PR TITLE
fix(query-bar): blank page shown on clicking x button in date input

### DIFF
--- a/src/features/query-bar/__tests__/ValueField-test.js
+++ b/src/features/query-bar/__tests__/ValueField-test.js
@@ -56,13 +56,14 @@ describe('features/query-bar/components/filter/ValueField', () => {
             const dateValue = new Date(1995, 11, 25, 9, 30, 0);
 
             test.each`
-                description                                                      | valueType        | componentName          | selectedValues     | expectedValue
-                ${'should render MultiSelectField for valueType of multiSelect'} | ${'multiSelect'} | ${'MultiSelectField'}  | ${['r', 'g', 'b']} | ${['r', 'g', 'b']}
-                ${'should render SingleSelectField for valueType of enum'}       | ${'enum'}        | ${'SingleSelectField'} | ${[stringValue]}   | ${stringValue}
-                ${'should render DatePicker for valueType of date'}              | ${'date'}        | ${'DatePicker'}        | ${[dateValue]}     | ${dateValue}
-                ${'should render TextInput for valueType of string'}             | ${'string'}      | ${'TextInput'}         | ${[stringValue]}   | ${stringValue}
-                ${'should render TextInput for valueType of float'}              | ${'float'}       | ${'TextInput'}         | ${[stringValue]}   | ${stringValue}
-                ${'should render TextInput for valueType of number'}             | ${'number'}      | ${'TextInput'}         | ${[stringValue]}   | ${stringValue}
+                description                                                                                     | valueType        | componentName          | selectedValues     | expectedValue
+                ${'should render MultiSelectField for valueType of multiSelect'}                                | ${'multiSelect'} | ${'MultiSelectField'}  | ${['r', 'g', 'b']} | ${['r', 'g', 'b']}
+                ${'should render SingleSelectField for valueType of enum'}                                      | ${'enum'}        | ${'SingleSelectField'} | ${[stringValue]}   | ${stringValue}
+                ${'should render DatePicker for valueType of date'}                                             | ${'date'}        | ${'DatePicker'}        | ${[dateValue]}     | ${dateValue}
+                ${'should render DatePicker for valueType of date and user tries to delete the existing input'} | ${'date'}        | ${'DatePicker'}        | ${[null]}          | ${undefined}
+                ${'should render TextInput for valueType of string'}                                            | ${'string'}      | ${'TextInput'}         | ${[stringValue]}   | ${stringValue}
+                ${'should render TextInput for valueType of float'}                                             | ${'float'}       | ${'TextInput'}         | ${[stringValue]}   | ${stringValue}
+                ${'should render TextInput for valueType of number'}                                            | ${'number'}      | ${'TextInput'}         | ${[stringValue]}   | ${stringValue}
             `('$description', ({ componentName, expectedValue, selectedValues, valueType }) => {
                 const wrapper = getWrapper({ valueType, selectedValues });
 

--- a/src/features/query-bar/components/filter/ValueField.js
+++ b/src/features/query-bar/components/filter/ValueField.js
@@ -20,11 +20,7 @@ type Props = {
 };
 
 const getDateValue = selectedValues => {
-    if (selectedValues.length === 0) {
-        return undefined;
-    }
-
-    if (selectedValues[0] === null) {
+    if (selectedValues.length === 0 || selectedValues[0] === null) {
         return undefined;
     }
 

--- a/src/features/query-bar/components/filter/ValueField.js
+++ b/src/features/query-bar/components/filter/ValueField.js
@@ -24,6 +24,10 @@ const getDateValue = selectedValues => {
         return undefined;
     }
 
+    if (selectedValues[0] === null) {
+        return undefined;
+    }
+
     const value = selectedValues[0];
     if (value instanceof Date) {
         return value;


### PR DESCRIPTION
Changes in this PR:
- Check to see if `selectedValues` is an array of a null element, if so, return undefined
^The case above is due to the user clicking on the X button when deleting the Datepicker input
