### PR TITLE
feat(left-sidebar): LeftSidebar supports custom navLinkRenderer

### DIFF
--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -16,6 +16,7 @@ import LeftSidebarIconWrapper from './LeftSidebarIconWrapper';
 import NewItemsIndicator from './NewItemsIndicator';
 import defaultNavLinkRenderer from './defaultNavLinkRenderer';
 
+import type { Props as LeftSidebarLinkProps } from './LeftSidebarLink';
 import type { Callout } from './Callout';
 
 import './styles/LeftSidebar.scss';
@@ -40,7 +41,7 @@ type SubMenuItem = {
     /** Localized text string to use for individual menu items */
     message: string,
     /** Optional left side bar link renderer. Defaults to defaultNavLinkRenderer */
-    navLinkRenderer?: Function,
+    navLinkRenderer?: (props: LeftSidebarLinkProps) => React.Node,
     /** Whether we should show a badge marking new item content */
     newItemBadge?: boolean,
     /** Optional remove link click handler */
@@ -81,7 +82,7 @@ type MenuItem = {
     /** Localized text string to use for individual menu items */
     message: string,
     /** Optional left side bar link renderer. Defaults to defaultNavLinkRenderer */
-    navLinkRenderer?: Function,
+    navLinkRenderer?: (props: LeftSidebarLinkProps) => React.Node,
     /** Whether we should show a badge marking new item content */
     newItemBadge?: boolean,
     /** Optional remove link click handler */

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -39,6 +39,7 @@ type SubMenuItem = {
     id: string,
     /** Localized text string to use for individual menu items */
     message: string,
+    /** Optional left side bar link renderer. Defaults to defaultNavLinkRenderer */
     navLinkRenderer?: Function,
     /** Whether we should show a badge marking new item content */
     newItemBadge?: boolean,
@@ -79,6 +80,8 @@ type MenuItem = {
     menuItems?: Array<SubMenuItem>,
     /** Localized text string to use for individual menu items */
     message: string,
+    /** Optional left side bar link renderer. Defaults to defaultNavLinkRenderer */
+    navLinkRenderer?: Function,
     /** Whether we should show a badge marking new item content */
     newItemBadge?: boolean,
     /** Optional remove link click handler */

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -13,8 +13,8 @@ import CopyrightFooter from './CopyrightFooter';
 import InstantLogin from './InstantLogin';
 import LeftSidebarDropWrapper from './LeftSidebarDropWrapper';
 import LeftSidebarIconWrapper from './LeftSidebarIconWrapper';
-import LeftSidebarLink from './LeftSidebarLink';
 import NewItemsIndicator from './NewItemsIndicator';
+import defaultNavLinkRenderer from './defaultNavLinkRenderer';
 
 import type { Callout } from './Callout';
 
@@ -39,6 +39,7 @@ type SubMenuItem = {
     id: string,
     /** Localized text string to use for individual menu items */
     message: string,
+    navLinkRenderer?: Function,
     /** Whether we should show a badge marking new item content */
     newItemBadge?: boolean,
     /** Optional remove link click handler */
@@ -282,6 +283,7 @@ class LeftSidebar extends React.Component<Props, State> {
             iconElement,
             id,
             message,
+            navLinkRenderer,
             newItemBadge,
             onClickRemove,
             removeButtonHtmlAttributes,
@@ -296,26 +298,24 @@ class LeftSidebar extends React.Component<Props, State> {
             'is-selected': selected,
         });
 
-        const builtLink = (
-            <LeftSidebarLink
-                callout={callout}
-                canReceiveDrop={canReceiveDrop}
-                className={linkClassNames}
-                customTheme={leftSidebarProps.customTheme}
-                onClickRemove={onClickRemove}
-                htmlAttributes={htmlAttributes}
-                icon={this.getIcon(iconElement, iconComponent, leftSidebarProps.customTheme, selected, scaleIcon)}
-                isScrolling={this.state.isScrolling}
-                key={`link-${id}`}
-                message={message}
-                newItemBadge={this.getNewItemBadge(newItemBadge, leftSidebarProps.customTheme)}
-                removeButtonHtmlAttributes={removeButtonHtmlAttributes}
-                routerLink={routerLink}
-                routerProps={routerProps}
-                selected={selected}
-                showTooltip={showTooltip}
-            />
-        );
+        const linkProps = {
+            callout,
+            className: linkClassNames,
+            customTheme: leftSidebarProps.customTheme,
+            onClickRemove,
+            htmlAttributes,
+            icon: this.getIcon(iconElement, iconComponent, leftSidebarProps.customTheme, selected, scaleIcon),
+            isScrolling: this.state.isScrolling,
+            message,
+            newItemBadge: this.getNewItemBadge(newItemBadge, leftSidebarProps.customTheme),
+            removeButtonHtmlAttributes,
+            routerLink,
+            routerProps,
+            selected,
+            showTooltip,
+        };
+
+        const builtLink = navLinkRenderer ? navLinkRenderer(linkProps) : defaultNavLinkRenderer(linkProps);
 
         // Check for menu items on links so we don't double-highlight groups
         return canReceiveDrop && !props.menuItems ? (
@@ -327,7 +327,7 @@ class LeftSidebar extends React.Component<Props, State> {
                 {builtLink}
             </LeftSidebarDropWrapper>
         ) : (
-            builtLink
+            <React.Fragment key={`link-${id}`}>{builtLink}</React.Fragment>
         );
     }
 

--- a/src/features/left-sidebar/LeftSidebarLink.js
+++ b/src/features/left-sidebar/LeftSidebarLink.js
@@ -11,7 +11,7 @@ import type { Callout } from './Callout';
 
 import './styles/LeftSidebarLink.scss';
 
-type Props = {
+export type Props = {
     callout?: Callout,
     className?: string,
     customTheme?: Object,

--- a/src/features/left-sidebar/__tests__/LeftSidebar-test.js
+++ b/src/features/left-sidebar/__tests__/LeftSidebar-test.js
@@ -285,6 +285,26 @@ describe('feature/left-sidebar/LeftSidebar', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should use custom render for menu item if provided', () => {
+        const oneMenuItem = [
+            {
+                navLinkRenderer: () => <h1>Custom Link</h1>,
+                id: 'all-files',
+                message: 'All Files',
+                htmlAttributes: {
+                    href: '/folder/0',
+                },
+                routerLink: undefined,
+                routerProps: undefined,
+                showTooltip: true,
+            },
+        ];
+
+        const wrapper = shallow(<LeftSidebar menuItems={oneMenuItem} />);
+
+        expect(wrapper.exists('h1')).toBeTruthy();
+    });
+
     describe('checkAndChangeScrollShadows()', () => {
         [
             // isn't scrollable

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar-test.js.snap
@@ -10,28 +10,28 @@ exports[`feature/left-sidebar/LeftSidebar should not render nested menu items wi
     <NavList
       className="left-sidebar-list"
       heading={
-        <LeftSidebarLink
-          canReceiveDrop={false}
-          className="left-sidebar-link"
-          htmlAttributes={
-            Object {
-              "href": "/folder/0",
+        <React.Fragment>
+          <LeftSidebarLink
+            className="left-sidebar-link"
+            htmlAttributes={
+              Object {
+                "href": "/folder/0",
+              }
             }
-          }
-          icon={null}
-          isScrolling={false}
-          message="All Files"
-          newItemBadge={null}
-          selected={false}
-          showTooltip={true}
-        />
+            icon={null}
+            isScrolling={false}
+            message="All Files"
+            newItemBadge={null}
+            selected={false}
+            showTooltip={true}
+          />
+        </React.Fragment>
       }
       key="list-all-files"
       placeholder={null}
       ulProps={Object {}}
     >
       <LeftSidebarLink
-        canReceiveDrop={false}
         className="left-sidebar-link"
         htmlAttributes={
           Object {
@@ -40,7 +40,6 @@ exports[`feature/left-sidebar/LeftSidebar should not render nested menu items wi
         }
         icon={null}
         isScrolling={false}
-        key="link-recents"
         message="Recents"
         newItemBadge={null}
         selected={false}
@@ -60,7 +59,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass badge elements appropriate
     className="left-sidebar-container"
   >
     <LeftSidebarLink
-      canReceiveDrop={false}
       className="left-sidebar-link"
       htmlAttributes={
         Object {
@@ -69,7 +67,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass badge elements appropriate
       }
       icon={null}
       isScrolling={false}
-      key="link-all-files"
       message="All Files"
       newItemBadge={<NewItemsIndicator />}
       selected={false}
@@ -88,7 +85,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass icon components appropriat
     className="left-sidebar-container"
   >
     <LeftSidebarLink
-      canReceiveDrop={false}
       className="left-sidebar-link"
       htmlAttributes={
         Object {
@@ -106,7 +102,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass icon components appropriat
         </LeftSidebarIconWrapper>
       }
       isScrolling={false}
-      key="link-all-files"
       message="All Files"
       newItemBadge={<NewItemsIndicator />}
       selected={false}
@@ -125,7 +120,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass icon elements appropriatel
     className="left-sidebar-container"
   >
     <LeftSidebarLink
-      canReceiveDrop={false}
       className="left-sidebar-link"
       htmlAttributes={
         Object {
@@ -142,7 +136,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass icon elements appropriatel
         </LeftSidebarIconWrapper>
       }
       isScrolling={false}
-      key="link-all-files"
       message="All Files"
       newItemBadge={<NewItemsIndicator />}
       selected={false}
@@ -162,7 +155,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass in custom sidebar properti
     className="left-sidebar-container"
   >
     <LeftSidebarLink
-      canReceiveDrop={false}
       className="left-sidebar-link is-selected"
       customTheme={
         Object {
@@ -182,7 +174,6 @@ exports[`feature/left-sidebar/LeftSidebar should pass in custom sidebar properti
       }
       icon={null}
       isScrolling={false}
-      key="link-all-files"
       message="All Files"
       newItemBadge={null}
       selected={true}
@@ -233,21 +224,22 @@ exports[`feature/left-sidebar/LeftSidebar should render collapsible nested menu 
           <NavListCollapseHeader
             onToggleCollapse={[Function]}
           >
-            <LeftSidebarLink
-              canReceiveDrop={false}
-              className="left-sidebar-link"
-              htmlAttributes={
-                Object {
-                  "href": "/folder/0",
+            <React.Fragment>
+              <LeftSidebarLink
+                className="left-sidebar-link"
+                htmlAttributes={
+                  Object {
+                    "href": "/folder/0",
+                  }
                 }
-              }
-              icon={null}
-              isScrolling={false}
-              message="All Files"
-              newItemBadge={null}
-              selected={false}
-              showTooltip={true}
-            />
+                icon={null}
+                isScrolling={false}
+                message="All Files"
+                newItemBadge={null}
+                selected={false}
+                showTooltip={true}
+              />
+            </React.Fragment>
           </NavListCollapseHeader>
         }
         key="list-all-files"
@@ -260,7 +252,6 @@ exports[`feature/left-sidebar/LeftSidebar should render collapsible nested menu 
         }
       >
         <LeftSidebarLink
-          canReceiveDrop={false}
           className="left-sidebar-link"
           htmlAttributes={
             Object {
@@ -269,7 +260,6 @@ exports[`feature/left-sidebar/LeftSidebar should render collapsible nested menu 
           }
           icon={null}
           isScrolling={false}
-          key="link-recents"
           message="Recents"
           newItemBadge={null}
           selected={false}
@@ -299,7 +289,6 @@ exports[`feature/left-sidebar/LeftSidebar should render instant login component 
     className="left-sidebar-container"
   >
     <LeftSidebarLink
-      canReceiveDrop={false}
       className="left-sidebar-link"
       htmlAttributes={
         Object {
@@ -308,7 +297,6 @@ exports[`feature/left-sidebar/LeftSidebar should render instant login component 
       }
       icon={null}
       isScrolling={false}
-      key="link-all-files"
       message="All Files"
       newItemBadge={null}
       selected={false}
@@ -329,28 +317,28 @@ exports[`feature/left-sidebar/LeftSidebar should render non-collapsible nested m
     <NavList
       className="left-sidebar-list"
       heading={
-        <LeftSidebarLink
-          canReceiveDrop={false}
-          className="left-sidebar-link"
-          htmlAttributes={
-            Object {
-              "href": "/folder/0",
+        <React.Fragment>
+          <LeftSidebarLink
+            className="left-sidebar-link"
+            htmlAttributes={
+              Object {
+                "href": "/folder/0",
+              }
             }
-          }
-          icon={null}
-          isScrolling={false}
-          message="All Files"
-          newItemBadge={null}
-          selected={false}
-          showTooltip={true}
-        />
+            icon={null}
+            isScrolling={false}
+            message="All Files"
+            newItemBadge={null}
+            selected={false}
+            showTooltip={true}
+          />
+        </React.Fragment>
       }
       key="list-all-files"
       placeholder={null}
       ulProps={Object {}}
     >
       <LeftSidebarLink
-        canReceiveDrop={false}
         className="left-sidebar-link"
         htmlAttributes={
           Object {
@@ -359,7 +347,6 @@ exports[`feature/left-sidebar/LeftSidebar should render non-collapsible nested m
         }
         icon={null}
         isScrolling={false}
-        key="link-recents"
         message="Recents"
         newItemBadge={null}
         selected={false}
@@ -379,7 +366,6 @@ exports[`feature/left-sidebar/LeftSidebar should render one menu item with appro
     className="left-sidebar-container"
   >
     <LeftSidebarLink
-      canReceiveDrop={false}
       className="left-sidebar-link"
       htmlAttributes={
         Object {
@@ -388,7 +374,6 @@ exports[`feature/left-sidebar/LeftSidebar should render one menu item with appro
       }
       icon={null}
       isScrolling={false}
-      key="link-all-files"
       message="All Files"
       newItemBadge={null}
       selected={false}
@@ -417,21 +402,22 @@ exports[`feature/left-sidebar/LeftSidebar should render placeholder inside neste
           <NavListCollapseHeader
             onToggleCollapse={[Function]}
           >
-            <LeftSidebarLink
-              canReceiveDrop={false}
-              className="left-sidebar-link"
-              htmlAttributes={
-                Object {
-                  "href": "/folder/0",
+            <React.Fragment>
+              <LeftSidebarLink
+                className="left-sidebar-link"
+                htmlAttributes={
+                  Object {
+                    "href": "/folder/0",
+                  }
                 }
-              }
-              icon={null}
-              isScrolling={false}
-              message="All Files"
-              newItemBadge={null}
-              selected={false}
-              showTooltip={true}
-            />
+                icon={null}
+                isScrolling={false}
+                message="All Files"
+                newItemBadge={null}
+                selected={false}
+                showTooltip={true}
+              />
+            </React.Fragment>
           </NavListCollapseHeader>
         }
         key="list-all-files"

--- a/src/features/left-sidebar/__tests__/__snapshots__/defaultNavLinkRenderer-test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/defaultNavLinkRenderer-test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`feature/left-sidebar/defaultNavLinkRenderer should render default NavLink comoponent 1`] = `
+<Tooltip
+  className="nav-link-tooltip"
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isDisabled={false}
+  isTabbable={false}
+  position="middle-right"
+  theme="default"
+>
+  <LinkBase
+    className=""
+    style={Object {}}
+  >
+    <span
+      className="left-sidebar-link-text"
+    />
+  </LinkBase>
+</Tooltip>
+`;

--- a/src/features/left-sidebar/__tests__/defaultNavLinkRenderer-test.js
+++ b/src/features/left-sidebar/__tests__/defaultNavLinkRenderer-test.js
@@ -1,0 +1,12 @@
+// @flow
+import defaultNavLinkRenderer from '../defaultNavLinkRenderer';
+
+describe('feature/left-sidebar/defaultNavLinkRenderer', () => {
+    const getWrapper = (props = {}) => shallow(defaultNavLinkRenderer(props));
+
+    test('should render default NavLink comoponent', () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/src/features/left-sidebar/defaultNavLinkRenderer.js
+++ b/src/features/left-sidebar/defaultNavLinkRenderer.js
@@ -2,61 +2,10 @@
 import * as React from 'react';
 import LeftSidebarLink from './LeftSidebarLink';
 
-import type { Callout } from './Callout';
-
-type Props = {
-    callout?: Callout,
-    className?: string,
-    customTheme?: Object,
-    htmlAttributes?: Object,
-    icon?: ?React.Element<any>,
-    isScrolling?: boolean,
-    message: string,
-    newItemBadge?: React.Element<any> | null,
-    onClickRemove?: Function,
-    removeButtonHtmlAttributes?: Object,
-    routerLink?: React.ComponentType<any>,
-    routerProps?: Object,
-    selected?: boolean,
-    showTooltip?: boolean,
-};
+import type { Props } from './LeftSidebarLink';
 
 function defaultNavLinkRenderer(props: Props): React.Node {
-    const {
-        callout,
-        className,
-        customTheme,
-        htmlAttributes,
-        icon,
-        isScrolling,
-        message,
-        newItemBadge,
-        onClickRemove,
-        removeButtonHtmlAttributes,
-        routerLink,
-        routerProps,
-        selected,
-        showTooltip,
-    } = props;
-
-    return (
-        <LeftSidebarLink
-            callout={callout}
-            className={className}
-            customTheme={customTheme}
-            onClickRemove={onClickRemove}
-            htmlAttributes={htmlAttributes}
-            icon={icon}
-            isScrolling={isScrolling}
-            message={message}
-            newItemBadge={newItemBadge}
-            removeButtonHtmlAttributes={removeButtonHtmlAttributes}
-            routerLink={routerLink}
-            routerProps={routerProps}
-            selected={selected}
-            showTooltip={showTooltip}
-        />
-    );
+    return <LeftSidebarLink {...props} />;
 }
 
 export default defaultNavLinkRenderer;

--- a/src/features/left-sidebar/defaultNavLinkRenderer.js
+++ b/src/features/left-sidebar/defaultNavLinkRenderer.js
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import LeftSidebarLink from './LeftSidebarLink';
 
+import type { Callout } from './Callout';
+
 type Props = {
     callout?: Callout,
     className?: string,

--- a/src/features/left-sidebar/defaultNavLinkRenderer.js
+++ b/src/features/left-sidebar/defaultNavLinkRenderer.js
@@ -1,0 +1,60 @@
+// @flow
+import * as React from 'react';
+import LeftSidebarLink from './LeftSidebarLink';
+
+type Props = {
+    callout?: Callout,
+    className?: string,
+    customTheme?: Object,
+    htmlAttributes?: Object,
+    icon?: ?React.Element<any>,
+    isScrolling?: boolean,
+    message: string,
+    newItemBadge?: React.Element<any> | null,
+    onClickRemove?: Function,
+    removeButtonHtmlAttributes?: Object,
+    routerLink?: React.ComponentType<any>,
+    routerProps?: Object,
+    selected?: boolean,
+    showTooltip?: boolean,
+};
+
+function defaultNavLinkRenderer(props: Props): React.Node {
+    const {
+        callout,
+        className,
+        customTheme,
+        htmlAttributes,
+        icon,
+        isScrolling,
+        message,
+        newItemBadge,
+        onClickRemove,
+        removeButtonHtmlAttributes,
+        routerLink,
+        routerProps,
+        selected,
+        showTooltip,
+    } = props;
+
+    return (
+        <LeftSidebarLink
+            callout={callout}
+            className={className}
+            customTheme={customTheme}
+            onClickRemove={onClickRemove}
+            htmlAttributes={htmlAttributes}
+            icon={icon}
+            isScrolling={isScrolling}
+            message={message}
+            newItemBadge={newItemBadge}
+            removeButtonHtmlAttributes={removeButtonHtmlAttributes}
+            routerLink={routerLink}
+            routerProps={routerProps}
+            selected={selected}
+            showTooltip={showTooltip}
+        />
+    );
+}
+
+export default defaultNavLinkRenderer;

--- a/src/features/left-sidebar/index.js
+++ b/src/features/left-sidebar/index.js
@@ -1,1 +1,2 @@
+export { default as defaultNavLinkRenderer } from './defaultNavLinkRenderer';
 export { default } from './LeftSidebar';


### PR DESCRIPTION
Follow up to #1495 

This prop allows for changing Left Nav menu items with UI treatment or wrapping the `defaultNavLinkRenderer` with another component or both!