### PR TITLE
fix(task-form): disallow text input in date picker

### DIFF
--- a/src/components/date-picker/DatePicker.js
+++ b/src/components/date-picker/DatePicker.js
@@ -125,7 +125,7 @@ type Props = {
     isDisabled?: boolean,
     /** Is input required */
     isRequired?: boolean,
-    /** Is user allowed to manually input a value */
+    /** Is user allowed to manually input a value (WARNING: this doesn't work with internationalization) */
     isTextInputAllowed?: boolean,
     /** Label displayed for the text input */
     label: React.Node,

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -417,7 +417,6 @@ class TaskForm extends React.Component<Props, State> {
                             }}
                             isDisabled={isLoading}
                             isRequired={false}
-                            isTextInputAllowed
                             label={<FormattedMessage {...messages.tasksAddTaskFormDueDateLabel} />}
                             minDate={new Date()}
                             name="taskDueDate"


### PR DESCRIPTION
In some languages, the day and month are reversed, and so when this is converted to a `new Date()` it gets the incorrect date. Example in German: September 7, 2019 would do `new Date('7.9.2019')` which would create a JS object for July 9, 2019.

In the long term, we'd like to revisit and update the datepicker input field so that the input isn't so freeform, but rather divided into 3 separate fields so that we can distinguish which part is the month, day, and year. This would have the benefit of giving the user an indication of the expected format and prevent them from inputing invalid data.

An example from a credit card form:
<img width="623" alt="Screen Shot 2019-08-14 at 4 26 55 PM" src="https://user-images.githubusercontent.com/1280912/63063169-66d0eb00-beb0-11e9-8549-d747702c4487.png">

For now, though, this PR simply stops allowing freeform input for the task form to sidestep the issue.

Ticket to track this: https://github.com/box/box-ui-elements/issues/1542