### PR TITLE
build: perf improvements and fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,6 @@ aliases:
       - ~/.cache/Cypress
     key: yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ checksum ".circleci/config.yml" }}
 
-  - &filter-only-master
-    branches:
-      only:
-        - master
-
 defaults: &defaults
   working_directory: ~/buie
   docker:
@@ -34,7 +29,7 @@ defaults: &defaults
 
 version: 2
 jobs:
-  babel-build:
+  build:
     <<: *defaults
     steps:
       - checkout
@@ -46,16 +41,6 @@ jobs:
       - run:
           name: Babel build
           command: yarn build:ci:es
-
-  webpack-build:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore-cache: *restore-yarn-cache
-      - run: *yarn
-      - save-cache: *save-yarn-cache
-      - run: *clean
-      - run: *i18n
       - run:
           name: Webpack build
           command: yarn build:ci:dist
@@ -92,13 +77,8 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  lint_test_build:
     jobs:
-      - lint:
-          filters: *filter-only-master
-      - unit-tests:
-          filters: *filter-only-master
-      - babel-build:
-          filters: *filter-only-master
-      - webpack-build:
-          filters: *filter-only-master
+      - lint
+      - unit-tests
+      - build

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "scripts": {
         "build": "yarn build:dev:dist",
         "build:ci:es": "yarn build:prod:es",
-        "build:ci:dist": "LANGUAGE=en-US REACT=true yarn build:prod:dist",
+        "build:ci:dist": "LANGUAGE=en-US ENTRY=explorer REACT=true yarn build:prod:dist",
         "build:dev:dist": "LANGUAGE=en-US BABEL_ENV=dev NODE_ENV=dev webpack --config scripts/webpack.config.js --mode development --progress --colors",
         "build:dev:es": "BABEL_ENV=dev NODE_ENV=dev yarn build:es --copy-files --source-maps inline --watch --ignore \"**/__tests__/**\"",
         "build:es": "babel src --out-dir es",

--- a/scripts/prepush.sh
+++ b/scripts/prepush.sh
@@ -43,19 +43,9 @@ prepush() {
     yarn build:i18n || exit 1
 
     printf "${blue}-------------------------------------------------------------${end}"
-    printf "${blue}Linting${end}"
-    printf "${blue}-------------------------------------------------------------${end}"
-    yarn lint || exit 1
-
-    printf "${blue}-------------------------------------------------------------${end}"
-    printf "${blue}Checking flow types${end}"
-    printf "${blue}-------------------------------------------------------------${end}"
-    yarn flow check || exit 1
-
-    printf "${blue}-------------------------------------------------------------${end}"
     printf "${blue}Testing${end}"
     printf "${blue}-------------------------------------------------------------${end}"
-    yarn test || exit 1
+    yarn test --lastCommit || exit 1
 
     printf "${blue}-------------------------------------------------------------${end}"
     printf "${blue}Building all sources, this will update i18n/json${end}"


### PR DESCRIPTION
1. Only builds the explorer entry point that includes explorer, preview, sidebar and open with. Does not include content picker so we may need another job for that but that can be added later.
2. Fixes an issue in circle config that was preventing PR builds
3. Combines babel and webpack build for circle
4. Removes a couple of steps from pre-push hook

Should show circle under checks tab now