### PR TITLE
feat(modal): prop to override X dismiss icon with text

### DIFF
--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -15,6 +15,8 @@ type Props = {
     children: React.Node,
     /** Additional CSS classname of the `.modal` element */
     className?: string,
+    /** If provided, will render a button with this text instead of the 'X' to dismiss the modal (onRequestClose must also be provided) */
+    closeButtonText?: string,
     focusElementSelector?: string,
     isLoading?: boolean,
     isOpen?: boolean,
@@ -130,7 +132,16 @@ class Modal extends React.Component<Props> {
     };
 
     render() {
-        const { className, isLoading, isOpen, onRequestClose, shouldNotUsePortal, style, ...rest } = this.props;
+        const {
+            className,
+            closeButtonText,
+            isLoading,
+            isOpen,
+            onRequestClose,
+            shouldNotUsePortal,
+            style,
+            ...rest
+        } = this.props;
 
         if (!isOpen) {
             return null;
@@ -156,6 +167,7 @@ class Modal extends React.Component<Props> {
                         <LoadingIndicator size="large" />
                     ) : (
                         <ModalDialog
+                            closeButtonText={closeButtonText}
                             modalRef={modalEl => {
                                 // This callback gets passed through as a regular prop since
                                 // ModalDialog is wrapped in a HOC

--- a/src/components/modal/Modal.md
+++ b/src/components/modal/Modal.md
@@ -46,6 +46,38 @@ closeModal = () => setState({ isModalOpen: false });
 </div>
 ```
 
+**Basic With Close Button Text**
+
+```
+const SimpleModal = ({ isOpen, onRequestClose }) => (
+    <Modal
+        closeButtonText="Close Me Here!"
+        title="Box: Sharing is simple"
+        onRequestClose={ onRequestClose }
+        isOpen={ isOpen }
+    >
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum congue, lacus ut scelerisque porttitor, libero diam luctus ante, non porta lectus dolor eu lectus. Suspendisse sagittis ut orci eget placerat.
+        </p>
+    </Modal>
+);
+openModal = () =>
+    setState({
+        isModalOpen: true,
+    });
+closeModal = () => setState({ isModalOpen: false });
+
+<div>
+    <SimpleModal
+        onRequestClose={ closeModal }
+        isOpen={ state.isModalOpen }
+    />
+    <PrimaryButton onClick={ openModal }>
+        Launch standard modal with close button text
+    </PrimaryButton>
+</div>
+```
+
 **Include a custom backdrop click handler, which overrides the default behavior**
 
 ```

--- a/src/components/modal/Modal.scss
+++ b/src/components/modal/Modal.scss
@@ -93,6 +93,12 @@
     top: 20px;
 }
 
+.bdl-ModalCloseButton--with-custom-text {
+    position: absolute;
+    right: 20px;
+    top: 20px;
+}
+
 .modal-backdrop {
     background: fade-out($black, .25);
     bottom: 0;

--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -5,6 +5,7 @@ import omit from 'lodash/omit';
 import uniqueId from 'lodash/uniqueId';
 import { defineMessages, injectIntl } from 'react-intl';
 
+import Button from '../button';
 import IconClose from '../../icons/general/IconClose';
 
 const ALERT_TYPE = 'alert';
@@ -22,6 +23,7 @@ type Props = {
     children: React.Node,
     className?: string,
     closeButtonProps: Object,
+    closeButtonText?: string,
     intl: Object,
     modalRef?: Function,
     onRequestClose?: Function,
@@ -58,20 +60,25 @@ class ModalDialog extends React.Component<Props> {
      * @return {ReactElement|null} - Returns the button, or null if the button shouldn't be rendered
      */
     renderCloseButton() {
-        const { closeButtonProps, onRequestClose, intl } = this.props;
+        const { closeButtonProps, closeButtonText, onRequestClose, intl } = this.props;
         const { formatMessage } = intl;
         if (!onRequestClose) {
             return null;
         }
 
-        return (
+        const sharedProps = {
+            ...closeButtonProps,
+            'aria-label': formatMessage(messages.closeModalText),
+            onClick: this.onCloseButtonClick,
+        };
+
+        return closeButtonText ? (
+            <Button className="bdl-ModalCloseButton--with-custom-text" {...sharedProps}>
+                {closeButtonText}
+            </Button>
+        ) : (
             // eslint-disable-next-line react/button-has-type
-            <button
-                {...closeButtonProps}
-                aria-label={formatMessage(messages.closeModalText)}
-                className="modal-close-button"
-                onClick={this.onCloseButtonClick}
-            >
+            <button className="modal-close-button" {...sharedProps}>
                 <IconClose color="#909090" height={18} width={18} />
             </button>
         );
@@ -106,7 +113,7 @@ class ModalDialog extends React.Component<Props> {
             ...rest // Useful for resin tagging, and other misc tags such as a11y
         } = this.props;
         const isAlertType = type === ALERT_TYPE;
-        const divProps = omit(rest, ['children', 'closeButtonProps', 'onRequestClose', 'intl']);
+        const divProps = omit(rest, ['children', 'closeButtonProps', 'closeButtonText', 'onRequestClose', 'intl']);
 
         divProps.role = isAlertType ? 'alertdialog' : 'dialog';
         divProps['aria-labelledby'] = `${this.modalID}-label`;

--- a/src/components/modal/__tests__/Modal-test.js
+++ b/src/components/modal/__tests__/Modal-test.js
@@ -50,6 +50,7 @@ describe('components/modal/Modal', () => {
 
         test('should render a modal dialog with props in a div when isOpen is true', () => {
             wrapper.setProps({
+                closeButtonText: 'hello',
                 shouldNotUsePortal: true,
                 title: 'title',
             });
@@ -61,6 +62,7 @@ describe('components/modal/Modal', () => {
             const dialog = wrapperComponent.find('ModalDialog');
             expect(dialog.length).toBeTruthy();
 
+            expect(dialog.prop('closeButtonText')).toEqual('hello');
             expect(dialog.prop('onRequestClose')).toEqual(onRequestClose);
             expect(dialog.prop('title')).toEqual('title');
         });

--- a/src/components/modal/__tests__/ModalDialog-test.js
+++ b/src/components/modal/__tests__/ModalDialog-test.js
@@ -64,6 +64,14 @@ describe('components/modal/ModalDialog', () => {
         expect(closeButtonWrapper.prop('data-custom-close-button')).toEqual('asdf');
     });
 
+    test('should render button instead of icon to close modal when closeButtonText provided', () => {
+        wrapper.setProps({
+            closeButtonProps: { 'data-custom-close-button': 'asdf' },
+            closeButtonText: 'hello',
+        });
+        expect(wrapper.find('.bdl-ModalCloseButton--with-custom-text')).toMatchSnapshot();
+    });
+
     test('should not render close button when onRequestClose is falsey', () => {
         wrapper.setProps({ onRequestClose: undefined });
         expect(wrapper.find('.modal-close-button').length).toBeFalsy();

--- a/src/components/modal/__tests__/__snapshots__/ModalDialog-test.js.snap
+++ b/src/components/modal/__tests__/__snapshots__/ModalDialog-test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/modal/ModalDialog should render button instead of icon to close modal when closeButtonText provided 1`] = `
+<Button
+  aria-label="boxui.modalDialog.closeModalText"
+  className="bdl-ModalCloseButton--with-custom-text"
+  data-custom-close-button="asdf"
+  onClick={[Function]}
+>
+  hello
+</Button>
+`;


### PR DESCRIPTION
### Existing default close icon
<img width="538" alt="Screen Shot 2019-08-15 at 11 11 12 AM" src="https://user-images.githubusercontent.com/12469495/63116858-7a7f5e80-bf4f-11e9-8ebe-230247832b18.png">

### With button text override
<img width="520" alt="Screen Shot 2019-08-15 at 11 11 06 AM" src="https://user-images.githubusercontent.com/12469495/63116861-7bb08b80-bf4f-11e9-8a04-2466782811d0.png">
