### PR TITLE
fix(query-bar): persist changes after closing flyout

### DIFF
--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -76,7 +76,7 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
 
         test.each`
             innerColumns | conditions         | transientConditions | expectedConditions    | should
-            ${columns}   | ${validConditions} | ${[]}               | ${validConditions}    | ${'should reinitialize conditions from props.conditions when flyout is opened and transientConditions is not empty'}
+            ${columns}   | ${validConditions} | ${[]}               | ${validConditions}    | ${'should reinitialize conditions from props.conditions when flyout is opened and props.conditions is not empty'}
             ${columns}   | ${[]}              | ${[]}               | ${[initialCondition]} | ${'should set initial condition if props.conditions is empty and transientConditions are empty'}
             ${[]}        | ${[]}              | ${[]}               | ${[]}                 | ${'should set empty array if props.conditions is empty and transientConditions are empty and columns are empty'}
         `('$should', ({ innerColumns, conditions, transientConditions, expectedConditions }) => {

--- a/src/features/query-bar/__tests__/FilterButton-test.js
+++ b/src/features/query-bar/__tests__/FilterButton-test.js
@@ -69,19 +69,21 @@ describe('feature/query-bar/components/filter/FilterButton', () => {
     describe('componentDidUpdate()', () => {
         const initialCondition = {
             columnId: columnForTemplateFieldName.id,
-            id: '2',
+            id: '1',
             operator: '=',
             values: [],
         };
+
         test.each`
-            innerColumns | conditions         | expectedConditions    | should
-            ${columns}   | ${validConditions} | ${validConditions}    | ${'should reinitialize conditions from props.conditions when flyout is opened and props.conditions is not empty'}
-            ${columns}   | ${[]}              | ${[initialCondition]} | ${'should set to initial condition when flyout is opened and props.conditions is empty'}
-            ${[]}        | ${[]}              | ${[]}                 | ${'should set to empty array when flyout is opened and both props.columns and props.conditions is empty'}
-        `('$should', ({ innerColumns, conditions, expectedConditions }) => {
+            innerColumns | conditions         | transientConditions | expectedConditions    | should
+            ${columns}   | ${validConditions} | ${[]}               | ${validConditions}    | ${'should reinitialize conditions from props.conditions when flyout is opened and transientConditions is not empty'}
+            ${columns}   | ${[]}              | ${[]}               | ${[initialCondition]} | ${'should set initial condition if props.conditions is empty and transientConditions are empty'}
+            ${[]}        | ${[]}              | ${[]}               | ${[]}                 | ${'should set empty array if props.conditions is empty and transientConditions are empty and columns are empty'}
+        `('$should', ({ innerColumns, conditions, transientConditions, expectedConditions }) => {
             const wrapper = getWrapper({ columns: innerColumns, conditions });
             wrapper.setState({
                 isMenuOpen: true,
+                transientConditions,
             });
             wrapper.instance().componentDidUpdate({}, { isMenuOpen: false });
 

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -51,17 +51,21 @@ class FilterButton extends React.Component<Props, State> {
 
     componentDidUpdate(prevProps: Props, prevState: State) {
         const { columns } = this.props;
-        const { isMenuOpen } = this.state;
+        const { isMenuOpen, transientConditions } = this.state;
         const { isMenuOpen: prevIsMenuOpen } = prevState;
         const wasFlyoutOpened = isMenuOpen && !prevIsMenuOpen;
         if (wasFlyoutOpened) {
             const areConditionsEmpty = this.props.conditions.length === 0;
-            if (areConditionsEmpty) {
-                const transientConditions = columns && columns.length === 0 ? [] : [this.createCondition()];
+            const isInitialConditionSet = transientConditions.length > 0;
+            const shouldSetInitialCondition = areConditionsEmpty && !isInitialConditionSet;
+            const shouldReinitializeConditions = !isInitialConditionSet;
+
+            if (shouldSetInitialCondition) {
+                const conditions = columns && columns.length === 0 ? [] : [this.createCondition()];
                 this.setState({
-                    transientConditions,
+                    transientConditions: conditions,
                 });
-            } else {
+            } else if (shouldReinitializeConditions) {
                 this.setState({
                     transientConditions: cloneDeep(this.props.conditions),
                 });

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -50,25 +50,25 @@ class FilterButton extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props, prevState: State) {
-        const { columns } = this.props;
+        const { columns, conditions } = this.props;
         const { isMenuOpen, transientConditions } = this.state;
         const { isMenuOpen: prevIsMenuOpen } = prevState;
         const wasFlyoutOpened = isMenuOpen && !prevIsMenuOpen;
         if (wasFlyoutOpened) {
-            const areConditionsEmpty = this.props.conditions.length === 0;
             const isInitialConditionSet = transientConditions.length > 0;
-            const shouldSetInitialCondition = areConditionsEmpty && !isInitialConditionSet;
-            const shouldReinitializeConditions = !isInitialConditionSet;
+            const shouldSetInitialCondition = conditions.length === 0;
 
-            if (shouldSetInitialCondition) {
-                const conditions = columns && columns.length === 0 ? [] : [this.createCondition()];
-                this.setState({
-                    transientConditions: conditions,
-                });
-            } else if (shouldReinitializeConditions) {
-                this.setState({
-                    transientConditions: cloneDeep(this.props.conditions),
-                });
+            if (!isInitialConditionSet) {
+                if (shouldSetInitialCondition) {
+                    const newConditions = columns && columns.length === 0 ? [] : [this.createCondition()];
+                    this.setState({
+                        transientConditions: newConditions,
+                    });
+                } else {
+                    this.setState({
+                        transientConditions: cloneDeep(this.props.conditions),
+                    });
+                }
             }
         }
     }

--- a/src/features/query-bar/components/filter/FilterButton.js
+++ b/src/features/query-bar/components/filter/FilterButton.js
@@ -55,10 +55,10 @@ class FilterButton extends React.Component<Props, State> {
         const { isMenuOpen: prevIsMenuOpen } = prevState;
         const wasFlyoutOpened = isMenuOpen && !prevIsMenuOpen;
         if (wasFlyoutOpened) {
-            const isInitialConditionSet = transientConditions.length > 0;
+            const hasUnsavedConditions = transientConditions.length > 0;
             const shouldSetInitialCondition = conditions.length === 0;
 
-            if (!isInitialConditionSet) {
+            if (!hasUnsavedConditions) {
                 if (shouldSetInitialCondition) {
                     const newConditions = columns && columns.length === 0 ? [] : [this.createCondition()];
                     this.setState({


### PR DESCRIPTION
Changes in this PR:
- handle two distinct cases:
   1. whether or not the initial condition should be set
   2. whether or not we want to reinitialize conditions from the parent app

![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/7213887/56165437-cdd4a680-5f87-11e9-8c88-31d5c38da29a.gif)
