### PR TITLE
fix(footer-indicator): move tooltip to appear above footer indicator

### DIFF
--- a/src/components/footer-indicator/FooterIndicator.js
+++ b/src/components/footer-indicator/FooterIndicator.js
@@ -14,7 +14,7 @@ type Props = {
 const FooterIndicator = ({ indicatorText }: Props) => {
     return (
         <div className="bdl-FooterIndicator">
-            <Tooltip position="middle-right" text={indicatorText}>
+            <Tooltip position="top-right" text={indicatorText}>
                 <div className="bdl-FooterIndicator-content">
                     <span className="bdl-FooterIndicator-iconWrapper">
                         <IconPuzzlePiece />

--- a/src/components/footer-indicator/FooterIndicator.md
+++ b/src/components/footer-indicator/FooterIndicator.md
@@ -27,7 +27,7 @@ Renders a small tab with text in the bottom-left corner of a page.
     transform: 'translate3d(0,0,0)',
 }}>
     <FooterIndicator
-        indicatorText="FooterIndicatorWithExtremelyLongName"
+        indicatorText="FooterIndicatorWithExtremelyRemarkablyStupendouslyTerrificallyLongName"
     />
 </div>
 ```
@@ -35,323 +35,326 @@ Renders a small tab with text in the bottom-left corner of a page.
 #### In a `NavSidebar`
 
 ```js
-const NavSidebar = require('box-ui-elements/es/components/nav-sidebar/NavSidebar').default;
-const NavList = require('box-ui-elements/es/components/nav-sidebar/NavList').default;
+const NavSidebar = require('box-ui-elements/es/components/nav-sidebar/NavSidebar')
+  .default;
+const NavList = require('box-ui-elements/es/components/nav-sidebar/NavList')
+  .default;
 
 <div
-    style={{
-        transform: 'translate3d(0,0,0)',
-    }}
+  style={{
+    transform: 'translate3d(0,0,0)',
+  }}
 >
-    <NavSidebar style={{ padding: 0 }}>
-        <div style={{ padding: '20px' }}>
-            <NavList>
-                <Link>Item A</Link>
-                <Link>Item B</Link>
-                <Link>Item C</Link>
-                <Link>Item D</Link>
-                <Link>Item E</Link>
-            </NavList>
-        </div>
-        <FooterIndicator indicatorText="FooterIndicatorInANavSidebar" />
-    </NavSidebar>
+  <NavSidebar style={{ padding: 0 }}>
+    <div style={{ padding: '20px' }}>
+      <NavList>
+        <Link>Item A</Link>
+        <Link>Item B</Link>
+        <Link>Item C</Link>
+        <Link>Item D</Link>
+        <Link>Item E</Link>
+      </NavList>
+    </div>
+    <FooterIndicator indicatorText="FooterIndicatorInANavSidebar" />
+  </NavSidebar>
 </div>;
 ```
 
 #### In a `LeftSidebar`
 
 ```js
-const LeftSidebar = require('box-ui-elements/es/features/left-sidebar/LeftSidebar').default;
+const LeftSidebar = require('box-ui-elements/es/features/left-sidebar/LeftSidebar')
+  .default;
 const IconReturnToAdminConsole = require('box-ui-elements/es/features/left-sidebar/icons/IconReturnToAdminConsole')
-    .default;
+  .default;
 const IconFilePDF = require('../../icons/file/IconFilePDF').default;
 
 const leftSidebarProps = {
-    customTheme: {
-        isLight: 'yes',
-        primaryColorLight: '#f0f0f0', // selected menu item background color
-        primaryColorLighter: '#123',
-        primaryColorDark: '#123',
-        primaryColorDarker: '#123',
-        contrastColor: '#123',
-        secondaryColor: '#123', // icons, selected menu item border, selected menu item icon
-    },
+  customTheme: {
+    isLight: 'yes',
+    primaryColorLight: '#f0f0f0', // selected menu item background color
+    primaryColorLighter: '#123',
+    primaryColorDark: '#123',
+    primaryColorDarker: '#123',
+    contrastColor: '#123',
+    secondaryColor: '#123', // icons, selected menu item border, selected menu item icon
+  },
+  htmlAttributes: {
+    'data-resin-component': 'leftnav',
+  },
+  copyrightFooterProps: {
+    'data-resin-target': 'copyright',
+    href: '/about-us',
+  },
+  indicatorText: 'FooterIndicatorInALeftSidebar',
+  instantLoginProps: {
     htmlAttributes: {
-        'data-resin-component': 'leftnav',
+      href: '/logout',
+      'data-resin-target': 'exitinstantlogin',
+      rel: 'external',
     },
-    copyrightFooterProps: {
-        'data-resin-target': 'copyright',
-        href: '/about-us',
-    },
-    indicatorText: 'FooterIndicatorInALeftSidebar',
-    instantLoginProps: {
-        htmlAttributes: {
-            href: '/logout',
-            'data-resin-target': 'exitinstantlogin',
-            rel: 'external',
-        },
-        iconComponent: IconReturnToAdminConsole,
-        id: 'return-to-admin-console',
-        message: 'Return to Admin Console',
-        showTooltip: true,
-    },
-    isInstantLoggedIn: true,
-    isDragging: true,
+    iconComponent: IconReturnToAdminConsole,
+    id: 'return-to-admin-console',
+    message: 'Return to Admin Console',
+    showTooltip: true,
+  },
+  isInstantLoggedIn: true,
+  isDragging: true,
 };
 
 const menuItems = [
-    {
-        id: 'favorites',
-        canReceiveDrop: false,
-        message: 'Favorites',
-        htmlAttributes: {
-            href: '/favorites',
-            rel: 'some-rel',
-            target: '_blank',
-            'data-resin-target': 'favorites',
-        },
-        selected: false,
-        showTooltip: true,
-        showLoadingIndicator: false,
-        placeholder: 'Drag items here for quick access',
-        menuItems: [
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-1',
-                message: 'Some Really Longggggg Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-2',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-3',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-4',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-5',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-6',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-7',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-8',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-9',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-10',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-11',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-12',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-13',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-14',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-15',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-16',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-17',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-18',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-            {
-                iconComponent: IconFilePDF,
-                id: 'favorites-item-19',
-                message: 'Some Short Favorite',
-                htmlAttributes: {
-                    href: '/1234',
-                    'data-resin-feature': 'favorites',
-                    'data-resin-target': 'itemname',
-                },
-                scaleIcon: true,
-                showTooltip: true,
-            },
-        ],
+  {
+    id: 'favorites',
+    canReceiveDrop: false,
+    message: 'Favorites',
+    htmlAttributes: {
+      href: '/favorites',
+      rel: 'some-rel',
+      target: '_blank',
+      'data-resin-target': 'favorites',
     },
+    selected: false,
+    showTooltip: true,
+    showLoadingIndicator: false,
+    placeholder: 'Drag items here for quick access',
+    menuItems: [
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-1',
+        message: 'Some Really Longggggg Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-2',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-3',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-4',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-5',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-6',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-7',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-8',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-9',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-10',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-11',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-12',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-13',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-14',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-15',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-16',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-17',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-18',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+      {
+        iconComponent: IconFilePDF,
+        id: 'favorites-item-19',
+        message: 'Some Short Favorite',
+        htmlAttributes: {
+          href: '/1234',
+          'data-resin-feature': 'favorites',
+          'data-resin-target': 'itemname',
+        },
+        scaleIcon: true,
+        showTooltip: true,
+      },
+    ],
+  },
 ];
 
 <div
-    style={{
-        transform: 'translate3d(0,0,0)',
-    }}
+  style={{
+    transform: 'translate3d(0,0,0)',
+  }}
 >
-    <LeftSidebar menuItems={menuItems} leftSidebarProps={leftSidebarProps} />
+  <LeftSidebar menuItems={menuItems} leftSidebarProps={leftSidebarProps} />
 </div>;
 ```

--- a/src/components/footer-indicator/__tests__/__snapshots__/FooterIndicator-test.js.snap
+++ b/src/components/footer-indicator/__tests__/__snapshots__/FooterIndicator-test.js.snap
@@ -8,7 +8,7 @@ exports[`feature/footer-indicator/FooterIndicator should render a FooterIndicato
     constrainToScrollParent={false}
     constrainToWindow={true}
     isDisabled={false}
-    position="middle-right"
+    position="top-right"
     text="abcdefghijklmnopqrstuvwxyz"
     theme="default"
   >


### PR DESCRIPTION
The current footer indicator tooltip appears to the right of the indicator, which causes unwanted scrollbars to appear in certain browsers and pages and long text to get cut off at the bottom of the viewport.

<img width="414" alt="current-footer-indicator-tooltip" src="https://user-images.githubusercontent.com/2956895/59076749-74546e00-888c-11e9-9f8e-60e34d3b941b.png">

This pull request fixes the above issues by changing the position of the footer indicator tooltip from `middle-right` to `top-right`.

<img width="234" alt="proposed-footer-indicator-tooltip" src="https://user-images.githubusercontent.com/2956895/59076819-d3b27e00-888c-11e9-9914-707cf54f7e3e.png">

