### PR TITLE
feat(office-online): adding excel spreadsheet icon for xlsb files

### DIFF
--- a/src/icons/file-icon/FileIcon.js
+++ b/src/icons/file-icon/FileIcon.js
@@ -133,7 +133,7 @@ const EXTENSIONS = {
     ]),
     IconFileDocument: mirror(['csv', 'dot', 'dotx', 'msg', 'odt', 'rtf', 'tsv', 'wpd', 'xhtml', 'xml', 'xsd', 'xsl']),
     IconFileDwg: mirror(['dwg', 'dwgzip']),
-    IconFileExcelSpreadsheet: mirror(['xls', 'xlsx', 'xlsm']),
+    IconFileExcelSpreadsheet: mirror(['xls', 'xlsx', 'xlsm', 'xlsb']),
     IconFileGoogleDocs: mirror(['gdoc']),
     IconFileGoogleSheets: mirror(['gsheet']),
     IconFileGoogleSlides: mirror(['gslide', 'gslides']),

--- a/src/icons/file-icon/__tests__/FileIcon-test.js
+++ b/src/icons/file-icon/__tests__/FileIcon-test.js
@@ -57,6 +57,9 @@ describe('icons/file-icon/FileIcon', () => {
             extension: 'xlsm',
         },
         {
+            extension: 'xlsb',
+        },
+        {
             extension: 'zip',
         },
     ].forEach(({ extension }) => {

--- a/src/icons/file-icon/__tests__/__snapshots__/FileIcon-test.js.snap
+++ b/src/icons/file-icon/__tests__/__snapshots__/FileIcon-test.js.snap
@@ -120,6 +120,13 @@ exports[`icons/file-icon/FileIcon should render the expected icon when extension
 `;
 
 exports[`icons/file-icon/FileIcon should render the expected icon when extension is defined 16`] = `
+<IconFileExcelSpreadsheet
+  height={32}
+  width={32}
+/>
+`;
+
+exports[`icons/file-icon/FileIcon should render the expected icon when extension is defined 17`] = `
 <IconFileZip
   height={32}
   width={32}

--- a/src/icons/microsoft-office/OfficeDesktopIcon.js
+++ b/src/icons/microsoft-office/OfficeDesktopIcon.js
@@ -30,6 +30,7 @@ const OfficeDesktopIcon = ({ className, dimension = 30, extension, title }: Prop
         case 'xls':
         case 'xlsx':
         case 'xlsm':
+        case 'xlsb':
             Component = IconExcelDesktop;
             break;
         // no default

--- a/src/icons/microsoft-office/OfficeOnlineIcon.js
+++ b/src/icons/microsoft-office/OfficeOnlineIcon.js
@@ -30,6 +30,7 @@ const OfficeOnlineIcon = ({ className, dimension = 30, extension, title }: Props
         case 'xls':
         case 'xlsx':
         case 'xlsm':
+        case 'xlsb':
             Component = IconExcelOnline;
             break;
         // no default

--- a/src/icons/microsoft-office/__tests__/OfficeDesktopIcon-test.js
+++ b/src/icons/microsoft-office/__tests__/OfficeDesktopIcon-test.js
@@ -34,6 +34,10 @@ describe('icons/microsoft-office/OfficeDesktopIcon', () => {
             extension: 'xlsm',
             component: 'IconExcelDesktop',
         },
+        {
+            extension: 'xlsb',
+            component: 'IconExcelDesktop',
+        },
     ].forEach(({ extension, component }) => {
         test('should correctly render default icon', () => {
             const wrapper = getWrapper({ extension });

--- a/src/icons/microsoft-office/__tests__/OfficeOnlineIcon-test.js
+++ b/src/icons/microsoft-office/__tests__/OfficeOnlineIcon-test.js
@@ -27,11 +27,15 @@ describe('icons/microsoft-office/OfficeOnlineIcon', () => {
             component: 'IconExcelOnline',
         },
         {
-            extension: 'xlsm',
+            extension: 'xlsx',
             component: 'IconExcelOnline',
         },
         {
             extension: 'xlsm',
+            component: 'IconExcelOnline',
+        },
+        {
+            extension: 'xlsb',
             component: 'IconExcelOnline',
         },
     ].forEach(({ extension, component }) => {


### PR DESCRIPTION
Updating the icon for xlsb files to match the excel spreadsheet icon currently used for xlsx and xlsm files.