### PR TITLE
fix(icon-sort-chevron): user should see a larger sort icon

### DIFF
--- a/src/icons/general/IconSortChevron.js
+++ b/src/icons/general/IconSortChevron.js
@@ -12,7 +12,7 @@ type Props = {
     width?: number,
 };
 
-const IconSortChevron = ({ className = '', color = '#aeaeae', height = 11, title, width = 11 }: Props) => (
+const IconSortChevron = ({ className = '', color = '#aeaeae', height = 12, title, width = 12 }: Props) => (
     <AccessibleSVG
         className={`bdl-icon-sort-chevron ${className}`}
         height={height}

--- a/src/icons/general/__tests__/__snapshots__/IconSortChevron-test.js.snap
+++ b/src/icons/general/__tests__/__snapshots__/IconSortChevron-test.js.snap
@@ -3,9 +3,9 @@
 exports[`icons/general/IconSortChevron should correctly render default icon 1`] = `
 <AccessibleSVG
   className="bdl-icon-sort-chevron "
-  height={11}
+  height={12}
   viewBox="0 0 9.8 9.7"
-  width={11}
+  width={12}
 >
   <path
     className="fill-color"


### PR DESCRIPTION
Changes in this PR:
- IconSortChevron's default height / width should be 12x12 as requested by design
