### PR TITLE
fix(floatfield): always allow trailing period for float field

### DIFF
--- a/src/features/metadata-instance-editor/fields/FloatField.js
+++ b/src/features/metadata-instance-editor/fields/FloatField.js
@@ -23,7 +23,7 @@ const FloatField = ({ dataKey, dataValue, displayName, description, error, onCha
         displayName={displayName}
         error={error}
         onChange={(key: string, value: MetadataFieldValue) => {
-            if (isValidValue(type, value, { allowTrailingPeriod: true })) {
+            if (isValidValue(type, value)) {
                 onChange(key, value);
             }
         }}

--- a/src/features/metadata-instance-editor/fields/__tests__/validateField-test.js
+++ b/src/features/metadata-instance-editor/fields/__tests__/validateField-test.js
@@ -10,23 +10,15 @@ import { FIELD_TYPE_FLOAT, FIELD_TYPE_INTEGER } from '../../constants';
         expected: true,
     },
     {
-        description: `should validate ${FIELD_TYPE_FLOAT} and return false`,
-        type: FIELD_TYPE_FLOAT,
-        value: '123.',
-        expected: false,
-    },
-    {
         description: `should validate ${FIELD_TYPE_FLOAT} with trailing period and return true`,
         type: FIELD_TYPE_FLOAT,
         value: '123.',
-        option: { allowTrailingPeriod: true },
         expected: true,
     },
     {
         description: `should validate ${FIELD_TYPE_FLOAT} with trailing period and return false`,
         type: FIELD_TYPE_FLOAT,
         value: '123..',
-        option: { allowTrailingPeriod: true },
         expected: false,
     },
     {
@@ -34,12 +26,6 @@ import { FIELD_TYPE_FLOAT, FIELD_TYPE_INTEGER } from '../../constants';
         type: FIELD_TYPE_INTEGER,
         value: '123',
         expected: true,
-    },
-    {
-        description: `should validate ${FIELD_TYPE_INTEGER} with trailing period and return false`,
-        type: FIELD_TYPE_INTEGER,
-        value: '123.',
-        expected: false,
     },
     {
         description: `should validate any random type and return true`,

--- a/src/features/metadata-instance-editor/fields/validateField.js
+++ b/src/features/metadata-instance-editor/fields/validateField.js
@@ -1,21 +1,15 @@
 // @flow
 import { FIELD_TYPE_FLOAT, FIELD_TYPE_INTEGER } from '../constants';
 
-const floatRegexAllowTrailingPeriod = /^[-+]?[0-9]*\.?[0-9]*$/;
-const floatRegex = /^[-+]?[0-9]*\.?[0-9]+$/;
+const floatRegex = /^[-+]?[0-9]*\.?[0-9]*$/;
 const integerRegex = /^[-+]?[0-9]+$/;
 
-const floatValidatorAllowTrailingPeriod = (value: string) => !!value.match(floatRegexAllowTrailingPeriod);
 const floatValidator = (value: string) => !!value.match(floatRegex);
 const integerValidator = (value: string) => !!value.match(integerRegex);
 
-type Options = {
-    allowTrailingPeriod?: boolean,
-};
-
-const isValidValue = (type: string, value: MetadataFieldValue, options?: Options = {}) => {
+const isValidValue = (type: string, value: MetadataFieldValue) => {
     if (type === FIELD_TYPE_FLOAT && typeof value === 'string') {
-        return options.allowTrailingPeriod ? floatValidatorAllowTrailingPeriod(value) : floatValidator(value);
+        return floatValidator(value);
     }
 
     if (type === FIELD_TYPE_INTEGER && typeof value === 'string') {


### PR DESCRIPTION
FloatField was took an optional `allowTrailingPeriod` which wasn't passed in all field validations. This caused inconsistent behavior.

Since there isn't a clear use case for disallowing trailing period, I'm removing the extra option.