### PR TITLE
fix(comments): format existing mentions in editor

### DIFF
--- a/examples/src/DraftJSMentionSelectorExamples.js
+++ b/examples/src/DraftJSMentionSelectorExamples.js
@@ -5,7 +5,10 @@ import { ContentState, EditorState } from 'draft-js';
 import Avatar from '../../src/components/avatar';
 import Section from '../../src/components/section';
 import PrimaryButton from '../../src/components/primary-button';
-import { DraftMentionDecorator } from '../../src/components/form-elements/draft-js-mention-selector';
+import {
+    DraftMentionDecorator,
+    createMentionSelectorState,
+} from '../../src/components/form-elements/draft-js-mention-selector';
 
 import MentionSelectorContainer from './MentionSelectorContainer';
 
@@ -34,11 +37,16 @@ class DraftJSMentionSelectorExamples extends Component {
 
         this.state = {
             exampleExternalEditorState: this.initialEditorState,
+            exampleExternalMentionsState: this.initialStateWithMentions,
         };
     }
 
     onExternalEditorStateChange = newEditorState => {
         this.setState({ exampleExternalEditorState: newEditorState });
+    };
+
+    onExternaMentionsStateChange = newEditorState => {
+        this.setState({ exampleExternalMentionsState: newEditorState });
     };
 
     getMentionReplacement(mention) {
@@ -69,12 +77,14 @@ class DraftJSMentionSelectorExamples extends Component {
         DraftMentionDecorator,
     );
 
+    initialStateWithMentions = createMentionSelectorState('Hey @[123:Jim], watch my desk');
+
     initializeEditorState = () => {
         this.setState({ exampleExternalEditorState: this.initialEditorState });
     };
 
     render() {
-        const { exampleExternalEditorState } = this.state;
+        const { exampleExternalEditorState, exampleExternalMentionsState } = this.state;
 
         return (
             <div className="example-section mention-selector">
@@ -90,6 +100,12 @@ class DraftJSMentionSelectorExamples extends Component {
                 </Section>
                 <Section id="mention-selector-required-draft" title="Required">
                     <MentionSelectorContainer isRequired name="comments1" placeholder="Enter a comment (uses draft)" />
+                </Section>
+                <Section id="mention-selector-existing-mentions-draft" title="With createMentionSelectorState">
+                    <MentionSelectorContainer
+                        editorState={exampleExternalMentionsState}
+                        onChange={this.onExternaMentionsStateChange}
+                    />
                 </Section>
                 <Section id="mention-selector-required-draft" title="Handle Return Key">
                     <MentionSelectorContainer

--- a/flow/DraftJSFlowStub.js.flow
+++ b/flow/DraftJSFlowStub.js.flow
@@ -4,4 +4,5 @@ declare export var ContentState: any
 declare export var Editor: any
 declare export var CompositeDecorator: any
 declare export var Modifier: any
+declare export var SelectionState: any
 declare export default {}

--- a/src/components/form-elements/draft-js-mention-selector/DraftMentionItem.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftMentionItem.js
@@ -5,11 +5,15 @@ import { ContentState } from 'draft-js';
 type Props = {
     children: React.Node, // React.ChildrenArray<React.Element<any>> unsupported by babel-plugin-flow-react-proptypes
     contentState: ContentState,
-    entityKey: string,
+    decoratedText: string,
+    entityKey?: string,
 };
 
 const DraftMentionItem = ({ contentState, entityKey, children }: Props) => {
-    const { id } = contentState.getEntity(entityKey).getData();
+    let id = '';
+    if (entityKey) {
+        id = contentState.getEntity(entityKey).getData().id;
+    }
 
     return <a href={`/profile/${id}`}>{children}</a>;
 };

--- a/src/components/form-elements/draft-js-mention-selector/README.md
+++ b/src/components/form-elements/draft-js-mention-selector/README.md
@@ -37,7 +37,14 @@ The component hierarchy from topmost to bottommost is:
             Your component should look like `<foo>{ props.children }</foo>`, not `<foo>{ props.text }</foo>`, or else the rendered state won't match the internal state.
         - Strategies can be more or less complex, but our mentionStrategy just checks if an Entity is annotated as being a "MENTION".
 
+### Restoring Editor State
+
+Use `createMentionSelectorState(tagged_message)` instead of `EditorState.createFromContent()` when restoring content that already contains mentions.
+
+This will parse the tagged message and create `type: MENTION` entities. It returns an EditorState instance.
+
 ### Examples
+
 ```
 const DraftJSMentionSelectorExamples = require('examples').DraftJSMentionSelectorExamples;
 

--- a/src/components/form-elements/draft-js-mention-selector/__tests__/createMentionSelectorState-test.js
+++ b/src/components/form-elements/draft-js-mention-selector/__tests__/createMentionSelectorState-test.js
@@ -1,0 +1,33 @@
+import { convertToRaw } from 'draft-js';
+import createMentionSelectorState from '../createMentionSelectorState';
+
+describe('components/form-elements/draft-js-mention-selector/createMentionSelectorState', () => {
+    test('restores mentions from string', () => {
+        const stringWithMentions = `Hey @[123:Jim], do this`;
+        const editorState = createMentionSelectorState(stringWithMentions);
+        const contentStateRaw = convertToRaw(editorState.getCurrentContent());
+
+        expect(contentStateRaw.blocks[0].text).toEqual('Hey @Jim, do this');
+        expect(contentStateRaw.entityMap[0].type).toEqual('MENTION');
+        expect(contentStateRaw.entityMap[0].data.id).toEqual('123');
+    });
+
+    test('restores multiline mentions from string', () => {
+        const stringWithMentions = `Hey @[456:Pam], do this\nand talk to @[789:Dwight]`;
+        const editorState = createMentionSelectorState(stringWithMentions);
+        const contentStateRaw = convertToRaw(editorState.getCurrentContent());
+
+        expect(contentStateRaw.entityMap[0].type).toEqual('MENTION');
+        expect(contentStateRaw.entityMap[0].data.id).toEqual('456');
+
+        expect(contentStateRaw.entityMap[1].type).toEqual('MENTION');
+        expect(contentStateRaw.entityMap[1].data.id).toEqual('789');
+
+        expect(contentStateRaw.blocks).toEqual(
+            expect.arrayContaining([expect.objectContaining({ text: `Hey @Pam, do this` })]),
+        );
+        expect(contentStateRaw.blocks).toEqual(
+            expect.arrayContaining([expect.objectContaining({ text: `and talk to @Dwight` })]),
+        );
+    });
+});

--- a/src/components/form-elements/draft-js-mention-selector/createMentionSelectorState.js
+++ b/src/components/form-elements/draft-js-mention-selector/createMentionSelectorState.js
@@ -5,9 +5,11 @@ import DraftMentionDecorator from './DraftMentionDecorator';
 // returns data for first mention in a string
 const getMentionFromText = (text: string) => {
     // RegEx.exec() is stateful, so we create a new regex instance each time
-    const MENTION_REGEX = /([@＠﹫])\[([0-9]+):([^\]]+)]/gi;
-    const matchArray = MENTION_REGEX.exec(text);
-    if (!matchArray) return null;
+    const mentionRegex = /([@＠﹫])\[([0-9]+):([^\]]+)]/gi;
+    const matchArray = mentionRegex.exec(text);
+    if (!matchArray) {
+        return null;
+    }
     const [fullMatch, triggerSymbol, id, name] = matchArray;
     const start = matchArray.index;
     const end = start + fullMatch.length;
@@ -29,8 +31,7 @@ const createMentionSelectorState = (message: string = '') => {
             const { data, start, end } = mention;
             contentState.createEntity('MENTION', 'IMMUTABLE', data);
             const mentionEntityKey = contentState.getLastCreatedEntityKey();
-            let mentionRange = SelectionState.createEmpty(contentBlock.getKey());
-            mentionRange = mentionRange.merge({
+            const mentionRange = SelectionState.createEmpty(contentBlock.getKey()).merge({
                 anchorOffset: start,
                 focusOffset: end,
             });
@@ -38,8 +39,7 @@ const createMentionSelectorState = (message: string = '') => {
             contentBlock = contentState.getBlockForKey(contentBlock.getKey());
         }
     }
-    const editorState = EditorState.createWithContent(contentState, DraftMentionDecorator);
-    return editorState;
+    return EditorState.createWithContent(contentState, DraftMentionDecorator);
 };
 
 export default createMentionSelectorState;

--- a/src/components/form-elements/draft-js-mention-selector/createMentionSelectorState.js
+++ b/src/components/form-elements/draft-js-mention-selector/createMentionSelectorState.js
@@ -1,0 +1,45 @@
+// @flow
+import { ContentState, EditorState, Modifier, SelectionState } from 'draft-js';
+import DraftMentionDecorator from './DraftMentionDecorator';
+
+// returns data for first mention in a string
+const getMentionFromText = (text: string) => {
+    // RegEx.exec() is stateful, so we create a new regex instance each time
+    const MENTION_REGEX = /([@＠﹫])\[([0-9]+):([^\]]+)]/gi;
+    const matchArray = MENTION_REGEX.exec(text);
+    if (!matchArray) return null;
+    const [fullMatch, triggerSymbol, id, name] = matchArray;
+    const start = matchArray.index;
+    const end = start + fullMatch.length;
+    const data = { id, name, content: `${triggerSymbol}${name}` };
+    return { start, end, data };
+};
+
+// creates draftjs state with mentions parsed into entities
+const createMentionSelectorState = (message: string = '') => {
+    let contentState = ContentState.createFromText(message);
+    let contentBlock = contentState.getFirstBlock();
+
+    while (contentBlock != null) {
+        const text = contentBlock.getText();
+        const mention = text ? getMentionFromText(text) : null;
+        if (mention == null) {
+            contentBlock = contentState.getBlockAfter(contentBlock.getKey());
+        } else {
+            const { data, start, end } = mention;
+            contentState.createEntity('MENTION', 'IMMUTABLE', data);
+            const mentionEntityKey = contentState.getLastCreatedEntityKey();
+            let mentionRange = SelectionState.createEmpty(contentBlock.getKey());
+            mentionRange = mentionRange.merge({
+                anchorOffset: start,
+                focusOffset: end,
+            });
+            contentState = Modifier.replaceText(contentState, mentionRange, data.content, null, mentionEntityKey);
+            contentBlock = contentState.getBlockForKey(contentBlock.getKey());
+        }
+    }
+    const editorState = EditorState.createWithContent(contentState, DraftMentionDecorator);
+    return editorState;
+};
+
+export default createMentionSelectorState;

--- a/src/components/form-elements/draft-js-mention-selector/index.js
+++ b/src/components/form-elements/draft-js-mention-selector/index.js
@@ -1,3 +1,4 @@
 // @flow
 export { default } from './DraftJSMentionSelector';
+export { default as createMentionSelectorState } from './createMentionSelectorState';
 export { default as DraftMentionDecorator } from './DraftMentionDecorator';

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -6,12 +6,11 @@
 import * as React from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
-import { ContentState, EditorState } from 'draft-js';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import Avatar from '../Avatar';
 import CommentFormControls from './CommentFormControls';
 import DraftJSMentionSelector, {
-    DraftMentionDecorator,
+    createMentionSelectorState,
 } from '../../../../components/form-elements/draft-js-mention-selector';
 import Form from '../../../../components/form-elements/form/Form';
 import Media from '../../../../components/media';
@@ -47,10 +46,7 @@ class CommentForm extends React.Component<Props, State> {
     };
 
     state = {
-        commentEditorState: EditorState.createWithContent(
-            ContentState.createFromText(this.props.tagged_message || ''),
-            DraftMentionDecorator,
-        ),
+        commentEditorState: createMentionSelectorState(this.props.tagged_message),
     };
 
     componentWillReceiveProps(nextProps: Props): void {
@@ -58,7 +54,7 @@ class CommentForm extends React.Component<Props, State> {
 
         if (isOpen !== this.props.isOpen && !isOpen) {
             this.setState({
-                commentEditorState: EditorState.createEmpty(DraftMentionDecorator),
+                commentEditorState: createMentionSelectorState(),
             });
         }
     }
@@ -83,7 +79,7 @@ class CommentForm extends React.Component<Props, State> {
         }
 
         this.setState({
-            commentEditorState: EditorState.createEmpty(DraftMentionDecorator),
+            commentEditorState: createMentionSelectorState(),
         });
     };
 

--- a/src/elements/content-sidebar/activity-feed/comment/Comment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.js
@@ -16,7 +16,6 @@ import UserLink from '../common/user-link';
 import ActivityError from '../common/activity-error';
 import ActivityMessage from '../common/activity-message';
 import CommentForm from '../comment-form';
-import formatTaggedMessage from '../utils/formatTaggedMessage';
 import { bdlGray80 } from '../../../../styles/variables';
 import { PLACEHOLDER_USER } from '../../../../constants';
 import messages from './messages';
@@ -189,7 +188,7 @@ class Comment extends React.Component<Props, State> {
                                 onFocus={this.commentFormFocusHandler}
                                 isEditing={isEditing}
                                 entityId={id}
-                                tagged_message={formatTaggedMessage(tagged_message, id, true, getUserProfileUrl)}
+                                tagged_message={tagged_message}
                                 getAvatarUrl={getAvatarUrl}
                                 mentionSelectorContacts={mentionSelectorContacts}
                                 getMentionWithQuery={getMentionWithQuery}


### PR DESCRIPTION
Followup to #1468 - fixes issue with the draftjs comment editor where text already containing mentions was turned back into plaintext, which destroys the references on save.