### PR TITLE
fix(comment): use overlay z-index for confirmation dialog

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/Comment.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.scss
@@ -2,7 +2,7 @@
 
 // tethered styles
 .bcs-comment-delete-confirm {
-    z-index: 1;
+    z-index: $overlay-z-index;
 }
 
 .bcs-comment-confirm-container {


### PR DESCRIPTION
Client apps which might have more deeply-nested structure will require a standard, higher z-index value. This applies one to the tethered container.