### PR TITLE
fix(list-view): show pointer on hover of metadata column header

### DIFF
--- a/src/features/list-view/ListView.js
+++ b/src/features/list-view/ListView.js
@@ -47,16 +47,16 @@ class ListView extends React.PureComponent<Props> {
             });
             const isHeaderSortable = isGridHeaderSortable(columnIndex);
 
-            const headerClassName = classNames('bdl-ListView-columnHeader', {
+            const buttonClassName = classNames('bdl-ListView-columnHeader', {
                 'bdl-ListView-isHeaderSortable': isHeaderSortable,
             });
             return (
                 <button
-                    className={headerClassName}
+                    className={buttonClassName}
                     key={key}
                     style={style}
                     type="button"
-                    onClick={() => onSortChange(columnIndex)}
+                    onClick={() => isHeaderSortable && onSortChange(columnIndex)}
                 >
                     {displayName}
                     {sortDirection && <IconSortChevron className={iconClassName} />}

--- a/src/features/list-view/ListView.js
+++ b/src/features/list-view/ListView.js
@@ -22,6 +22,7 @@ type Props = {
     getGridHeader: (columnIndex: number) => any,
     getGridHeaderSort?: (columnIndex: number) => typeof SORT_ORDER_ASCENDING | typeof SORT_ORDER_DESCENDING | null,
     height: number,
+    isGridHeaderSortable?: (columnIndex: number) => boolean,
     onSortChange?: (columnIndex: number) => void,
     rowCount: number,
     width: number,
@@ -29,26 +30,36 @@ type Props = {
 
 class ListView extends React.PureComponent<Props> {
     cellRenderer = ({ columnIndex, key, rowIndex, style }: CellRendererArgs) => {
-        const { getGridCell, getGridHeader, getGridHeaderSort = noop, onSortChange = noop } = this.props;
+        const {
+            getGridCell,
+            getGridHeader,
+            getGridHeaderSort = noop,
+            isGridHeaderSortable = noop,
+            onSortChange = noop,
+        } = this.props;
 
         if (rowIndex === 0) {
             const displayName = getGridHeader(columnIndex);
             const sortDirection = getGridHeaderSort(columnIndex);
             const isSortAsc = sortDirection === SORT_ORDER_ASCENDING;
-            const className = classNames({
+            const iconClassName = classNames({
                 'bdl-ListView-isSortAsc': isSortAsc,
             });
+            const isHeaderSortable = isGridHeaderSortable(columnIndex);
 
+            const headerClassName = classNames('bdl-ListView-columnHeader', {
+                'bdl-ListView-isHeaderSortable': isHeaderSortable,
+            });
             return (
                 <button
-                    className="bdl-ListView-columnHeader"
+                    className={headerClassName}
                     key={key}
                     style={style}
                     type="button"
                     onClick={() => onSortChange(columnIndex)}
                 >
                     {displayName}
-                    {sortDirection && <IconSortChevron className={className} />}
+                    {sortDirection && <IconSortChevron className={iconClassName} />}
                 </button>
             );
         }

--- a/src/features/list-view/examples/ListViewExamples.js
+++ b/src/features/list-view/examples/ListViewExamples.js
@@ -15,6 +15,11 @@ const getGridHeader = columnIndex => `Header ${generateRandomString(columnIndex)
 
 const getGridCell = ({ columnIndex, rowIndex }) => `Row ${rowIndex}, Column ${columnIndex}`;
 
+const onSortChange = columnIndex => {
+    // eslint-disable-next-line no-console
+    console.log(`Column header #${columnIndex} clicked`);
+};
+
 const ListViewExamples = ({ columnCount }: Props) => {
     return (
         <div style={{ height: '300px' }}>
@@ -25,6 +30,7 @@ const ListViewExamples = ({ columnCount }: Props) => {
                         height={height}
                         getGridCell={getGridCell}
                         getGridHeader={getGridHeader}
+                        onSortChange={onSortChange}
                         rowCount={1000}
                         width={width}
                     />

--- a/src/features/list-view/styles/ListView.scss
+++ b/src/features/list-view/styles/ListView.scss
@@ -36,4 +36,8 @@
         justify-content: flex-start;
         padding-top: 16px;
     }
+
+    .ReactVirtualized__Grid {
+        outline: none;
+    }
 }

--- a/src/features/list-view/styles/ListView.scss
+++ b/src/features/list-view/styles/ListView.scss
@@ -20,6 +20,10 @@
         text-transform: none;
         width: 100%;
 
+        &.bdl-ListView-isHeaderSortable {
+            cursor: pointer;
+        }
+
         .bdl-icon-sort-chevron.bdl-ListView-isSortAsc {
             transform: rotate(180deg);
         }


### PR DESCRIPTION
Changes in this PR:
- Take in isGridHeaderSortable handler that determines whether or not a column header is sortable
- Apply ```cursor: pointer``` if they column header is sortable

![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/7213887/56620315-5cc36d80-65dd-11e9-9882-f536bc96829b.gif)
