### PR TITLE
fix(versions): Reload the page when a version is promoted (temporary)

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -51,6 +51,8 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
         versions: [],
     };
 
+    window: any = window;
+
     componentDidMount() {
         this.fetchData();
     }
@@ -160,6 +162,10 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
 
         if (fileVersion) {
             this.updateVersion(fileVersion.id);
+
+            if (this.window) {
+                this.window.location.reload(); // TODO: Replace with callback to inform the host app of version actions
+            }
         }
     };
 


### PR DESCRIPTION
Currently, the host application isn't informed when a version is promoted, which can lead to stale data and user confusion. This is a temporary workaround to avoid a launch blocker; I intend to follow-up with a better solution soon.