### PR TITLE
feat(leftsidebar): LeftSidebar supports customLinkRenderer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,10 @@
     "prettier.eslintIntegration": true,
     "prettier.printWidth": 120,
     "prettier.tabWidth": 4,
-    "prettier.singleQuote": true
+    "prettier.singleQuote": true,
+    "files.exclude": {
+        "**/flow-typed": true,
+        "**/i18n": true,
+        "**/node_modules": true
+    }
 }

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -13,8 +13,8 @@ import CopyrightFooter from './CopyrightFooter';
 import InstantLogin from './InstantLogin';
 import LeftSidebarDropWrapper from './LeftSidebarDropWrapper';
 import LeftSidebarIconWrapper from './LeftSidebarIconWrapper';
-import LeftSidebarLink from './LeftSidebarLink';
 import NewItemsIndicator from './NewItemsIndicator';
+import defaultNavLinkRenderer from './defaultNavLinkRenderer';
 
 import type { Callout } from './Callout';
 
@@ -27,6 +27,7 @@ type SubMenuItem = {
     canReceiveDrop?: boolean,
     /** class to add to sub menu element */
     className?: string,
+    customLinkRenderer?: Function,
     /** Ref for parent to access drop target */
     dropTargetRef?: { current: null | HTMLDivElement },
     /** Optional HTML attributes to append to menu item */
@@ -64,6 +65,7 @@ type MenuItem = {
     className?: string,
     /** Whether the menu should render as collapsed or expanded */
     collapsed?: boolean,
+    customRender?: Function,
     /** Ref for parent to access drop target */
     dropTargetRef?: { current: null | HTMLDivElement },
     /** Optional HTML attributes to append to menu item */
@@ -276,6 +278,7 @@ class LeftSidebar extends React.Component<Props, State> {
             callout,
             canReceiveDrop = false,
             className = '',
+            customLinkRenderer,
             dropTargetRef,
             htmlAttributes,
             iconComponent,
@@ -296,26 +299,47 @@ class LeftSidebar extends React.Component<Props, State> {
             'is-selected': selected,
         });
 
-        const builtLink = (
-            <LeftSidebarLink
-                callout={callout}
-                canReceiveDrop={canReceiveDrop}
-                className={linkClassNames}
-                customTheme={leftSidebarProps.customTheme}
-                onClickRemove={onClickRemove}
-                htmlAttributes={htmlAttributes}
-                icon={this.getIcon(iconElement, iconComponent, leftSidebarProps.customTheme, selected, scaleIcon)}
-                isScrolling={this.state.isScrolling}
-                key={`link-${id}`}
-                message={message}
-                newItemBadge={this.getNewItemBadge(newItemBadge, leftSidebarProps.customTheme)}
-                removeButtonHtmlAttributes={removeButtonHtmlAttributes}
-                routerLink={routerLink}
-                routerProps={routerProps}
-                selected={selected}
-                showTooltip={showTooltip}
-            />
-        );
+        let builtLink;
+
+        if (customLinkRenderer) {
+            builtLink = customLinkRenderer({
+                callout,
+                canReceiveDrop,
+                linkClassNames,
+                customTheme: leftSidebarProps.customTheme,
+                onClickRemove,
+                htmlAttributes,
+                icon: this.getIcon(iconElement, iconComponent, leftSidebarProps.customTheme, selected, scaleIcon),
+                isScrolling: this.state.isScrolling,
+                key: `link-${id}`,
+                message,
+                newItemBadge: this.getNewItemBadge(newItemBadge, leftSidebarProps.customTheme),
+                removeButtonHtmlAttributes,
+                routerLink,
+                routerProps,
+                selected,
+                showTooltip,
+            });
+        } else {
+            builtLink = defaultNavLinkRenderer({
+                callout,
+                canReceiveDrop,
+                linkClassNames,
+                customTheme: leftSidebarProps.customTheme,
+                onClickRemove,
+                htmlAttributes,
+                icon: this.getIcon(iconElement, iconComponent, leftSidebarProps.customTheme, selected, scaleIcon),
+                isScrolling: this.state.isScrolling,
+                key: `link-${id}`,
+                message,
+                newItemBadge: this.getNewItemBadge(newItemBadge, leftSidebarProps.customTheme),
+                removeButtonHtmlAttributes,
+                routerLink,
+                routerProps,
+                selected,
+                showTooltip,
+            });
+        }
 
         // Check for menu items on links so we don't double-highlight groups
         return canReceiveDrop && !props.menuItems ? (

--- a/src/features/left-sidebar/LeftSidebar.md
+++ b/src/features/left-sidebar/LeftSidebar.md
@@ -216,6 +216,7 @@ const menuItems = [
     showTooltip: true,
   },
   {
+    customLinkRenderer: () => <h1>woot</h1>,
     htmlAttributes: {
       href: '/developers/services',
       rel: 'external',

--- a/src/features/left-sidebar/__tests__/LeftSidebar-test.js
+++ b/src/features/left-sidebar/__tests__/LeftSidebar-test.js
@@ -285,6 +285,26 @@ describe('feature/left-sidebar/LeftSidebar', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should use custom render for menu item if provided', () => {
+        const oneMenuItem = [
+            {
+                customLinkRenderer: () => <h1 key="abc">Custom Link</h1>,
+                id: 'all-files',
+                message: 'All Files',
+                htmlAttributes: {
+                    href: '/folder/0',
+                },
+                routerLink: undefined,
+                routerProps: undefined,
+                showTooltip: true,
+            },
+        ];
+
+        const wrapper = shallow(<LeftSidebar menuItems={oneMenuItem} />);
+
+        expect(wrapper.exists('h1')).toBeTruthy();
+    });
+
     describe('checkAndChangeScrollShadows()', () => {
         [
             // isn't scrollable

--- a/src/features/left-sidebar/index.js
+++ b/src/features/left-sidebar/index.js
@@ -1,1 +1,2 @@
+export { default as defaultNavLinkRenderer } from './defaultNavLinkRenderer';
 export { default } from './LeftSidebar';


### PR DESCRIPTION
LeftSidebar menu items support for `customLinkRenderer`.
This prop allows for changing Left Nav menu items with UI treatment or wrapping the `defaultNavLinkRenderer` with another component or both!

The PR isn't ready to be merged yet. I'm pushing it as a hand-off.