### PR TITLE
feat(unified-share-modal): add property to limit the number of contacts

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1170,6 +1170,8 @@ boxui.unifiedShare.collaboration.userCollabText = User
 boxui.unifiedShare.collaboratorListTitle = People in '{itemName}'
 # This string is displayed as tooltip on hovering over expire icon for collab
 boxui.unifiedShare.collaborators.expirationTooltipClickableText = Access expires on {date}. Click for details.
+# Error message when more than the maximum number of contacts is entered
+boxui.unifiedShare.contactsExceedLimitError = Oops! The maximum number of collaborators that can be added at once is {maxContacts} collaborators. Please try again by splitting your invitations into batches.
 # Text shown in share modal when there is at least one external collaborators
 boxui.unifiedShare.contentSharedWithExternalCollaborators = This content will be shared with external collaborators.
 # Text used in button label to describe permission level - co-owner

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -58,6 +58,8 @@ type Props = {
     collaborationRestrictionWarning: React.Node,
     /** List of existing collaborators */
     collaboratorsList?: collaboratorsListType,
+    /** Used to limit the number of contacts that can be added in the contacts field */
+    contactLimit?: number,
     /** User ID of currently logged in user */
     currentUserID: string,
     /** Whether the modal should focus the shared link after the URL is resolved */
@@ -454,6 +456,7 @@ class UnifiedShareModal extends React.Component<Props, State> {
         const {
             canInvite,
             collaborationRestrictionWarning,
+            contactLimit,
             getCollaboratorContacts,
             item,
             sendInvitesError,
@@ -519,6 +522,7 @@ class UnifiedShareModal extends React.Component<Props, State> {
                 >
                     <div className="invite-collaborator-container">
                         <EmailForm
+                            contactLimit={contactLimit}
                             contactsFieldAvatars={avatars}
                             contactsFieldDisabledTooltip={contactsFieldDisabledTooltip}
                             contactsFieldLabel={<FormattedMessage {...messages.inviteFieldLabel} />}

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -17,6 +17,12 @@ const messages = defineMessages({
         description: 'Error message when user tries to send Shared Link as email without entering any recipients',
         id: 'boxui.unifiedShare.enterAtLeastOneEmail',
     },
+    contactsExceedLimitError: {
+        defaultMessage:
+            'Oops! The maximum number of collaborators that can be added at once is {maxContacts} collaborators. Please try again by splitting your invitations into batches.',
+        description: 'Error message when more than the maximum number of contacts is entered',
+        id: 'boxui.unifiedShare.contactsExceedLimitError',
+    },
     enterEmailAddressesCalloutText: {
         defaultMessage: 'Share this item with coworkers by entering their email addresses',
         description:


### PR DESCRIPTION
Add property to limit the number of contact pills that can be created at one time.
Remove reset of error on contact input.  This preserves the contact limit error.