### PR TITLE
build(scripts): Build and update all files prior to push

### DIFF
--- a/scripts/prepush.sh
+++ b/scripts/prepush.sh
@@ -38,7 +38,14 @@ check_and_commit_updated_translations() {
 # lint, test, and build assets to update translations
 prepush() {
     printf "${blue}-------------------------------------------------------------${end}"
-    printf "${blue}Building bundles${end}"
+    printf "${blue}Building all sources, this will update i18n/json${end}"
+    printf "${blue}-------------------------------------------------------------${end}"
+    yarn build:prod:es || exit 1
+
+    check_uncommitted_files || exit 1
+
+    printf "${blue}-------------------------------------------------------------${end}"
+    printf "${blue}Building localized bundles, this will update en-US.properties${end}"
     printf "${blue}-------------------------------------------------------------${end}"
     yarn build:i18n || exit 1
 
@@ -47,18 +54,6 @@ prepush() {
     printf "${blue}-------------------------------------------------------------${end}"
     git fetch upstream
     yarn test --changedSince=upstream/master || exit 1
-
-    printf "${blue}-------------------------------------------------------------${end}"
-    printf "${blue}Building all sources, this will update i18n/json${end}"
-    printf "${blue}-------------------------------------------------------------${end}"
-    yarn build:prod:es || exit 1
-
-    check_uncommitted_files || exit 1
-
-    printf "${blue}-------------------------------------------------------------${end}"
-    printf "${blue}Building bundles again, this will update en-US.properties${end}"
-    printf "${blue}-------------------------------------------------------------${end}"
-    yarn build:i18n || exit 1
 
     check_and_commit_updated_translations
 }


### PR DESCRIPTION
small change to the prepush script which prevents building against stale files that are `.gitignore`d. (e.g., i18n/json and i18n/*.js)

- run all the bundle builds prior to tests and localization updates
- remove duplicate call to `yarn build:i18n` (which would build translations against the contents of es/ *before* updating it)

Tested via:

- populating en-US.js, messages.json, and es/**/messages.js with dummy data to make sure they were updated prior to the uncommited file check
- same as № 1 but adding a new message
- same as № 1 and № 2, but also removing the newly-added message to make sure .properties got updated properly