### PR TITLE
fix(scroll-if-needed): fix scroll-if-needed on selector dropdown

### DIFF
--- a/src/components/selector-dropdown/SelectorDropdown.js
+++ b/src/components/selector-dropdown/SelectorDropdown.js
@@ -80,7 +80,7 @@ class SelectorDropdown extends React.Component<Props, State> {
     setActiveItemID = (id: string | null) => {
         const itemEl = id ? document.getElementById(id) : null;
         this.setState({ activeItemID: id });
-        scrollIntoView(itemEl);
+        scrollIntoView(itemEl, { block: 'nearest' });
     };
 
     listboxID: string;


### PR DESCRIPTION
The auto scroll for the selector dropdown will scroll the item in to
center of the container when hover over. The correct behavior should
only scroll the item into the nearest view of the container.