### PR TITLE
 build: fix caching for circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ aliases:
 
   - &restore-yarn-cache
     keys:
-      - yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - yarn-{{ checksum "yarn.lock" }}-{{ checksum ".circleci/config.yml" }}
 
   - &save-yarn-cache
     paths:
@@ -19,7 +19,7 @@ aliases:
       - ~/.npm
       - ~/.cache/yarn
       - ~/.cache/Cypress
-    key: yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ checksum ".circleci/config.yml" }}
+    key: yarn-{{ checksum "yarn.lock" }}-{{ checksum ".circleci/config.yml" }}
 
 defaults: &defaults
   working_directory: ~/buie

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Project Status](https://img.shields.io/badge/status-active-brightgreen.svg)](http://opensource.box.com/badges)
 [![build status](https://travis-ci.com/box/box-ui-elements.svg?branch=master)](https://travis-ci.com/box/box-ui-elements)
+[![CircleCI](https://circleci.com/gh/box/box-ui-elements/tree/master.svg?style=shield)](https://circleci.com/gh/box/box-ui-elements/tree/master)
 [![Styled With Prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![Mergify Status](https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/box/box-ui-elements&style=flat)](https://mergify.io)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
Fixes an issue where yarn cache was getting bust due to branch/PR name, which was adding 1-2m to the build time.

Also adds a badge <img src="https://circleci.com/gh/box/box-ui-elements/tree/master.svg?style=shield"/>