### PR TITLE
chore: rename onMenuToggle to onDropdownToggle

### DIFF
--- a/src/features/metadata-instance-editor/TemplateDropdown.js
+++ b/src/features/metadata-instance-editor/TemplateDropdown.js
@@ -24,7 +24,7 @@ type Props = {
     intl: any,
     isDropdownBusy?: boolean,
     onAdd: (template: MetadataTemplate) => void,
-    onMenuToggle?: (isDropdownOpen: boolean) => void,
+    onDropdownToggle?: (isDropdownOpen: boolean) => void,
     templates: Array<MetadataTemplate>,
     title?: React.Node,
     usedTemplates: Array<MetadataTemplate>,
@@ -209,10 +209,10 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
     };
 
     onOpen = () => {
-        const { onMenuToggle, templates, usedTemplates } = this.props;
+        const { onDropdownToggle, templates, usedTemplates } = this.props;
 
-        if (onMenuToggle) {
-            onMenuToggle(true);
+        if (onDropdownToggle) {
+            onDropdownToggle(true);
         }
 
         this.setState({
@@ -223,10 +223,10 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
     };
 
     onClose = () => {
-        const { onMenuToggle } = this.props;
+        const { onDropdownToggle } = this.props;
 
-        if (onMenuToggle) {
-            onMenuToggle(false);
+        if (onDropdownToggle) {
+            onDropdownToggle(false);
         }
 
         this.setState({ isDropdownOpen: false });

--- a/src/features/metadata-instance-editor/__tests__/TemplateDropdown-test.js
+++ b/src/features/metadata-instance-editor/__tests__/TemplateDropdown-test.js
@@ -229,24 +229,24 @@ describe('features/metadata-instance-editor/fields/', () => {
     });
 
     test('onOpen()', () => {
-        const onMenuToggle = jest.fn();
-        const wrapper = getWrapper({ onMenuToggle, templates: [], usedTemplates: [] });
+        const onDropdownToggle = jest.fn();
+        const wrapper = getWrapper({ onDropdownToggle, templates: [], usedTemplates: [] });
 
         wrapper.instance().onOpen();
 
-        expect(onMenuToggle).toHaveBeenCalledWith(true);
+        expect(onDropdownToggle).toHaveBeenCalledWith(true);
         expect(wrapper.state('isDropdownOpen')).toBe(true);
         expect(wrapper.state('filterText')).toBe('');
         expect(wrapper.state('templates')).toEqual([]);
     });
 
     test('onClose()', () => {
-        const onMenuToggle = jest.fn();
-        const wrapper = getWrapper({ onMenuToggle, templates: [], usedTemplates: [] });
+        const onDropdownToggle = jest.fn();
+        const wrapper = getWrapper({ onDropdownToggle, templates: [], usedTemplates: [] });
 
         wrapper.instance().onClose();
 
-        expect(onMenuToggle).toHaveBeenCalledWith(false);
+        expect(onDropdownToggle).toHaveBeenCalledWith(false);
         expect(wrapper.state('isDropdownOpen')).toBe(false);
     });
 });


### PR DESCRIPTION
Changes in this PR:
- Change onMenuToggle to onDropdownToggle as the client app is now using onDropdownToggle