### PR TITLE
fix(left-sidebar): Adjust margins for loading indicator

### DIFF
--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -236,6 +236,8 @@ class LeftSidebar extends React.Component<Props, State> {
             );
 
         const classes = classNames('left-sidebar-list', className, {
+            'is-loading-empty': showLoadingIndicator && menuItems && menuItems.length === 0,
+            'is-loading': showLoadingIndicator && menuItems && menuItems.length > 0,
             'lsb-scrollable-shadow-top': this.state.isScrollableAbove,
             'lsb-scrollable-shadow-bottom': this.state.isScrollableBelow,
         });

--- a/src/features/left-sidebar/styles/LeftSidebar.scss
+++ b/src/features/left-sidebar/styles/LeftSidebar.scss
@@ -88,6 +88,14 @@
         margin-bottom: 0;
     }
 
+    &.is-loading {
+        margin-bottom: 0;
+    }
+
+    &.is-loading-empty {
+        margin-bottom: 40px;
+    }
+
     // Override nav-list default color for link
     .left-sidebar-link:not(.is-selected) {
         color: $light-charcoal;


### PR DESCRIPTION
When `NavList` is wrapped in `LoadingIndicatorWrapper`, it appends a `LoadingIndicator` as a child which `:last-child` pseudo class rule does not account for.

Added additional rules when loading indicator is present.