### PR TITLE
fix(button): remove horizontal margin from buttons

### DIFF
--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -82,7 +82,7 @@
     }
 
     & + & {
-        margin-left: 5px;
+        margin-left: 10px;
     }
 }
 

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -18,7 +18,7 @@
     font-weight: 400;
     letter-spacing: .035em;
     line-height: 10px;
-    margin: 5px;
+    margin: 5px 0;
     padding: 10px 16px;
     position: relative;
     text-align: center;
@@ -79,6 +79,10 @@
     &.is-disabled {
         box-shadow: none;
         opacity: .4;
+    }
+
+    & + & {
+        margin-left: 5px;
     }
 }
 


### PR DESCRIPTION
Changes buttons to not have a default horizontal margin, except between other buttons. The current 5px margin is almost always overridden when used.