### PR TITLE
fix(i18n): Fix bug where messages starting with HTML cause an exception

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -208,6 +208,8 @@ be.deleteDialogFileText = Are you sure you want to delete {name}?
 be.deleteDialogFolderText = Are you sure you want to delete {name} and all its contents?
 # Label for delete confirmation dialog
 be.deleteDialogLabel = Confirm Delete
+# Aria label for button to delete a comment, task, or app activity
+be.deleteLabel = Delete
 # Label for the description field in the preview sidebar.
 be.description = Description
 # Placeholder for file description in preview sidebar.
@@ -256,6 +258,10 @@ be.getVersionInfo = Get version information
 be.gridView = Switch to Grid View
 # Label for in action.
 be.in = In
+# Button text to cancel inline item deletion
+be.inlineDeleteCancel = No
+# Button text to confirm inline item deletion
+be.inlineDeleteConfirm = Yes
 # Text for last accessed date with last access prefix.
 be.interactedDate = Last accessed on {date}
 # Label for item created date.
@@ -838,6 +844,22 @@ boxui.metadataInstanceEditor.templatesNoResults = No Results
 boxui.metadataInstanceEditor.templatesServerHasNoTemplates = Zero templates
 # Overall title of metadata
 boxui.metadataInstanceEditor.templatesTitle = Templates
+# Header text shown in metadata view for when the user has too many results within some range
+boxui.metadataView.needRefiningHeaderText = Too many results
+# Subtitle text shown in metadata view for when the user has too many results within some range
+boxui.metadataView.needRefiningSubtitleText = Please use filters to refine your results.
+# Header text shown in metadata view for when there are no results for the current query
+boxui.metadataView.noResultsForQueryHeaderText = No results
+# Subtitle text shown in metadata view for when there are no results for the current query
+boxui.metadataView.noResultsForQuerySubtitleText = You do not have access to any files that match your query. Please use filters to modify your query.
+# Header text shown in metadata view for when there are no results for the current template
+boxui.metadataView.noResultsForTemplateHeaderText = No results
+# Subtitle text shown in metadata view for when there are no results for the current template
+boxui.metadataView.noResultsForTemplateSubtitleText = You do not have access to any files that match this template.
+# Header text shown in metadata view for when the user has too many results past an upper limit
+boxui.metadataView.tooManyResultsHeaderText = Over {upperFileLimit} files match this template
+# Subtitle text shown in metadata view for when the user has too many results past an upper limit
+boxui.metadataView.tooManyResultsSubtitleText = Result sets of this size are not currently supported in Box.
 # Button to close modal
 boxui.modalDialog.closeModalText = Close Modal
 # Text shown on button to close the modal used to create a new folder

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -208,8 +208,6 @@ be.deleteDialogFileText = Are you sure you want to delete {name}?
 be.deleteDialogFolderText = Are you sure you want to delete {name} and all its contents?
 # Label for delete confirmation dialog
 be.deleteDialogLabel = Confirm Delete
-# Aria label for button to delete a comment, task, or app activity
-be.deleteLabel = Delete
 # Label for the description field in the preview sidebar.
 be.description = Description
 # Placeholder for file description in preview sidebar.
@@ -258,10 +256,6 @@ be.getVersionInfo = Get version information
 be.gridView = Switch to Grid View
 # Label for in action.
 be.in = In
-# Button text to cancel inline item deletion
-be.inlineDeleteCancel = No
-# Button text to confirm inline item deletion
-be.inlineDeleteConfirm = Yes
 # Text for last accessed date with last access prefix.
 be.interactedDate = Last accessed on {date}
 # Label for item created date.
@@ -844,22 +838,6 @@ boxui.metadataInstanceEditor.templatesNoResults = No Results
 boxui.metadataInstanceEditor.templatesServerHasNoTemplates = Zero templates
 # Overall title of metadata
 boxui.metadataInstanceEditor.templatesTitle = Templates
-# Header text shown in metadata view for when the user has too many results within some range
-boxui.metadataView.needRefiningHeaderText = Too many results
-# Subtitle text shown in metadata view for when the user has too many results within some range
-boxui.metadataView.needRefiningSubtitleText = Please use filters to refine your results.
-# Header text shown in metadata view for when there are no results for the current query
-boxui.metadataView.noResultsForQueryHeaderText = No results
-# Subtitle text shown in metadata view for when there are no results for the current query
-boxui.metadataView.noResultsForQuerySubtitleText = You do not have access to any files that match your query. Please use filters to modify your query.
-# Header text shown in metadata view for when there are no results for the current template
-boxui.metadataView.noResultsForTemplateHeaderText = No results
-# Subtitle text shown in metadata view for when there are no results for the current template
-boxui.metadataView.noResultsForTemplateSubtitleText = You do not have access to any files that match this template.
-# Header text shown in metadata view for when the user has too many results past an upper limit
-boxui.metadataView.tooManyResultsHeaderText = Over {upperFileLimit} files match this template
-# Subtitle text shown in metadata view for when the user has too many results past an upper limit
-boxui.metadataView.tooManyResultsSubtitleText = Result sets of this size are not currently supported in Box.
 # Button to close modal
 boxui.modalDialog.closeModalText = Close Modal
 # Text shown on button to close the modal used to create a new folder

--- a/src/components/i18n/Composition.js
+++ b/src/components/i18n/Composition.js
@@ -18,6 +18,7 @@ class Composition {
         this.isComposed = false;
 
         this.ma = new MessageAccumulator();
+        this.keyIndex = 0;
     }
 
     recompose(element) {
@@ -67,6 +68,15 @@ class Composition {
     /**
      * @private
      */
+    nextKey() {
+        const ret = `key${this.keyIndex}`;
+        this.keyIndex += 1;
+        return ret;
+    }
+
+    /**
+     * @private
+     */
     mapToReactElements(node) {
         if (!node) return '';
 
@@ -86,11 +96,11 @@ class Composition {
 
         if (el) {
             return children && children.length
-                ? React.cloneElement(el, { key: el.key }, children)
-                : React.cloneElement(el, { key: el.key });
+                ? React.cloneElement(el, { key: el.key || this.nextKey() }, children)
+                : React.cloneElement(el, { key: el.key || this.nextKey() });
         }
         if (children.length) {
-            return children;
+            return children.length > 1 ? children : children[0];
         }
 
         return node.value || '';
@@ -112,10 +122,21 @@ class Composition {
             this.compose();
         }
         const translation = MessageAccumulator.create(string, this.ma);
-        const nodeArray = this.ma
-            .getPrefix()
+        const nodeArray = [
+            new Node({
+                type: 'root',
+                use: 'start',
+            }),
+        ]
+            .concat(this.ma.getPrefix())
             .concat(translation.root.toArray().slice(1, -1))
-            .concat(this.ma.getSuffix());
+            .concat(this.ma.getSuffix())
+            .concat([
+                new Node({
+                    type: 'root',
+                    use: 'end',
+                }),
+            ]);
         // convert to a tree again
         return this.mapToReactElements(Node.fromArray(nodeArray));
     }

--- a/src/components/i18n/Composition.js
+++ b/src/components/i18n/Composition.js
@@ -69,9 +69,9 @@ class Composition {
      * @private
      */
     nextKey() {
-        const ret = `key${this.keyIndex}`;
+        const result = `key${this.keyIndex}`;
         this.keyIndex += 1;
-        return ret;
+        return result;
     }
 
     /**

--- a/src/components/i18n/FormattedCompMessage.js
+++ b/src/components/i18n/FormattedCompMessage.js
@@ -150,7 +150,7 @@ class FormattedCompMessage extends React.Component<Props, State> {
     }
 
     render() {
-        const { count, tagName, intl, description, id, ...rest } = this.props;
+        const { count, tagName, intl, description, id, defaultMessage, ...rest } = this.props;
         const { composition, source } = this.state;
         const values = {};
         if (typeof count === 'number') {

--- a/src/components/i18n/__tests__/Composition-test.js
+++ b/src/components/i18n/__tests__/Composition-test.js
@@ -102,6 +102,22 @@ describe('components/i18n/Composition', () => {
         expect(actual).toEqual(expected);
     });
 
+    test('Compose properly with a complex set of nested subchildren at the beginning of the string to a coded string', () => {
+        const el = React.createElement('span', { key: 'x' }, [
+            React.createElement('b', { key: 'y' }, [
+                'emergency ',
+                React.createElement('i', { key: 'z' }, 'broadcast'),
+                ' system',
+            ]),
+            '. This is only a test.',
+        ]);
+
+        const c = new Composition(el);
+        const expected = '<c0>emergency <c1>broadcast</c1> system</c0>. This is only a test.';
+        const actual = c.compose();
+        expect(actual).toEqual(expected);
+    });
+
     test('Decompose a React element with a string', () => {
         const c = new Composition('simple string');
         expect(c.decompose('einfache Zeichenfolge')).toEqual('einfache Zeichenfolge');
@@ -160,6 +176,21 @@ describe('components/i18n/Composition', () => {
         expect(
             c.decompose('Dies ist ein Test des <c0>Notfall-<c1>Broadcast</c1>-Systems</c0>. Dies ist nur ein Test.'),
         ).toEqual(expected);
+    });
+
+    test('Decompose a React element with subchildren at the beginning of the string', () => {
+        const el = React.createElement('span', { key: 'a' }, [
+            React.createElement('b', { key: 'b' }, 'emergency broadcast system'),
+            '. This is only a test.',
+        ]);
+
+        const expected = React.createElement('span', { key: 'a' }, [
+            React.createElement('b', { key: 'b' }, 'Notfall-Broadcast-Systems'),
+            '. Dies ist nur ein Test.',
+        ]);
+
+        const c = new Composition(el);
+        expect(c.decompose('<c0>Notfall-Broadcast-Systems</c0>. Dies ist nur ein Test.')).toEqual(expected);
     });
 
     test('Make sure other properties are preserved while decomposing', () => {

--- a/src/components/i18n/__tests__/FormattedCompMessage-test.js
+++ b/src/components/i18n/__tests__/FormattedCompMessage-test.js
@@ -73,6 +73,16 @@ describe('components/i18n', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
+        test('should correctly render FormattedCompMessage which starts with HTML, snapshot', () => {
+            const wrapper = mount(
+                <FormattedCompMessage id="test" description="asdf">
+                    <b>bold</b> text. More text.
+                </FormattedCompMessage>,
+            );
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
         test('should correctly render FormattedCompMessage with subcomponents', () => {
             const wrapper = mount(
                 <FormattedCompMessage id="test" description="asdf">

--- a/src/components/i18n/__tests__/__snapshots__/FormattedCompMessage-test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/FormattedCompMessage-test.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/i18n components/i18n/FormattedCompMessage should correctly render FormattedCompMessage which starts with HTML, snapshot 1`] = `
+<FormattedCompMessage
+  description="asdf"
+  id="test"
+>
+  <FormattedCompMessage
+    description="asdf"
+    id="test"
+    intl={
+      Object {
+        "formatDate": [Function],
+        "formatMessage": [Function],
+      }
+    }
+    tagName="span"
+  >
+    <span
+      key="test"
+      x-resource-id="test"
+    >
+      <b
+        key="key0"
+      >
+        bold
+      </b>
+       text. More text.
+    </span>
+  </FormattedCompMessage>
+</FormattedCompMessage>
+`;
+
 exports[`components/i18n components/i18n/FormattedCompMessage should correctly render FormattedCompMessage with HTML snapshot 1`] = `
 <FormattedCompMessage
   description="asdf"
@@ -22,7 +53,7 @@ exports[`components/i18n components/i18n/FormattedCompMessage should correctly r
     >
       some 
       <b
-        key="null"
+        key="key0"
       >
         bold
       </b>
@@ -80,7 +111,7 @@ exports[`components/i18n components/i18n/FormattedCompMessage should correctly r
     >
       some 
       <LinkButton
-        key="null"
+        key="key0"
         to="foo"
       >
         <a


### PR DESCRIPTION
A message like this:

```jsx
<FormattedCompMessage
  description="Body for tooltip pointing to add user button"
    id="adminConsole.components.Onboarding.addUserButtonTooltipBodyText"
>
    <b>Managed users</b> are employees in your Box Enterprise. They often share your company domain(s) and require a greater amount of control, while <b>External users</b> are clients or partners who have been invited to collaborate on specific content in your enterprise.
</FormattedCompMessage>
```

Caused an exception even though it is perfectly valid.