### PR TITLE
fix(text-input): looses focus when tooltip toggles

### DIFF
--- a/src/components/text-input/README.md
+++ b/src/components/text-input/README.md
@@ -37,3 +37,17 @@ In addition to the properties defined above, you can also specify any of the `in
     const TextInput = require('box-ui-elements/es/components/text-input').default;
     <TextInput label='Email' name='textinput' type="email" isValid placeholder='Enter email here' />
 ```
+**Required with onChange**
+```jsx
+    const TextInput = require('box-ui-elements/es/components/text-input').default;
+    initialState = { error: 'required', value: '' };
+    <TextInput
+        label='Email'
+        name='textinput'
+        type="text"
+        placeholder='Enter email here'
+        value={state.value}
+        error={state.error}
+        onChange={(e) => setState({ error: e.target.value ? '' : 'required', value: e.target.value })}
+    />
+```

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -200,8 +200,8 @@ class Tooltip extends React.Component<Props, State> {
             theme,
         } = this.props;
 
-        // If the tooltip is disabled or if the text is missing, just render the children
-        if (isDisabled || !text) {
+        // If the tooltip is disabled just render the children
+        if (isDisabled) {
             return React.Children.only(children);
         }
 

--- a/src/components/tooltip/__tests__/Tooltip-test.js
+++ b/src/components/tooltip/__tests__/Tooltip-test.js
@@ -223,7 +223,7 @@ describe('components/tooltip/Tooltip', () => {
             ).toMatchSnapshot();
         });
 
-        test('should render children only when tooltip text is missing', () => {
+        test('should render children wrapped in tether when tooltip has text missing', () => {
             expect(
                 getWrapper({
                     text: null,

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip-test.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip-test.js.snap
@@ -87,10 +87,35 @@ exports[`components/tooltip/Tooltip render() should render children only when to
 </div>
 `;
 
-exports[`components/tooltip/Tooltip render() should render children only when tooltip text is missing 1`] = `
-<div>
-  Hello
-</div>
+exports[`components/tooltip/Tooltip render() should render children wrapped in tether when tooltip has text missing 1`] = `
+<TetherComponent
+  attachment="bottom center"
+  bodyElement={<body />}
+  classPrefix="tooltip"
+  constraints={
+    Array [
+      Object {
+        "attachment": "together",
+        "to": "window",
+      },
+    ]
+  }
+  enabled={false}
+  renderElementTag="div"
+  renderElementTo={null}
+  targetAttachment="top center"
+>
+  <div
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    tabIndex="0"
+  >
+    Hello
+  </div>
+</TetherComponent>
 `;
 
 exports[`components/tooltip/Tooltip render() should render correctly with callout theme 1`] = `


### PR DESCRIPTION
If text is absent for the tooltip it rendered only its children otherwise a tethered component. As such the DOM is re-rendered when tooltip gets text and thus the underlying input loses focus.

This partially reverts #1066 