### PR TITLE
fix(preview): Preview now expands to fill its flex parent when possible

### DIFF
--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -2,6 +2,7 @@
 
 .bcpr {
     display: flex;
+    flex: 1;
     flex-direction: column;
 
     .bcpr-body {


### PR DESCRIPTION
This fixes an issue in the beta versions of Chrome 74 and 75 where Preview is not shown on the shared files page. Using `height: 100%` inside a flex parent without its own height defined can be very flaky.