### PR TITLE
feat(preview): new icon for security blocking

### DIFF
--- a/src/elements/content-preview/PreviewLoading.js
+++ b/src/elements/content-preview/PreviewLoading.js
@@ -7,6 +7,7 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import IconFileDefault from '../../icons/file/IconFileDefault';
+import SecurityBlockedState from '../../icons/states/SecurityBlockedState';
 import makeLoadable from '../../components/loading-indicator/makeLoadable';
 import messages from '../common/messages';
 import { ERROR_CODE_FETCH_FILE_DUE_TO_POLICY } from '../../constants';
@@ -19,9 +20,10 @@ type Props = {
 const PreviewLoading = ({ errorCode }: Props) => {
     const isBlockedByPolicy = errorCode === ERROR_CODE_FETCH_FILE_DUE_TO_POLICY;
     const message = isBlockedByPolicy ? messages.previewErrorBlockedByPolicy : messages.previewError;
+    const icon = isBlockedByPolicy ? <SecurityBlockedState /> : <IconFileDefault height={160} width={160} />;
     return (
         <div className="bcpr-PreviewLoading">
-            <IconFileDefault height={160} width={160} />
+            {icon}
             <div className="bcpr-PreviewLoading-message">
                 <FormattedMessage {...message} />
             </div>

--- a/src/elements/content-preview/__tests__/__snapshots__/PreviewLoading-test.js.snap
+++ b/src/elements/content-preview/__tests__/__snapshots__/PreviewLoading-test.js.snap
@@ -23,10 +23,7 @@ exports[`elements/content-preview/PreviewLoading render() should render correctl
 <div
   className="bcpr-PreviewLoading"
 >
-  <IconFileDefault
-    height={160}
-    width={160}
-  />
+  <SecurityBlockedState />
   <div
     className="bcpr-PreviewLoading-message"
   >

--- a/src/icons/states/README.md
+++ b/src/icons/states/README.md
@@ -109,6 +109,10 @@ const icons = [
         component: require('./SearchEmptyState').default,
     },
     {
+        name: 'SecurityBlockedState',
+        component: require('./SecurityBlockedState').default,
+    },
+    {
         name: 'SelectedItemsEmptyState',
         component: require('./SelectedItemsEmptyState').default,
     },

--- a/src/icons/states/SecurityBlockedState.js
+++ b/src/icons/states/SecurityBlockedState.js
@@ -1,0 +1,66 @@
+// @flow
+import * as React from 'react';
+
+import AccessibleSVG from '../accessible-svg';
+import { bdlGray10, bdlGray50, white } from '../../styles/variables';
+
+type Props = {
+    className?: string,
+    color?: string,
+    height?: number,
+    strokeColor?: string,
+    /** A text-only string describing the icon if it's not purely decorative for accessibility */
+    title?: string | React.Element<any>,
+    width?: number,
+};
+
+const SecurityBlockedState = ({
+    className = '',
+    color = bdlGray10,
+    height = 167,
+    strokeColor = bdlGray50,
+    title,
+    width = 130,
+}: Props) => (
+    <AccessibleSVG
+        className={`bdl-SecurityBlockedState ${className}`}
+        height={height}
+        title={title}
+        viewBox="0 0 130 167"
+        width={width}
+    >
+        <path
+            className="stroke-color"
+            stroke={color}
+            strokeWidth="4"
+            fill={white}
+            strokeDasharray="3"
+            d="M7 0h91l32 30v130a7 7 0 0 1-7 7H7a7 7 0 0 1-7-7V7a7 7 0 0 1 7-7z"
+        />
+        <path className="fill-color" fill={color} d="M98 0l32 30H98z" />
+        <path
+            className="stroke-color"
+            d="M35 55.385S50 63.91 65 50c15 13.91 30 5.385 30 5.385v47.788L65 120l-30-16.827V55.385z"
+            stroke={strokeColor}
+            strokeWidth="4"
+            fill={white}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+        <path
+            className="fill-color"
+            d="M64.412 57c-12.353 11.128-24.706 4.308-24.706 4.308v38.23L64.412 113V57z"
+            fill={color}
+        />
+        <path
+            className="stroke-color"
+            d="M85.588 71v23.333"
+            stroke={strokeColor}
+            strokeWidth="4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </AccessibleSVG>
+);
+
+export default SecurityBlockedState;

--- a/src/icons/states/SecurityBlockedState.js
+++ b/src/icons/states/SecurityBlockedState.js
@@ -6,9 +6,9 @@ import { bdlGray10, bdlGray50, white } from '../../styles/variables';
 
 type Props = {
     className?: string,
-    color?: string,
     height?: number,
-    strokeColor?: string,
+    primaryColor?: string,
+    secondaryColor?: string,
     /** A text-only string describing the icon if it's not purely decorative for accessibility */
     title?: string | React.Element<any>,
     width?: number,
@@ -16,9 +16,9 @@ type Props = {
 
 const SecurityBlockedState = ({
     className = '',
-    color = bdlGray10,
+    primaryColor = bdlGray10,
     height = 167,
-    strokeColor = bdlGray50,
+    secondaryColor = bdlGray50,
     title,
     width = 130,
 }: Props) => (
@@ -31,17 +31,17 @@ const SecurityBlockedState = ({
     >
         <path
             className="stroke-color"
-            stroke={color}
+            stroke={primaryColor}
             strokeWidth="4"
             fill={white}
             strokeDasharray="3"
             d="M7 0h91l32 30v130a7 7 0 0 1-7 7H7a7 7 0 0 1-7-7V7a7 7 0 0 1 7-7z"
         />
-        <path className="fill-color" fill={color} d="M98 0l32 30H98z" />
+        <path className="fill-color" fill={primaryColor} d="M98 0l32 30H98z" />
         <path
             className="stroke-color"
             d="M35 55.385S50 63.91 65 50c15 13.91 30 5.385 30 5.385v47.788L65 120l-30-16.827V55.385z"
-            stroke={strokeColor}
+            stroke={secondaryColor}
             strokeWidth="4"
             fill={white}
             strokeLinecap="round"
@@ -50,12 +50,12 @@ const SecurityBlockedState = ({
         <path
             className="fill-color"
             d="M64.412 57c-12.353 11.128-24.706 4.308-24.706 4.308v38.23L64.412 113V57z"
-            fill={color}
+            fill={primaryColor}
         />
         <path
             className="stroke-color"
             d="M85.588 71v23.333"
-            stroke={strokeColor}
+            stroke={secondaryColor}
             strokeWidth="4"
             strokeLinecap="round"
             strokeLinejoin="round"

--- a/src/icons/states/__tests__/SecurityBlockedState-test.js
+++ b/src/icons/states/__tests__/SecurityBlockedState-test.js
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import SecurityBlockedState from '../SecurityBlockedState';
+
+describe('icons/states/SecurityBlockedState', () => {
+    test('should correctly render default icon with default colors', () => {
+        const wrapper = shallow(<SecurityBlockedState />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should correctly render icon with specified color', () => {
+        const wrapper = shallow(<SecurityBlockedState color="#fcfcfc" strokeColor="#eee" />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should correctly render icon with specified width and height and default viewBox value', () => {
+        const wrapper = shallow(<SecurityBlockedState height={131} width={200} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should correctly render icon with title', () => {
+        const wrapper = shallow(<SecurityBlockedState title="abcde" />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should correctly render icon with custom class name', () => {
+        const wrapper = shallow(<SecurityBlockedState className="empty" />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/icons/states/__tests__/SecurityBlockedState-test.js
+++ b/src/icons/states/__tests__/SecurityBlockedState-test.js
@@ -9,7 +9,7 @@ describe('icons/states/SecurityBlockedState', () => {
     });
 
     test('should correctly render icon with specified color', () => {
-        const wrapper = shallow(<SecurityBlockedState color="#fcfcfc" strokeColor="#eee" />);
+        const wrapper = shallow(<SecurityBlockedState primaryColor="#fcfcfc" secondaryColor="#eee" />);
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/icons/states/__tests__/__snapshots__/SecurityBlockedState-test.js.snap
+++ b/src/icons/states/__tests__/__snapshots__/SecurityBlockedState-test.js.snap
@@ -1,0 +1,227 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`icons/states/SecurityBlockedState should correctly render default icon with default colors 1`] = `
+<AccessibleSVG
+  className="bdl-SecurityBlockedState "
+  height={167}
+  viewBox="0 0 130 167"
+  width={130}
+>
+  <path
+    className="stroke-color"
+    d="M7 0h91l32 30v130a7 7 0 0 1-7 7H7a7 7 0 0 1-7-7V7a7 7 0 0 1 7-7z"
+    fill="#fff"
+    stroke="#e8e8e8"
+    strokeDasharray="3"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M98 0l32 30H98z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M35 55.385S50 63.91 65 50c15 13.91 30 5.385 30 5.385v47.788L65 120l-30-16.827V55.385z"
+    fill="#fff"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M64.412 57c-12.353 11.128-24.706 4.308-24.706 4.308v38.23L64.412 113V57z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M85.588 71v23.333"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+</AccessibleSVG>
+`;
+
+exports[`icons/states/SecurityBlockedState should correctly render icon with custom class name 1`] = `
+<AccessibleSVG
+  className="bdl-SecurityBlockedState empty"
+  height={167}
+  viewBox="0 0 130 167"
+  width={130}
+>
+  <path
+    className="stroke-color"
+    d="M7 0h91l32 30v130a7 7 0 0 1-7 7H7a7 7 0 0 1-7-7V7a7 7 0 0 1 7-7z"
+    fill="#fff"
+    stroke="#e8e8e8"
+    strokeDasharray="3"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M98 0l32 30H98z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M35 55.385S50 63.91 65 50c15 13.91 30 5.385 30 5.385v47.788L65 120l-30-16.827V55.385z"
+    fill="#fff"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M64.412 57c-12.353 11.128-24.706 4.308-24.706 4.308v38.23L64.412 113V57z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M85.588 71v23.333"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+</AccessibleSVG>
+`;
+
+exports[`icons/states/SecurityBlockedState should correctly render icon with specified color 1`] = `
+<AccessibleSVG
+  className="bdl-SecurityBlockedState "
+  height={167}
+  viewBox="0 0 130 167"
+  width={130}
+>
+  <path
+    className="stroke-color"
+    d="M7 0h91l32 30v130a7 7 0 0 1-7 7H7a7 7 0 0 1-7-7V7a7 7 0 0 1 7-7z"
+    fill="#fff"
+    stroke="#fcfcfc"
+    strokeDasharray="3"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M98 0l32 30H98z"
+    fill="#fcfcfc"
+  />
+  <path
+    className="stroke-color"
+    d="M35 55.385S50 63.91 65 50c15 13.91 30 5.385 30 5.385v47.788L65 120l-30-16.827V55.385z"
+    fill="#fff"
+    stroke="#eee"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M64.412 57c-12.353 11.128-24.706 4.308-24.706 4.308v38.23L64.412 113V57z"
+    fill="#fcfcfc"
+  />
+  <path
+    className="stroke-color"
+    d="M85.588 71v23.333"
+    stroke="#eee"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+</AccessibleSVG>
+`;
+
+exports[`icons/states/SecurityBlockedState should correctly render icon with specified width and height and default viewBox value 1`] = `
+<AccessibleSVG
+  className="bdl-SecurityBlockedState "
+  height={131}
+  viewBox="0 0 130 167"
+  width={200}
+>
+  <path
+    className="stroke-color"
+    d="M7 0h91l32 30v130a7 7 0 0 1-7 7H7a7 7 0 0 1-7-7V7a7 7 0 0 1 7-7z"
+    fill="#fff"
+    stroke="#e8e8e8"
+    strokeDasharray="3"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M98 0l32 30H98z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M35 55.385S50 63.91 65 50c15 13.91 30 5.385 30 5.385v47.788L65 120l-30-16.827V55.385z"
+    fill="#fff"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M64.412 57c-12.353 11.128-24.706 4.308-24.706 4.308v38.23L64.412 113V57z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M85.588 71v23.333"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+</AccessibleSVG>
+`;
+
+exports[`icons/states/SecurityBlockedState should correctly render icon with title 1`] = `
+<AccessibleSVG
+  className="bdl-SecurityBlockedState "
+  height={167}
+  title="abcde"
+  viewBox="0 0 130 167"
+  width={130}
+>
+  <path
+    className="stroke-color"
+    d="M7 0h91l32 30v130a7 7 0 0 1-7 7H7a7 7 0 0 1-7-7V7a7 7 0 0 1 7-7z"
+    fill="#fff"
+    stroke="#e8e8e8"
+    strokeDasharray="3"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M98 0l32 30H98z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M35 55.385S50 63.91 65 50c15 13.91 30 5.385 30 5.385v47.788L65 120l-30-16.827V55.385z"
+    fill="#fff"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+  <path
+    className="fill-color"
+    d="M64.412 57c-12.353 11.128-24.706 4.308-24.706 4.308v38.23L64.412 113V57z"
+    fill="#e8e8e8"
+  />
+  <path
+    className="stroke-color"
+    d="M85.588 71v23.333"
+    stroke="#909090"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="4"
+  />
+</AccessibleSVG>
+`;


### PR DESCRIPTION
<img width="707" alt="Screen Shot 2019-07-12 at 2 35 21 PM" src="https://user-images.githubusercontent.com/1075325/61160094-23e7b600-a4b3-11e9-9b5e-29243bebfd73.png">
<img width="737" alt="Screen Shot 2019-07-12 at 2 34 56 PM" src="https://user-images.githubusercontent.com/1075325/61160095-23e7b600-a4b3-11e9-92d1-70c3147ecc3d.png">
