### PR TITLE
docs(styleguide): create usable import paths

### DIFF
--- a/scripts/styleguide.config.js
+++ b/scripts/styleguide.config.js
@@ -257,6 +257,12 @@ const allSections = [
 ];
 
 module.exports = {
+    getComponentPathLine(componentPath) {
+        const name = path.basename(componentPath, '.js');
+        const dir = path.dirname(componentPath);
+        const packageRelativePath = dir.replace(/.*\/src\//, '');
+        return `import ${name} from 'box-ui-elements/es/${packageRelativePath}/${name}';`;
+    },
     pagePerSection: true,
     require: [path.resolve(__dirname, 'styleguide.setup.js'), path.resolve(__dirname, 'styleguide.styles.scss')],
     styleguideDir: path.join(__dirname, '../styleguide'),


### PR DESCRIPTION
Adds a config option that formats component paths in the documentation in a way that can be copy-pasted into consuming apps

<img width="503" alt="Screen Shot 2019-07-09 at 3 12 30 PM" src="https://user-images.githubusercontent.com/1571667/60926878-c3f7d200-a25c-11e9-9101-439a10347c2a.png">
