### PR TITLE
fix(versions): Disable prior version preview for watermarked files

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsItem.js
+++ b/src/elements/content-sidebar/versions/VersionsItem.js
@@ -77,7 +77,7 @@ const VersionsItem = ({
     const isDeleted = action === VERSION_DELETE_ACTION;
     const isDownloadable = !!is_download_available;
     const isLimited = versionCount - versionInteger >= versionLimit;
-    const isRestricted = isWatermarked && !isCurrent && !can_download; // Watermarked files use can_download for preview
+    const isRestricted = isWatermarked && !isCurrent; // Watermarked files do not support prior version preview
 
     // Version action helpers
     const canPreview = can_preview && !isDeleted && !isLimited && !isRestricted;


### PR DESCRIPTION
Watermarked files currently do not support preview for older versions. I hope to be able to revert this change in the future, but the timeline is uncertain.