### PR TITLE
fix(metadataeditor): send cascadeId onRemove

### DIFF
--- a/src/features/metadata-instance-editor/Instance.js
+++ b/src/features/metadata-instance-editor/Instance.js
@@ -45,7 +45,7 @@ type Props = {
     isDirty: boolean,
     isOpen: boolean,
     onModification?: (id: string, isDirty: boolean, type?: string) => void,
-    onRemove?: (id: string) => void,
+    onRemove?: (id: string, cascadePolicyId?: string | null) => void,
     onSave?: (
         id: string,
         data: JSONPatchOperations,
@@ -185,9 +185,16 @@ class Instance extends React.PureComponent<Props, State> {
             return;
         }
 
-        const { id, onRemove }: Props = this.props;
+        const { id, onRemove, cascadePolicy }: Props = this.props;
+
         if (onRemove) {
-            onRemove(id);
+            if (cascadePolicy) {
+                // the endpoint for instances/:id doesn't exist, so we have to send the cascadePolicy id, in order to fully clear the instance
+                onRemove(id, cascadePolicy.id);
+            } else {
+                onRemove(id, null);
+            }
+
             this.setState({ isBusy: true });
         }
     };

--- a/src/features/metadata-instance-editor/__tests__/Instance-test.js
+++ b/src/features/metadata-instance-editor/__tests__/Instance-test.js
@@ -688,5 +688,30 @@ describe('features/metadata-instance-editor/fields/Instance', () => {
                 expect.any(Function),
             );
         });
+
+        describe('onRemove()', () => {
+            test('onRemove should be called with both the id and cascadePolicy id if both are present', () => {
+                const onRemoveMock = jest.fn();
+                const testId = 'test-id-123';
+                const wrapper = shallow(
+                    <Instance
+                        canEdit
+                        cascadePolicy={{
+                            id: 'hello',
+                        }}
+                        id={testId}
+                        onRemove={onRemoveMock}
+                        onModification={jest.fn()}
+                        onSave={jest.fn()}
+                        template={{
+                            fields,
+                        }}
+                    />,
+                );
+                wrapper.setState({ isEditing: true });
+                wrapper.instance().onRemove();
+                expect(onRemoveMock).toBeCalledWith(testId, 'hello');
+            });
+        });
     });
 });


### PR DESCRIPTION
What this PR Does:

Adds the cascadePolicy Id to the onRemove action. 
This only has to happen because the instance/:id endpoint hasn't been created. Once it is I will remove this from the implementation.