### PR TITLE
fix(metadata): template dropdown scrollbar issue in safari

### DIFF
--- a/src/features/metadata-instance-editor/TemplateDropdown.scss
+++ b/src/features/metadata-instance-editor/TemplateDropdown.scss
@@ -38,6 +38,13 @@
             @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
                 max-height: 300px;
             }
+
+            // TemplateDropdown component is wrapped under two layers of Overlay components.
+            // Removing the extra transform and animation properties so it doesn't mess up safari's scroll bar.
+            ul.overlay {
+                animation: none;
+                transform: none;
+            }
         }
 
         .overlay {


### PR DESCRIPTION
The template dropdown uses the Flyout component which wraps a SelectorDropdown component.
Both of these components use the Overlay component in its implementation.
This results in the TemplateDropdown component having two layers of Overlay components.
This isn't a problem for most cases for in Safari causes the vertical scroll bar to disappear because of the nested transform CSS properties.
This change manually removes the CSS transform of the inner Overlay component to fix this bug.
