### PR TITLE
fix(list-view): add styles for icon sort chevron

### DIFF
--- a/src/features/list-view/styles/ListView.scss
+++ b/src/features/list-view/styles/ListView.scss
@@ -25,7 +25,11 @@
         }
 
         .bdl-icon-sort-chevron.bdl-ListView-isSortAsc {
+            height: 12px;
+            margin-left: 2px;
+            margin-top: 3px;
             transform: rotate(180deg);
+            width: 12px;
         }
     }
 


### PR DESCRIPTION
Changes in this PR:
- make icon sort chevron have a height / width of 12px
- adjust margins to center the icon

<img width="375" alt="Screen Shot 2019-04-26 at 11 50 37 AM" src="https://user-images.githubusercontent.com/7213887/56836346-d486d780-682b-11e9-95eb-a94902e0eba1.png">