### PR TITLE
fix(classification): Classification badge UX tweaks

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -581,7 +581,7 @@ boxui.checkboxTooltip.iconInfoText = Info
 # Button to add classification on an item
 boxui.classification.add = Add
 # Button to add classification on an item
-boxui.classification.addClassification = Add Classification
+boxui.classification.addClassification = CLASSIFY
 # Header for classification section in sidebar
 boxui.classification.classification = Classification
 # Button to edit classification on an item

--- a/src/features/classification/AddClassificationBadge.js
+++ b/src/features/classification/AddClassificationBadge.js
@@ -2,14 +2,11 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import IconAddTags from '../../icons/general/IconAddTags';
-import { bdlGray50 } from '../../styles/variables';
 import messages from './messages';
 import './AddClassificationBadge.scss';
 
 const AddClassificationBadge = () => (
     <h1 className="bdl-AddClassificationBadge">
-        <IconAddTags color={bdlGray50} height={10} width={10} strokeWidth={3} />
         <FormattedMessage {...messages.addClassification}>
             {value => <span className="bdl-AddClassificationBadge-name">{value}</span>}
         </FormattedMessage>

--- a/src/features/classification/AddClassificationBadge.scss
+++ b/src/features/classification/AddClassificationBadge.scss
@@ -15,5 +15,5 @@
 .bdl-AddClassificationBadge-name {
     @include bdl-ClassificationBadge-name;
 
-    color: $bdl-gray-50 !important; // To inhibit overriding
+    color: $bdl-gray-62 !important; // To inhibit overriding
 }

--- a/src/features/classification/ClassifiedBadge.js
+++ b/src/features/classification/ClassifiedBadge.js
@@ -2,8 +2,6 @@
 import * as React from 'react';
 
 import Tooltip from '../../components/tooltip';
-import IconAddTags from '../../icons/general/IconAddTags';
-import { bdlYellorange } from '../../styles/variables';
 import type { Position } from '../../components/tooltip';
 import './ClassifiedBadge.scss';
 
@@ -16,7 +14,6 @@ type Props = {
 const ClassifiedBadge = ({ name, tooltipPosition = 'bottom-center', tooltipText }: Props) => (
     <Tooltip isDisabled={!tooltipText} position={tooltipPosition} text={tooltipText}>
         <h1 className="bdl-ClassifiedBadge">
-            <IconAddTags color={bdlYellorange} height={10} width={10} strokeWidth={3} />
             <span className="bdl-ClassifiedBadge-name">{name}</span>
         </h1>
     </Tooltip>

--- a/src/features/classification/ClassifiedBadge.scss
+++ b/src/features/classification/ClassifiedBadge.scss
@@ -13,4 +13,5 @@
     @include bdl-ClassificationBadge-name;
 
     color: $bdl-gray !important; // To inhibit overriding
+    text-transform: uppercase;
 }

--- a/src/features/classification/__tests__/__snapshots__/AddClassificationBadge-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/AddClassificationBadge-test.js.snap
@@ -11,7 +11,7 @@ exports[`features/classification/AddClassificationBadge should render a classifi
     width={10}
   />
   <FormattedMessage
-    defaultMessage="Classify"
+    defaultMessage="CLASSIFY"
     id="boxui.classification.addClassification"
   >
     <Component />

--- a/src/features/classification/__tests__/__snapshots__/AddClassificationBadge-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/AddClassificationBadge-test.js.snap
@@ -4,12 +4,6 @@ exports[`features/classification/AddClassificationBadge should render a classifi
 <h1
   className="bdl-AddClassificationBadge"
 >
-  <IconAddTags
-    color="#909090"
-    height={10}
-    strokeWidth={3}
-    width={10}
-  />
   <FormattedMessage
     defaultMessage="CLASSIFY"
     id="boxui.classification.addClassification"

--- a/src/features/classification/__tests__/__snapshots__/AddClassificationBadge-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/AddClassificationBadge-test.js.snap
@@ -11,7 +11,7 @@ exports[`features/classification/AddClassificationBadge should render a classifi
     width={10}
   />
   <FormattedMessage
-    defaultMessage="Add Classification"
+    defaultMessage="Classify"
     id="boxui.classification.addClassification"
   >
     <Component />

--- a/src/features/classification/__tests__/__snapshots__/ClassifiedBadge-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/ClassifiedBadge-test.js.snap
@@ -12,12 +12,6 @@ exports[`features/classification/ClassifiedBadge should render a classified badg
   <h1
     className="bdl-ClassifiedBadge"
   >
-    <IconAddTags
-      color="#f5b31b"
-      height={10}
-      strokeWidth={3}
-      width={10}
-    />
     <span
       className="bdl-ClassifiedBadge-name"
     >
@@ -38,12 +32,6 @@ exports[`features/classification/ClassifiedBadge should render a classified badg
   <h1
     className="bdl-ClassifiedBadge"
   >
-    <IconAddTags
-      color="#f5b31b"
-      height={10}
-      strokeWidth={3}
-      width={10}
-    />
     <span
       className="bdl-ClassifiedBadge-name"
     >

--- a/src/features/classification/_mixins.scss
+++ b/src/features/classification/_mixins.scss
@@ -14,5 +14,4 @@
     font-weight: 600;
     line-height: initial;
     margin-left: 5px;
-    text-transform: uppercase;
 }

--- a/src/features/classification/_mixins.scss
+++ b/src/features/classification/_mixins.scss
@@ -6,12 +6,11 @@
     border-radius: $bdl-border-radius-size;
     display: inline-flex;
     margin: 0;
-    padding: 2px 5px;
+    padding: 0 5px;
 }
 
 @mixin bdl-ClassificationBadge-name {
     font-size: 10px !important; // To inhibit overriding
     font-weight: 600;
-    line-height: initial;
-    margin-left: 5px;
+    line-height: 16px;
 }

--- a/src/features/classification/messages.js
+++ b/src/features/classification/messages.js
@@ -7,7 +7,7 @@ const messages = defineMessages({
         id: 'boxui.classification.add',
     },
     addClassification: {
-        defaultMessage: 'Classify',
+        defaultMessage: 'CLASSIFY',
         description: 'Button to add classification on an item',
         id: 'boxui.classification.addClassification',
     },

--- a/src/features/classification/messages.js
+++ b/src/features/classification/messages.js
@@ -7,7 +7,7 @@ const messages = defineMessages({
         id: 'boxui.classification.add',
     },
     addClassification: {
-        defaultMessage: 'Add Classification',
+        defaultMessage: 'Classify',
         description: 'Button to add classification on an item',
         id: 'boxui.classification.addClassification',
     },


### PR DESCRIPTION
Just a few small UI updates for the classification badge:

- Changed "Add Classification" text to "Classify"
- Updated "Classify" button text color for better accessibility
- Capitalized "Classify" for better i18n
- Removed tag icon
- Alignment adjustment