### PR TITLE
build: add clean command to prepush

### DIFF
--- a/scripts/prepush.sh
+++ b/scripts/prepush.sh
@@ -37,6 +37,7 @@ check_and_commit_updated_translations() {
 
 # lint, test, and build assets to update translations
 prepush() {
+    yarn clean || exit 1
     printf "${blue}-------------------------------------------------------------${end}"
     printf "${blue}Building all sources, this will update i18n/json${end}"
     printf "${blue}-------------------------------------------------------------${end}"


### PR DESCRIPTION
- Pros: this prevents all flows that might use a dirty i18n directory from producing inaccurate changes to .properties files
- Cons: users who push for review while running development servers will have the running instance get corrupted

- Workaround suggestion (1): prepush should work on a temp directory to avoid any discrepancies, and make different git workflows more predictable

Discuss? Other alternatives?