### PR TITLE
feat(tasks): show full task assignee list in dropdown

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -410,6 +410,8 @@ be.tasks.createTask.general.title = Create General Task
 be.tasks.feed.approveAction = Approve
 # Label for an approved task
 be.tasks.feed.approvedLabel = Task Approved
+# Title for list of all task assignees
+be.tasks.feed.assigneeList.title = Assignees
 # Completion option for a general task
 be.tasks.feed.completeAction = Mark as Complete
 # Label for a completed task
@@ -424,10 +426,22 @@ be.tasks.feed.headline.general = {user} assigned a Task
 be.tasks.feed.headline.general.currentUser = {user} assigned you a Task
 # Label for an incomplete task
 be.tasks.feed.incompleteLabel = Awaiting Assignees
+# Label for button to expand flyout to see all task assignees
+be.tasks.feed.moreAssigneesLabel = See all assignees
 # Reject option for an approval task
 be.tasks.feed.rejectAction = Reject
 # Label for a rejected task
 be.tasks.feed.rejectedLabel = Task Rejected
+# accepted task status
+be.tasks.status.accepted = Accepted
+# Completed task status
+be.tasks.status.completed = Completed
+# Task status when in progress
+be.tasks.status.inProgress = Awaiting
+# Task status when not started
+be.tasks.status.notStarted = Awaiting
+# Rejected task status
+be.tasks.status.rejected = Rejected
 # Label and date for task due date
 be.tasks.taskDueDate = Due: {date}
 # Tasks for approval

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -1003,6 +1003,41 @@ const messages = defineMessages({
         defaultMessage: '{ user } assigned a Task',
         description: 'Comment headline for a general task',
     },
+    tasksFeedMoreAssigneesLabel: {
+        id: 'be.tasks.feed.moreAssigneesLabel',
+        defaultMessage: 'See all assignees',
+        description: 'Label for button to expand flyout to see all task assignees',
+    },
+    tasksFeedAssigneeListTitle: {
+        id: 'be.tasks.feed.assigneeList.title',
+        defaultMessage: 'Assignees',
+        description: 'Title for list of all task assignees',
+    },
+    tasksFeedStatusRejected: {
+        id: 'be.tasks.status.rejected',
+        defaultMessage: 'Rejected',
+        description: 'Rejected task status',
+    },
+    tasksFeedStatusAccepted: {
+        id: 'be.tasks.status.accepted',
+        defaultMessage: 'Accepted',
+        description: 'accepted task status',
+    },
+    tasksFeedStatusCompleted: {
+        id: 'be.tasks.status.completed',
+        defaultMessage: 'Completed',
+        description: 'Completed task status',
+    },
+    tasksFeedStatusNotStarted: {
+        id: 'be.tasks.status.notStarted',
+        defaultMessage: 'Awaiting',
+        description: 'Task status when not started',
+    },
+    tasksFeedStatusInProgress: {
+        id: 'be.tasks.status.inProgress',
+        defaultMessage: 'Awaiting',
+        description: 'Task status when in progress',
+    },
     versionDeleted: {
         id: 'be.versionDeleted',
         defaultMessage: '{ name } deleted version { version_number }',

--- a/src/elements/content-sidebar/activity-feed/task-new/AssigneeStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/AssigneeStatus.js
@@ -27,8 +27,8 @@ const StatusIcon = ({ status, ...rest }: { status: TaskCollabStatus }) => {
     }
 };
 
-const AssignmentStatus = React.memo<Props>(({ user, status, getAvatarUrl, ...rest }: Props) => (
-    <div className="bcs-task-assignment-status" {...rest}>
+const AssignmentStatus = React.memo<Props>(({ user, status, getAvatarUrl, className, ...rest }: Props) => (
+    <div className={`bcs-task-assignment-status ${className}`} {...rest}>
         <Avatar className="bcs-task-assignment-avatar" user={user} getAvatarUrl={getAvatarUrl} />
         <StatusIcon
             status={status}

--- a/src/elements/content-sidebar/activity-feed/task-new/AssigneeStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/AssigneeStatus.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
+import classNames from 'classnames';
 import camelCase from 'lodash/camelCase';
 import IconComplete from '../../../../icons/general/IconVerified';
 import IconReject from '../../../../icons/general/IconRejected';
@@ -9,6 +10,7 @@ import { TASK_NEW_APPROVED, TASK_NEW_REJECTED, TASK_NEW_COMPLETED, TASK_NEW_NOT_
 import messages from '../../../common/messages';
 
 type Props = {
+    className?: string,
     getAvatarUrl?: GetAvatarUrlCallback,
     status: TaskCollabStatus,
     user: UserMini,
@@ -28,7 +30,7 @@ const StatusIcon = ({ status, ...rest }: { status: TaskCollabStatus }) => {
 };
 
 const AssignmentStatus = React.memo<Props>(({ user, status, getAvatarUrl, className, ...rest }: Props) => (
-    <div className={`bcs-task-assignment-status ${className}`} {...rest}>
+    <div className={classNames('bcs-task-assignment-status', className)} {...rest}>
         <Avatar className="bcs-task-assignment-avatar" user={user} getAvatarUrl={getAvatarUrl} />
         <StatusIcon
             status={status}

--- a/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
@@ -83,7 +83,8 @@ class Assignees extends React.Component<Props> {
                     {visibleAssignees}
                     {hiddenAssigneeCount > 0 && (
                         <Flyout position="top-left">
-                            <span
+                            <button
+                                type="button"
                                 className="bcs-task-assignment-count-container"
                                 data-testid="task-assignment-overflow"
                             >
@@ -92,7 +93,7 @@ class Assignees extends React.Component<Props> {
                                         {overflowLabel}
                                     </span>
                                 </Tooltip>
-                            </span>
+                            </button>
                             <Overlay>
                                 <div className="bcs-task-assignment-list">
                                     <h5 className="bcs-task-assignment-list-title">

--- a/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
@@ -1,0 +1,112 @@
+// @flow strict
+import * as React from 'react';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import type { InjectIntlProvidedProps } from 'react-intl';
+import { Flyout, Overlay } from '../../../../components/flyout';
+import Tooltip from '../../../../components/tooltip';
+import messages from '../../../common/messages';
+import AssigneeStatus from './AssigneeStatus';
+import { TASK_NEW_APPROVED, TASK_NEW_REJECTED, TASK_NEW_COMPLETED, TASK_NEW_NOT_STARTED } from '../../../../constants';
+
+const MAX_AVATARS = 3;
+
+type Props = {|
+    assignees: TaskAssigneeCollection,
+    getAvatarUrl: GetAvatarUrlCallback,
+    maxAvatars?: number,
+    ...InjectIntlProvidedProps,
+|};
+
+const statusMessages = {
+    [TASK_NEW_APPROVED]: <FormattedMessage {...messages.tasksFeedStatusAccepted} />,
+    [TASK_NEW_REJECTED]: <FormattedMessage {...messages.tasksFeedStatusRejected} />,
+    [TASK_NEW_COMPLETED]: <FormattedMessage {...messages.tasksFeedStatusCompleted} />,
+    [TASK_NEW_NOT_STARTED]: <FormattedMessage {...messages.tasksFeedStatusNotStarted} />,
+};
+
+const AssigneeTooltipLabel = React.memo(({ user, status }) => {
+    const statusMessage = statusMessages[status] || null;
+    return (
+        <div className="bcs-task-assignment-tooltip-text">
+            <div>
+                <strong>{user.name}</strong>
+            </div>
+            {statusMessage && <div>{statusMessage}</div>}
+        </div>
+    );
+});
+
+class Assignees extends React.Component<Props> {
+    state = {};
+
+    render() {
+        const { maxAvatars = MAX_AVATARS, assignees, getAvatarUrl, intl } = this.props;
+        const assigneeCount = (assignees && assignees.entries.length) || 0;
+        const hiddenAssigneeCount = assigneeCount - maxAvatars;
+        const overflowLabel = `+${hiddenAssigneeCount}`;
+        const visibleAssignees = assignees.entries
+            .slice(0, maxAvatars)
+            .map(({ id: assignmentId, target, status: assigneeStatus }) => {
+                return (
+                    <Tooltip key={assignmentId} text={<AssigneeTooltipLabel user={target} status={assigneeStatus} />}>
+                        <AssigneeStatus
+                            key={assignmentId}
+                            status={assigneeStatus}
+                            user={target}
+                            getAvatarUrl={getAvatarUrl}
+                            data-testid="task-assignment-status"
+                        />
+                    </Tooltip>
+                );
+            });
+        const hiddenAssignees = assignees.entries.map(({ id: assignmentId, target, status: assigneeStatus }) => {
+            const statusMessage = statusMessages[assigneeStatus] || null;
+            return (
+                <div key={assignmentId} className="bcs-task-assignment-list-item">
+                    <AssigneeStatus
+                        status={assigneeStatus}
+                        className="bcs-task-assignment-list-item-avatar"
+                        user={target}
+                        getAvatarUrl={getAvatarUrl}
+                        data-testid="task-assignment-status"
+                    />
+                    <div className="bcs-task-assignment-list-item-details">
+                        <div>{target.name}</div>
+                        <div className="bcs-task-assignment-list-item-status">{statusMessage}</div>
+                    </div>
+                </div>
+            );
+        });
+        return (
+            <div className="bcs-task-assignment-container">
+                <div className="bcs-task-assignments">
+                    {visibleAssignees}
+                    {hiddenAssigneeCount > 0 && (
+                        <Flyout position="top-left">
+                            <span
+                                className="bcs-task-assignment-count-container"
+                                data-testid="task-assignment-overflow"
+                            >
+                                <Tooltip text={intl.formatMessage(messages.tasksFeedMoreAssigneesLabel)}>
+                                    <span className="bcs-task-assignment-count bcs-task-assignment-avatar">
+                                        {overflowLabel}
+                                    </span>
+                                </Tooltip>
+                            </span>
+                            <Overlay>
+                                <div className="bcs-task-assignment-list">
+                                    <h5 className="bcs-task-assignment-list-title">
+                                        <FormattedMessage {...messages.tasksFeedAssigneeListTitle} />
+                                    </h5>
+                                    {hiddenAssignees}
+                                </div>
+                            </Overlay>
+                        </Flyout>
+                    )}
+                </div>
+            </div>
+        );
+    }
+}
+
+export default injectIntl(Assignees);

--- a/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
@@ -101,13 +101,13 @@ class Assignees extends React.Component<Props> {
                                     </span>
                                 </Tooltip>
                             </PlainButton>
-                            <Overlay>
-                                <div className="bcs-task-assignment-list">
-                                    <p className="bcs-task-assignment-list-title" id={this.listTitleId}>
-                                        <FormattedMessage {...messages.tasksFeedAssigneeListTitle} />
-                                    </p>
-                                    <ul arial-labelledby={this.listTitleId}>{allAssignees}</ul>
-                                </div>
+                            <Overlay className="bcs-task-assignment-list-flyout">
+                                <p className="bcs-task-assignment-list-title" id={this.listTitleId}>
+                                    <FormattedMessage {...messages.tasksFeedAssigneeListTitle} />
+                                </p>
+                                <ul className="bcs-task-assignment-list" arial-labelledby={this.listTitleId}>
+                                    {allAssignees}
+                                </ul>
                             </Overlay>
                         </Flyout>
                     )}

--- a/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Assignees.js
@@ -14,8 +14,7 @@ type Props = {|
     assignees: TaskAssigneeCollection,
     getAvatarUrl: GetAvatarUrlCallback,
     maxAvatars?: number,
-    ...InjectIntlProvidedProps,
-|};
+|} & InjectIntlProvidedProps;
 
 const statusMessages = {
     [TASK_NEW_APPROVED]: <FormattedMessage {...messages.tasksFeedStatusAccepted} />,
@@ -36,9 +35,8 @@ const AssigneeTooltipLabel = React.memo(({ user, status }) => {
     );
 });
 
+/* eslint-disable react/prefer-stateless-function */
 class Assignees extends React.Component<Props> {
-    state = {};
-
     render() {
         const { maxAvatars = MAX_AVATARS, assignees, getAvatarUrl, intl } = this.props;
         const assigneeCount = (assignees && assignees.entries.length) || 0;

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.js
@@ -3,13 +3,10 @@ import * as React from 'react';
 import noop from 'lodash/noop';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import { fillUserPlaceholder } from '../../../../utils/fields';
 import messages from '../../../common/messages';
-
 import CommentInlineError from '../comment/CommentInlineError';
 import IconTaskApproval from '../../../../icons/two-toned/IconTaskApproval';
 import IconTaskGeneral from '../../../../icons/two-toned/IconTaskGeneral';
-
 import {
     TASK_NEW_APPROVED,
     TASK_NEW_REJECTED,
@@ -19,13 +16,11 @@ import {
     TASK_TYPE_APPROVAL,
 } from '../../../../constants';
 import Comment from '../comment';
-import AssigneeStatus from './AssigneeStatus';
 import TaskActions from './TaskActions';
 import TaskDueDate from './TaskDueDate';
 import Status from './TaskStatus';
+import Assignees from './Assignees';
 import './Task.scss';
-
-const MAX_AVATARS = 3;
 
 type Props = {|
     ...TaskNew,
@@ -43,41 +38,6 @@ type Props = {|
     translatedTaggedMessage?: string,
     translations?: Translations,
 |};
-
-type AssigneeProps = {|
-    assignees: TaskAssigneeCollection,
-    getAvatarUrl: GetAvatarUrlCallback,
-    maxAvatars?: number,
-|};
-
-const Assignees = React.memo<AssigneeProps>(({ maxAvatars = MAX_AVATARS, assignees, getAvatarUrl }: AssigneeProps) => {
-    const assigneeCount = (assignees && assignees.entries.length) || 0;
-    const hiddenAssigneeCount = assigneeCount - maxAvatars;
-    return (
-        <div className="bcs-task-assignment-container">
-            <div className="bcs-task-assignments">
-                {assigneeCount > 0 &&
-                    assignees.entries
-                        .map(fillUserPlaceholder)
-                        .slice(0, MAX_AVATARS)
-                        .map(({ id: assignmentId, target, status: assigneeStatus }) => {
-                            return (
-                                <AssigneeStatus
-                                    key={assignmentId}
-                                    status={assigneeStatus}
-                                    user={target}
-                                    getAvatarUrl={getAvatarUrl}
-                                    data-testid="task-assignment-status"
-                                />
-                            );
-                        })}
-                {hiddenAssigneeCount > 0 ? (
-                    <span className="bcs-task-assignment-avatar bcs-task-assignment-count">+{hiddenAssigneeCount}</span>
-                ) : null}
-            </div>
-        </div>
-    );
-});
 
 const getMessageForTask = (isCurrentUser: boolean, taskType: TaskType) => {
     if (isCurrentUser) {
@@ -179,7 +139,7 @@ const Task = ({
                 />
                 <div className="bcs-task-content">{!!due_at && <TaskDueDate dueDate={due_at} status={status} />}</div>
                 <div className="bcs-task-content">
-                    <Assignees maxAvatars={MAX_AVATARS} assignees={assigned_to} getAvatarUrl={getAvatarUrl} />
+                    <Assignees maxAvatars={3} assignees={assigned_to} getAvatarUrl={getAvatarUrl} />
                 </div>
                 <div className="bcs-task-content">
                     {currentUserAssignment && shouldShowActions ? (

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -141,7 +141,7 @@ $card-left-offset: 40px;
     @include avatar-badge-icon;
 }
 
-.bcs-task-assignment-list {
+.bcs-task-assignment-list-flyout {
     max-width: 100%;
     width: 280px;
 
@@ -152,6 +152,12 @@ $card-left-offset: 40px;
     }
 }
 
+.bcs-task-assignment-list {
+    max-height: 215px;
+    overflow: hidden auto;
+    overflow-y: overlay; // nicer scroll bar for Blink engines only
+}
+
 .bcs-task-assignment-list-title {
     font-size: 15px;
     margin: 0 0 12px 0;
@@ -160,7 +166,8 @@ $card-left-offset: 40px;
 .bcs-task-assignment-list-item {
     align-items: flex-start;
     display: flex;
-    margin: 12px 0 0 0;
+    margin: 6px 0 0 0;
+    padding: 3px 0;
 }
 
 .bcs-task-assignment-list-item-avatar {

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -2,7 +2,6 @@
 
 $success-color: $shady-acres;
 $error-color: $red;
-$gray: $bdl-neutral-03;
 $assignment-avatar-spacing: 4px;
 $card-left-offset: 40px;
 
@@ -64,7 +63,7 @@ $card-left-offset: 40px;
 
     .bcs-task-assignment-count {
         align-items: center;
-        background: $gray;
+        background: $bdl-neutral-02;
         border-radius: 100%;
         color: #fff;
         cursor: pointer;
@@ -104,7 +103,7 @@ $card-left-offset: 40px;
             justify-content: center;
 
             .fill-color {
-                fill: $gray;
+                fill: $bdl-neutral-02;
             }
         }
     }
@@ -173,5 +172,5 @@ $card-left-offset: 40px;
 }
 
 .bcs-task-assignment-list-item-status {
-    color: $bdl-neutral-03;
+    color: $bdl-neutral-02;
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -62,13 +62,6 @@ $card-left-offset: 40px;
         right: 4px;
     }
 
-    .bcs-task-assignment-count-container {
-        // override button styles
-        border: 0;
-        font-size: 100%;
-        padding: 0;
-    }
-
     .bcs-task-assignment-count {
         align-items: center;
         background: $gray;
@@ -152,16 +145,23 @@ $card-left-offset: 40px;
 .bcs-task-assignment-list {
     max-width: 100%;
     width: 280px;
+
+    // reset base styles set by ui-elements
+    ul {
+        margin: 0;
+        padding: 0;
+    }
 }
 
 .bcs-task-assignment-list-title {
-    margin-top: 0;
+    font-size: 15px;
+    margin: 0 0 12px 0;
 }
 
 .bcs-task-assignment-list-item {
     align-items: flex-start;
     display: flex;
-    margin-top: 12px;
+    margin: 12px 0 0 0;
 }
 
 .bcs-task-assignment-list-item-avatar {

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -2,17 +2,20 @@
 
 $success-color: $shady-acres;
 $error-color: $red;
-$gray: $nines;
+$gray: $bdl-neutral-03;
 $assignment-avatar-spacing: 4px;
 $card-left-offset: 40px;
 
 @mixin avatar-badge-icon {
+    background: $white;
     border: 1px solid $white;
     border-radius: 50%;
+    bottom: 0;
     position: absolute;
+    right: 0;
 }
 
-.be .bcs-task {
+.bcs-task {
     opacity: 1;
     transition: opacity .33s;
 
@@ -56,7 +59,6 @@ $card-left-offset: 40px;
     .bcs-task-avatar-badge {
         @include avatar-badge-icon;
 
-        bottom: 0;
         right: 4px;
     }
 
@@ -65,33 +67,10 @@ $card-left-offset: 40px;
         background: $gray;
         border-radius: 100%;
         color: #fff;
+        cursor: pointer;
         display: flex;
+        font-weight: bold;
         justify-content: center;
-    }
-
-    .bcs-task-assignment-status {
-        display: inline-block;
-        height: 32px;
-        position: relative;
-        width: 32px;
-
-        & + .bcs-task-assignment-status,
-        & + .bcs-task-assignment-count {
-            margin-left: $assignment-avatar-spacing;
-        }
-    }
-
-    .bcs-task-assignment-status-icon {
-        @include avatar-badge-icon;
-
-        bottom: 0;
-        right: 0;
-
-        &.completed,
-        &.approved,
-        &.rejected {
-            background: $white;
-        }
     }
 
     .bcs-task-status {
@@ -141,4 +120,51 @@ $card-left-offset: 40px;
     button:first-of-type.bcs-task-action-button {
         margin-left: 0;
     }
+}
+
+.bcs-task-assignment-tooltip-text {
+    text-align: center;
+}
+
+.bcs-task-assignment-status {
+    display: inline-block;
+    height: 32px;
+    position: relative;
+    width: 32px;
+
+    & + .bcs-task-assignment-status,
+    & + .bcs-task-assignment-count-container {
+        margin-left: $assignment-avatar-spacing;
+    }
+}
+
+.bcs-task-assignment-status-icon {
+    @include avatar-badge-icon;
+}
+
+.bcs-task-assignment-list {
+    max-width: 100%;
+    width: 280px;
+}
+
+.bcs-task-assignment-list-title {
+    margin-top: 0;
+}
+
+.bcs-task-assignment-list-item {
+    align-items: flex-start;
+    display: flex;
+    margin-top: 12px;
+}
+
+.bcs-task-assignment-list-item-avatar {
+    margin-right: 10px;
+}
+
+.bcs-task-assignment-list-item-details {
+    line-height: 16px;
+}
+
+.bcs-task-assignment-list-item-status {
+    color: $bdl-neutral-03;
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -62,6 +62,13 @@ $card-left-offset: 40px;
         right: 4px;
     }
 
+    .bcs-task-assignment-count-container {
+        // override button styles
+        border: 0;
+        font-size: 100%;
+        padding: 0;
+    }
+
     .bcs-task-assignment-count {
         align-items: center;
         background: $gray;

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/Assignees-test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/Assignees-test.js
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { shallow, mount } from 'enzyme';
+import { TASK_NEW_APPROVED, TASK_NEW_REJECTED, TASK_NEW_NOT_STARTED } from '../../../../../constants';
+
+import Assignees from '../Assignees';
+
+const entries = [
+    {
+        id: '0001',
+        target: {
+            type: 'user',
+            id: '111',
+            name: 'AL',
+        },
+        status: TASK_NEW_REJECTED,
+    },
+    {
+        id: '0002',
+        target: {
+            type: 'user',
+            id: '222',
+            name: 'AK',
+        },
+        status: TASK_NEW_APPROVED,
+    },
+    {
+        id: '0003',
+        target: {
+            type: 'user',
+            id: '333',
+            name: 'AJ',
+        },
+        status: TASK_NEW_NOT_STARTED,
+    },
+];
+const assignees = {
+    entries,
+    limit: null,
+    next_marker: null,
+};
+
+const mockGetAvatarUrl = () => Promise.resolve('url.jpg');
+
+describe('elements/content-sidebar/ActivityFeed/task-new/Assignees', () => {
+    test('should render avatars for each assignee up to maxAvatars', () => {
+        const max = 2;
+        const wrapper = mount(<Assignees assignees={assignees} maxAvatars={max} getAvatarUrl={mockGetAvatarUrl} />);
+        expect(global.queryAllByTestId(wrapper.render(), 'task-assignment-status')).toHaveLength(max);
+        expect(wrapper).toMatchSnapshot('assignment avatars with overflow icon');
+    });
+
+    test('should show +N overflow when there are more assignees than maxAvatars', () => {
+        const max = 2;
+        const wrapper = shallow(<Assignees assignees={assignees} maxAvatars={max} getAvatarUrl={mockGetAvatarUrl} />);
+        expect(global.queryAllByTestId(wrapper.render(), 'task-assignment-overflow')).toHaveLength(1);
+    });
+
+    test('should show not show overflow icon when there are fewer assignees than maxAvatars', () => {
+        const max = 3;
+        const wrapper = shallow(<Assignees assignees={assignees} maxAvatars={max} getAvatarUrl={mockGetAvatarUrl} />);
+        expect(global.queryAllByTestId(wrapper.render(), 'task-assignment-overflow')).toHaveLength(0);
+    });
+
+    test('should open assignee list when overflow icon is clicked', () => {
+        const max = 2;
+        const wrapper = mount(<Assignees assignees={assignees} maxAvatars={max} getAvatarUrl={mockGetAvatarUrl} />);
+        const overflowIcon = global.queryAllByTestId(wrapper, 'task-assignment-overflow').first();
+        expect(wrapper.find('Overlay')).toHaveLength(0);
+        overflowIcon.simulate('click');
+        expect(wrapper.find('Overlay')).toHaveLength(1);
+        const assignmentList = wrapper.find('.bcs-task-assignment-list');
+        expect(assignmentList.find('.bcs-task-assignment-list-item')).toHaveLength(3);
+        expect(assignmentList).toMatchSnapshot('assignment list');
+    });
+});

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
@@ -854,7 +854,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
             renderElementTo={null}
             targetAttachment="top right"
           >
-            <span
+            <button
               aria-expanded="false"
               aria-haspopup="true"
               className="bcs-task-assignment-count-container"
@@ -865,6 +865,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
               role="button"
+              type="button"
             >
               <Tooltip
                 constrainToScrollParent={false}
@@ -905,7 +906,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
                   </span>
                 </TetherComponent>
               </Tooltip>
-            </span>
+            </button>
           </TetherComponent>
         </Flyout>
       </div>

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
@@ -1,32 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open assignee list when overflow icon is clicked: assignment list 1`] = `
-<div
+<ul
+  arial-labelledby="task-assignment-list-title-23"
   className="bcs-task-assignment-list"
 >
-  <p
-    className="bcs-task-assignment-list-title"
-    id="task-assignment-list-title-23"
+  <li
+    className="bcs-task-assignment-list-item"
+    key="0001"
   >
-    <FormattedMessage
-      defaultMessage="Assignees"
-      id="be.tasks.feed.assigneeList.title"
+    <Component
+      className="bcs-task-assignment-list-item-avatar"
+      data-testid="task-assignment-status"
+      getAvatarUrl={[Function]}
+      status="REJECTED"
+      user={
+        Object {
+          "id": "111",
+          "name": "AL",
+          "type": "user",
+        }
+      }
     >
-      <div />
-    </FormattedMessage>
-  </p>
-  <ul
-    arial-labelledby="task-assignment-list-title-23"
-  >
-    <li
-      className="bcs-task-assignment-list-item"
-      key="0001"
-    >
-      <Component
-        className="bcs-task-assignment-list-item-avatar"
-        data-testid="task-assignment-status"
+      <Avatar
+        className="bcs-task-assignment-avatar"
         getAvatarUrl={[Function]}
-        status="REJECTED"
         user={
           Object {
             "id": "111",
@@ -36,48 +34,48 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
         }
       >
         <Avatar
+          avatarUrl={null}
           className="bcs-task-assignment-avatar"
-          getAvatarUrl={[Function]}
-          user={
-            Object {
-              "id": "111",
-              "name": "AL",
-              "type": "user",
-            }
-          }
+          id="111"
+          name="AL"
         >
-          <Avatar
-            avatarUrl={null}
-            className="bcs-task-assignment-avatar"
-            id="111"
-            name="AL"
+          <span
+            className="avatar bcs-task-assignment-avatar"
+            role="presentation"
           >
-            <span
-              className="avatar bcs-task-assignment-avatar"
-              role="presentation"
+            <AvatarInitials
+              id="111"
+              name="AL"
             >
-              <AvatarInitials
-                id="111"
-                name="AL"
-              >
-                <span
-                  className="avatar-initials "
-                  style={
-                    Object {
-                      "backgroundColor": "#26c281",
-                    }
+              <span
+                className="avatar-initials "
+                style={
+                  Object {
+                    "backgroundColor": "#26c281",
                   }
-                >
-                  AA
-                </span>
-              </AvatarInitials>
-            </span>
-          </Avatar>
+                }
+              >
+                AA
+              </span>
+            </AvatarInitials>
+          </span>
         </Avatar>
-        <StatusIcon
+      </Avatar>
+      <StatusIcon
+        className="bcs-task-assignment-status-icon rejected"
+        height={12}
+        status="REJECTED"
+        title={
+          <FormattedMessage
+            defaultMessage="Completed"
+            id="be.completedAssignment"
+          />
+        }
+        width={12}
+      >
+        <IconRejected
           className="bcs-task-assignment-status-icon rejected"
           height={12}
-          status="REJECTED"
           title={
             <FormattedMessage
               defaultMessage="Completed"
@@ -86,8 +84,8 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
           }
           width={12}
         >
-          <IconRejected
-            className="bcs-task-assignment-status-icon rejected"
+          <AccessibleSVG
+            className="icon-rejected bcs-task-assignment-status-icon rejected"
             height={12}
             title={
               <FormattedMessage
@@ -95,87 +93,87 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
                 id="be.completedAssignment"
               />
             }
+            viewBox="0 0 18 18"
             width={12}
           >
-            <AccessibleSVG
+            <svg
+              aria-labelledby="icon31-title"
               className="icon-rejected bcs-task-assignment-status-icon rejected"
+              focusable="false"
               height={12}
-              title={
-                <FormattedMessage
-                  defaultMessage="Completed"
-                  id="be.completedAssignment"
-                />
-              }
+              role="img"
               viewBox="0 0 18 18"
               width={12}
             >
-              <svg
-                aria-labelledby="icon31-title"
-                className="icon-rejected bcs-task-assignment-status-icon rejected"
-                focusable="false"
-                height={12}
-                role="img"
-                viewBox="0 0 18 18"
-                width={12}
+              <title
+                id="icon31-title"
               >
-                <title
-                  id="icon31-title"
+                <FormattedMessage
+                  defaultMessage="Completed"
+                  id="be.completedAssignment"
                 >
-                  <FormattedMessage
-                    defaultMessage="Completed"
-                    id="be.completedAssignment"
-                  >
-                    <div />
-                  </FormattedMessage>
-                </title>
-                <g
-                  fill="none"
-                  fillRule="evenodd"
-                >
-                  <circle
-                    cx={9}
-                    cy={9}
-                    fill="#ED3757"
-                    r={9}
-                  />
-                  <path
-                    d="M9 7.586l2.828-2.829 1.415 1.415L10.414 9l2.829 2.828-1.415 1.415L9 10.414l-2.828 2.829-1.415-1.415L7.586 9 4.757 6.172l1.415-1.415z"
-                    fill="#FFF"
-                    fillRule="nonzero"
-                  />
-                </g>
-              </svg>
-            </AccessibleSVG>
-          </IconRejected>
-        </StatusIcon>
-      </Component>
-      <div
-        className="bcs-task-assignment-list-item-details"
-      >
-        <div>
-          AL
-        </div>
-        <div
-          className="bcs-task-assignment-list-item-status"
-        >
-          <FormattedMessage
-            defaultMessage="Rejected"
-            id="be.tasks.status.rejected"
-          >
-            <div />
-          </FormattedMessage>
-        </div>
-      </div>
-    </li>
-    <li
-      className="bcs-task-assignment-list-item"
-      key="0002"
+                  <div />
+                </FormattedMessage>
+              </title>
+              <g
+                fill="none"
+                fillRule="evenodd"
+              >
+                <circle
+                  cx={9}
+                  cy={9}
+                  fill="#ED3757"
+                  r={9}
+                />
+                <path
+                  d="M9 7.586l2.828-2.829 1.415 1.415L10.414 9l2.829 2.828-1.415 1.415L9 10.414l-2.828 2.829-1.415-1.415L7.586 9 4.757 6.172l1.415-1.415z"
+                  fill="#FFF"
+                  fillRule="nonzero"
+                />
+              </g>
+            </svg>
+          </AccessibleSVG>
+        </IconRejected>
+      </StatusIcon>
+    </Component>
+    <div
+      className="bcs-task-assignment-list-item-details"
     >
-      <Component
-        className="bcs-task-assignment-list-item-avatar"
-        data-testid="task-assignment-status"
+      <div>
+        AL
+      </div>
+      <div
+        className="bcs-task-assignment-list-item-status"
+      >
+        <FormattedMessage
+          defaultMessage="Rejected"
+          id="be.tasks.status.rejected"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </li>
+  <li
+    className="bcs-task-assignment-list-item"
+    key="0002"
+  >
+    <Component
+      className="bcs-task-assignment-list-item-avatar"
+      data-testid="task-assignment-status"
+      getAvatarUrl={[Function]}
+      status="APPROVED"
+      user={
+        Object {
+          "id": "222",
+          "name": "AK",
+          "type": "user",
+        }
+      }
+    >
+      <Avatar
+        className="bcs-task-assignment-avatar"
         getAvatarUrl={[Function]}
-        status="APPROVED"
         user={
           Object {
             "id": "222",
@@ -185,48 +183,48 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
         }
       >
         <Avatar
+          avatarUrl={null}
           className="bcs-task-assignment-avatar"
-          getAvatarUrl={[Function]}
-          user={
-            Object {
-              "id": "222",
-              "name": "AK",
-              "type": "user",
-            }
-          }
+          id="222"
+          name="AK"
         >
-          <Avatar
-            avatarUrl={null}
-            className="bcs-task-assignment-avatar"
-            id="222"
-            name="AK"
+          <span
+            className="avatar bcs-task-assignment-avatar"
+            role="presentation"
           >
-            <span
-              className="avatar bcs-task-assignment-avatar"
-              role="presentation"
+            <AvatarInitials
+              id="222"
+              name="AK"
             >
-              <AvatarInitials
-                id="222"
-                name="AK"
-              >
-                <span
-                  className="avatar-initials "
-                  style={
-                    Object {
-                      "backgroundColor": "#9f3fed",
-                    }
+              <span
+                className="avatar-initials "
+                style={
+                  Object {
+                    "backgroundColor": "#9f3fed",
                   }
-                >
-                  AA
-                </span>
-              </AvatarInitials>
-            </span>
-          </Avatar>
+                }
+              >
+                AA
+              </span>
+            </AvatarInitials>
+          </span>
         </Avatar>
-        <StatusIcon
+      </Avatar>
+      <StatusIcon
+        className="bcs-task-assignment-status-icon approved"
+        height={12}
+        status="APPROVED"
+        title={
+          <FormattedMessage
+            defaultMessage="Completed"
+            id="be.completedAssignment"
+          />
+        }
+        width={12}
+      >
+        <IconVerified
           className="bcs-task-assignment-status-icon approved"
           height={12}
-          status="APPROVED"
           title={
             <FormattedMessage
               defaultMessage="Completed"
@@ -235,87 +233,87 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
           }
           width={12}
         >
-          <IconVerified
-            className="bcs-task-assignment-status-icon approved"
+          <AccessibleSVG
+            className="icon-verified bcs-task-assignment-status-icon approved"
             height={12}
+            opacity={1}
             title={
               <FormattedMessage
                 defaultMessage="Completed"
                 id="be.completedAssignment"
               />
             }
+            viewBox="0 0 14 14"
             width={12}
           >
-            <AccessibleSVG
+            <svg
+              aria-labelledby="icon32-title"
               className="icon-verified bcs-task-assignment-status-icon approved"
+              focusable="false"
               height={12}
               opacity={1}
-              title={
-                <FormattedMessage
-                  defaultMessage="Completed"
-                  id="be.completedAssignment"
-                />
-              }
+              role="img"
               viewBox="0 0 14 14"
               width={12}
             >
-              <svg
-                aria-labelledby="icon32-title"
-                className="icon-verified bcs-task-assignment-status-icon approved"
-                focusable="false"
-                height={12}
-                opacity={1}
-                role="img"
-                viewBox="0 0 14 14"
-                width={12}
+              <title
+                id="icon32-title"
               >
-                <title
-                  id="icon32-title"
+                <FormattedMessage
+                  defaultMessage="Completed"
+                  id="be.completedAssignment"
                 >
-                  <FormattedMessage
-                    defaultMessage="Completed"
-                    id="be.completedAssignment"
-                  >
-                    <div />
-                  </FormattedMessage>
-                </title>
-                <path
-                  d="M7 14c-3.865993 0-7-3.134007-7-7s3.134007-7 7-7 7 3.134007 7 7-3.134007 7-7 7zM5.31288 9.303048l1.44555 1.21296 4.499514-5.36231-1.44555-1.21296-4.499514 5.36231zM3 7.36231L5.31288 9.30305l1.21296-1.44555L4.21296 5.91676 3 7.36231z"
-                  fill="#00E287"
-                  fillRule="evenodd"
-                />
-              </svg>
-            </AccessibleSVG>
-          </IconVerified>
-        </StatusIcon>
-      </Component>
-      <div
-        className="bcs-task-assignment-list-item-details"
-      >
-        <div>
-          AK
-        </div>
-        <div
-          className="bcs-task-assignment-list-item-status"
-        >
-          <FormattedMessage
-            defaultMessage="Accepted"
-            id="be.tasks.status.accepted"
-          >
-            <div />
-          </FormattedMessage>
-        </div>
-      </div>
-    </li>
-    <li
-      className="bcs-task-assignment-list-item"
-      key="0003"
+                  <div />
+                </FormattedMessage>
+              </title>
+              <path
+                d="M7 14c-3.865993 0-7-3.134007-7-7s3.134007-7 7-7 7 3.134007 7 7-3.134007 7-7 7zM5.31288 9.303048l1.44555 1.21296 4.499514-5.36231-1.44555-1.21296-4.499514 5.36231zM3 7.36231L5.31288 9.30305l1.21296-1.44555L4.21296 5.91676 3 7.36231z"
+                fill="#00E287"
+                fillRule="evenodd"
+              />
+            </svg>
+          </AccessibleSVG>
+        </IconVerified>
+      </StatusIcon>
+    </Component>
+    <div
+      className="bcs-task-assignment-list-item-details"
     >
-      <Component
-        className="bcs-task-assignment-list-item-avatar"
-        data-testid="task-assignment-status"
+      <div>
+        AK
+      </div>
+      <div
+        className="bcs-task-assignment-list-item-status"
+      >
+        <FormattedMessage
+          defaultMessage="Accepted"
+          id="be.tasks.status.accepted"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </li>
+  <li
+    className="bcs-task-assignment-list-item"
+    key="0003"
+  >
+    <Component
+      className="bcs-task-assignment-list-item-avatar"
+      data-testid="task-assignment-status"
+      getAvatarUrl={[Function]}
+      status="NOT_STARTED"
+      user={
+        Object {
+          "id": "333",
+          "name": "AJ",
+          "type": "user",
+        }
+      }
+    >
+      <Avatar
+        className="bcs-task-assignment-avatar"
         getAvatarUrl={[Function]}
-        status="NOT_STARTED"
         user={
           Object {
             "id": "333",
@@ -325,77 +323,65 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
         }
       >
         <Avatar
+          avatarUrl={null}
           className="bcs-task-assignment-avatar"
-          getAvatarUrl={[Function]}
-          user={
-            Object {
-              "id": "333",
-              "name": "AJ",
-              "type": "user",
-            }
-          }
+          id="333"
+          name="AJ"
         >
-          <Avatar
-            avatarUrl={null}
-            className="bcs-task-assignment-avatar"
-            id="333"
-            name="AJ"
+          <span
+            className="avatar bcs-task-assignment-avatar"
+            role="presentation"
           >
-            <span
-              className="avatar bcs-task-assignment-avatar"
-              role="presentation"
+            <AvatarInitials
+              id="333"
+              name="AJ"
             >
-              <AvatarInitials
-                id="333"
-                name="AJ"
-              >
-                <span
-                  className="avatar-initials "
-                  style={
-                    Object {
-                      "backgroundColor": "#0061d5",
-                    }
+              <span
+                className="avatar-initials "
+                style={
+                  Object {
+                    "backgroundColor": "#0061d5",
                   }
-                >
-                  AA
-                </span>
-              </AvatarInitials>
-            </span>
-          </Avatar>
+                }
+              >
+                AA
+              </span>
+            </AvatarInitials>
+          </span>
         </Avatar>
-        <StatusIcon
-          className="bcs-task-assignment-status-icon notStarted"
-          height={12}
-          status="NOT_STARTED"
-          title={
-            <FormattedMessage
-              defaultMessage="Completed"
-              id="be.completedAssignment"
-            />
-          }
-          width={12}
-        />
-      </Component>
-      <div
-        className="bcs-task-assignment-list-item-details"
-      >
-        <div>
-          AJ
-        </div>
-        <div
-          className="bcs-task-assignment-list-item-status"
-        >
+      </Avatar>
+      <StatusIcon
+        className="bcs-task-assignment-status-icon notStarted"
+        height={12}
+        status="NOT_STARTED"
+        title={
           <FormattedMessage
-            defaultMessage="Awaiting"
-            id="be.tasks.status.notStarted"
-          >
-            <div />
-          </FormattedMessage>
-        </div>
+            defaultMessage="Completed"
+            id="be.completedAssignment"
+          />
+        }
+        width={12}
+      />
+    </Component>
+    <div
+      className="bcs-task-assignment-list-item-details"
+    >
+      <div>
+        AJ
       </div>
-    </li>
-  </ul>
-</div>
+      <div
+        className="bcs-task-assignment-list-item-status"
+      >
+        <FormattedMessage
+          defaultMessage="Awaiting"
+          id="be.tasks.status.notStarted"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </li>
+</ul>
 `;
 
 exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render avatars for each assignee up to maxAvatars: assignment avatars with overflow icon 1`] = `

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
@@ -1,0 +1,915 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open assignee list when overflow icon is clicked: assignment list 1`] = `
+<div
+  className="bcs-task-assignment-list"
+>
+  <h5
+    className="bcs-task-assignment-list-title"
+  >
+    <FormattedMessage
+      defaultMessage="Assignees"
+      id="be.tasks.feed.assigneeList.title"
+    >
+      <div />
+    </FormattedMessage>
+  </h5>
+  <div
+    className="bcs-task-assignment-list-item"
+    key="0001"
+  >
+    <Component
+      className="bcs-task-assignment-list-item-avatar"
+      data-testid="task-assignment-status"
+      getAvatarUrl={[Function]}
+      status="REJECTED"
+      user={
+        Object {
+          "id": "111",
+          "name": "AL",
+          "type": "user",
+        }
+      }
+    >
+      <Avatar
+        className="bcs-task-assignment-avatar"
+        getAvatarUrl={[Function]}
+        user={
+          Object {
+            "id": "111",
+            "name": "AL",
+            "type": "user",
+          }
+        }
+      >
+        <Avatar
+          avatarUrl={null}
+          className="bcs-task-assignment-avatar"
+          id="111"
+          name="AL"
+        >
+          <span
+            className="avatar bcs-task-assignment-avatar"
+            role="presentation"
+          >
+            <AvatarInitials
+              id="111"
+              name="AL"
+            >
+              <span
+                className="avatar-initials "
+                style={
+                  Object {
+                    "backgroundColor": "#26c281",
+                  }
+                }
+              >
+                AA
+              </span>
+            </AvatarInitials>
+          </span>
+        </Avatar>
+      </Avatar>
+      <StatusIcon
+        className="bcs-task-assignment-status-icon rejected"
+        height={12}
+        status="REJECTED"
+        title={
+          <FormattedMessage
+            defaultMessage="Completed"
+            id="be.completedAssignment"
+          />
+        }
+        width={12}
+      >
+        <IconRejected
+          className="bcs-task-assignment-status-icon rejected"
+          height={12}
+          title={
+            <FormattedMessage
+              defaultMessage="Completed"
+              id="be.completedAssignment"
+            />
+          }
+          width={12}
+        >
+          <AccessibleSVG
+            className="icon-rejected bcs-task-assignment-status-icon rejected"
+            height={12}
+            title={
+              <FormattedMessage
+                defaultMessage="Completed"
+                id="be.completedAssignment"
+              />
+            }
+            viewBox="0 0 18 18"
+            width={12}
+          >
+            <svg
+              aria-labelledby="icon27-title"
+              className="icon-rejected bcs-task-assignment-status-icon rejected"
+              focusable="false"
+              height={12}
+              role="img"
+              viewBox="0 0 18 18"
+              width={12}
+            >
+              <title
+                id="icon27-title"
+              >
+                <FormattedMessage
+                  defaultMessage="Completed"
+                  id="be.completedAssignment"
+                >
+                  <div />
+                </FormattedMessage>
+              </title>
+              <g
+                fill="none"
+                fillRule="evenodd"
+              >
+                <circle
+                  cx={9}
+                  cy={9}
+                  fill="#ED3757"
+                  r={9}
+                />
+                <path
+                  d="M9 7.586l2.828-2.829 1.415 1.415L10.414 9l2.829 2.828-1.415 1.415L9 10.414l-2.828 2.829-1.415-1.415L7.586 9 4.757 6.172l1.415-1.415z"
+                  fill="#FFF"
+                  fillRule="nonzero"
+                />
+              </g>
+            </svg>
+          </AccessibleSVG>
+        </IconRejected>
+      </StatusIcon>
+    </Component>
+    <div
+      className="bcs-task-assignment-list-item-details"
+    >
+      <div>
+        AL
+      </div>
+      <div
+        className="bcs-task-assignment-list-item-status"
+      >
+        <FormattedMessage
+          defaultMessage="Rejected"
+          id="be.tasks.status.rejected"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </div>
+  <div
+    className="bcs-task-assignment-list-item"
+    key="0002"
+  >
+    <Component
+      className="bcs-task-assignment-list-item-avatar"
+      data-testid="task-assignment-status"
+      getAvatarUrl={[Function]}
+      status="APPROVED"
+      user={
+        Object {
+          "id": "222",
+          "name": "AK",
+          "type": "user",
+        }
+      }
+    >
+      <Avatar
+        className="bcs-task-assignment-avatar"
+        getAvatarUrl={[Function]}
+        user={
+          Object {
+            "id": "222",
+            "name": "AK",
+            "type": "user",
+          }
+        }
+      >
+        <Avatar
+          avatarUrl={null}
+          className="bcs-task-assignment-avatar"
+          id="222"
+          name="AK"
+        >
+          <span
+            className="avatar bcs-task-assignment-avatar"
+            role="presentation"
+          >
+            <AvatarInitials
+              id="222"
+              name="AK"
+            >
+              <span
+                className="avatar-initials "
+                style={
+                  Object {
+                    "backgroundColor": "#9f3fed",
+                  }
+                }
+              >
+                AA
+              </span>
+            </AvatarInitials>
+          </span>
+        </Avatar>
+      </Avatar>
+      <StatusIcon
+        className="bcs-task-assignment-status-icon approved"
+        height={12}
+        status="APPROVED"
+        title={
+          <FormattedMessage
+            defaultMessage="Completed"
+            id="be.completedAssignment"
+          />
+        }
+        width={12}
+      >
+        <IconVerified
+          className="bcs-task-assignment-status-icon approved"
+          height={12}
+          title={
+            <FormattedMessage
+              defaultMessage="Completed"
+              id="be.completedAssignment"
+            />
+          }
+          width={12}
+        >
+          <AccessibleSVG
+            className="icon-verified bcs-task-assignment-status-icon approved"
+            height={12}
+            opacity={1}
+            title={
+              <FormattedMessage
+                defaultMessage="Completed"
+                id="be.completedAssignment"
+              />
+            }
+            viewBox="0 0 14 14"
+            width={12}
+          >
+            <svg
+              aria-labelledby="icon28-title"
+              className="icon-verified bcs-task-assignment-status-icon approved"
+              focusable="false"
+              height={12}
+              opacity={1}
+              role="img"
+              viewBox="0 0 14 14"
+              width={12}
+            >
+              <title
+                id="icon28-title"
+              >
+                <FormattedMessage
+                  defaultMessage="Completed"
+                  id="be.completedAssignment"
+                >
+                  <div />
+                </FormattedMessage>
+              </title>
+              <path
+                d="M7 14c-3.865993 0-7-3.134007-7-7s3.134007-7 7-7 7 3.134007 7 7-3.134007 7-7 7zM5.31288 9.303048l1.44555 1.21296 4.499514-5.36231-1.44555-1.21296-4.499514 5.36231zM3 7.36231L5.31288 9.30305l1.21296-1.44555L4.21296 5.91676 3 7.36231z"
+                fill="#00E287"
+                fillRule="evenodd"
+              />
+            </svg>
+          </AccessibleSVG>
+        </IconVerified>
+      </StatusIcon>
+    </Component>
+    <div
+      className="bcs-task-assignment-list-item-details"
+    >
+      <div>
+        AK
+      </div>
+      <div
+        className="bcs-task-assignment-list-item-status"
+      >
+        <FormattedMessage
+          defaultMessage="Accepted"
+          id="be.tasks.status.accepted"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </div>
+  <div
+    className="bcs-task-assignment-list-item"
+    key="0003"
+  >
+    <Component
+      className="bcs-task-assignment-list-item-avatar"
+      data-testid="task-assignment-status"
+      getAvatarUrl={[Function]}
+      status="NOT_STARTED"
+      user={
+        Object {
+          "id": "333",
+          "name": "AJ",
+          "type": "user",
+        }
+      }
+    >
+      <Avatar
+        className="bcs-task-assignment-avatar"
+        getAvatarUrl={[Function]}
+        user={
+          Object {
+            "id": "333",
+            "name": "AJ",
+            "type": "user",
+          }
+        }
+      >
+        <Avatar
+          avatarUrl={null}
+          className="bcs-task-assignment-avatar"
+          id="333"
+          name="AJ"
+        >
+          <span
+            className="avatar bcs-task-assignment-avatar"
+            role="presentation"
+          >
+            <AvatarInitials
+              id="333"
+              name="AJ"
+            >
+              <span
+                className="avatar-initials "
+                style={
+                  Object {
+                    "backgroundColor": "#0061d5",
+                  }
+                }
+              >
+                AA
+              </span>
+            </AvatarInitials>
+          </span>
+        </Avatar>
+      </Avatar>
+      <StatusIcon
+        className="bcs-task-assignment-status-icon notStarted"
+        height={12}
+        status="NOT_STARTED"
+        title={
+          <FormattedMessage
+            defaultMessage="Completed"
+            id="be.completedAssignment"
+          />
+        }
+        width={12}
+      />
+    </Component>
+    <div
+      className="bcs-task-assignment-list-item-details"
+    >
+      <div>
+        AJ
+      </div>
+      <div
+        className="bcs-task-assignment-list-item-status"
+      >
+        <FormattedMessage
+          defaultMessage="Awaiting"
+          id="be.tasks.status.notStarted"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render avatars for each assignee up to maxAvatars: assignment avatars with overflow icon 1`] = `
+<Assignees
+  assignees={
+    Object {
+      "entries": Array [
+        Object {
+          "id": "0001",
+          "status": "REJECTED",
+          "target": Object {
+            "id": "111",
+            "name": "AL",
+            "type": "user",
+          },
+        },
+        Object {
+          "id": "0002",
+          "status": "APPROVED",
+          "target": Object {
+            "id": "222",
+            "name": "AK",
+            "type": "user",
+          },
+        },
+        Object {
+          "id": "0003",
+          "status": "NOT_STARTED",
+          "target": Object {
+            "id": "333",
+            "name": "AJ",
+            "type": "user",
+          },
+        },
+      ],
+      "limit": null,
+      "next_marker": null,
+    }
+  }
+  getAvatarUrl={[Function]}
+  maxAvatars={2}
+>
+  <Assignees
+    assignees={
+      Object {
+        "entries": Array [
+          Object {
+            "id": "0001",
+            "status": "REJECTED",
+            "target": Object {
+              "id": "111",
+              "name": "AL",
+              "type": "user",
+            },
+          },
+          Object {
+            "id": "0002",
+            "status": "APPROVED",
+            "target": Object {
+              "id": "222",
+              "name": "AK",
+              "type": "user",
+            },
+          },
+          Object {
+            "id": "0003",
+            "status": "NOT_STARTED",
+            "target": Object {
+              "id": "333",
+              "name": "AJ",
+              "type": "user",
+            },
+          },
+        ],
+        "limit": null,
+        "next_marker": null,
+      }
+    }
+    getAvatarUrl={[Function]}
+    intl={
+      Object {
+        "formatDate": [Function],
+        "formatMessage": [Function],
+      }
+    }
+    maxAvatars={2}
+  >
+    <div
+      className="bcs-task-assignment-container"
+    >
+      <div
+        className="bcs-task-assignments"
+      >
+        <Tooltip
+          constrainToScrollParent={false}
+          constrainToWindow={true}
+          isDisabled={false}
+          key="0001"
+          position="top-center"
+          text={
+            <Memo
+              status="REJECTED"
+              user={
+                Object {
+                  "id": "111",
+                  "name": "AL",
+                  "type": "user",
+                }
+              }
+            />
+          }
+          theme="default"
+        >
+          <TetherComponent
+            attachment="bottom center"
+            bodyElement={<body />}
+            classPrefix="tooltip"
+            constraints={
+              Array [
+                Object {
+                  "attachment": "together",
+                  "to": "window",
+                },
+              ]
+            }
+            enabled={false}
+            renderElementTag="div"
+            renderElementTo={null}
+            targetAttachment="top center"
+          >
+            <Component
+              data-testid="task-assignment-status"
+              getAvatarUrl={[Function]}
+              key=".$0001"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              status="REJECTED"
+              tabIndex="0"
+              user={
+                Object {
+                  "id": "111",
+                  "name": "AL",
+                  "type": "user",
+                }
+              }
+            >
+              <Avatar
+                className="bcs-task-assignment-avatar"
+                getAvatarUrl={[Function]}
+                user={
+                  Object {
+                    "id": "111",
+                    "name": "AL",
+                    "type": "user",
+                  }
+                }
+              >
+                <Avatar
+                  avatarUrl={null}
+                  className="bcs-task-assignment-avatar"
+                  id="111"
+                  name="AL"
+                >
+                  <span
+                    className="avatar bcs-task-assignment-avatar"
+                    role="presentation"
+                  >
+                    <AvatarInitials
+                      id="111"
+                      name="AL"
+                    >
+                      <span
+                        className="avatar-initials "
+                        style={
+                          Object {
+                            "backgroundColor": "#26c281",
+                          }
+                        }
+                      >
+                        AA
+                      </span>
+                    </AvatarInitials>
+                  </span>
+                </Avatar>
+              </Avatar>
+              <StatusIcon
+                className="bcs-task-assignment-status-icon rejected"
+                height={12}
+                status="REJECTED"
+                title={
+                  <FormattedMessage
+                    defaultMessage="Completed"
+                    id="be.completedAssignment"
+                  />
+                }
+                width={12}
+              >
+                <IconRejected
+                  className="bcs-task-assignment-status-icon rejected"
+                  height={12}
+                  title={
+                    <FormattedMessage
+                      defaultMessage="Completed"
+                      id="be.completedAssignment"
+                    />
+                  }
+                  width={12}
+                >
+                  <AccessibleSVG
+                    className="icon-rejected bcs-task-assignment-status-icon rejected"
+                    height={12}
+                    title={
+                      <FormattedMessage
+                        defaultMessage="Completed"
+                        id="be.completedAssignment"
+                      />
+                    }
+                    viewBox="0 0 18 18"
+                    width={12}
+                  >
+                    <svg
+                      aria-labelledby="icon2-title"
+                      className="icon-rejected bcs-task-assignment-status-icon rejected"
+                      focusable="false"
+                      height={12}
+                      role="img"
+                      viewBox="0 0 18 18"
+                      width={12}
+                    >
+                      <title
+                        id="icon2-title"
+                      >
+                        <FormattedMessage
+                          defaultMessage="Completed"
+                          id="be.completedAssignment"
+                        >
+                          <div />
+                        </FormattedMessage>
+                      </title>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <circle
+                          cx={9}
+                          cy={9}
+                          fill="#ED3757"
+                          r={9}
+                        />
+                        <path
+                          d="M9 7.586l2.828-2.829 1.415 1.415L10.414 9l2.829 2.828-1.415 1.415L9 10.414l-2.828 2.829-1.415-1.415L7.586 9 4.757 6.172l1.415-1.415z"
+                          fill="#FFF"
+                          fillRule="nonzero"
+                        />
+                      </g>
+                    </svg>
+                  </AccessibleSVG>
+                </IconRejected>
+              </StatusIcon>
+            </Component>
+          </TetherComponent>
+        </Tooltip>
+        <Tooltip
+          constrainToScrollParent={false}
+          constrainToWindow={true}
+          isDisabled={false}
+          key="0002"
+          position="top-center"
+          text={
+            <Memo
+              status="APPROVED"
+              user={
+                Object {
+                  "id": "222",
+                  "name": "AK",
+                  "type": "user",
+                }
+              }
+            />
+          }
+          theme="default"
+        >
+          <TetherComponent
+            attachment="bottom center"
+            bodyElement={<body />}
+            classPrefix="tooltip"
+            constraints={
+              Array [
+                Object {
+                  "attachment": "together",
+                  "to": "window",
+                },
+              ]
+            }
+            enabled={false}
+            renderElementTag="div"
+            renderElementTo={null}
+            targetAttachment="top center"
+          >
+            <Component
+              data-testid="task-assignment-status"
+              getAvatarUrl={[Function]}
+              key=".$0002"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              status="APPROVED"
+              tabIndex="0"
+              user={
+                Object {
+                  "id": "222",
+                  "name": "AK",
+                  "type": "user",
+                }
+              }
+            >
+              <Avatar
+                className="bcs-task-assignment-avatar"
+                getAvatarUrl={[Function]}
+                user={
+                  Object {
+                    "id": "222",
+                    "name": "AK",
+                    "type": "user",
+                  }
+                }
+              >
+                <Avatar
+                  avatarUrl={null}
+                  className="bcs-task-assignment-avatar"
+                  id="222"
+                  name="AK"
+                >
+                  <span
+                    className="avatar bcs-task-assignment-avatar"
+                    role="presentation"
+                  >
+                    <AvatarInitials
+                      id="222"
+                      name="AK"
+                    >
+                      <span
+                        className="avatar-initials "
+                        style={
+                          Object {
+                            "backgroundColor": "#9f3fed",
+                          }
+                        }
+                      >
+                        AA
+                      </span>
+                    </AvatarInitials>
+                  </span>
+                </Avatar>
+              </Avatar>
+              <StatusIcon
+                className="bcs-task-assignment-status-icon approved"
+                height={12}
+                status="APPROVED"
+                title={
+                  <FormattedMessage
+                    defaultMessage="Completed"
+                    id="be.completedAssignment"
+                  />
+                }
+                width={12}
+              >
+                <IconVerified
+                  className="bcs-task-assignment-status-icon approved"
+                  height={12}
+                  title={
+                    <FormattedMessage
+                      defaultMessage="Completed"
+                      id="be.completedAssignment"
+                    />
+                  }
+                  width={12}
+                >
+                  <AccessibleSVG
+                    className="icon-verified bcs-task-assignment-status-icon approved"
+                    height={12}
+                    opacity={1}
+                    title={
+                      <FormattedMessage
+                        defaultMessage="Completed"
+                        id="be.completedAssignment"
+                      />
+                    }
+                    viewBox="0 0 14 14"
+                    width={12}
+                  >
+                    <svg
+                      aria-labelledby="icon4-title"
+                      className="icon-verified bcs-task-assignment-status-icon approved"
+                      focusable="false"
+                      height={12}
+                      opacity={1}
+                      role="img"
+                      viewBox="0 0 14 14"
+                      width={12}
+                    >
+                      <title
+                        id="icon4-title"
+                      >
+                        <FormattedMessage
+                          defaultMessage="Completed"
+                          id="be.completedAssignment"
+                        >
+                          <div />
+                        </FormattedMessage>
+                      </title>
+                      <path
+                        d="M7 14c-3.865993 0-7-3.134007-7-7s3.134007-7 7-7 7 3.134007 7 7-3.134007 7-7 7zM5.31288 9.303048l1.44555 1.21296 4.499514-5.36231-1.44555-1.21296-4.499514 5.36231zM3 7.36231L5.31288 9.30305l1.21296-1.44555L4.21296 5.91676 3 7.36231z"
+                        fill="#00E287"
+                        fillRule="evenodd"
+                      />
+                    </svg>
+                  </AccessibleSVG>
+                </IconVerified>
+              </StatusIcon>
+            </Component>
+          </TetherComponent>
+        </Tooltip>
+        <Flyout
+          className=""
+          closeOnClick={true}
+          closeOnClickOutside={true}
+          closeOnWindowBlur={false}
+          constrainToScrollParent={true}
+          constrainToWindow={false}
+          isVisibleByDefault={false}
+          openOnHover={false}
+          openOnHoverDelayTimeout={300}
+          portaledClasses={Array []}
+          position="top-left"
+        >
+          <TetherComponent
+            attachment="bottom right"
+            classPrefix="flyout-overlay"
+            classes={
+              Object {
+                "element": "flyout-overlay ",
+              }
+            }
+            constraints={
+              Array [
+                Object {
+                  "attachment": "together",
+                  "to": "scrollParent",
+                },
+              ]
+            }
+            enabled={false}
+            offset="10px 0"
+            renderElementTag="div"
+            renderElementTo={null}
+            targetAttachment="top right"
+          >
+            <span
+              aria-expanded="false"
+              aria-haspopup="true"
+              className="bcs-task-assignment-count-container"
+              data-testid="task-assignment-overflow"
+              id="flyoutbutton6"
+              key=".$flyoutbutton6"
+              onClick={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="button"
+            >
+              <Tooltip
+                constrainToScrollParent={false}
+                constrainToWindow={true}
+                isDisabled={false}
+                position="top-center"
+                text="See all assignees"
+                theme="default"
+              >
+                <TetherComponent
+                  attachment="bottom center"
+                  bodyElement={<body />}
+                  classPrefix="tooltip"
+                  constraints={
+                    Array [
+                      Object {
+                        "attachment": "together",
+                        "to": "window",
+                      },
+                    ]
+                  }
+                  enabled={false}
+                  renderElementTag="div"
+                  renderElementTo={null}
+                  targetAttachment="top center"
+                >
+                  <span
+                    className="bcs-task-assignment-count bcs-task-assignment-avatar"
+                    key=".0"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    tabIndex="0"
+                  >
+                    +1
+                  </span>
+                </TetherComponent>
+              </Tooltip>
+            </span>
+          </TetherComponent>
+        </Flyout>
+      </div>
+    </div>
+  </Assignees>
+</Assignees>
+`;

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Assignees-test.js.snap
@@ -4,8 +4,9 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
 <div
   className="bcs-task-assignment-list"
 >
-  <h5
+  <p
     className="bcs-task-assignment-list-title"
+    id="task-assignment-list-title-23"
   >
     <FormattedMessage
       defaultMessage="Assignees"
@@ -13,27 +14,19 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
     >
       <div />
     </FormattedMessage>
-  </h5>
-  <div
-    className="bcs-task-assignment-list-item"
-    key="0001"
+  </p>
+  <ul
+    arial-labelledby="task-assignment-list-title-23"
   >
-    <Component
-      className="bcs-task-assignment-list-item-avatar"
-      data-testid="task-assignment-status"
-      getAvatarUrl={[Function]}
-      status="REJECTED"
-      user={
-        Object {
-          "id": "111",
-          "name": "AL",
-          "type": "user",
-        }
-      }
+    <li
+      className="bcs-task-assignment-list-item"
+      key="0001"
     >
-      <Avatar
-        className="bcs-task-assignment-avatar"
+      <Component
+        className="bcs-task-assignment-list-item-avatar"
+        data-testid="task-assignment-status"
         getAvatarUrl={[Function]}
+        status="REJECTED"
         user={
           Object {
             "id": "111",
@@ -43,48 +36,48 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
         }
       >
         <Avatar
-          avatarUrl={null}
           className="bcs-task-assignment-avatar"
-          id="111"
-          name="AL"
+          getAvatarUrl={[Function]}
+          user={
+            Object {
+              "id": "111",
+              "name": "AL",
+              "type": "user",
+            }
+          }
         >
-          <span
-            className="avatar bcs-task-assignment-avatar"
-            role="presentation"
+          <Avatar
+            avatarUrl={null}
+            className="bcs-task-assignment-avatar"
+            id="111"
+            name="AL"
           >
-            <AvatarInitials
-              id="111"
-              name="AL"
+            <span
+              className="avatar bcs-task-assignment-avatar"
+              role="presentation"
             >
-              <span
-                className="avatar-initials "
-                style={
-                  Object {
-                    "backgroundColor": "#26c281",
-                  }
-                }
+              <AvatarInitials
+                id="111"
+                name="AL"
               >
-                AA
-              </span>
-            </AvatarInitials>
-          </span>
+                <span
+                  className="avatar-initials "
+                  style={
+                    Object {
+                      "backgroundColor": "#26c281",
+                    }
+                  }
+                >
+                  AA
+                </span>
+              </AvatarInitials>
+            </span>
+          </Avatar>
         </Avatar>
-      </Avatar>
-      <StatusIcon
-        className="bcs-task-assignment-status-icon rejected"
-        height={12}
-        status="REJECTED"
-        title={
-          <FormattedMessage
-            defaultMessage="Completed"
-            id="be.completedAssignment"
-          />
-        }
-        width={12}
-      >
-        <IconRejected
+        <StatusIcon
           className="bcs-task-assignment-status-icon rejected"
           height={12}
+          status="REJECTED"
           title={
             <FormattedMessage
               defaultMessage="Completed"
@@ -93,8 +86,8 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
           }
           width={12}
         >
-          <AccessibleSVG
-            className="icon-rejected bcs-task-assignment-status-icon rejected"
+          <IconRejected
+            className="bcs-task-assignment-status-icon rejected"
             height={12}
             title={
               <FormattedMessage
@@ -102,87 +95,87 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
                 id="be.completedAssignment"
               />
             }
-            viewBox="0 0 18 18"
             width={12}
           >
-            <svg
-              aria-labelledby="icon27-title"
+            <AccessibleSVG
               className="icon-rejected bcs-task-assignment-status-icon rejected"
-              focusable="false"
               height={12}
-              role="img"
-              viewBox="0 0 18 18"
-              width={12}
-            >
-              <title
-                id="icon27-title"
-              >
+              title={
                 <FormattedMessage
                   defaultMessage="Completed"
                   id="be.completedAssignment"
-                >
-                  <div />
-                </FormattedMessage>
-              </title>
-              <g
-                fill="none"
-                fillRule="evenodd"
+                />
+              }
+              viewBox="0 0 18 18"
+              width={12}
+            >
+              <svg
+                aria-labelledby="icon31-title"
+                className="icon-rejected bcs-task-assignment-status-icon rejected"
+                focusable="false"
+                height={12}
+                role="img"
+                viewBox="0 0 18 18"
+                width={12}
               >
-                <circle
-                  cx={9}
-                  cy={9}
-                  fill="#ED3757"
-                  r={9}
-                />
-                <path
-                  d="M9 7.586l2.828-2.829 1.415 1.415L10.414 9l2.829 2.828-1.415 1.415L9 10.414l-2.828 2.829-1.415-1.415L7.586 9 4.757 6.172l1.415-1.415z"
-                  fill="#FFF"
-                  fillRule="nonzero"
-                />
-              </g>
-            </svg>
-          </AccessibleSVG>
-        </IconRejected>
-      </StatusIcon>
-    </Component>
-    <div
-      className="bcs-task-assignment-list-item-details"
-    >
-      <div>
-        AL
-      </div>
+                <title
+                  id="icon31-title"
+                >
+                  <FormattedMessage
+                    defaultMessage="Completed"
+                    id="be.completedAssignment"
+                  >
+                    <div />
+                  </FormattedMessage>
+                </title>
+                <g
+                  fill="none"
+                  fillRule="evenodd"
+                >
+                  <circle
+                    cx={9}
+                    cy={9}
+                    fill="#ED3757"
+                    r={9}
+                  />
+                  <path
+                    d="M9 7.586l2.828-2.829 1.415 1.415L10.414 9l2.829 2.828-1.415 1.415L9 10.414l-2.828 2.829-1.415-1.415L7.586 9 4.757 6.172l1.415-1.415z"
+                    fill="#FFF"
+                    fillRule="nonzero"
+                  />
+                </g>
+              </svg>
+            </AccessibleSVG>
+          </IconRejected>
+        </StatusIcon>
+      </Component>
       <div
-        className="bcs-task-assignment-list-item-status"
+        className="bcs-task-assignment-list-item-details"
       >
-        <FormattedMessage
-          defaultMessage="Rejected"
-          id="be.tasks.status.rejected"
+        <div>
+          AL
+        </div>
+        <div
+          className="bcs-task-assignment-list-item-status"
         >
-          <div />
-        </FormattedMessage>
+          <FormattedMessage
+            defaultMessage="Rejected"
+            id="be.tasks.status.rejected"
+          >
+            <div />
+          </FormattedMessage>
+        </div>
       </div>
-    </div>
-  </div>
-  <div
-    className="bcs-task-assignment-list-item"
-    key="0002"
-  >
-    <Component
-      className="bcs-task-assignment-list-item-avatar"
-      data-testid="task-assignment-status"
-      getAvatarUrl={[Function]}
-      status="APPROVED"
-      user={
-        Object {
-          "id": "222",
-          "name": "AK",
-          "type": "user",
-        }
-      }
+    </li>
+    <li
+      className="bcs-task-assignment-list-item"
+      key="0002"
     >
-      <Avatar
-        className="bcs-task-assignment-avatar"
+      <Component
+        className="bcs-task-assignment-list-item-avatar"
+        data-testid="task-assignment-status"
         getAvatarUrl={[Function]}
+        status="APPROVED"
         user={
           Object {
             "id": "222",
@@ -192,48 +185,48 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
         }
       >
         <Avatar
-          avatarUrl={null}
           className="bcs-task-assignment-avatar"
-          id="222"
-          name="AK"
+          getAvatarUrl={[Function]}
+          user={
+            Object {
+              "id": "222",
+              "name": "AK",
+              "type": "user",
+            }
+          }
         >
-          <span
-            className="avatar bcs-task-assignment-avatar"
-            role="presentation"
+          <Avatar
+            avatarUrl={null}
+            className="bcs-task-assignment-avatar"
+            id="222"
+            name="AK"
           >
-            <AvatarInitials
-              id="222"
-              name="AK"
+            <span
+              className="avatar bcs-task-assignment-avatar"
+              role="presentation"
             >
-              <span
-                className="avatar-initials "
-                style={
-                  Object {
-                    "backgroundColor": "#9f3fed",
-                  }
-                }
+              <AvatarInitials
+                id="222"
+                name="AK"
               >
-                AA
-              </span>
-            </AvatarInitials>
-          </span>
+                <span
+                  className="avatar-initials "
+                  style={
+                    Object {
+                      "backgroundColor": "#9f3fed",
+                    }
+                  }
+                >
+                  AA
+                </span>
+              </AvatarInitials>
+            </span>
+          </Avatar>
         </Avatar>
-      </Avatar>
-      <StatusIcon
-        className="bcs-task-assignment-status-icon approved"
-        height={12}
-        status="APPROVED"
-        title={
-          <FormattedMessage
-            defaultMessage="Completed"
-            id="be.completedAssignment"
-          />
-        }
-        width={12}
-      >
-        <IconVerified
+        <StatusIcon
           className="bcs-task-assignment-status-icon approved"
           height={12}
+          status="APPROVED"
           title={
             <FormattedMessage
               defaultMessage="Completed"
@@ -242,87 +235,87 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
           }
           width={12}
         >
-          <AccessibleSVG
-            className="icon-verified bcs-task-assignment-status-icon approved"
+          <IconVerified
+            className="bcs-task-assignment-status-icon approved"
             height={12}
-            opacity={1}
             title={
               <FormattedMessage
                 defaultMessage="Completed"
                 id="be.completedAssignment"
               />
             }
-            viewBox="0 0 14 14"
             width={12}
           >
-            <svg
-              aria-labelledby="icon28-title"
+            <AccessibleSVG
               className="icon-verified bcs-task-assignment-status-icon approved"
-              focusable="false"
               height={12}
               opacity={1}
-              role="img"
-              viewBox="0 0 14 14"
-              width={12}
-            >
-              <title
-                id="icon28-title"
-              >
+              title={
                 <FormattedMessage
                   defaultMessage="Completed"
                   id="be.completedAssignment"
+                />
+              }
+              viewBox="0 0 14 14"
+              width={12}
+            >
+              <svg
+                aria-labelledby="icon32-title"
+                className="icon-verified bcs-task-assignment-status-icon approved"
+                focusable="false"
+                height={12}
+                opacity={1}
+                role="img"
+                viewBox="0 0 14 14"
+                width={12}
+              >
+                <title
+                  id="icon32-title"
                 >
-                  <div />
-                </FormattedMessage>
-              </title>
-              <path
-                d="M7 14c-3.865993 0-7-3.134007-7-7s3.134007-7 7-7 7 3.134007 7 7-3.134007 7-7 7zM5.31288 9.303048l1.44555 1.21296 4.499514-5.36231-1.44555-1.21296-4.499514 5.36231zM3 7.36231L5.31288 9.30305l1.21296-1.44555L4.21296 5.91676 3 7.36231z"
-                fill="#00E287"
-                fillRule="evenodd"
-              />
-            </svg>
-          </AccessibleSVG>
-        </IconVerified>
-      </StatusIcon>
-    </Component>
-    <div
-      className="bcs-task-assignment-list-item-details"
-    >
-      <div>
-        AK
-      </div>
+                  <FormattedMessage
+                    defaultMessage="Completed"
+                    id="be.completedAssignment"
+                  >
+                    <div />
+                  </FormattedMessage>
+                </title>
+                <path
+                  d="M7 14c-3.865993 0-7-3.134007-7-7s3.134007-7 7-7 7 3.134007 7 7-3.134007 7-7 7zM5.31288 9.303048l1.44555 1.21296 4.499514-5.36231-1.44555-1.21296-4.499514 5.36231zM3 7.36231L5.31288 9.30305l1.21296-1.44555L4.21296 5.91676 3 7.36231z"
+                  fill="#00E287"
+                  fillRule="evenodd"
+                />
+              </svg>
+            </AccessibleSVG>
+          </IconVerified>
+        </StatusIcon>
+      </Component>
       <div
-        className="bcs-task-assignment-list-item-status"
+        className="bcs-task-assignment-list-item-details"
       >
-        <FormattedMessage
-          defaultMessage="Accepted"
-          id="be.tasks.status.accepted"
+        <div>
+          AK
+        </div>
+        <div
+          className="bcs-task-assignment-list-item-status"
         >
-          <div />
-        </FormattedMessage>
+          <FormattedMessage
+            defaultMessage="Accepted"
+            id="be.tasks.status.accepted"
+          >
+            <div />
+          </FormattedMessage>
+        </div>
       </div>
-    </div>
-  </div>
-  <div
-    className="bcs-task-assignment-list-item"
-    key="0003"
-  >
-    <Component
-      className="bcs-task-assignment-list-item-avatar"
-      data-testid="task-assignment-status"
-      getAvatarUrl={[Function]}
-      status="NOT_STARTED"
-      user={
-        Object {
-          "id": "333",
-          "name": "AJ",
-          "type": "user",
-        }
-      }
+    </li>
+    <li
+      className="bcs-task-assignment-list-item"
+      key="0003"
     >
-      <Avatar
-        className="bcs-task-assignment-avatar"
+      <Component
+        className="bcs-task-assignment-list-item-avatar"
+        data-testid="task-assignment-status"
         getAvatarUrl={[Function]}
+        status="NOT_STARTED"
         user={
           Object {
             "id": "333",
@@ -332,64 +325,76 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should open as
         }
       >
         <Avatar
-          avatarUrl={null}
           className="bcs-task-assignment-avatar"
-          id="333"
-          name="AJ"
+          getAvatarUrl={[Function]}
+          user={
+            Object {
+              "id": "333",
+              "name": "AJ",
+              "type": "user",
+            }
+          }
         >
-          <span
-            className="avatar bcs-task-assignment-avatar"
-            role="presentation"
+          <Avatar
+            avatarUrl={null}
+            className="bcs-task-assignment-avatar"
+            id="333"
+            name="AJ"
           >
-            <AvatarInitials
-              id="333"
-              name="AJ"
+            <span
+              className="avatar bcs-task-assignment-avatar"
+              role="presentation"
             >
-              <span
-                className="avatar-initials "
-                style={
-                  Object {
-                    "backgroundColor": "#0061d5",
-                  }
-                }
+              <AvatarInitials
+                id="333"
+                name="AJ"
               >
-                AA
-              </span>
-            </AvatarInitials>
-          </span>
+                <span
+                  className="avatar-initials "
+                  style={
+                    Object {
+                      "backgroundColor": "#0061d5",
+                    }
+                  }
+                >
+                  AA
+                </span>
+              </AvatarInitials>
+            </span>
+          </Avatar>
         </Avatar>
-      </Avatar>
-      <StatusIcon
-        className="bcs-task-assignment-status-icon notStarted"
-        height={12}
-        status="NOT_STARTED"
-        title={
-          <FormattedMessage
-            defaultMessage="Completed"
-            id="be.completedAssignment"
-          />
-        }
-        width={12}
-      />
-    </Component>
-    <div
-      className="bcs-task-assignment-list-item-details"
-    >
-      <div>
-        AJ
-      </div>
+        <StatusIcon
+          className="bcs-task-assignment-status-icon notStarted"
+          height={12}
+          status="NOT_STARTED"
+          title={
+            <FormattedMessage
+              defaultMessage="Completed"
+              id="be.completedAssignment"
+            />
+          }
+          width={12}
+        />
+      </Component>
       <div
-        className="bcs-task-assignment-list-item-status"
+        className="bcs-task-assignment-list-item-details"
       >
-        <FormattedMessage
-          defaultMessage="Awaiting"
-          id="be.tasks.status.notStarted"
+        <div>
+          AJ
+        </div>
+        <div
+          className="bcs-task-assignment-list-item-status"
         >
-          <div />
-        </FormattedMessage>
+          <FormattedMessage
+            defaultMessage="Awaiting"
+            id="be.tasks.status.notStarted"
+          >
+            <div />
+          </FormattedMessage>
+        </div>
       </div>
-    </div>
-  </div>
+    </li>
+  </ul>
 </div>
 `;
 
@@ -615,7 +620,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
                     width={12}
                   >
                     <svg
-                      aria-labelledby="icon2-title"
+                      aria-labelledby="icon3-title"
                       className="icon-rejected bcs-task-assignment-status-icon rejected"
                       focusable="false"
                       height={12}
@@ -624,7 +629,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
                       width={12}
                     >
                       <title
-                        id="icon2-title"
+                        id="icon3-title"
                       >
                         <FormattedMessage
                           defaultMessage="Completed"
@@ -788,7 +793,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
                     width={12}
                   >
                     <svg
-                      aria-labelledby="icon4-title"
+                      aria-labelledby="icon5-title"
                       className="icon-verified bcs-task-assignment-status-icon approved"
                       focusable="false"
                       height={12}
@@ -798,7 +803,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
                       width={12}
                     >
                       <title
-                        id="icon4-title"
+                        id="icon5-title"
                       >
                         <FormattedMessage
                           defaultMessage="Completed"
@@ -831,6 +836,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
           openOnHoverDelayTimeout={300}
           portaledClasses={Array []}
           position="top-left"
+          shouldDefaultFocus={true}
         >
           <TetherComponent
             attachment="bottom right"
@@ -854,59 +860,72 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Assignees should render 
             renderElementTo={null}
             targetAttachment="top right"
           >
-            <button
+            <PlainButton
               aria-expanded="false"
               aria-haspopup="true"
               className="bcs-task-assignment-count-container"
               data-testid="task-assignment-overflow"
-              id="flyoutbutton6"
-              key=".$flyoutbutton6"
+              id="flyoutbutton7"
+              key=".$flyoutbutton7"
               onClick={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
               role="button"
               type="button"
             >
-              <Tooltip
-                constrainToScrollParent={false}
-                constrainToWindow={true}
-                isDisabled={false}
-                position="top-center"
-                text="See all assignees"
-                theme="default"
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                className="btn-plain bcs-task-assignment-count-container"
+                data-testid="task-assignment-overflow"
+                id="flyoutbutton7"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="button"
+                type="button"
               >
-                <TetherComponent
-                  attachment="bottom center"
-                  bodyElement={<body />}
-                  classPrefix="tooltip"
-                  constraints={
-                    Array [
-                      Object {
-                        "attachment": "together",
-                        "to": "window",
-                      },
-                    ]
-                  }
-                  enabled={false}
-                  renderElementTag="div"
-                  renderElementTo={null}
-                  targetAttachment="top center"
+                <Tooltip
+                  constrainToScrollParent={false}
+                  constrainToWindow={true}
+                  isDisabled={false}
+                  position="top-center"
+                  text="See all assignees"
+                  theme="default"
                 >
-                  <span
-                    className="bcs-task-assignment-count bcs-task-assignment-avatar"
-                    key=".0"
-                    onBlur={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    tabIndex="0"
+                  <TetherComponent
+                    attachment="bottom center"
+                    bodyElement={<body />}
+                    classPrefix="tooltip"
+                    constraints={
+                      Array [
+                        Object {
+                          "attachment": "together",
+                          "to": "window",
+                        },
+                      ]
+                    }
+                    enabled={false}
+                    renderElementTag="div"
+                    renderElementTo={null}
+                    targetAttachment="top center"
                   >
-                    +1
-                  </span>
-                </TetherComponent>
-              </Tooltip>
-            </button>
+                    <span
+                      className="bcs-task-assignment-count bcs-task-assignment-avatar"
+                      key=".0"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      tabIndex="0"
+                    >
+                      +1
+                    </span>
+                  </TetherComponent>
+                </Tooltip>
+              </button>
+            </PlainButton>
           </TetherComponent>
         </Flyout>
       </div>

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
@@ -52,7 +52,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
     <div
       className="bcs-task-content"
     >
-      <Component
+      <Assignees
         assignees={
           Object {
             "entries": Array [


### PR DESCRIPTION
- This currently renders the full assignee list in a dropdown
  when the +N icon next to the first 3 assignment avatars is clicked
- A followup commit will add pagination via infinite scroll