### PR TITLE
fix(template-dropdown): add onMenuToggle handler to TemplateDropdown

### DIFF
--- a/src/features/metadata-instance-editor/TemplateDropdown.js
+++ b/src/features/metadata-instance-editor/TemplateDropdown.js
@@ -24,6 +24,7 @@ type Props = {
     intl: any,
     isDropdownBusy?: boolean,
     onAdd: (template: MetadataTemplate) => void,
+    onMenuToggle?: (isDropdownOpen: boolean) => void,
     templates: Array<MetadataTemplate>,
     title?: React.Node,
     usedTemplates: Array<MetadataTemplate>,
@@ -208,7 +209,11 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
     };
 
     onOpen = () => {
-        const { templates, usedTemplates } = this.props;
+        const { onMenuToggle, templates, usedTemplates } = this.props;
+
+        if (onMenuToggle) {
+            onMenuToggle(true);
+        }
 
         this.setState({
             isDropdownOpen: true,
@@ -218,6 +223,12 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
     };
 
     onClose = () => {
+        const { onMenuToggle } = this.props;
+
+        if (onMenuToggle) {
+            onMenuToggle(false);
+        }
+
         this.setState({ isDropdownOpen: false });
     };
 

--- a/src/features/metadata-instance-editor/__tests__/TemplateDropdown-test.js
+++ b/src/features/metadata-instance-editor/__tests__/TemplateDropdown-test.js
@@ -227,4 +227,26 @@ describe('features/metadata-instance-editor/fields/', () => {
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.containsMatchingElement(<Button />)).toEqual(true);
     });
+
+    test('onOpen()', () => {
+        const onMenuToggle = jest.fn();
+        const wrapper = getWrapper({ onMenuToggle, templates: [], usedTemplates: [] });
+
+        wrapper.instance().onOpen();
+
+        expect(onMenuToggle).toHaveBeenCalledWith(true);
+        expect(wrapper.state('isDropdownOpen')).toBe(true);
+        expect(wrapper.state('filterText')).toBe('');
+        expect(wrapper.state('templates')).toEqual([]);
+    });
+
+    test('onClose()', () => {
+        const onMenuToggle = jest.fn();
+        const wrapper = getWrapper({ onMenuToggle, templates: [], usedTemplates: [] });
+
+        wrapper.instance().onClose();
+
+        expect(onMenuToggle).toHaveBeenCalledWith(false);
+        expect(wrapper.state('isDropdownOpen')).toBe(false);
+    });
 });


### PR DESCRIPTION
Changes in this PR:
- add onMenuToggleHandler because in the client app there is a use case where the caret icon needs to be transformed depending on if the menu is open or not

![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/7213887/59901579-8ff16580-93b0-11e9-85e6-95fc3d51763b.gif)

