### PR TITLE
feat(uploads): add resin tracking for uploads manager

### DIFF
--- a/src/elements/content-uploader/ItemAction.js
+++ b/src/elements/content-uploader/ItemAction.js
@@ -26,6 +26,7 @@ type Props = {
 
 const ItemAction = ({ status, onClick, intl, isFolder = false }: Props) => {
     let icon = <IconClose />;
+    let retry = false;
     let tooltip = intl.formatMessage(messages.uploadsCancelButtonTooltip);
 
     if (isFolder && status !== STATUS_PENDING) {
@@ -40,6 +41,7 @@ const ItemAction = ({ status, onClick, intl, isFolder = false }: Props) => {
         case STATUS_ERROR:
             icon = <IconRetry />;
             tooltip = intl.formatMessage(messages.retry);
+            retry = true;
             break;
         case STATUS_IN_PROGRESS:
             icon = <IconInProgress />;
@@ -52,7 +54,7 @@ const ItemAction = ({ status, onClick, intl, isFolder = false }: Props) => {
     return (
         <div className="bcu-item-action">
             <Tooltip position="top-left" text={tooltip}>
-                <PlainButton onClick={onClick} type="button">
+                <PlainButton onClick={onClick} type="button" {...(retry ? { 'data-resin-target': 'uploadretry' } : {})}>
                     {icon}
                 </PlainButton>
             </Tooltip>

--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -52,6 +52,7 @@ const getPercent = (view: string, percent: number): number => {
 
 type Props = {
     isDragging: boolean,
+    isExpanded: boolean,
     isVisible: boolean,
     onClick: Function,
     onKeyDown: Function,
@@ -59,7 +60,7 @@ type Props = {
     view: View,
 };
 
-const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isDragging, isVisible }: Props) => {
+const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isDragging, isVisible, isExpanded }: Props) => {
     // Show the upload prompt and set progress to 0 when the uploads manager
     // is invisible or is having files dragged to it
     const shouldShowPrompt = isDragging || !isVisible;
@@ -73,6 +74,7 @@ const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isDraggi
     return (
         <div
             className="bcu-overall-progress-bar"
+            data-resin-target={isExpanded ? 'uploadcollapse' : 'uploadexpand'}
             onClick={onClick}
             onKeyDown={onKeyDown}
             role="button"

--- a/src/elements/content-uploader/UploadsManager.js
+++ b/src/elements/content-uploader/UploadsManager.js
@@ -62,6 +62,8 @@ const UploadsManager = ({
 
     return (
         <div
+            data-resin-component="uploadsmanager"
+            data-resin-feature="uploads"
             className={classNames('be bcu-uploads-manager-container', {
                 'bcu-is-expanded': isExpanded,
                 'bcu-is-visible': isVisible,
@@ -69,6 +71,7 @@ const UploadsManager = ({
         >
             <OverallUploadsProgressBar
                 isDragging={isDragging}
+                isExpanded={isExpanded}
                 isVisible={isVisible}
                 onClick={toggleUploadsManager}
                 onKeyDown={handleProgressBarKeyDown}

--- a/src/elements/content-uploader/__tests__/OverallUploadsProgressBar-test.js
+++ b/src/elements/content-uploader/__tests__/OverallUploadsProgressBar-test.js
@@ -9,6 +9,7 @@ describe('elements/content-uploader/OverallUploadsProgressBar', () => {
         shallow(
             <OverallUploadsProgressBar
                 isDragging={false}
+                isExpanded
                 isVisible
                 onClick={noop}
                 onKeyDown={noop}

--- a/src/elements/content-uploader/__tests__/__snapshots__/ItemAction-test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/ItemAction-test.js.snap
@@ -47,6 +47,7 @@ exports[`elements/content-uploader/ItemAction should render correctly with STATU
     theme="default"
   >
     <PlainButton
+      data-resin-target="uploadretry"
       onClick={[Function]}
       type="button"
     >

--- a/src/elements/content-uploader/__tests__/__snapshots__/OverallUploadsProgressBar-test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/OverallUploadsProgressBar-test.js.snap
@@ -3,6 +3,7 @@
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isDragging is true 1`] = `
 <div
   className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="button"
@@ -28,6 +29,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isVisible is false 1`] = `
 <div
   className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="button"
@@ -53,6 +55,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_ERROR 1`] = `
 <div
   className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="button"
@@ -78,6 +81,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_UPLOAD_EMPTY 1`] = `
 <div
   className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="button"
@@ -103,6 +107,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_UPLOAD_IN_PROGRESS 1`] = `
 <div
   className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="button"
@@ -128,6 +133,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_UPLOAD_SUCCESS 1`] = `
 <div
   className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
   onClick={[Function]}
   onKeyDown={[Function]}
   role="button"


### PR DESCRIPTION
Adding resin tracking for retrying failed uploads and expanding/collapsing the uploads manager.