### PR TITLE
fix(radio-group): fix radio group by passing the value prop

### DIFF
--- a/src/components/radio/RadioGroup.js
+++ b/src/components/radio/RadioGroup.js
@@ -54,7 +54,7 @@ class RadioGroup extends React.Component<Props, State> {
                 {React.Children.map(children, radio => {
                     const { value, ...rest } = radio.props;
 
-                    return <RadioButton isSelected={value === stateValue} name={name} {...rest} />;
+                    return <RadioButton isSelected={value === stateValue} name={name} value={value} {...rest} />;
                 })}
             </div>
         );

--- a/src/components/radio/__tests__/RadioGroup-test.js
+++ b/src/components/radio/__tests__/RadioGroup-test.js
@@ -45,6 +45,23 @@ describe('components/radio/RadioGroup', () => {
         ).toEqual('radio3desc');
     });
 
+    test('should set correct value to input', () => {
+        const component = renderRadioButtons();
+
+        expect(
+            component
+                .find('input')
+                .at(0)
+                .prop('value'),
+        ).toEqual('radio1');
+        expect(
+            component
+                .find('input')
+                .at(0)
+                .prop('value'),
+        ).toEqual('radio1');
+    });
+
     test('should pass rest of props to input', () => {
         const component = renderRadioButtons();
         const inputEl = component.find('input').at(0);


### PR DESCRIPTION
Had to add the `value` prop explicitly as it was extracted from the props and was not part of the `...rest`