### PR TITLE
refactor(versions): Move version api helper methods to a separate class

### DIFF
--- a/src/api/Versions.js
+++ b/src/api/Versions.js
@@ -338,25 +338,6 @@ class Versions extends OffsetBasedAPI {
             errorCallback,
         });
     }
-
-    /**
-     * Helper to sort versions by their created date
-     *
-     * @param {FileVersions} versions - API returned file versions for this file
-     * @return {FileVersions} sorted versions array
-     */
-    sortVersions(versions: ?FileVersions): ?FileVersions {
-        if (!versions) {
-            return versions;
-        }
-
-        const { entries, total_count } = versions;
-
-        return {
-            entries: [...entries].sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at)),
-            total_count,
-        };
-    }
 }
 
 export default Versions;

--- a/src/api/__tests__/Versions-test.js
+++ b/src/api/__tests__/Versions-test.js
@@ -135,18 +135,6 @@ describe('api/Versions', () => {
         });
     });
 
-    describe('sortVersions', () => {
-        test('should sort versions by their created date', () => {
-            const { entries: entriesOrigin } = response;
-            const { entries: entriesSorted, total_count } = versions.sortVersions(response);
-
-            expect(entriesOrigin).not.toBe(entriesSorted); // Sort call should create a new array
-            expect(entriesOrigin).toEqual([firstVersion, deleteVersion, restoreVersion]);
-            expect(entriesSorted).toEqual([restoreVersion, deleteVersion, firstVersion]);
-            expect(total_count).toEqual(response.total_count);
-        });
-    });
-
     describe('CRUD operations', () => {
         const successCallback = jest.fn();
         const errorCallback = jest.fn();

--- a/src/elements/content-sidebar/versions/VersionsSidebarAPI.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarAPI.js
@@ -70,12 +70,12 @@ export default class VersionsSidebarAPI {
     deleteVersion = (version: ?BoxItemVersion): Promise<null> => {
         const { id: versionId, permissions = {} } = version || {};
 
-        return new Promise((successCallback, errorCallback) =>
+        return new Promise((resolve, reject) =>
             this.api.getVersionsAPI(false).deleteVersion({
                 fileId: this.fileId,
                 permissions,
-                successCallback,
-                errorCallback,
+                successCallback: resolve,
+                errorCallback: reject,
                 versionId,
             }),
         );
@@ -84,12 +84,12 @@ export default class VersionsSidebarAPI {
     promoteVersion = (version: ?BoxItemVersion): Promise<BoxItemVersion> => {
         const { id: versionId, permissions = {} } = version || {};
 
-        return new Promise((successCallback, errorCallback) =>
+        return new Promise((resolve, reject) =>
             this.api.getVersionsAPI(false).promoteVersion({
                 fileId: this.fileId,
                 permissions,
-                successCallback,
-                errorCallback,
+                successCallback: resolve,
+                errorCallback: reject,
                 versionId,
             }),
         );
@@ -98,12 +98,12 @@ export default class VersionsSidebarAPI {
     restoreVersion = (version: ?BoxItemVersion): Promise<any> => {
         const { id: versionId, permissions = {} } = version || {};
 
-        return new Promise((successCallback, errorCallback) =>
+        return new Promise((resolve, reject) =>
             this.api.getVersionsAPI(false).restoreVersion({
                 fileId: this.fileId,
                 permissions,
-                successCallback,
-                errorCallback,
+                successCallback: resolve,
+                errorCallback: reject,
                 versionId,
             }),
         );

--- a/src/elements/content-sidebar/versions/VersionsSidebarAPI.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarAPI.js
@@ -1,0 +1,111 @@
+/**
+ * @flow
+ * @file Versions Sidebar API Helper
+ * @author Box
+ */
+import API from '../../../api';
+import { FILE_VERSION_FIELDS_TO_FETCH } from '../../../utils/fields';
+
+export type fetchPayload = [BoxItem, FileVersions];
+
+export default class VersionsSidebarAPI {
+    api: API;
+
+    fileId: string;
+
+    constructor({ api, fileId }: { api: API, fileId: string }) {
+        this.api = api;
+        this.fileId = fileId;
+    }
+
+    fetchData = (): Promise<fetchPayload> => {
+        return Promise.all([this.fetchFile(), this.fetchVersions()]).then(this.fetchVersionCurrent);
+    };
+
+    fetchDownloadUrl = (version: ?BoxItemVersion): Promise<string> => {
+        return new Promise((resolve, reject) => {
+            if (!version) {
+                return reject(new Error('Could not find requested version'));
+            }
+
+            return this.api.getFileAPI().getDownloadUrl(this.fileId, version, resolve, reject);
+        });
+    };
+
+    fetchFile = (): Promise<BoxItem> => {
+        return new Promise((resolve, reject) =>
+            this.api.getFileAPI().getFile(this.fileId, resolve, reject, {
+                fields: FILE_VERSION_FIELDS_TO_FETCH,
+                forceFetch: true,
+            }),
+        );
+    };
+
+    fetchVersions = (): Promise<FileVersions> => {
+        return new Promise((resolve, reject) =>
+            this.api.getVersionsAPI(false).getVersions(this.fileId, resolve, reject),
+        );
+    };
+
+    fetchVersionCurrent = ([fileResponse, versionsResponse]: fetchPayload): Promise<fetchPayload> => {
+        const { file_version = {} } = fileResponse;
+
+        return new Promise((resolve, reject) =>
+            this.api.getVersionsAPI(false).getCurrentVersion(
+                this.fileId,
+                file_version.id,
+                (currentVersionResponse: BoxItemVersion) => {
+                    resolve([
+                        fileResponse,
+                        this.api
+                            .getVersionsAPI(false)
+                            .addCurrentVersion(currentVersionResponse, versionsResponse, fileResponse),
+                    ]);
+                },
+                reject,
+            ),
+        );
+    };
+
+    deleteVersion = (version: ?BoxItemVersion): Promise<null> => {
+        const { id: versionId, permissions = {} } = version || {};
+
+        return new Promise((successCallback, errorCallback) =>
+            this.api.getVersionsAPI(false).deleteVersion({
+                fileId: this.fileId,
+                permissions,
+                successCallback,
+                errorCallback,
+                versionId,
+            }),
+        );
+    };
+
+    promoteVersion = (version: ?BoxItemVersion): Promise<BoxItemVersion> => {
+        const { id: versionId, permissions = {} } = version || {};
+
+        return new Promise((successCallback, errorCallback) =>
+            this.api.getVersionsAPI(false).promoteVersion({
+                fileId: this.fileId,
+                permissions,
+                successCallback,
+                errorCallback,
+                versionId,
+            }),
+        );
+    };
+
+    restoreVersion = (version: ?BoxItemVersion): Promise<any> => {
+        const { id: versionId, permissions = {} } = version || {};
+
+        return new Promise((successCallback, errorCallback) =>
+            this.api.getVersionsAPI(false).restoreVersion({
+                fileId: this.fileId,
+                permissions,
+                successCallback,
+                errorCallback,
+                versionId,
+            }),
+        );
+    };
+}

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebarAPI-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebarAPI-test.js
@@ -1,0 +1,141 @@
+import VersionsSidebarAPI from '../VersionsSidebarAPI';
+import { FILE_VERSION_FIELDS_TO_FETCH } from '../../../../utils/fields';
+
+describe('VersionsSidebarAPI', () => {
+    const defaultFileId = '123';
+    const defaultVersionId = '4567';
+    const fileAPI = {
+        getDownloadUrl: jest.fn(),
+        getFile: jest.fn(),
+    };
+    const versionsAPI = {
+        addCurrentVersion: jest.fn(),
+        addPermissions: jest.fn(),
+        deleteVersion: jest.fn(),
+        getVersions: jest.fn(),
+        getCurrentVersion: jest.fn(),
+        promoteVersion: jest.fn(),
+        restoreVersion: jest.fn(),
+        sortVersions: jest.fn(),
+    };
+    const mockAPI = {
+        getFileAPI: () => fileAPI,
+        getVersionsAPI: () => versionsAPI,
+    };
+    const mockPermissons = { can_delete: true, can_download: true, can_upload: true };
+    const mockVersion = { id: defaultVersionId, permissions: mockPermissons };
+    const getInstance = (options = {}) => new VersionsSidebarAPI({ api: mockAPI, fileId: defaultFileId, ...options });
+
+    describe('deleteVersion', () => {
+        test('should call deleteVersion', () => {
+            const instance = getInstance();
+
+            expect(instance.deleteVersion(mockVersion)).toBeInstanceOf(Promise);
+            expect(versionsAPI.deleteVersion).toBeCalledWith({
+                fileId: defaultFileId,
+                permissions: mockVersion.permissions,
+                errorCallback: expect.any(Function),
+                successCallback: expect.any(Function),
+                versionId: defaultVersionId,
+            });
+        });
+    });
+
+    describe('fetchData', () => {
+        test('should call getFile and getVersions', () => {
+            const instance = getInstance();
+
+            instance.fetchData().then(() => {
+                expect(fileAPI.getFile).toBeCalled();
+                expect(versionsAPI.getVersions).toBeCalled();
+            });
+        });
+    });
+
+    describe('fetchDownloadUrl', () => {
+        test('should call getDownloadUrl', () => {
+            const instance = getInstance();
+            const urlPromise = instance.fetchDownloadUrl(mockVersion);
+
+            expect(urlPromise).toBeInstanceOf(Promise);
+            expect(fileAPI.getDownloadUrl).toBeCalledWith(
+                defaultFileId,
+                mockVersion,
+                expect.any(Function),
+                expect.any(Function),
+            );
+        });
+    });
+
+    describe('fetchFile', () => {
+        test('should call getFile', () => {
+            const instance = getInstance();
+
+            expect(instance.fetchFile()).toBeInstanceOf(Promise);
+            expect(fileAPI.getFile).toBeCalledWith(defaultFileId, expect.any(Function), expect.any(Function), {
+                fields: FILE_VERSION_FIELDS_TO_FETCH,
+                forceFetch: true,
+            });
+        });
+    });
+
+    describe('fetchVersions', () => {
+        test('should call getVersions', () => {
+            const instance = getInstance();
+
+            expect(instance.fetchVersions()).toBeInstanceOf(Promise);
+            expect(versionsAPI.getVersions).toBeCalledWith(defaultFileId, expect.any(Function), expect.any(Function));
+        });
+    });
+
+    describe('fetchVersionCurrent', () => {
+        test('should get the current version and add it to the versions response', () => {
+            const file = {
+                id: defaultFileId,
+                file_version: {
+                    id: defaultVersionId,
+                },
+            };
+            const instance = getInstance();
+            const versions = { entries: [mockVersion], total_count: 1 };
+
+            expect(instance.fetchVersionCurrent([file, versions])).toBeInstanceOf(Promise);
+            expect(versionsAPI.getCurrentVersion).toBeCalledWith(
+                defaultFileId,
+                defaultVersionId,
+                expect.any(Function),
+                expect.any(Function),
+            );
+        });
+    });
+
+    describe('promoteVersion', () => {
+        test('should call promoteVersion', () => {
+            const instance = getInstance();
+
+            expect(instance.promoteVersion(mockVersion)).toBeInstanceOf(Promise);
+            expect(versionsAPI.promoteVersion).toBeCalledWith({
+                fileId: defaultFileId,
+                permissions: mockVersion.permissions,
+                errorCallback: expect.any(Function),
+                successCallback: expect.any(Function),
+                versionId: defaultVersionId,
+            });
+        });
+    });
+
+    describe('restoreVersion', () => {
+        test('should call restoreVersion', () => {
+            const instance = getInstance();
+
+            expect(instance.restoreVersion(mockVersion)).toBeInstanceOf(Promise);
+            expect(versionsAPI.restoreVersion).toBeCalledWith({
+                fileId: defaultFileId,
+                permissions: mockVersion.permissions,
+                errorCallback: expect.any(Function),
+                successCallback: expect.any(Function),
+                versionId: defaultVersionId,
+            });
+        });
+    });
+});

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer-test.js
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme/build';
 import messages from '../messages';
 import openUrlInsideIframe from '../../../../utils/iframe';
 import VersionsSidebar from '../VersionsSidebarContainer';
-import { FILE_VERSION_FIELDS_TO_FETCH } from '../../../../utils/fields';
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
@@ -22,50 +21,27 @@ jest.mock('../../../../utils/iframe', () => ({
 const versions = [{ id: '123', name: 'Version 1' }, { id: '456', name: 'Version 2' }, { id: '789', name: 'Version 3' }];
 
 describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
-    const defaultId = '12345';
-    const fileAPI = {
-        getDownloadUrl: jest.fn(),
-        getFile: jest.fn(),
-    };
     const versionsAPI = {
-        addCurrentVersion: jest.fn(),
         addPermissions: jest.fn(),
-        deleteVersion: jest.fn(),
-        getVersions: jest.fn(),
-        getCurrentVersion: jest.fn(),
-        promoteVersion: jest.fn(),
-        restoreVersion: jest.fn(),
         sortVersions: jest.fn(),
     };
     const api = {
-        getFileAPI: () => fileAPI,
         getVersionsAPI: () => versionsAPI,
     };
-    const getWrapper = ({ ...props } = {}) => shallow(<VersionsSidebar api={api} fileId={defaultId} {...props} />);
-
-    describe('componentDidMount', () => {
-        test('should fetch file info', () => {
-            const wrapper = getWrapper();
-
-            expect(wrapper.state('versions')).toHaveLength(0);
-            expect(fileAPI.getFile).toHaveBeenCalled();
-        });
-    });
+    const getWrapper = ({ ...props } = {}) => shallow(<VersionsSidebar api={api} fileId="12345" {...props} />);
 
     describe('componentDidUpdate', () => {
         test('should verify the selected version id exists when it changes', () => {
             const onVersionChange = jest.fn();
             const wrapper = getWrapper({ onVersionChange });
             const instance = wrapper.instance();
-            const version = { id: '12345' };
+            const version = { id: '45678' };
             const currentVersion = { id: '54321' };
 
             instance.verifyVersion = jest.fn();
 
-            wrapper.setState({
-                versions: [currentVersion, version],
-            });
-            wrapper.setProps({ versionId: '12345' });
+            wrapper.setState({ versions: [currentVersion, version] });
+            wrapper.setProps({ versionId: '45678' });
 
             expect(instance.verifyVersion).toHaveBeenCalled();
         });
@@ -76,7 +52,7 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
             const onVersionChange = jest.fn();
             const wrapper = getWrapper({ onVersionChange });
 
-            wrapper.unmount();
+            wrapper.instance().componentWillUnmount();
 
             expect(onVersionChange).toBeCalledWith(null);
         });
@@ -87,17 +63,20 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
             const handleDelete = jest.fn();
             const wrapper = getWrapper({ onVersionDelete: handleDelete, versionId: '123' });
             const instance = wrapper.instance();
-            const versionId = '456';
+            const version = { id: '456' };
 
-            instance.deleteVersion = jest.fn().mockResolvedValueOnce();
-            instance.fetchData = jest.fn().mockResolvedValueOnce();
+            instance.api.deleteVersion = jest.fn().mockResolvedValueOnce();
+            instance.api.fetchData = jest.fn().mockResolvedValueOnce();
+            instance.findVersion = jest.fn(() => version);
+            instance.handleFetchSuccess = jest.fn();
             instance.handleDeleteSuccess = jest.fn();
 
-            instance.handleActionDelete(versionId).then(() => {
-                expect(instance.deleteVersion).toHaveBeenCalledWith(versionId);
-                expect(instance.fetchData).toHaveBeenCalled();
-                expect(instance.handleDeleteSuccess).toHaveBeenCalledWith(versionId);
-                expect(handleDelete).toHaveBeenCalledWith(versionId);
+            instance.handleActionDelete(version.id).then(() => {
+                expect(instance.api.deleteVersion).toHaveBeenCalledWith(version);
+                expect(instance.api.fetchData).toHaveBeenCalled();
+                expect(instance.handleFetchSuccess).toHaveBeenCalled();
+                expect(instance.handleDeleteSuccess).toHaveBeenCalledWith(version.id);
+                expect(handleDelete).toHaveBeenCalledWith(version.id);
             });
         });
     });
@@ -108,14 +87,15 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
             const handleDownload = jest.fn();
             const wrapper = getWrapper({ onVersionDownload: handleDownload, versionId: '123' });
             const instance = wrapper.instance();
-            const versionId = '456';
+            const version = { id: '456' };
 
-            instance.fetchDownloadUrl = jest.fn().mockResolvedValueOnce(downloadUrl);
+            instance.api.fetchDownloadUrl = jest.fn().mockResolvedValueOnce(downloadUrl);
+            instance.findVersion = jest.fn(() => version);
 
-            instance.handleActionDownload(versionId).then(() => {
-                expect(instance.fetchDownloadUrl).toHaveBeenCalledWith(versionId);
+            instance.handleActionDownload(version.id).then(() => {
+                expect(instance.api.fetchDownloadUrl).toHaveBeenCalledWith(version);
                 expect(openUrlInsideIframe).toHaveBeenCalledWith(downloadUrl);
-                expect(handleDownload).toHaveBeenCalledWith(versionId);
+                expect(handleDownload).toHaveBeenCalledWith(version.id);
             });
         });
     });
@@ -125,17 +105,20 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
             const handlePromote = jest.fn();
             const wrapper = getWrapper({ onVersionPromote: handlePromote, versionId: '123' });
             const instance = wrapper.instance();
-            const versionId = '456';
+            const version = { id: '456' };
 
-            instance.fetchData = jest.fn().mockResolvedValueOnce();
+            instance.api.fetchData = jest.fn().mockResolvedValueOnce();
+            instance.api.promoteVersion = jest.fn().mockResolvedValueOnce();
+            instance.findVersion = jest.fn(() => version);
+            instance.handleFetchSuccess = jest.fn();
             instance.handlePromoteSuccess = jest.fn();
-            instance.promoteVersion = jest.fn().mockResolvedValueOnce();
 
-            instance.handleActionPromote(versionId).then(() => {
-                expect(instance.promoteVersion).toHaveBeenCalledWith(versionId);
-                expect(instance.fetchData).toHaveBeenCalled();
+            instance.handleActionPromote(version.id).then(() => {
+                expect(instance.api.promoteVersion).toHaveBeenCalledWith(version);
+                expect(instance.api.fetchData).toHaveBeenCalled();
+                expect(instance.handleFetchSuccess).toHaveBeenCalled();
                 expect(instance.handlePromoteSuccess).toHaveBeenCalled();
-                expect(handlePromote).toHaveBeenCalledWith(versionId);
+                expect(handlePromote).toHaveBeenCalledWith(version.id);
             });
         });
     });
@@ -145,15 +128,18 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
             const handleRestore = jest.fn();
             const wrapper = getWrapper({ onVersionRestore: handleRestore, versionId: '123' });
             const instance = wrapper.instance();
-            const versionId = '456';
+            const version = { id: '456' };
 
-            instance.restoreVersion = jest.fn().mockResolvedValueOnce();
-            instance.fetchData = jest.fn().mockResolvedValueOnce();
+            instance.api.fetchData = jest.fn().mockResolvedValueOnce();
+            instance.api.restoreVersion = jest.fn().mockResolvedValueOnce();
+            instance.findVersion = jest.fn(() => version);
+            instance.handleFetchSuccess = jest.fn();
 
-            instance.handleActionRestore(versionId).then(() => {
-                expect(instance.restoreVersion).toHaveBeenCalledWith(versionId);
-                expect(instance.fetchData).toHaveBeenCalled();
-                expect(handleRestore).toHaveBeenCalledWith(versionId);
+            instance.handleActionRestore(version.id).then(() => {
+                expect(instance.api.restoreVersion).toHaveBeenCalledWith(version);
+                expect(instance.api.fetchData).toHaveBeenCalled();
+                expect(instance.handleFetchSuccess).toHaveBeenCalled();
+                expect(handleRestore).toHaveBeenCalledWith(version.id);
             });
         });
     });
@@ -188,19 +174,19 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
             versionsWithCurrent = { entries: [version, ...currentVersion.entries], total_count: 2 };
 
             versionsAPI.addPermissions.mockReturnValueOnce(versionsWithCurrent);
-            versionsAPI.sortVersions.mockReturnValueOnce(versionsWithCurrent);
         });
 
         test('should set state with the updated versions', () => {
             const wrapper = getWrapper();
             const instance = wrapper.instance();
 
+            instance.sortVersions = jest.fn().mockReturnValue(versionsWithCurrent.entries);
             instance.verifyVersion = jest.fn();
             instance.handleFetchSuccess([file, versionsWithCurrent]);
 
-            expect(instance.verifyVersion).toBeCalled();
             expect(versionsAPI.addPermissions).toBeCalledWith(versionsWithCurrent, file);
-            expect(versionsAPI.sortVersions).toBeCalledWith(versionsWithCurrent);
+            expect(instance.verifyVersion).toBeCalled();
+            expect(instance.sortVersions).toBeCalledWith(versionsWithCurrent.entries);
             expect(wrapper.state()).toMatchObject({
                 error: undefined,
                 isLoading: false,
@@ -223,105 +209,6 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
         });
     });
 
-    describe('fetchData', () => {
-        test('should call getFile and getVersions', () => {
-            const wrapper = getWrapper();
-            const dataPromise = wrapper.instance().fetchData();
-
-            expect(dataPromise).toBeInstanceOf(Promise);
-            expect(fileAPI.getFile).toBeCalled();
-            expect(versionsAPI.getVersions).toBeCalled();
-        });
-    });
-
-    describe('fetchDownloadUrl', () => {
-        test('should call getDownloadUrl', () => {
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-            const versionId = '456';
-            const version = { id: versionId };
-
-            instance.findVersion = jest.fn().mockReturnValueOnce(version);
-
-            const urlPromise = instance.fetchDownloadUrl(versionId);
-
-            expect(urlPromise).toBeInstanceOf(Promise);
-            expect(fileAPI.getDownloadUrl).toBeCalledWith(
-                defaultId,
-                version,
-                expect.any(Function),
-                expect.any(Function),
-            );
-        });
-    });
-
-    describe('fetchFile', () => {
-        test('should call getFile', () => {
-            const wrapper = getWrapper();
-            const filePromise = wrapper.instance().fetchFile();
-
-            expect(filePromise).toBeInstanceOf(Promise);
-            expect(fileAPI.getFile).toBeCalledWith(defaultId, expect.any(Function), expect.any(Function), {
-                fields: FILE_VERSION_FIELDS_TO_FETCH,
-                forceFetch: true,
-            });
-        });
-    });
-
-    describe('fetchVersions', () => {
-        test('should call getVersions', () => {
-            const wrapper = getWrapper();
-            const versionsPromise = wrapper.instance().fetchVersions();
-
-            expect(versionsPromise).toBeInstanceOf(Promise);
-            expect(versionsAPI.getVersions).toBeCalledWith(defaultId, expect.any(Function), expect.any(Function));
-        });
-    });
-
-    describe('fetchVersionCurrent', () => {
-        const fileVersionId = '1234';
-        test('should get the current version and add it to the versions response', () => {
-            const file = {
-                id: defaultId,
-                file_version: {
-                    id: fileVersionId,
-                },
-            };
-
-            versionsAPI.getCurrentVersion.mockResolvedValueOnce();
-
-            const wrapper = getWrapper();
-            const currentVersionsPromise = wrapper.instance().fetchVersionCurrent([file, versions]);
-
-            expect(currentVersionsPromise).toBeInstanceOf(Promise);
-            expect(versionsAPI.getCurrentVersion).toBeCalledWith(
-                defaultId,
-                fileVersionId,
-                expect.any(Function),
-                expect.any(Function),
-            );
-        });
-    });
-
-    describe('deleteVersion', () => {
-        test('should call deleteVersion', () => {
-            const wrapper = getWrapper();
-            const permissions = { can_delete: true };
-            const instance = wrapper.instance();
-
-            instance.findVersion = jest.fn(() => ({ id: '123', permissions }));
-
-            expect(instance.deleteVersion('123')).toBeInstanceOf(Promise);
-            expect(versionsAPI.deleteVersion).toBeCalledWith({
-                fileId: defaultId,
-                permissions,
-                errorCallback: expect.any(Function),
-                successCallback: expect.any(Function),
-                versionId: '123',
-            });
-        });
-    });
-
     describe('findVersion', () => {
         test('should return the version stored in state if available', () => {
             const wrapper = getWrapper();
@@ -334,41 +221,18 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
         });
     });
 
-    describe('promoteVersion', () => {
-        test('should call promoteVersion', () => {
-            const wrapper = getWrapper();
-            const permissions = { can_upload: true };
-            const instance = wrapper.instance();
+    describe('sortVersions', () => {
+        test('should sort versions by their created date', () => {
+            const instance = getWrapper().instance();
+            const unsortedVersions = [
+                { id: '123', created_at: '2018-10-02T13:01:24-07:00' },
+                { id: '456', created_at: '2018-10-02T13:01:41-07:00' },
+                { id: '789', created_at: '2018-11-29T17:47:57-08:00' },
+            ];
+            const sortedVersions = instance.sortVersions(unsortedVersions);
 
-            instance.findVersion = jest.fn(() => ({ id: '123', permissions }));
-
-            expect(instance.promoteVersion('123')).toBeInstanceOf(Promise);
-            expect(versionsAPI.promoteVersion).toBeCalledWith({
-                fileId: defaultId,
-                permissions,
-                errorCallback: expect.any(Function),
-                successCallback: expect.any(Function),
-                versionId: '123',
-            });
-        });
-    });
-
-    describe('restoreVersion', () => {
-        test('should call restoreVersion', () => {
-            const wrapper = getWrapper();
-            const permissions = { can_upload: true };
-            const instance = wrapper.instance();
-
-            instance.findVersion = jest.fn(() => ({ id: '123', permissions }));
-
-            expect(instance.restoreVersion('123')).toBeInstanceOf(Promise);
-            expect(versionsAPI.restoreVersion).toBeCalledWith({
-                fileId: defaultId,
-                permissions,
-                errorCallback: expect.any(Function),
-                successCallback: expect.any(Function),
-                versionId: '123',
-            });
+            expect(unsortedVersions).not.toBe(sortedVersions); // Sort call should create a new array
+            expect(sortedVersions).toEqual([unsortedVersions[2], unsortedVersions[1], unsortedVersions[0]]);
         });
     });
 


### PR DESCRIPTION
The versions container was getting a bit large, so it seemed like a good idea to extract the data access layer to its own class.