### PR TITLE
fix(uploader): MultiputUploads stop hanging in IE11

### DIFF
--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -82,8 +82,6 @@ class MultiputUpload extends BaseMultiput {
 
     commitSessionTimeout: TimeoutID;
 
-    partsUploaded: number;
-
     /**
      * [constructor]
      *
@@ -565,9 +563,7 @@ class MultiputUpload extends BaseMultiput {
         } else if (data.type === 'done') {
             this.fileSha1 = hexToBase64(data.sha1);
             this.sha1Worker.terminate();
-            if (this.partsUploaded === this.parts.length) {
-                this.commitSession();
-            }
+            this.processNextParts();
         } else if (data.type === 'error') {
             this.sessionErrorHandler(null, LOG_EVENT_TYPE_WEB_WORKER_ERROR, JSON.stringify(data));
         }


### PR DESCRIPTION
`partsUploaded` was a field that was never updated, so we entered into a race condition: (1) uploading all the chunked parts and (2) sha1Worker computing all the digests. If (2) finishes first (which is the case in probably all of the other browsers), then there is no issue. But if (1) finishes first (which is the case in IE11), committing the upload session was at the mercy of `onWorkerMessage` which was referencing the value of `partsUploaded` which was never updated and as a result, `undefined`.

The fix below was to redirect the logic when the `done` event is sent from the sha1Worker back to `processNextParts` which will commit the session