### PR TITLE
refactor(task-new): componentize task assignee css

### DIFF
--- a/src/elements/content-sidebar/activity-feed/task-new/AssigneeList.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/AssigneeList.js
@@ -92,24 +92,24 @@ function AssigneeList(props: Props) {
                 {visibleUsers}
             </ul>
             {!isOpen && hiddenAssigneeCount > 0 && (
-                <span>
+                <span className="bcs-AssigneeList-expandBtn">
                     <PlainButton
                         data-resin-target="showmorebtn"
                         data-testid="show-more-assignees"
                         onClick={onExpand}
-                        className="lnk bcs-AssigneeList-expandBtn"
+                        className="lnk"
                     >
                         <FormattedMessage {...messages.taskShowMoreAssignees} values={{ additionalAssigneeCount }} />
                     </PlainButton>
                 </span>
             )}
             {isOpen && (
-                <span>
+                <span className="bcs-AssigneeList-expandBtn">
                     <PlainButton
                         data-resin-target="showlessbtn"
                         data-testid="show-less-assignees"
                         onClick={onCollapse}
-                        className="lnk bcs-AssigneeList-expandBtn"
+                        className="lnk"
                     >
                         <FormattedMessage {...messages.taskShowLessAssignees} />
                     </PlainButton>

--- a/src/elements/content-sidebar/activity-feed/task-new/AssigneeList.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/AssigneeList.scss
@@ -1,7 +1,7 @@
 @import '../../../common/variables';
 @import './mixins';
 
-$avatar-size: 28px;
+$bcs-AssigneeList-avatar-size: 32px;
 
 .bcs-AssigneeList-list {
     margin: 0;
@@ -13,20 +13,17 @@ $avatar-size: 28px;
     display: flex;
     margin: 6px 0 0 0;
     padding: 3px 0;
+}
 
-    .bcs-AssigneeList-detailsStatus {
-        color: $bdl-neutral-02;
-        font-size: 12px;
-    }
+.bcs-AssigneeList-detailsStatus {
+    color: $bdl-neutral-02;
+    font-size: 12px;
 }
 
 .bcs-AssigneeList-listItemAvatar {
+    height: $bcs-AssigneeList-avatar-size;
     margin-right: 10px;
-
-    .bcs-AvatarGroup-avatar {
-        height: $avatar-size;
-        width: $avatar-size;
-    }
+    width: $bcs-AssigneeList-avatar-size;
 }
 
 .bcs-AssigneeList-listItemDetails {
@@ -37,18 +34,7 @@ $avatar-size: 28px;
     color: $bdl-neutral-02;
 }
 
-.lnk.bcs-AssigneeList-expandBtn {
-    margin-left: $avatar-size + 10px;
-    margin-top: 5px;
-}
-
-.bcs-AssigneeList-statusIcon {
-    @include avatar-badge-icon;
-}
-
-.bcs-AvatarGroup-avatarContainer {
-    display: inline-block;
-    height: $avatar-size;
-    position: relative;
-    width: $avatar-size;
+.bcs-AssigneeList-expandBtn {
+    color: $bdl-box-blue;
+    margin-left: $bcs-AssigneeList-avatar-size + 10px;
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/AssigneeList.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/AssigneeList.scss
@@ -1,7 +1,7 @@
 @import '../../../common/variables';
 @import './mixins';
 
-$bcs-AssigneeList-avatar-size: 32px;
+$bcs-AssigneeList-avatar-size: 28px;
 
 .bcs-AssigneeList-list {
     margin: 0;

--- a/src/elements/content-sidebar/activity-feed/task-new/AvatarGroupAvatar.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/AvatarGroupAvatar.js
@@ -9,6 +9,8 @@ import Avatar from '../Avatar';
 import { TASK_NEW_APPROVED, TASK_NEW_REJECTED, TASK_NEW_COMPLETED, TASK_NEW_NOT_STARTED } from '../../../../constants';
 import messages from '../../../common/messages';
 
+import './AvatarGroupAvatar.scss';
+
 type Props = {
     className?: string,
     getAvatarUrl?: GetAvatarUrlCallback,
@@ -31,14 +33,14 @@ const StatusIcon = ({ status, ...rest }: { status: TaskCollabStatus }) => {
 
 const AvatarGroupAvatar = React.memo<Props>(({ user, status, getAvatarUrl, className, ...rest }: Props) => (
     <div
-        className={classNames('bcs-AvatarGroup-avatarContainer', className)}
+        className={classNames('bcs-AvatarGroupAvatar', className)}
         data-testid="avatar-group-avatar-container"
         {...rest}
     >
-        <Avatar className="bcs-AvatarGroup-avatar" user={user} getAvatarUrl={getAvatarUrl} />
+        <Avatar className="bcs-AvatarGroupAvatar-avatar" user={user} getAvatarUrl={getAvatarUrl} />
         <StatusIcon
             status={status}
-            className={`bcs-AvatarGroup-statusIcon ${camelCase(status)}`}
+            className={`bcs-AvatarGroupAvatar-statusIcon ${camelCase(status)}`}
             height={12}
             width={12}
             title={<FormattedMessage {...messages.completedAssignment} />}

--- a/src/elements/content-sidebar/activity-feed/task-new/AvatarGroupAvatar.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/AvatarGroupAvatar.scss
@@ -1,0 +1,20 @@
+@import '../../../common/variables';
+@import './mixins';
+
+$bcs-AvatarGroupAvatar-avatar-size: 32px;
+
+.bcs-AvatarGroupAvatar {
+    display: inline-block;
+    height: $bcs-AvatarGroupAvatar-avatar-size;
+    position: relative;
+    width: $bcs-AvatarGroupAvatar-avatar-size;
+}
+
+.bcs-AvatarGroupAvatar-avatar {
+    height: 100%;
+    width: 100%;
+}
+
+.bcs-AvatarGroupAvatar-statusIcon {
+    @include avatar-badge-icon;
+}

--- a/src/elements/content-sidebar/activity-feed/task-new/_mixins.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/_mixins.scss
@@ -4,7 +4,7 @@
     background: $white;
     border: 1px solid $white;
     border-radius: 50%;
-    bottom: 0;
+    bottom: -1px;
     position: absolute;
-    right: 0;
+    right: -1px;
 }


### PR DESCRIPTION
- This pulls out the CSS for the avatar component so that it imports its own stylesheet instead of relying on the AvatarGroup stylesheet
- Slight refactors:
  - Offset the border by nudging badges by 1px
  - Change avatar inner component size to 100% of the container instead of hardcoding the size twice. This makes it so adding a class to the container will set the width for both without referencing private classes or increasing specificity.

<img width="298" alt="Screen Shot 2019-06-20 at 10 41 56 AM" src="https://user-images.githubusercontent.com/1571667/59869408-1aea4580-9348-11e9-8a42-c8211eb35102.png">
<img width="499" alt="Screen Shot 2019-06-20 at 10 41 41 AM" src="https://user-images.githubusercontent.com/1571667/59869409-1b82dc00-9348-11e9-8f04-8e14a50776ae.png">
