### PR TITLE
feat(leftsidebar): Show drop zones only on hover

### DIFF
--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -51,6 +51,8 @@ type SubMenuItem = {
     scaleIcon?: boolean,
     /** Whether the current page is associated with the current link */
     selected?: boolean,
+    /** Whether to show drop zone only when hovered over */
+    showDropZoneOnHover?: boolean,
     /** Whether the tooltip should be shown */
     showTooltip?: boolean,
 };
@@ -95,6 +97,8 @@ type MenuItem = {
     selected?: boolean,
     /** Whether child icons of this menu item should be shown */
     showChildIcons?: boolean,
+    /** Whether to show drop zone only when hovered over */
+    showDropZoneOnHover?: boolean,
     /** Whether to show a loading indicator on the list */
     showLoadingIndicator?: boolean,
     /** Whether the tooltip should be shown */
@@ -220,6 +224,7 @@ class LeftSidebar extends React.Component<Props, State> {
             id,
             menuItems,
             placeholder,
+            showDropZoneOnHover,
         } = headerLinkProps;
 
         const heading = onToggleCollapse ? (
@@ -263,7 +268,11 @@ class LeftSidebar extends React.Component<Props, State> {
         );
 
         return canReceiveDrop ? (
-            <LeftSidebarDropWrapper isDragging={leftSidebarProps.isDragging} dropTargetRef={dropTargetRef}>
+            <LeftSidebarDropWrapper
+                isDragging={leftSidebarProps.isDragging}
+                dropTargetRef={dropTargetRef}
+                showDropZoneOnHover={showDropZoneOnHover}
+            >
                 {builtNavList}
             </LeftSidebarDropWrapper>
         ) : (
@@ -290,6 +299,7 @@ class LeftSidebar extends React.Component<Props, State> {
             scaleIcon,
             selected = false,
             showTooltip,
+            showDropZoneOnHover,
         } = props;
 
         const linkClassNames = classNames('left-sidebar-link', className, {
@@ -323,6 +333,7 @@ class LeftSidebar extends React.Component<Props, State> {
                 isDragging={leftSidebarProps.isDragging}
                 dropTargetRef={dropTargetRef}
                 key={`link-${id}`}
+                showDropZoneOnHover={showDropZoneOnHover}
             >
                 {builtLink}
             </LeftSidebarDropWrapper>

--- a/src/features/left-sidebar/LeftSidebarDropWrapper.js
+++ b/src/features/left-sidebar/LeftSidebarDropWrapper.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import classNames from 'classnames';
 
 import './styles/LeftSidebarDropWrapper.scss';
 
@@ -9,24 +10,63 @@ type Props = {
     dropTargetRef?: { current: null | HTMLDivElement },
     isDragging?: boolean,
     message?: string,
+    showDropZoneOnHover?: boolean,
 };
 
-const LeftSidebarDropWrapper = ({
-    children,
-    className = '',
-    isDragging = false,
-    message = '',
-    dropTargetRef,
-    ...rest
-}: Props) => (
-    <div ref={dropTargetRef} className={`left-sidebar-drop-wrapper ${className}`} {...rest}>
-        {isDragging ? (
-            <div className="left-sidebar-drop-veil">
-                <span className="left-sidebar-drop-wrapper-text">{message}</span>
+type State = {
+    dropZoneHover: boolean,
+};
+
+class LeftSidebarDropWrapper extends React.Component<Props, State> {
+    state = {
+        dropZoneHover: false,
+    };
+
+    componentDidUpdate(prevProps: Props) {
+        const { showDropZoneOnHover, isDragging } = this.props;
+
+        // Reset drop zone hover state if dragging has stopped without firing a mouseleave event.
+        if (showDropZoneOnHover && !isDragging && prevProps.isDragging) {
+            this.setState({ dropZoneHover: false });
+        }
+    }
+
+    handleDropZoneHover = () => this.setState({ dropZoneHover: true });
+
+    handleDropZoneHoverLeave = () => this.setState({ dropZoneHover: false });
+
+    render() {
+        const {
+            children,
+            className = '',
+            isDragging = false,
+            showDropZoneOnHover = false,
+            message = '',
+            dropTargetRef,
+            ...rest
+        } = this.props;
+        const { dropZoneHover } = this.state;
+        const shouldShowVeil = isDragging && (showDropZoneOnHover ? dropZoneHover : true);
+        const hoverEventHandlers =
+            isDragging && showDropZoneOnHover
+                ? {
+                      onMouseEnter: this.handleDropZoneHover,
+                      onMouseLeave: this.handleDropZoneHoverLeave,
+                  }
+                : {};
+        const classes = classNames('left-sidebar-drop-wrapper', className);
+
+        return (
+            <div ref={dropTargetRef} className={classes} {...hoverEventHandlers} {...rest}>
+                {shouldShowVeil ? (
+                    <div className="left-sidebar-drop-veil">
+                        <span className="left-sidebar-drop-wrapper-text">{message}</span>
+                    </div>
+                ) : null}
+                {children}
             </div>
-        ) : null}
-        {children}
-    </div>
-);
+        );
+    }
+}
 
 export default LeftSidebarDropWrapper;

--- a/src/features/left-sidebar/__tests__/LeftSidebarDropWrapper-test.js
+++ b/src/features/left-sidebar/__tests__/LeftSidebarDropWrapper-test.js
@@ -1,0 +1,80 @@
+// @flow
+import React from 'react';
+
+import LeftSidebarDropWrapper from '../LeftSidebarDropWrapper';
+
+describe('feature/left-sidebar/LeftSidebarDropWrapper', () => {
+    const getWrapper = (props = {}) =>
+        shallow(
+            <LeftSidebarDropWrapper {...props}>
+                <div />
+            </LeftSidebarDropWrapper>,
+        );
+
+    describe('render', () => {
+        test('should render a LeftSidebarDropWrapper component', () => {
+            const wrapper = getWrapper();
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should not render drop zone if it is not hovered and showDropZoneOnHover is true ', () => {
+            const wrapper = getWrapper({
+                showDropZoneOnHover: true,
+                isDragging: true,
+            });
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should render drop zone if it is hovered and showDropZoneOnHover is true ', () => {
+            const wrapper = getWrapper({
+                showDropZoneOnHover: true,
+                isDragging: true,
+            });
+            wrapper.setState({ dropZoneHover: true });
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should set dropZoneHover on mouse enter', () => {
+            const wrapper = getWrapper({
+                showDropZoneOnHover: true,
+                isDragging: true,
+            });
+            const previousDropZoneHover = wrapper.state().dropZoneHover;
+            const dropZone = wrapper.find('.left-sidebar-drop-wrapper');
+
+            dropZone.simulate('mouseEnter');
+
+            expect(previousDropZoneHover).toBe(false);
+            expect(wrapper.state().dropZoneHover).toBe(true);
+        });
+
+        test('should set dropZoneHover to false on mouse leave', () => {
+            const wrapper = getWrapper({
+                showDropZoneOnHover: true,
+                isDragging: true,
+            });
+            const dropZone = wrapper.find('.left-sidebar-drop-wrapper');
+
+            wrapper.setState({ dropZoneHover: true });
+            dropZone.simulate('mouseLeave');
+
+            expect(wrapper.state().dropZoneHover).toBe(false);
+        });
+    });
+
+    describe('componentDidUpdate', () => {
+        test('should set dropZoneHover state to false when dragging stops without mouseleave', () => {
+            const wrapper = getWrapper({
+                showDropZoneOnHover: true,
+                isDragging: true,
+            });
+            wrapper.setState({ dropZoneHover: true });
+            wrapper.setProps({ isDragging: false });
+
+            expect(wrapper.state().dropZoneHover).toBe(false);
+        });
+    });
+});

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarDropWrapper-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarDropWrapper-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`feature/left-sidebar/LeftSidebarDropWrapper render should not render drop zone if it is not hovered and showDropZoneOnHover is true  1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
@@ -12,7 +12,7 @@ exports[`feature/left-sidebar/LeftSidebarDropWrapper render should not render dr
 
 exports[`feature/left-sidebar/LeftSidebarDropWrapper render should render a LeftSidebarDropWrapper component 1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
 >
   <div />
 </div>
@@ -20,7 +20,7 @@ exports[`feature/left-sidebar/LeftSidebarDropWrapper render should render a Left
 
 exports[`feature/left-sidebar/LeftSidebarDropWrapper render should render drop zone if it is hovered and showDropZoneOnHover is true  1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarDropWrapper-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebarDropWrapper-test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`feature/left-sidebar/LeftSidebarDropWrapper render should not render drop zone if it is not hovered and showDropZoneOnHover is true  1`] = `
+<div
+  className="left-sidebar-drop-wrapper "
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div />
+</div>
+`;
+
+exports[`feature/left-sidebar/LeftSidebarDropWrapper render should render a LeftSidebarDropWrapper component 1`] = `
+<div
+  className="left-sidebar-drop-wrapper "
+>
+  <div />
+</div>
+`;
+
+exports[`feature/left-sidebar/LeftSidebarDropWrapper render should render drop zone if it is hovered and showDropZoneOnHover is true  1`] = `
+<div
+  className="left-sidebar-drop-wrapper "
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
+    className="left-sidebar-drop-veil"
+  >
+    <span
+      className="left-sidebar-drop-wrapper-text"
+    />
+  </div>
+  <div />
+</div>
+`;

--- a/src/features/left-sidebar/__tests__/__snapshots__/LoadingIndicatorWrapper-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LoadingIndicatorWrapper-test.js.snap
@@ -19,7 +19,7 @@ exports[`features/left-sidebar/LeftSidebarDropWrapper should allow custom classn
 
 exports[`features/left-sidebar/LeftSidebarDropWrapper should not render drag target or drag text when specificed 1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
 >
   <div
     className="left-sidebar-drop-veil"
@@ -38,7 +38,7 @@ exports[`features/left-sidebar/LeftSidebarDropWrapper should not render drag tar
 
 exports[`features/left-sidebar/LeftSidebarDropWrapper should not render drag target when specificed 1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
 >
   <div
     className="left-sidebar-drop-veil"
@@ -73,7 +73,7 @@ exports[`features/left-sidebar/LeftSidebarDropWrapper should pass thru any rest 
 
 exports[`features/left-sidebar/LeftSidebarDropWrapper should render drag target and message when specificed 1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
 >
   <div
     className="left-sidebar-drop-veil"
@@ -92,7 +92,7 @@ exports[`features/left-sidebar/LeftSidebarDropWrapper should render drag target 
 
 exports[`features/left-sidebar/LeftSidebarDropWrapper should render dragging veil properly when specificed 1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
 >
   <div
     className="left-sidebar-drop-veil"
@@ -109,7 +109,7 @@ exports[`features/left-sidebar/LeftSidebarDropWrapper should render dragging vei
 
 exports[`features/left-sidebar/LeftSidebarDropWrapper should render with default properties intact 1`] = `
 <div
-  className="left-sidebar-drop-wrapper "
+  className="left-sidebar-drop-wrapper"
 >
   <div
     className="left-sidebar-drop-veil"


### PR DESCRIPTION
This PR allows you to set `showDropZoneOnHover` for menu items in left sidebar. 

`showDropZoneOnHover`  when true it will only show drop veil on hover. 
`showDropZoneOnHover`  when false it will show drop veil for the duration of items being dragged.

Updated: GIF to show behavior on favorites 

![favoritesDragDrop2](https://user-images.githubusercontent.com/1920133/62913052-7b41a600-bd3f-11e9-991f-4d4cd769ec97.gif)
