### PR TITLE
Fix styleguidest warnings for new i18n components

### DIFF
--- a/conf/styleguide.config.js
+++ b/conf/styleguide.config.js
@@ -52,8 +52,6 @@ const allSections = [
             '../src/components/hotkeys/HotkeyLayer.js',
             '../src/components/hotkeys/Hotkeys.js',
             '../src/components/i18n/FormattedCompMessage.js',
-            '../src/components/i18n/Param.js',
-            '../src/components/i18n/Plural.js',
             '../src/components/infinite-scroll/InfiniteScroll.js',
             '../src/components/inline-error/InlineError.js',
             '../src/components/inline-notice/InlineNotice.js',


### PR DESCRIPTION
Param and Plural should not be in the styleguide.conf.  These are covered by the documentation for FormattedCompMessage already.