### PR TITLE
fix(tasks_new): add missing resin component

### DIFF
--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -234,7 +234,7 @@ class TaskForm extends React.Component<Props, State> {
         const taskErrorMessage = isCreateEditMode ? messages.taskCreateErrorMessage : messages.taskUpdateErrorMessage;
 
         return (
-            <div className={inputContainerClassNames}>
+            <div className={inputContainerClassNames} data-resin-component="taskform">
                 <div className="bcs-task-input-form-container">
                     {error ? (
                         <InlineError title={<FormattedMessage {...messages.taskCreateErrorTitle} />}>


### PR DESCRIPTION
Events within the add/edit modal for tasks fail to send because of missing component value. 