### PR TITLE
fix(nav-sidebar): reduce size of toggle button to fix focus outline

### DIFF
--- a/src/components/nav-sidebar/NavSidebar.scss
+++ b/src/components/nav-sidebar/NavSidebar.scss
@@ -46,8 +46,9 @@
         position: relative;
 
         .nav-list-collapse {
-            height: 100%;
-            padding: 0 10px;
+            height: calc(100% - 6px);
+            margin: 3px 5px;
+            padding: 3px 7px;
             position: absolute;
             right: 0;
 

--- a/src/components/nav-sidebar/NavSidebar.scss
+++ b/src/components/nav-sidebar/NavSidebar.scss
@@ -46,9 +46,12 @@
         position: relative;
 
         .nav-list-collapse {
-            height: calc(100% - 6px);
-            margin: 3px 5px;
-            padding: 3px 7px;
+            align-items: center;
+            display: flex;
+            height: calc(100% - 10px);
+            justify-content: center;
+            margin: 5px;
+            padding: 0 5px;
             position: absolute;
             right: 0;
 

--- a/src/features/left-sidebar/LeftSidebar.md
+++ b/src/features/left-sidebar/LeftSidebar.md
@@ -241,7 +241,7 @@ const menuItems = [
     selected: false,
     showTooltip: true,
     iconComponent: IconFavorites,
-    showLoadingIndicator: true,
+    showLoadingIndicator: false,
     onToggleCollapse: onToggleCollapse,
     collapsed: state.collapsed.favorites,
     placeholder: 'Drag items here for quick access',


### PR DESCRIPTION
Reduces the size of the sidebar toggle button to reduce the overflow of the focus outline, which is a bit jarring when hovering other items. Below shows the reduced size.

Before
![image](https://user-images.githubusercontent.com/9208519/59809574-f6de2400-92b5-11e9-810b-b83090d692eb.png)

After
![image](https://user-images.githubusercontent.com/9208519/59809921-baabc300-92b7-11e9-87ae-472a7cc2c08f.png)

