### PR TITLE
 feat(uploads): resume failed uploads from uploads manager

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -352,6 +352,10 @@ be.renameDialogErrorTooLong = This name is too long.
 be.renameDialogLabel = Rename
 # Text for rename dialog
 be.renameDialogText = Please enter a new name for {name}:
+# Label for resume action for a single file.
+be.resume = Resume
+# Label for resume action for multiple files.
+be.resumeAll = Resume All
 # Label for retry action.
 be.retry = Retry
 # Default label for root folder.

--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -15,7 +15,13 @@ import {
     ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED,
     HTTP_STATUS_CODE_FORBIDDEN,
 } from '../../constants';
-import MultiputPart, { PART_STATE_UPLOADED, PART_STATE_DIGEST_READY, PART_STATE_NOT_STARTED } from './MultiputPart';
+import MultiputPart, {
+    PART_STATE_UPLOADED,
+    PART_STATE_UPLOADING,
+    PART_STATE_DIGEST_READY,
+    PART_STATE_COMPUTING_DIGEST,
+    PART_STATE_NOT_STARTED,
+} from './MultiputPart';
 import BaseMultiput from './BaseMultiput';
 
 // Constants used for specifying log event types.
@@ -49,6 +55,8 @@ class MultiputUpload extends BaseMultiput {
     initialFileLastModified: ?string;
 
     initialFileSize: number;
+
+    isResumableUploadsEnabled: boolean;
 
     successCallback: Function;
 
@@ -115,6 +123,7 @@ class MultiputUpload extends BaseMultiput {
         this.partSize = 0;
         this.commitRetryCount = 0;
         this.clientId = null;
+        this.isResumableUploadsEnabled = false;
     }
 
     /**
@@ -330,6 +339,182 @@ class MultiputUpload extends BaseMultiput {
     }
 
     /**
+     * Resume uploading the given file
+     *
+     *
+     * @param {Object} options
+     * @param {File} options.file
+     * @param {string} options.folderId - Untyped folder id (e.g. no "folder_" prefix)
+     * @param {string} [options.fileId] - Untyped file id (e.g. no "file_" prefix)
+     * @param {string} options.sessionId
+     * @param {Function} [options.errorCallback]
+     * @param {Function} [options.progressCallback]
+     * @param {Function} [options.successCallback]
+     * @return {void}
+     */
+    resume({
+        file,
+        folderId,
+        errorCallback,
+        progressCallback,
+        sessionId,
+        successCallback,
+        overwrite = true,
+        fileId,
+    }: {
+        errorCallback?: Function,
+        file: File,
+        fileId: ?string,
+        folderId: string,
+        overwrite?: boolean,
+        progressCallback?: Function,
+        sessionId: string,
+        successCallback?: Function,
+    }): void {
+        this.file = file;
+        this.fileName = this.file.name;
+        this.folderId = folderId;
+        this.errorCallback = errorCallback || noop;
+        this.progressCallback = progressCallback || noop;
+        this.successCallback = successCallback || noop;
+
+        if (!this.sha1Worker) {
+            this.sha1Worker = createWorker();
+        }
+        this.sha1Worker.addEventListener('message', this.onWorkerMessage);
+
+        this.overwrite = overwrite;
+        this.fileId = fileId;
+        this.sessionId = sessionId;
+
+        this.getSessionInfo(sessionId);
+    }
+
+    /**
+     * Get session information from API.
+     * Uses session info to commit a complete session or continue an in-progress session.
+     *
+     * @private
+     * @return {void}
+     */
+    getSessionInfo = async (session: string): Promise<any> => {
+        const uploadUrl = this.getBaseUploadUrl();
+        const sessionUrl = `${uploadUrl}/files/upload_sessions/${session}`;
+        try {
+            const response = await this.xhr.get({ url: sessionUrl });
+            this.getSessionSuccessHandler(response.data);
+        } catch (error) {
+            this.getSessionErrorHandler(error);
+        }
+    };
+
+    /**
+     * Handles a getSessionInfo success and either commits the session or continues to process
+     * the parts that still need to be uploaded.
+     *
+     * @param response
+     * @return {void}
+     */
+    getSessionSuccessHandler(data: any): void {
+        const { total_parts, part_size, session_endpoints } = data;
+
+        // Set session information gotten from API response
+        this.partSize = part_size;
+        this.sessionEndpoints = {
+            ...this.sessionEndpoints,
+            uploadPart: session_endpoints.upload_part,
+            listParts: session_endpoints.list_parts,
+            commit: session_endpoints.commit,
+            abort: session_endpoints.abort,
+            logEvent: session_endpoints.log_event,
+        };
+
+        // Reset uploading process for parts that were in progress when the upload failed
+        let nextUploadIndex = this.firstUnuploadedPartIndex;
+        while (this.numPartsUploading > 0 || this.numPartsDigestComputing > 0) {
+            const part = this.parts[nextUploadIndex];
+            if (part && part.state === PART_STATE_UPLOADING) {
+                part.state = PART_STATE_DIGEST_READY;
+                part.numUploadRetriesPerformed = 0;
+                part.timing = {};
+                part.uploadedBytes = 0;
+
+                this.numPartsUploading -= 1;
+                this.numPartsDigestReady += 1;
+            } else if (part && part.state === PART_STATE_COMPUTING_DIGEST) {
+                part.state = PART_STATE_NOT_STARTED;
+                part.numDigestRetriesPerformed = 0;
+                part.timing = {};
+
+                this.numPartsDigestComputing -= 1;
+                this.numPartsNotStarted += 1;
+            }
+            nextUploadIndex += 1;
+        }
+
+        if (this.numPartsUploaded === total_parts) {
+            // Commit sessions that have all the parts of the file uploaded
+            this.commitSession();
+        } else {
+            this.processNextParts();
+        }
+    }
+
+    /**
+     * Handle error from getting upload session.
+     * Restart uploads without valid sessions from the beginning of the upload process.
+     *
+     * @param error
+     * @return {void}
+     */
+    getSessionErrorHandler(error: Object): void {
+        if (this.isDestroyed()) {
+            return;
+        }
+
+        const errorData = this.getErrorResponse(error);
+        if (errorData && errorData.status >= 429) {
+            return;
+        }
+
+        // Restart upload process for errors resulting from invalid session
+        this.parts.forEach(part => {
+            part.cancel();
+        });
+        this.parts = [];
+
+        // Reset information about uploaded parts
+        this.fileSha1 = null;
+        this.totalUploadedBytes = 0;
+        this.numPartsNotStarted = 0;
+        this.numPartsDigestComputing = 0;
+        this.numPartsDigestReady = 0;
+        this.numPartsUploading = 0;
+        this.numPartsUploaded = 0;
+        this.firstUnuploadedPartIndex = 0;
+        this.createSessionNumRetriesPerformed = 0;
+        this.partSize = 0;
+        this.commitRetryCount = 0;
+
+        // Abort session
+        clearTimeout(this.createSessionTimeout);
+        clearTimeout(this.commitSessionTimeout);
+        this.abortSession();
+
+        // Restart the uploading process from the beginning
+        const uploadOptions: Object = {
+            file: this.file,
+            folderId: this.folderId,
+            errorCallback: this.errorCallback,
+            progressCallback: this.progressCallback,
+            successCallback: this.successCallback,
+            overwrite: this.overwrite,
+            fileId: this.fileId,
+        };
+        this.upload(uploadOptions);
+    }
+
+    /**
      * Session error handler.
      * Retries the create session request or fails the upload.
      *
@@ -340,7 +525,9 @@ class MultiputUpload extends BaseMultiput {
      * @return {Promise}
      */
     async sessionErrorHandler(error: ?Error, logEventType: string, logMessage?: string): Promise<any> {
-        this.destroy();
+        if (!this.isResumableUploadsEnabled) {
+            this.destroy();
+        }
         const errorData = this.getErrorResponse(error);
         this.errorCallback(errorData);
 
@@ -358,8 +545,9 @@ class MultiputUpload extends BaseMultiput {
                 this.config.retries,
                 this.config.initialRetryDelayMs,
             );
-
-            this.abortSession();
+            if (!this.isResumableUploadsEnabled) {
+                this.abortSession();
+            }
         } catch (err) {
             this.abortSession();
         }

--- a/src/api/uploads/__tests__/MultiputUpload-test.js
+++ b/src/api/uploads/__tests__/MultiputUpload-test.js
@@ -420,35 +420,9 @@ describe('api/uploads/MultiputUpload', () => {
     });
 
     describe('getSessionSuccessHandler()', () => {
-        test('should commit if all parts have been uploaded', () => {
-            // Setup
-            multiputUploadTest.numPartsUploaded = 20;
-            const response = {
-                data: {
-                    total_parts: 20,
-                    part_size: multiputUploadTest.partSize,
-                    session_endpoints: {
-                        uploadPart: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
-                        listParts: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/parts',
-                        commit: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/commit',
-                        abort: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
-                        logEvent: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/log',
-                    },
-                },
-            };
-
-            // Expectations
-            multiputUploadTest.commitSession = jest.fn();
-
-            // Execute
-            multiputUploadTest.getSessionSuccessHandler(response.data);
-            expect(multiputUploadTest.commitSession).toHaveBeenCalled();
-        });
-
-        test('should call processNextParts if some parts are not uploaded', () => {
-            // Setup
-            multiputUploadTest.numPartsUploaded = 20;
-            const response = {
+        let response;
+        beforeEach(() => {
+            response = {
                 data: {
                     total_parts: 25,
                     part_size: multiputUploadTest.partSize,
@@ -461,6 +435,23 @@ describe('api/uploads/MultiputUpload', () => {
                     },
                 },
             };
+        });
+
+        test('should commit if all parts have been uploaded', () => {
+            // Setup
+            multiputUploadTest.numPartsUploaded = 25;
+
+            // Expectations
+            multiputUploadTest.commitSession = jest.fn();
+
+            // Execute
+            multiputUploadTest.getSessionSuccessHandler(response.data);
+            expect(multiputUploadTest.commitSession).toHaveBeenCalled();
+        });
+
+        test('should call processNextParts if some parts are not uploaded', () => {
+            // Setup
+            multiputUploadTest.numPartsUploaded = 20;
 
             multiputUploadTest.processNextParts = jest.fn();
 
@@ -481,19 +472,6 @@ describe('api/uploads/MultiputUpload', () => {
                 { state: PART_STATE_UPLOADING, numUploadRetriesPerformed: 2, uploadedBytes: 5 },
             ];
 
-            const response = {
-                data: {
-                    total_parts: 25,
-                    part_size: multiputUploadTest.partSize,
-                    session_endpoints: {
-                        uploadPart: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
-                        listParts: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/parts',
-                        commit: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/commit',
-                        abort: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
-                        logEvent: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/log',
-                    },
-                },
-            };
             multiputUploadTest.processNextParts = jest.fn();
 
             // Execute
@@ -525,19 +503,6 @@ describe('api/uploads/MultiputUpload', () => {
             multiputUploadTest.firstUnuploadedPartIndex = 0;
             multiputUploadTest.parts = [{ state: PART_STATE_COMPUTING_DIGEST, numDigestRetriesPerformed: 3 }];
 
-            const response = {
-                data: {
-                    total_parts: 25,
-                    part_size: multiputUploadTest.partSize,
-                    session_endpoints: {
-                        uploadPart: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
-                        listParts: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/parts',
-                        commit: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/commit',
-                        abort: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
-                        logEvent: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/log',
-                    },
-                },
-            };
             multiputUploadTest.processNextParts = jest.fn();
 
             // Execute

--- a/src/api/uploads/__tests__/MultiputUpload-test.js
+++ b/src/api/uploads/__tests__/MultiputUpload-test.js
@@ -861,6 +861,40 @@ describe('api/uploads/MultiputUpload', () => {
         });
     });
 
+    describe('commitSession()', () => {
+        beforeEach(() => {
+            multiputUploadTest.xhr.post = jest.fn().mockResolvedValue();
+            multiputUploadTest.sessionEndpoints.commit =
+                'https://upload.box.com/api/2.0/files/content?upload_session_id=123/commit';
+        });
+
+        test('should noop when isDestroyed', () => {
+            multiputUploadTest.destroyed = true;
+
+            multiputUploadTest.commitSession();
+
+            expect(multiputUploadTest.xhr.post).not.toHaveBeenCalled();
+        });
+
+        test('should commit session with file sha1 included in header', () => {
+            multiputUploadTest.parts = [];
+            multiputUploadTest.fileSha1 = '123456789';
+            const postData = {
+                url: multiputUploadTest.sessionEndpoints.commit,
+                data: { parts: [], attributes: {} },
+                headers: {
+                    Digest: `sha=${multiputUploadTest.fileSha1}`,
+                    'X-Box-Client-Event-Info':
+                        '{"avg_part_read_time":null,"avg_part_digest_time":null,"avg_file_digest_time":null,"avg_part_upload_time":null}',
+                },
+            };
+
+            multiputUploadTest.commitSession();
+
+            expect(multiputUploadTest.xhr.post).toHaveBeenCalledWith(postData);
+        });
+    });
+
     describe('onWorkerMessage()', () => {
         beforeEach(() => {
             multiputUploadTest.isDestroyed = jest.fn();

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -82,6 +82,16 @@ const messages = defineMessages({
         description: 'Label for remove action.',
         defaultMessage: 'Remove',
     },
+    resume: {
+        id: 'be.resume',
+        description: 'Label for resume action for a single file.',
+        defaultMessage: 'Resume',
+    },
+    resumeAll: {
+        id: 'be.resumeAll',
+        description: 'Label for resume action for multiple files.',
+        defaultMessage: 'Resume All',
+    },
     retry: {
         id: 'be.retry',
         description: 'Label for retry action.',

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -971,6 +971,24 @@ class ContentUploader extends Component<Props, State> {
     };
 
     /**
+     * Click all uploads in the Uploads Manager with the given status.
+     *
+     * @private
+     * @param {UploadStatus}
+     * @return {void}
+     */
+    clickAllWithStatus = (status?: UploadStatus) => {
+        const { items } = this.state;
+
+        for (let i = 0; i < items.length; i += 1) {
+            const item = items[i];
+            if (!status || (status && item.status === status)) {
+                this.onClick(item);
+            }
+        }
+    };
+
+    /**
      * Expands the upload manager
      *
      * @return {void}
@@ -1085,6 +1103,7 @@ class ContentUploader extends Component<Props, State> {
             isTouch,
             fileLimit,
             useUploadsManager,
+            isResumableUploadsEnabled,
             isFolderUploadEnabled,
             isDraggingItemsToUploadsManager = false,
         }: Props = this.props;
@@ -1107,9 +1126,11 @@ class ContentUploader extends Component<Props, State> {
                         <UploadsManager
                             isDragging={isDraggingItemsToUploadsManager}
                             isExpanded={isUploadsManagerExpanded}
+                            isResumableUploadsEnabled={isResumableUploadsEnabled}
                             isVisible={isVisible}
                             items={items}
                             onItemActionClick={this.onClick}
+                            onUploadsManagerActionClick={this.clickAllWithStatus}
                             toggleUploadsManager={this.toggleUploadsManager}
                             view={view}
                         />

--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -52,11 +52,11 @@ const getPercent = (view: string, percent: number): number => {
 };
 
 type Props = {
+    hasMultipleFailedUploads: boolean,
     isDragging: boolean,
     isExpanded: boolean,
-    isResumableUploadsEnabled: boolean,
+    isResumeVisible: boolean,
     isVisible: boolean,
-    numFailedUploads: number,
     onClick: Function,
     onKeyDown: Function,
     onUploadsManagerActionClick: Function,
@@ -70,11 +70,11 @@ const OverallUploadsProgressBar = ({
     onClick,
     onKeyDown,
     onUploadsManagerActionClick,
-    numFailedUploads,
     isDragging,
-    isResumableUploadsEnabled,
+    isResumeVisible,
     isVisible,
     isExpanded,
+    hasMultipleFailedUploads,
 }: Props) => {
     // Show the upload prompt and set progress to 0 when the uploads manager
     // is invisible or is having files dragged to it
@@ -85,11 +85,6 @@ const OverallUploadsProgressBar = ({
         getUploadStatus(view)
     );
     const updatedPercent = shouldShowPrompt ? 0 : getPercent(view, percent);
-
-    let button;
-    if (isResumableUploadsEnabled && numFailedUploads > 0) {
-        button = <UploadsManagerItemAction onClick={onUploadsManagerActionClick} numFailedUploads={numFailedUploads} />;
-    }
 
     return (
         <div
@@ -102,7 +97,12 @@ const OverallUploadsProgressBar = ({
         >
             <span className="bcu-upload-status">{status}</span>
             <ProgressBar percent={updatedPercent} />
-            {button}
+            {isResumeVisible && (
+                <UploadsManagerItemAction
+                    hasMultipleFailedUploads={hasMultipleFailedUploads}
+                    onClick={onUploadsManagerActionClick}
+                />
+            )}
             <span className="bcu-uploads-manager-toggle" />
         </div>
     );

--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -10,6 +10,7 @@ import ProgressBar from './ProgressBar';
 import { VIEW_UPLOAD_IN_PROGRESS, VIEW_UPLOAD_SUCCESS, VIEW_ERROR, VIEW_UPLOAD_EMPTY } from '../../constants';
 
 import './OverallUploadsProgressBar.scss';
+import UploadsManagerItemAction from './UploadsManagerAction';
 
 /**
  * Get upload status
@@ -53,14 +54,28 @@ const getPercent = (view: string, percent: number): number => {
 type Props = {
     isDragging: boolean,
     isExpanded: boolean,
+    isResumableUploadsEnabled: boolean,
     isVisible: boolean,
+    numFailedUploads: number,
     onClick: Function,
     onKeyDown: Function,
+    onUploadsManagerActionClick: Function,
     percent: number,
     view: View,
 };
 
-const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isDragging, isVisible, isExpanded }: Props) => {
+const OverallUploadsProgressBar = ({
+    percent,
+    view,
+    onClick,
+    onKeyDown,
+    onUploadsManagerActionClick,
+    numFailedUploads,
+    isDragging,
+    isResumableUploadsEnabled,
+    isVisible,
+    isExpanded,
+}: Props) => {
     // Show the upload prompt and set progress to 0 when the uploads manager
     // is invisible or is having files dragged to it
     const shouldShowPrompt = isDragging || !isVisible;
@@ -70,6 +85,11 @@ const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isDraggi
         getUploadStatus(view)
     );
     const updatedPercent = shouldShowPrompt ? 0 : getPercent(view, percent);
+
+    let button;
+    if (isResumableUploadsEnabled && numFailedUploads > 0) {
+        button = <UploadsManagerItemAction onClick={onUploadsManagerActionClick} numFailedUploads={numFailedUploads} />;
+    }
 
     return (
         <div
@@ -82,6 +102,7 @@ const OverallUploadsProgressBar = ({ percent, view, onClick, onKeyDown, isDraggi
         >
             <span className="bcu-upload-status">{status}</span>
             <ProgressBar percent={updatedPercent} />
+            {button}
             <span className="bcu-uploads-manager-toggle" />
         </div>
     );

--- a/src/elements/content-uploader/UploadsManager.js
+++ b/src/elements/content-uploader/UploadsManager.js
@@ -51,17 +51,18 @@ const UploadsManager = ({
         }
     };
 
-    const totalSize = items.reduce(
-        (updatedSize, item) => (item.status === STATUS_ERROR || item.isFolder ? updatedSize : updatedSize + item.size),
-        0,
-    );
-    const totalUploaded = items.reduce(
-        (updatedSize, item) =>
-            item.status === STATUS_ERROR || item.isFolder
-                ? updatedSize
-                : updatedSize + (item.size * item.progress) / 100.0,
-        0,
-    );
+    let numFailedUploads = 0;
+    let totalSize = 0;
+    let totalUploaded = 0;
+    items.forEach(item => {
+        if (!(item.status === STATUS_ERROR || item.isFolder)) {
+            totalSize += item.size;
+            totalUploaded += (item.size * item.progress) / 100.0;
+        } else if (item.status === STATUS_ERROR) {
+            numFailedUploads += 1;
+        }
+    });
+
     const percent = (totalUploaded / totalSize) * 100;
 
     return (
@@ -76,12 +77,9 @@ const UploadsManager = ({
             <OverallUploadsProgressBar
                 isDragging={isDragging}
                 isExpanded={isExpanded}
-                isResumableUploadsEnabled={isResumableUploadsEnabled}
+                isResumeVisible={isResumableUploadsEnabled && numFailedUploads > 0}
                 isVisible={isVisible}
-                numFailedUploads={items.reduce(
-                    (updatedCount, item) => (item.status === STATUS_ERROR ? updatedCount + 1 : updatedCount),
-                    0,
-                )}
+                hasMultipleFailedUploads={numFailedUploads > 1}
                 onClick={toggleUploadsManager}
                 onKeyDown={handleProgressBarKeyDown}
                 onUploadsManagerActionClick={onUploadsManagerActionClick}

--- a/src/elements/content-uploader/UploadsManager.js
+++ b/src/elements/content-uploader/UploadsManager.js
@@ -14,9 +14,11 @@ import { STATUS_ERROR } from '../../constants';
 type Props = {
     isDragging: boolean,
     isExpanded: boolean,
+    isResumableUploadsEnabled: boolean,
     isVisible: boolean,
     items: UploadItem[],
     onItemActionClick: Function,
+    onUploadsManagerActionClick: Function,
     toggleUploadsManager: Function,
     view: View,
 };
@@ -25,9 +27,11 @@ const UploadsManager = ({
     items,
     view,
     onItemActionClick,
+    onUploadsManagerActionClick,
     toggleUploadsManager,
     isExpanded,
     isVisible,
+    isResumableUploadsEnabled,
     isDragging,
 }: Props) => {
     /**
@@ -72,9 +76,15 @@ const UploadsManager = ({
             <OverallUploadsProgressBar
                 isDragging={isDragging}
                 isExpanded={isExpanded}
+                isResumableUploadsEnabled={isResumableUploadsEnabled}
                 isVisible={isVisible}
+                numFailedUploads={items.reduce(
+                    (updatedCount, item) => (item.status === STATUS_ERROR ? updatedCount + 1 : updatedCount),
+                    0,
+                )}
                 onClick={toggleUploadsManager}
                 onKeyDown={handleProgressBarKeyDown}
+                onUploadsManagerActionClick={onUploadsManagerActionClick}
                 percent={percent}
                 view={view}
             />

--- a/src/elements/content-uploader/UploadsManagerAction.js
+++ b/src/elements/content-uploader/UploadsManagerAction.js
@@ -1,0 +1,34 @@
+/**
+ * @flow
+ * @file Uploads Manager action component
+ */
+
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import messages from '../common/messages';
+import PrimaryButton from '../../components/primary-button';
+import { STATUS_ERROR } from '../../constants';
+
+type Props = {
+    numFailedUploads: number,
+    onClick: Function,
+};
+
+const UploadsManagerAction = ({ onClick, numFailedUploads }: Props) => {
+    const handleResumeClick = event => {
+        event.stopPropagation();
+        onClick(STATUS_ERROR);
+    };
+
+    const resumeMessage =
+        numFailedUploads > 1 ? <FormattedMessage {...messages.resumeAll} /> : <FormattedMessage {...messages.resume} />;
+
+    return (
+        <PrimaryButton onClick={handleResumeClick} type="button">
+            {resumeMessage}
+        </PrimaryButton>
+    );
+};
+
+export { UploadsManagerAction };
+export default UploadsManagerAction;

--- a/src/elements/content-uploader/UploadsManagerAction.js
+++ b/src/elements/content-uploader/UploadsManagerAction.js
@@ -10,25 +10,23 @@ import PrimaryButton from '../../components/primary-button';
 import { STATUS_ERROR } from '../../constants';
 
 type Props = {
-    numFailedUploads: number,
+    hasMultipleFailedUploads: boolean,
     onClick: Function,
 };
 
-const UploadsManagerAction = ({ onClick, numFailedUploads }: Props) => {
+const UploadsManagerAction = ({ onClick, hasMultipleFailedUploads }: Props) => {
     const handleResumeClick = event => {
         event.stopPropagation();
         onClick(STATUS_ERROR);
     };
 
-    const resumeMessage =
-        numFailedUploads > 1 ? <FormattedMessage {...messages.resumeAll} /> : <FormattedMessage {...messages.resume} />;
+    const resumeMessage = hasMultipleFailedUploads ? messages.resumeAll : messages.resume;
 
     return (
         <PrimaryButton onClick={handleResumeClick} type="button">
-            {resumeMessage}
+            <FormattedMessage {...resumeMessage} />
         </PrimaryButton>
     );
 };
 
-export { UploadsManagerAction };
 export default UploadsManagerAction;

--- a/src/elements/content-uploader/__tests__/ContentUploader-test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader-test.js
@@ -71,6 +71,21 @@ describe('elements/content-uploader/ContentUploader', () => {
         });
     });
 
+    describe('resumeFile()', () => {
+        test('should call resume from api and call updateViewAndCollection', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            const item = { api: {} };
+            item.api.resume = jest.fn();
+            instance.updateViewAndCollection = jest.fn();
+
+            instance.resumeFile(item);
+
+            expect(item.api.resume).toBeCalled();
+            expect(instance.updateViewAndCollection).toBeCalled();
+        });
+    });
+
     describe('getUploadAPI()', () => {
         let wrapper;
         let instance;

--- a/src/elements/content-uploader/__tests__/ContentUploader-test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader-test.js
@@ -83,7 +83,7 @@ describe('elements/content-uploader/ContentUploader', () => {
 
         beforeEach(() => {
             jest.spyOn(global.console, 'warn').mockImplementation();
-            wrapper = getWrapper();
+            wrapper = getWrapper({ isResumableUploadsEnabled: false });
             instance = wrapper.instance();
             getPlainUploadAPI = jest.fn();
             getChunkedUploadAPI = jest.fn();


### PR DESCRIPTION
Adding functionality to resume uploads for files of size >100 MB that have failed from where in the upload the file failed, rather than restarting the upload from the beginning. Additionally adding a button on the Uploads Manager header which will resume any items in the Uploads Manager that have failed.