### PR TITLE
fix(list-view): use smaller sort icon

### DIFF
--- a/src/features/list-view/styles/ListView.scss
+++ b/src/features/list-view/styles/ListView.scss
@@ -21,8 +21,8 @@
         width: 100%;
 
         .bdl-icon-sort-chevron {
-            height: 17px;
-            width: 17px;
+            height: 11px;
+            width: 11px;
         }
 
         .bdl-icon-sort-chevron.bdl-ListView-isSortAsc {

--- a/src/features/list-view/styles/ListView.scss
+++ b/src/features/list-view/styles/ListView.scss
@@ -20,11 +20,6 @@
         text-transform: none;
         width: 100%;
 
-        .bdl-icon-sort-chevron {
-            height: 11px;
-            width: 11px;
-        }
-
         .bdl-icon-sort-chevron.bdl-ListView-isSortAsc {
             transform: rotate(180deg);
         }


### PR DESCRIPTION
Changes in this PR:
- Use 11px for height and width instead of 17px to maintain consistency with parent app
<img width="163" alt="Screen Shot 2019-04-15 at 4 20 19 PM" src="https://user-images.githubusercontent.com/7213887/56171661-f6b26700-5f9a-11e9-8224-41a01f636d80.png">
