### PR TITLE
fix(radio-group): pass rest of props to radio input

### DIFF
--- a/src/components/radio/RadioGroup.js
+++ b/src/components/radio/RadioGroup.js
@@ -47,20 +47,15 @@ class RadioGroup extends React.Component<Props, State> {
 
     render() {
         const { children, className, name } = this.props;
-        const { value } = this.state;
+        const { value: stateValue } = this.state;
 
         return (
             <div className={`radio-group ${className}`} onChange={this.onChangeHandler}>
-                {React.Children.map(children, radio => (
-                    <RadioButton
-                        description={radio.props.description}
-                        isDisabled={radio.props.isDisabled}
-                        isSelected={radio.props.value === value}
-                        label={radio.props.label}
-                        name={name}
-                        value={radio.props.value}
-                    />
-                ))}
+                {React.Children.map(children, radio => {
+                    const { value, ...rest } = radio.props;
+
+                    return <RadioButton isSelected={value === stateValue} name={name} {...rest} />;
+                })}
             </div>
         );
     }

--- a/src/components/radio/__tests__/RadioGroup-test.js
+++ b/src/components/radio/__tests__/RadioGroup-test.js
@@ -14,7 +14,12 @@ describe('components/radio/RadioGroup', () => {
     const renderRadioButtons = onChange =>
         mount(
             <RadioGroup name="radiogroup" onChange={onChange} value="radio3">
-                <RadioButton description="radio1desc" label="Radio Button 1" value="radio1" />
+                <RadioButton
+                    data-resin-target="resin1"
+                    description="radio1desc"
+                    label="Radio Button 1"
+                    value="radio1"
+                />
                 <RadioButton label="Radio Button 2" value="radio2" />
                 <RadioButton description="radio3desc" label="Radio Button 3" value="radio3" />
                 <RadioButton label="Radio Button 4" value="radio4" />
@@ -38,6 +43,13 @@ describe('components/radio/RadioGroup', () => {
                 .at(1)
                 .text(),
         ).toEqual('radio3desc');
+    });
+
+    test('should pass rest of props to input', () => {
+        const component = renderRadioButtons();
+        const inputEl = component.find('input').at(0);
+
+        expect(inputEl.prop('data-resin-target')).toEqual('resin1');
     });
 
     test('should select the correct radio button based on value', () => {


### PR DESCRIPTION
The rest of the props are not being passed from radio group to the radio button input. Fixed that in this PR.