### PR TITLE
fix(button): don't override margin, padding for :hover state

### DIFF
--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -86,14 +86,22 @@
     }
 }
 
+.btn-plain {
+    margin: 0;
+    padding: 0;
+
+    // prevent default .btn behavior of adding space between buttons
+    & + & {
+        margin-left: 0;
+    }
+}
+
 .btn-plain,
 .btn-plain:hover,
 .btn-plain:active {
     border: none;
     cursor: pointer;
     font-weight: normal;
-    margin: 0;
-    padding: 0;
 }
 
 .btn-plain,


### PR DESCRIPTION
BREAKING: apply margin, padding overrides for .btn-plain only to base class, not to pseudoselectors, so that buttons do not reposition on focus/hover
BREAKING: add override to prevent margin being added between .btn-plain buttons