### PR TITLE
fix(api): Fix avatar resolution in activity sidebar

### DIFF
--- a/src/api/Users.js
+++ b/src/api/Users.js
@@ -54,7 +54,14 @@ class Users extends Base {
         const accessToken: TokenLiteral = await TokenService.getReadToken(getTypedFileId(fileId), this.options.token);
 
         if (typeof accessToken === 'string') {
-            const url = `${this.getAvatarUrl(userId)}?access_token=${accessToken}`;
+            const options = {
+                access_token: accessToken,
+                pic_type: 'large',
+            };
+            const urlParams = Object.keys(options)
+                .map(key => `${key}=${options[key]}`)
+                .join('&');
+            const url = `${this.getAvatarUrl(userId)}?${urlParams}`;
             cache.set(userId, url);
             return url;
         }

--- a/src/api/Users.js
+++ b/src/api/Users.js
@@ -4,6 +4,7 @@
  * @author Box
  */
 
+import queryString from 'query-string';
 import TokenService from '../utils/TokenService';
 import { getTypedFileId } from '../utils/file';
 import Base from './Base';
@@ -58,9 +59,7 @@ class Users extends Base {
                 access_token: accessToken,
                 pic_type: 'large',
             };
-            const urlParams = Object.keys(options)
-                .map(key => `${key}=${options[key]}`)
-                .join('&');
+            const urlParams = queryString.stringify(options);
             const url = `${this.getAvatarUrl(userId)}?${urlParams}`;
             cache.set(userId, url);
             return url;

--- a/src/api/__tests__/Users-test.js
+++ b/src/api/__tests__/Users-test.js
@@ -29,6 +29,7 @@ describe('api/Users', () => {
             const url2 = await users.getAvatarUrlWithAccessToken('foo');
             expect(url1).toEqual(url2);
             expect(url1.startsWith('https://api.box.com/2.0/users/foo/avatar?access_token=')).toBe(true);
+            expect(url1.indexOf('pic_type') !== -1).toBe(true);
         });
 
         test('should not return cached avatar url if called with another id', async () => {


### PR DESCRIPTION
Default avatar url returned by the API is 28*28. The avatar is 32*32 in the UI which makes the avatar look blurry. Fixing avatar urls in activity sidebar to add the pic_type param so we can specify next size up in the API for avatars which will return 40*40 image resolution.