### PR TITLE
fix(sidebar): Details sidebar render no longer collapses on load

### DIFF
--- a/src/elements/content-sidebar/DetailsSidebar.js
+++ b/src/elements/content-sidebar/DetailsSidebar.js
@@ -441,16 +441,15 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
             isLoadingClassification,
         }: State = this.state;
 
-        if (!file) {
-            return null; // TODO: change to loading indicator and handle errors once file call split out
-        }
-
+        // TODO: Add loading indicator and handle errors once file call is split out
         return (
             <SidebarContent className="bcs-details" title={SidebarUtils.getTitleForView(SIDEBAR_VIEW_DETAILS)}>
-                {hasNotices && (
-                    <div className="bcs-details-content">{hasNotices && <SidebarNotices file={file} />}</div>
+                {file && hasNotices && (
+                    <div className="bcs-details-content">
+                        <SidebarNotices file={file} />
+                    </div>
                 )}
-                {hasAccessStats && (
+                {file && hasAccessStats && (
                     <SidebarAccessStats
                         accessStats={accessStats}
                         file={file}
@@ -458,16 +457,14 @@ class DetailsSidebar extends React.PureComponent<Props, State> {
                         {...accessStatsError}
                     />
                 )}
-                {hasProperties && (
+                {file && hasProperties && (
                     <SidebarSection
                         interactionTarget={SECTION_TARGETS.FILE_PROPERTIES}
                         title={<FormattedMessage {...messages.sidebarProperties} />}
                     >
                         {hasVersions && (
                             <div className="bcs-details-content">
-                                {hasVersions && (
-                                    <SidebarVersions file={file} onVersionHistoryClick={onVersionHistoryClick} />
-                                )}
+                                <SidebarVersions file={file} onVersionHistoryClick={onVersionHistoryClick} />
                             </div>
                         )}
                         <SidebarFileProperties

--- a/src/elements/content-sidebar/__tests__/DetailsSidebar-test.js
+++ b/src/elements/content-sidebar/__tests__/DetailsSidebar-test.js
@@ -67,7 +67,7 @@ describe('elements/content-sidebar/DetailsSidebar', () => {
     });
 
     describe('render()', () => {
-        test('should render nothing if there is no file information', () => {
+        test('should render an empty container if there is no file information', () => {
             // TODO: replace this test with proper loading and error cases once files call split out
             const wrapper = getWrapper({}, { disableLifecycleMethods: true });
             expect(wrapper).toMatchSnapshot();

--- a/src/elements/content-sidebar/__tests__/__snapshots__/DetailsSidebar-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/DetailsSidebar-test.js.snap
@@ -166,4 +166,14 @@ exports[`elements/content-sidebar/DetailsSidebar render() should render DetailsS
 />
 `;
 
-exports[`elements/content-sidebar/DetailsSidebar render() should render nothing if there is no file information 1`] = `""`;
+exports[`elements/content-sidebar/DetailsSidebar render() should render an empty container if there is no file information 1`] = `
+<SidebarContent
+  className="bcs-details"
+  title={
+    <FormattedMessage
+      defaultMessage="Details"
+      id="be.sidebarDetailsTitle"
+    />
+  }
+/>
+`;


### PR DESCRIPTION
Returning `null` in render causes the Details sidebar to momentarily collapse, which is causing issues with the sidebar navigation tooltips.