### PR TITLE
chore: update metadata icon background color

### DIFF
--- a/src/icons/badges/MetadataActiveBadge.js
+++ b/src/icons/badges/MetadataActiveBadge.js
@@ -20,7 +20,7 @@ const MetadataActiveBadge = ({ className = '', height = 16, title, width = 16 }:
         width={width}
     >
         <g fill="none" fillRule="evenodd">
-            <circle cx="8" cy="8" fill="#D9E7F9" r="7.5" stroke="#4D91E2" />
+            <circle cx="8" cy="8" fill="none" r="7.5" stroke="#4D91E2" />
             <path
                 d="M5.126 10.545a.57.57 0 0 1-.693.437.603.603 0 0 1-.416-.728l1.143-4.8c.122-.513.772-.62 1.039-.172L8 8.308l1.801-3.026c.267-.449.917-.34 1.039.173l1.143 4.8a.603.603 0 0 1-.416.727.57.57 0 0 1-.693-.437l-.817-3.43-1.572 2.643a.557.557 0 0 1-.97 0L5.943 7.116l-.817 3.43z"
                 fill="#0061D5"

--- a/src/icons/badges/MetadataDefaultBadge.js
+++ b/src/icons/badges/MetadataDefaultBadge.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { bdlNeutral04 } from '../../styles/variables';
 import AccessibleSVG from '../accessible-svg';
 
 type Props = {
@@ -20,7 +19,7 @@ const MetadataDefaultBadge = ({ className = '', height = 16, title, width = 16 }
         width={width}
     >
         <g fill="none" fillRule="evenodd">
-            <circle cx="8" cy="8" fill={bdlNeutral04} r="7.5" stroke="#767676" />
+            <circle cx="8" cy="8" fill="none" r="7.5" stroke="#767676" />
             <path
                 d="M5.126 10.545a.57.57 0 0 1-.693.437.603.603 0 0 1-.416-.728l1.143-4.8c.122-.513.772-.62 1.039-.172L8 8.308l1.801-3.026c.267-.449.917-.34 1.039.173l1.143 4.8a.603.603 0 0 1-.416.727.57.57 0 0 1-.693-.437l-.817-3.43-1.572 2.643a.557.557 0 0 1-.97 0L5.943 7.116l-.817 3.43z"
                 fill="#767676"

--- a/src/icons/badges/__tests__/__snapshots__/MetadataActiveBadge-test.js.snap
+++ b/src/icons/badges/__tests__/__snapshots__/MetadataActiveBadge-test.js.snap
@@ -14,7 +14,7 @@ exports[`icons/badges/MetadataActiveBadge should correctly render icon with spec
     <circle
       cx="8"
       cy="8"
-      fill="#D9E7F9"
+      fill="none"
       r="7.5"
       stroke="#4D91E2"
     />

--- a/src/icons/badges/__tests__/__snapshots__/MetadataDefaultBadge-test.js.snap
+++ b/src/icons/badges/__tests__/__snapshots__/MetadataDefaultBadge-test.js.snap
@@ -14,7 +14,7 @@ exports[`icons/badges/MetadataDefaultBadge should correctly render icon with spe
     <circle
       cx="8"
       cy="8"
-      fill="#e8e8e8"
+      fill="none"
       r="7.5"
       stroke="#767676"
     />


### PR DESCRIPTION
As requested by design, the background for these icons should be set to none

<img width="319" alt="Screen Shot 2019-06-24 at 10 45 35 AM" src="https://user-images.githubusercontent.com/7213887/60040170-37022580-966d-11e9-82cc-a0743e279833.png">
<img width="326" alt="Screen Shot 2019-06-24 at 10 45 19 AM" src="https://user-images.githubusercontent.com/7213887/60040171-379abc00-966d-11e9-841b-46377704e208.png">
