### PR TITLE
refactor(comment): move comment delete to separate component

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/Comment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.js
@@ -12,14 +12,11 @@ import identity from 'lodash/identity';
 
 import { ReadableTime } from '../../../../components/time';
 import Tooltip from '../../../../components/tooltip';
-import { Overlay } from '../../../../components/flyout';
-import PrimaryButton from '../../../../components/primary-button';
-import Button from '../../../../components/button';
-import commonMessages from '../../../common/messages';
 import messages from './messages';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 
 import CommentMenu from './CommentMenu';
+import CommentDeleteConfirmation from './CommentDeleteConfirmation';
 import UserLink from './UserLink';
 import CommentInlineError from './CommentInlineError';
 import CommentText from './CommentText';
@@ -28,7 +25,7 @@ import formatTaggedMessage from '../utils/formatTaggedMessage';
 import Avatar from '../Avatar';
 
 import './Comment.scss';
-import { COMMENT_TYPE_DEFAULT, COMMENT_TYPE_TASK, PLACEHOLDER_USER, KEYS } from '../../../../constants';
+import { COMMENT_TYPE_DEFAULT, COMMENT_TYPE_TASK, PLACEHOLDER_USER } from '../../../../constants';
 
 type Props = {
     avatarRenderer?: React.Node => React.Element<any>,
@@ -57,7 +54,7 @@ type Props = {
 };
 
 type State = {
-    isConfirming: boolean,
+    isConfirmingDelete: boolean,
     isEditing: boolean,
     isInputOpen: boolean,
 };
@@ -68,7 +65,7 @@ class Comment extends React.Component<Props, State> {
     };
 
     state = {
-        isConfirming: false,
+        isConfirmingDelete: false,
         isEditing: false,
         isInputOpen: false,
     };
@@ -82,11 +79,11 @@ class Comment extends React.Component<Props, State> {
     };
 
     handleDeleteCancel = (): void => {
-        this.setState({ isConfirming: false });
+        this.setState({ isConfirmingDelete: false });
     };
 
     handleDeleteClick = () => {
-        this.setState({ isConfirming: true });
+        this.setState({ isConfirmingDelete: true });
     };
 
     handleEditClick = (): void => {
@@ -96,32 +93,6 @@ class Comment extends React.Component<Props, State> {
             onEditClick();
         } else {
             this.setState({ isEditing: true, isInputOpen: true });
-        }
-    };
-
-    onKeyDown = (event: SyntheticKeyboardEvent<>): void => {
-        const { nativeEvent } = event;
-        const { isConfirming } = this.state;
-
-        nativeEvent.stopImmediatePropagation();
-
-        switch (event.key) {
-            case KEYS.escape:
-                event.stopPropagation();
-                event.preventDefault();
-                if (isConfirming) {
-                    this.handleDeleteCancel();
-                }
-                break;
-            case KEYS.enter:
-                event.stopPropagation();
-                event.preventDefault();
-                if (isConfirming) {
-                    this.handleDeleteConfirm();
-                }
-                break;
-            default:
-                break;
         }
     };
 
@@ -158,11 +129,9 @@ class Comment extends React.Component<Props, State> {
             getMentionWithQuery,
             mentionSelectorContacts,
         } = this.props;
-        const { isConfirming, isEditing, isInputOpen } = this.state;
+        const { isConfirmingDelete, isEditing, isInputOpen } = this.state;
         const createdAtTimestamp = new Date(created_at).getTime();
         const createdByUser = created_by || PLACEHOLDER_USER;
-        const deleteConfirmMessage =
-            type === COMMENT_TYPE_DEFAULT ? messages.commentDeletePrompt : messages.taskDeletePrompt;
 
         return (
             <div className="bcs-comment-container">
@@ -194,40 +163,19 @@ class Comment extends React.Component<Props, State> {
                                 >
                                     <CommentMenu
                                         id={id}
-                                        isDisabled={isConfirming}
+                                        isDisabled={isConfirmingDelete}
                                         onDeleteClick={this.handleDeleteClick}
                                         onEditClick={this.handleEditClick}
                                         permissions={permissions}
                                         type={type}
                                     />
-                                    {isConfirming && (
-                                        <Overlay
-                                            className="be-modal bcs-comment-confirm-container"
-                                            onKeyDown={this.onKeyDown}
-                                            shouldOutlineFocus={false}
-                                            shouldDefaultFocus
-                                            role="dialog"
-                                        >
-                                            <div className="bcs-comment-confirm-prompt">
-                                                <FormattedMessage {...deleteConfirmMessage} />
-                                            </div>
-                                            <div>
-                                                <Button
-                                                    className="bcs-comment-confirm-cancel"
-                                                    onClick={this.handleDeleteCancel}
-                                                    type="button"
-                                                >
-                                                    <FormattedMessage {...commonMessages.cancel} />
-                                                </Button>
-                                                <PrimaryButton
-                                                    className="bcs-comment-confirm-delete"
-                                                    onClick={this.handleDeleteConfirm}
-                                                    type="button"
-                                                >
-                                                    <FormattedMessage {...commonMessages.delete} />
-                                                </PrimaryButton>
-                                            </div>
-                                        </Overlay>
+                                    {isConfirmingDelete && (
+                                        <CommentDeleteConfirmation
+                                            isOpen={isConfirmingDelete}
+                                            onDeleteCancel={this.handleDeleteCancel}
+                                            onDeleteConfirm={this.handleDeleteConfirm}
+                                            type={type}
+                                        />
                                     )}
                                 </TetherComponent>
                             )}

--- a/src/elements/content-sidebar/activity-feed/comment/CommentDeleteConfirmation.js
+++ b/src/elements/content-sidebar/activity-feed/comment/CommentDeleteConfirmation.js
@@ -1,0 +1,80 @@
+/**
+ * @flow
+ * @file Comment component
+ */
+
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { Overlay } from '../../../../components/flyout';
+import PrimaryButton from '../../../../components/primary-button';
+import Button from '../../../../components/button';
+import commonMessages from '../../../common/messages';
+import messages from './messages';
+
+import { COMMENT_TYPE_DEFAULT, COMMENT_TYPE_TASK, KEYS } from '../../../../constants';
+
+type Props = {
+    isOpen: boolean,
+    onDeleteCancel: Function,
+    onDeleteConfirm: Function,
+    type: typeof COMMENT_TYPE_DEFAULT | typeof COMMENT_TYPE_TASK,
+};
+
+class CommentDeleteConfirmation extends React.Component<Props> {
+    onKeyDown = (event: SyntheticKeyboardEvent<>): void => {
+        const { nativeEvent } = event;
+        const { isOpen, onDeleteCancel, onDeleteConfirm } = this.props;
+
+        nativeEvent.stopImmediatePropagation();
+
+        switch (event.key) {
+            case KEYS.escape:
+                event.stopPropagation();
+                event.preventDefault();
+                if (isOpen) {
+                    onDeleteCancel();
+                }
+                break;
+            case KEYS.enter:
+                event.stopPropagation();
+                event.preventDefault();
+                if (isOpen) {
+                    onDeleteConfirm();
+                }
+                break;
+            default:
+                break;
+        }
+    };
+
+    render() {
+        const { type, onDeleteCancel, onDeleteConfirm } = this.props;
+        const deleteConfirmMessage =
+            type === COMMENT_TYPE_DEFAULT ? messages.commentDeletePrompt : messages.taskDeletePrompt;
+
+        return (
+            <Overlay
+                className="be-modal bcs-comment-confirm-container"
+                onKeyDown={this.onKeyDown}
+                shouldOutlineFocus={false}
+                shouldDefaultFocus
+                role="dialog"
+            >
+                <div className="bcs-comment-confirm-prompt">
+                    <FormattedMessage {...deleteConfirmMessage} />
+                </div>
+                <div>
+                    <Button className="bcs-comment-confirm-cancel" onClick={onDeleteCancel} type="button">
+                        <FormattedMessage {...commonMessages.cancel} />
+                    </Button>
+                    <PrimaryButton className="bcs-comment-confirm-delete" onClick={onDeleteConfirm} type="button">
+                        <FormattedMessage {...commonMessages.delete} />
+                    </PrimaryButton>
+                </div>
+            </Overlay>
+        );
+    }
+}
+
+export default CommentDeleteConfirmation;

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/CommentDeleteConfirmation-test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/CommentDeleteConfirmation-test.js
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import CommentDeleteConfirmation from '../CommentDeleteConfirmation';
+import { COMMENT_TYPE_DEFAULT, COMMENT_TYPE_TASK } from '../../../../../constants';
+
+describe('elements/content-sidebar/ActivityFeed/comment/CommentDeleteConfirmation', () => {
+    const getWrapper = props =>
+        shallow(
+            <CommentDeleteConfirmation
+                isOpen
+                onDeleteCancel={jest.fn()}
+                onDeleteConfirm={jest.fn()}
+                type={COMMENT_TYPE_DEFAULT}
+                {...props}
+            />,
+        );
+
+    describe('render()', () => {
+        test('should render component with COMMENT_TYPE_DEFAULT', () => {
+            const wrapper = getWrapper({ type: COMMENT_TYPE_DEFAULT });
+            expect(wrapper.find('.bcs-comment-confirm-prompt')).toMatchSnapshot();
+        });
+
+        test('should render component with COMMENT_TYPE_TASK', () => {
+            const wrapper = getWrapper({ type: COMMENT_TYPE_TASK });
+            expect(wrapper.find('.bcs-comment-confirm-prompt')).toMatchSnapshot();
+        });
+    });
+
+    describe('onKeyDown', () => {
+        test('should handle Escape key', () => {
+            const onDeleteCancelMock = jest.fn();
+            const onDeleteConfirmMock = jest.fn();
+            const wrapper = getWrapper({ onDeleteCancel: onDeleteCancelMock, onDeleteConfirm: onDeleteConfirmMock });
+            wrapper.simulate('keydown', {
+                key: 'Escape',
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn(),
+                nativeEvent: { stopImmediatePropagation: jest.fn() },
+            });
+            expect(onDeleteCancelMock).toBeCalled();
+            expect(onDeleteConfirmMock).not.toBeCalled();
+        });
+
+        test('should handle Enter key', () => {
+            const onDeleteCancelMock = jest.fn();
+            const onDeleteConfirmMock = jest.fn();
+            const wrapper = getWrapper({ onDeleteCancel: onDeleteCancelMock, onDeleteConfirm: onDeleteConfirmMock });
+            wrapper.simulate('keydown', {
+                key: 'Enter',
+                preventDefault: jest.fn(),
+                stopPropagation: jest.fn(),
+                nativeEvent: { stopImmediatePropagation: jest.fn() },
+            });
+            expect(onDeleteConfirmMock).toBeCalled();
+            expect(onDeleteCancelMock).not.toBeCalled();
+        });
+    });
+});

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/CommentDeleteConfirmation-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/CommentDeleteConfirmation-test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`elements/content-sidebar/ActivityFeed/comment/CommentDeleteConfirmation render() should render component with COMMENT_TYPE_DEFAULT 1`] = `
+<div
+  className="bcs-comment-confirm-prompt"
+>
+  <FormattedMessage
+    defaultMessage="Delete comment?"
+    id="be.contentSidebar.activityFeed.comment.commentDeletePrompt"
+  />
+</div>
+`;
+
+exports[`elements/content-sidebar/ActivityFeed/comment/CommentDeleteConfirmation render() should render component with COMMENT_TYPE_TASK 1`] = `
+<div
+  className="bcs-comment-confirm-prompt"
+>
+  <FormattedMessage
+    defaultMessage="Are you sure you want to permanently delete this task?"
+    id="be.contentSidebar.activityFeed.comment.taskDeletePrompt"
+  />
+</div>
+`;


### PR DESCRIPTION
I initially started splitting the comment delete confirmation out into a separate component to address what I thought was an accessibility bug, but then realized it was behaving as intended. Anyhow, this is probably still better as a separate component.