### PR TITLE
fix(comment): padding and a11y adjustments for comment UI

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/Comment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.js
@@ -206,6 +206,7 @@ class Comment extends React.Component<Props, State> {
                                             onKeyDown={this.onKeyDown}
                                             shouldOutlineFocus={false}
                                             shouldDefaultFocus
+                                            role="dialog"
                                         >
                                             <div className="bcs-comment-confirm-prompt">
                                                 <FormattedMessage {...deleteConfirmMessage} />

--- a/src/elements/content-sidebar/activity-feed/comment/Comment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.js
@@ -205,6 +205,7 @@ class Comment extends React.Component<Props, State> {
                                             className="be-modal bcs-comment-confirm-container"
                                             onKeyDown={this.onKeyDown}
                                             shouldOutlineFocus={false}
+                                            shouldDefaultFocus
                                         >
                                             <div className="bcs-comment-confirm-prompt">
                                                 <FormattedMessage {...deleteConfirmMessage} />

--- a/src/elements/content-sidebar/activity-feed/comment/Comment.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.scss
@@ -18,11 +18,11 @@
 
     .bcs-comment-confirm-delete,
     .bcs-comment-confirm-cancel {
-        margin: 0;
+        margin-left: 0;
     }
 
     .bcs-comment-confirm-cancel {
-        margin-right: 8px;
+        margin-right: 10px;
     }
 }
 


### PR DESCRIPTION
- set default button to "cancel" on confirm mini-modal is open
- allow for escape to close when confirm mini-modal is open
- use consistent button padding/margin so if buttons stack they have space between (and sync up spacing with other buttons)