### PR TITLE
feat(navlist): add animation prop and enable for LeftSidebar

### DIFF
--- a/src/components/nav-sidebar/NavList.js
+++ b/src/components/nav-sidebar/NavList.js
@@ -2,25 +2,47 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import AnimateHeight from 'react-animate-height';
+
 type Props = {
     children: React.Node,
     className?: string,
     collapsed?: boolean,
+    enableAnimation?: boolean,
     heading?: React.Node,
     placeholder?: React.Node,
     ulProps?: Object,
 };
 
-const NavList = ({ children, className = '', collapsed = false, heading, placeholder, ulProps = {} }: Props) => {
+const NavList = ({
+    children,
+    className = '',
+    collapsed = false,
+    enableAnimation = false,
+    heading,
+    placeholder,
+    ulProps = {},
+}: Props) => {
     const classes = classNames(`nav-list`, className, {
+        'is-animation-enabled': enableAnimation,
         'is-collapsed': collapsed,
     });
+
+    const childrenParsed = React.Children.map(children, link => (link ? <li>{link}</li> : null));
 
     return (
         <nav className={classes}>
             {heading ? <h2>{heading}</h2> : null}
             {placeholder}
-            <ul {...ulProps}>{React.Children.map(children, link => (link ? <li>{link}</li> : null))}</ul>
+            <ul {...ulProps}>
+                {enableAnimation && children ? (
+                    <AnimateHeight duration={300} height={!collapsed ? 'auto' : 0}>
+                        {childrenParsed}
+                    </AnimateHeight>
+                ) : (
+                    childrenParsed
+                )}
+            </ul>
         </nav>
     );
 };

--- a/src/components/nav-sidebar/NavList.js
+++ b/src/components/nav-sidebar/NavList.js
@@ -10,6 +10,8 @@ type Props = {
     collapsed?: boolean,
     enableAnimation?: boolean,
     heading?: React.Node,
+    onAnimationEnd?: () => void,
+    onAnimationStart?: () => void,
     placeholder?: React.Node,
     ulProps?: Object,
 };
@@ -20,6 +22,8 @@ const NavList = ({
     collapsed = false,
     enableAnimation = false,
     heading,
+    onAnimationEnd,
+    onAnimationStart,
     placeholder,
     ulProps = {},
 }: Props) => {
@@ -36,7 +40,12 @@ const NavList = ({
             {placeholder}
             <ul {...ulProps}>
                 {enableAnimation && children ? (
-                    <AnimateHeight duration={200} height={collapsed ? 0 : 'auto'}>
+                    <AnimateHeight
+                        duration={200}
+                        height={collapsed ? 0 : 'auto'}
+                        onAnimationEnd={onAnimationEnd}
+                        onAnimationStart={onAnimationStart}
+                    >
                         {childrenParsed}
                     </AnimateHeight>
                 ) : (

--- a/src/components/nav-sidebar/NavList.js
+++ b/src/components/nav-sidebar/NavList.js
@@ -24,7 +24,7 @@ const NavList = ({
     ulProps = {},
 }: Props) => {
     const classes = classNames(`nav-list`, className, {
-        'is-animation-enabled': enableAnimation,
+        'is-animationEnabled': enableAnimation,
         'is-collapsed': collapsed,
     });
 
@@ -36,7 +36,7 @@ const NavList = ({
             {placeholder}
             <ul {...ulProps}>
                 {enableAnimation && children ? (
-                    <AnimateHeight duration={300} height={!collapsed ? 'auto' : 0}>
+                    <AnimateHeight duration={200} height={collapsed ? 0 : 'auto'}>
                         {childrenParsed}
                     </AnimateHeight>
                 ) : (

--- a/src/components/nav-sidebar/NavList.js
+++ b/src/components/nav-sidebar/NavList.js
@@ -8,8 +8,8 @@ type Props = {
     children: React.Node,
     className?: string,
     collapsed?: boolean,
-    enableAnimation?: boolean,
     heading?: React.Node,
+    isAnimationEnabled?: boolean,
     onAnimationEnd?: () => void,
     onAnimationStart?: () => void,
     placeholder?: React.Node,
@@ -20,7 +20,7 @@ const NavList = ({
     children,
     className = '',
     collapsed = false,
-    enableAnimation = false,
+    isAnimationEnabled = false,
     heading,
     onAnimationEnd,
     onAnimationStart,
@@ -28,7 +28,7 @@ const NavList = ({
     ulProps = {},
 }: Props) => {
     const classes = classNames(`nav-list`, className, {
-        'is-animationEnabled': enableAnimation,
+        'is-animationEnabled': isAnimationEnabled,
         'is-collapsed': collapsed,
     });
 
@@ -39,7 +39,7 @@ const NavList = ({
             {heading ? <h2>{heading}</h2> : null}
             {placeholder}
             <ul {...ulProps}>
-                {enableAnimation && children ? (
+                {isAnimationEnabled && children ? (
                     <AnimateHeight
                         duration={200}
                         height={collapsed ? 0 : 'auto'}

--- a/src/components/nav-sidebar/NavSidebar.scss
+++ b/src/components/nav-sidebar/NavSidebar.scss
@@ -46,8 +46,9 @@
         position: relative;
 
         .nav-list-collapse {
-            height: 100%;
-            padding: 0 10px;
+            height: calc(100% - 6px);
+            margin: 3px 5px;
+            padding: 3px 7px;
             position: absolute;
             right: 0;
 
@@ -58,7 +59,7 @@
     }
 
     &.is-collapsed {
-        > ul,
+        :not(.is-animation-enabled) > ul,
         .placeholder {
             display: none;
         }

--- a/src/components/nav-sidebar/NavSidebar.scss
+++ b/src/components/nav-sidebar/NavSidebar.scss
@@ -53,13 +53,13 @@
             right: 0;
 
             > svg {
-                transition: transform 100ms ease-in-out;
+                transition: transform 200ms;
             }
         }
     }
 
     &.is-collapsed {
-        :not(.is-animation-enabled) > ul,
+        :not(.is-animationEnabled) > ul,
         .placeholder {
             display: none;
         }

--- a/src/components/nav-sidebar/README.md
+++ b/src/components/nav-sidebar/README.md
@@ -43,6 +43,7 @@ initialState = {
         }
         className="is-collapsible example-collapsible"
         collapsed={state.collapsed}
+        enableAnimation
     >
         <Link>Item 1-1</Link>
         <Link>Item 1-2</Link>

--- a/src/components/nav-sidebar/__tests__/NavList-test.js
+++ b/src/components/nav-sidebar/__tests__/NavList-test.js
@@ -78,7 +78,7 @@ describe('components/nav-sidebar/NavList', () => {
             );
 
             if (expectAnimationComponent) {
-                expect(nav.find('.is-animation-enabled')).toHaveLength(1);
+                expect(nav.find('.is-animationEnabled')).toHaveLength(1);
                 expect(nav.find('AnimateHeight')).toHaveLength(1);
             } else {
                 expect(nav.exists('AnimateHeight')).toBe(false);

--- a/src/components/nav-sidebar/__tests__/NavList-test.js
+++ b/src/components/nav-sidebar/__tests__/NavList-test.js
@@ -70,9 +70,9 @@ describe('components/nav-sidebar/NavList', () => {
 
     test.each([[false, false], [true, true]])(
         'should render animate height component when appropriate',
-        (enableAnimationProp, expectAnimationComponent) => {
+        (isAnimationEnabled, expectAnimationComponent) => {
             const nav = shallow(
-                <NavList enableAnimation={enableAnimationProp}>
+                <NavList isAnimationEnabled={isAnimationEnabled}>
                     <Link>Test</Link>
                 </NavList>,
             );

--- a/src/components/nav-sidebar/__tests__/NavList-test.js
+++ b/src/components/nav-sidebar/__tests__/NavList-test.js
@@ -67,4 +67,22 @@ describe('components/nav-sidebar/NavList', () => {
 
         expect(nav.find('ul').props().hello).toEqual('world');
     });
+
+    test.each([[false, false], [true, true]])(
+        'should render animate height component when appropriate',
+        (enableAnimationProp, expectAnimationComponent) => {
+            const nav = shallow(
+                <NavList enableAnimation={enableAnimationProp}>
+                    <Link>Test</Link>
+                </NavList>,
+            );
+
+            if (expectAnimationComponent) {
+                expect(nav.find('.is-animation-enabled')).toHaveLength(1);
+                expect(nav.find('AnimateHeight')).toHaveLength(1);
+            } else {
+                expect(nav.exists('AnimateHeight')).toBe(false);
+            }
+        },
+    );
 });

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -257,7 +257,7 @@ class LeftSidebar extends React.Component<Props, State> {
             <NavList
                 className={classes}
                 collapsed={collapsed}
-                enableAnimation={isCollapsible}
+                isAnimationEnabled={isCollapsible}
                 heading={heading}
                 onAnimationStart={this.setAnimationStart}
                 onAnimationEnd={this.setAnimationStop}

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -128,6 +128,7 @@ type Props = {
 };
 
 type State = {
+    isAnimating: boolean,
     isScrollableAbove: boolean,
     isScrollableBelow: boolean,
     isScrolling: boolean,
@@ -143,6 +144,7 @@ class LeftSidebar extends React.Component<Props, State> {
         super(props);
 
         this.state = {
+            isAnimating: false,
             isScrollableAbove: false,
             isScrollableBelow: false,
             isScrolling: false,
@@ -212,6 +214,7 @@ class LeftSidebar extends React.Component<Props, State> {
         showLoadingIndicator?: boolean,
         onToggleCollapse?: ?Function,
     ) {
+        const { isAnimating, isScrollableAbove, isScrollableBelow } = this.state;
         const {
             canReceiveDrop = false,
             className = '',
@@ -221,8 +224,9 @@ class LeftSidebar extends React.Component<Props, State> {
             menuItems,
             placeholder,
         } = headerLinkProps;
+        const isCollapsible = !!onToggleCollapse;
 
-        const heading = onToggleCollapse ? (
+        const heading = isCollapsible ? (
             <NavListCollapseHeader onToggleCollapse={onToggleCollapse}>
                 {this.getNavLink(headerLinkProps, leftSidebarProps)}
             </NavListCollapseHeader>
@@ -236,11 +240,11 @@ class LeftSidebar extends React.Component<Props, State> {
             );
 
         const classes = classNames('left-sidebar-list', className, {
-            'lsb-scrollable-shadow-top': this.state.isScrollableAbove,
-            'lsb-scrollable-shadow-bottom': this.state.isScrollableBelow,
+            'lsb-scrollable-shadow-top': isScrollableAbove,
+            'lsb-scrollable-shadow-bottom': isScrollableBelow && !isAnimating,
         });
 
-        const ulProps = onToggleCollapse
+        const ulProps = isCollapsible
             ? {
                   onScroll: this.onListScroll,
                   ref: elScrollableList => {
@@ -253,8 +257,10 @@ class LeftSidebar extends React.Component<Props, State> {
             <NavList
                 className={classes}
                 collapsed={collapsed}
-                enableAnimation
+                enableAnimation={isCollapsible}
                 heading={heading}
+                onAnimationStart={this.setAnimationStart}
+                onAnimationEnd={this.setAnimationStop}
                 placeholder={placeholderEl}
                 key={`list-${id}`}
                 ulProps={ulProps}
@@ -271,6 +277,19 @@ class LeftSidebar extends React.Component<Props, State> {
             builtNavList
         );
     }
+
+    setAnimationStart = () => {
+        // we track animation to fix problem where bottom shadow shows when there is not overflow content
+        this.setState({
+            isAnimating: true,
+        });
+    };
+
+    setAnimationStop = () => {
+        this.setState({
+            isAnimating: false,
+        });
+    };
 
     getNavLink(props: MenuItem | SubMenuItem, leftSidebarProps: LeftSidebarProps) {
         const {

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -253,6 +253,7 @@ class LeftSidebar extends React.Component<Props, State> {
             <NavList
                 className={classes}
                 collapsed={collapsed}
+                enableAnimation
                 heading={heading}
                 placeholder={placeholderEl}
                 key={`list-${id}`}

--- a/src/features/left-sidebar/LeftSidebar.md
+++ b/src/features/left-sidebar/LeftSidebar.md
@@ -241,7 +241,7 @@ const menuItems = [
     selected: false,
     showTooltip: true,
     iconComponent: IconFavorites,
-    showLoadingIndicator: true,
+    showLoadingIndicator: false,
     onToggleCollapse: onToggleCollapse,
     collapsed: state.collapsed.favorites,
     placeholder: 'Drag items here for quick access',

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
@@ -9,7 +9,6 @@ exports[`feature/left-sidebar/LeftSidebar should not render nested menu items wi
   >
     <NavList
       className="left-sidebar-list"
-      enableAnimation={false}
       heading={
         <LeftSidebarLink
           canReceiveDrop={false}
@@ -27,6 +26,7 @@ exports[`feature/left-sidebar/LeftSidebar should not render nested menu items wi
           showTooltip={true}
         />
       }
+      isAnimationEnabled={false}
       key="list-all-files"
       onAnimationEnd={[Function]}
       onAnimationStart={[Function]}
@@ -232,7 +232,6 @@ exports[`feature/left-sidebar/LeftSidebar should render collapsible nested menu 
     >
       <NavList
         className="left-sidebar-list"
-        enableAnimation={true}
         heading={
           <NavListCollapseHeader
             onToggleCollapse={[Function]}
@@ -254,6 +253,7 @@ exports[`feature/left-sidebar/LeftSidebar should render collapsible nested menu 
             />
           </NavListCollapseHeader>
         }
+        isAnimationEnabled={true}
         key="list-all-files"
         onAnimationEnd={[Function]}
         onAnimationStart={[Function]}
@@ -334,7 +334,6 @@ exports[`feature/left-sidebar/LeftSidebar should render non-collapsible nested m
   >
     <NavList
       className="left-sidebar-list"
-      enableAnimation={false}
       heading={
         <LeftSidebarLink
           canReceiveDrop={false}
@@ -352,6 +351,7 @@ exports[`feature/left-sidebar/LeftSidebar should render non-collapsible nested m
           showTooltip={true}
         />
       }
+      isAnimationEnabled={false}
       key="list-all-files"
       onAnimationEnd={[Function]}
       onAnimationStart={[Function]}
@@ -422,7 +422,6 @@ exports[`feature/left-sidebar/LeftSidebar should render placeholder inside neste
     >
       <NavList
         className="left-sidebar-list"
-        enableAnimation={true}
         heading={
           <NavListCollapseHeader
             onToggleCollapse={[Function]}
@@ -444,6 +443,7 @@ exports[`feature/left-sidebar/LeftSidebar should render placeholder inside neste
             />
           </NavListCollapseHeader>
         }
+        isAnimationEnabled={true}
         key="list-all-files"
         onAnimationEnd={[Function]}
         onAnimationStart={[Function]}

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
@@ -9,6 +9,7 @@ exports[`feature/left-sidebar/LeftSidebar should not render nested menu items wi
   >
     <NavList
       className="left-sidebar-list"
+      enableAnimation={true}
       heading={
         <LeftSidebarLink
           canReceiveDrop={false}
@@ -229,6 +230,7 @@ exports[`feature/left-sidebar/LeftSidebar should render collapsible nested menu 
     >
       <NavList
         className="left-sidebar-list"
+        enableAnimation={true}
         heading={
           <NavListCollapseHeader
             onToggleCollapse={[Function]}
@@ -328,6 +330,7 @@ exports[`feature/left-sidebar/LeftSidebar should render non-collapsible nested m
   >
     <NavList
       className="left-sidebar-list"
+      enableAnimation={true}
       heading={
         <LeftSidebarLink
           canReceiveDrop={false}
@@ -413,6 +416,7 @@ exports[`feature/left-sidebar/LeftSidebar should render placeholder inside neste
     >
       <NavList
         className="left-sidebar-list"
+        enableAnimation={true}
         heading={
           <NavListCollapseHeader
             onToggleCollapse={[Function]}

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
@@ -9,7 +9,7 @@ exports[`feature/left-sidebar/LeftSidebar should not render nested menu items wi
   >
     <NavList
       className="left-sidebar-list"
-      enableAnimation={true}
+      enableAnimation={false}
       heading={
         <LeftSidebarLink
           canReceiveDrop={false}
@@ -28,6 +28,8 @@ exports[`feature/left-sidebar/LeftSidebar should not render nested menu items wi
         />
       }
       key="list-all-files"
+      onAnimationEnd={[Function]}
+      onAnimationStart={[Function]}
       placeholder={null}
       ulProps={Object {}}
     >
@@ -253,6 +255,8 @@ exports[`feature/left-sidebar/LeftSidebar should render collapsible nested menu 
           </NavListCollapseHeader>
         }
         key="list-all-files"
+        onAnimationEnd={[Function]}
+        onAnimationStart={[Function]}
         placeholder={null}
         ulProps={
           Object {
@@ -330,7 +334,7 @@ exports[`feature/left-sidebar/LeftSidebar should render non-collapsible nested m
   >
     <NavList
       className="left-sidebar-list"
-      enableAnimation={true}
+      enableAnimation={false}
       heading={
         <LeftSidebarLink
           canReceiveDrop={false}
@@ -349,6 +353,8 @@ exports[`feature/left-sidebar/LeftSidebar should render non-collapsible nested m
         />
       }
       key="list-all-files"
+      onAnimationEnd={[Function]}
+      onAnimationStart={[Function]}
       placeholder={null}
       ulProps={Object {}}
     >
@@ -439,6 +445,8 @@ exports[`feature/left-sidebar/LeftSidebar should render placeholder inside neste
           </NavListCollapseHeader>
         }
         key="list-all-files"
+        onAnimationEnd={[Function]}
+        onAnimationStart={[Function]}
         placeholder={
           <div
             className="placeholder"


### PR DESCRIPTION
NavList is given a new prop `enableAnimation` that will animate the height of it's contents. I think it is better to use a prop instead of just giving it a height animation so that we aren't injecting a useless component when it's not necessary. @priyajeet or @jstoffan let me know if you have any feedback for that approach.

This also includes a bug fix for the focus outline for the toggle button to prevent overflow and overlap with other components.

![2019-05-30 16 38 47](https://user-images.githubusercontent.com/9208519/58721960-0a6b2e80-838b-11e9-9884-b949c235f17b.gif)


