### PR TITLE
feat(uploads): resume a single file upload

### DIFF
--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -5,6 +5,7 @@
  */
 
 import noop from 'lodash/noop';
+import isNaN from 'lodash/isNaN';
 import { getFileLastModifiedAsISONoMSIfPossible, getBoundedExpBackoffRetryDelay } from '../../utils/uploads';
 import { retryNumOfTimes } from '../../utils/function';
 import { digest } from '../../utils/webcrypto';
@@ -534,7 +535,7 @@ class MultiputUpload extends BaseMultiput {
                     errorData.headers['retry-after'] || errorData.headers.get('Retry-After'),
                     10,
                 );
-                if (!Number.isNaN(retryAfterSec)) {
+                if (!isNaN(retryAfterSec)) {
                     retryAfterMs = retryAfterSec * MS_IN_S;
                 }
             }

--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -14,8 +14,15 @@ import {
     DEFAULT_RETRY_DELAY_MS,
     ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED,
     HTTP_STATUS_CODE_FORBIDDEN,
+    MS_IN_S,
 } from '../../constants';
-import MultiputPart, { PART_STATE_UPLOADED, PART_STATE_DIGEST_READY, PART_STATE_NOT_STARTED } from './MultiputPart';
+import MultiputPart, {
+    PART_STATE_UPLOADED,
+    PART_STATE_UPLOADING,
+    PART_STATE_DIGEST_READY,
+    PART_STATE_COMPUTING_DIGEST,
+    PART_STATE_NOT_STARTED,
+} from './MultiputPart';
 import BaseMultiput from './BaseMultiput';
 
 // Constants used for specifying log event types.
@@ -50,6 +57,8 @@ class MultiputUpload extends BaseMultiput {
 
     initialFileSize: number;
 
+    isResumableUploadsEnabled: boolean;
+
     successCallback: Function;
 
     progressCallback: Function;
@@ -69,6 +78,8 @@ class MultiputUpload extends BaseMultiput {
     numPartsUploaded: number;
 
     numPartsUploading: number;
+
+    numResumeRetries: number;
 
     sessionEndpoints: Object;
 
@@ -115,6 +126,66 @@ class MultiputUpload extends BaseMultiput {
         this.partSize = 0;
         this.commitRetryCount = 0;
         this.clientId = null;
+        this.isResumableUploadsEnabled = false;
+    }
+
+    /**
+     * Reset values for uploading process.
+     */
+    reset() {
+        this.parts = [];
+        this.fileSha1 = null;
+        this.totalUploadedBytes = 0;
+        this.numPartsNotStarted = 0; // # of parts yet to be processed
+        this.numPartsDigestComputing = 0; // # of parts sent to the digest worker
+        this.numPartsDigestReady = 0; // # of parts with digest finished that are waiting to be uploaded.
+        this.numPartsUploading = 0; // # of parts with upload requests currently inflight
+        this.numPartsUploaded = 0; // # of parts successfully uploaded
+        this.firstUnuploadedPartIndex = 0; // Index of first part that hasn't been uploaded yet.
+        this.createSessionNumRetriesPerformed = 0;
+        this.partSize = 0;
+        this.commitRetryCount = 0;
+    }
+
+    /**
+     * Set information about file being uploaded
+     *
+     *
+     * @param {Object} options
+     * @param {File} options.file
+     * @param {string} options.folderId - Untyped folder id (e.g. no "folder_" prefix)
+     * @param {string} [options.fileId] - Untyped file id (e.g. no "file_" prefix)
+     * @param {string} options.sessionId
+     * @param {Function} [options.errorCallback]
+     * @param {Function} [options.progressCallback]
+     * @param {Function} [options.successCallback]
+     * @return {void}
+     */
+    setFileInfo({
+        file,
+        folderId,
+        errorCallback,
+        progressCallback,
+        successCallback,
+        overwrite = true,
+        fileId,
+    }: {
+        errorCallback?: Function,
+        file: File,
+        fileId: ?string,
+        folderId: string,
+        overwrite?: boolean,
+        progressCallback?: Function,
+        successCallback?: Function,
+    }): void {
+        this.file = file;
+        this.fileName = this.file.name;
+        this.folderId = folderId;
+        this.errorCallback = errorCallback || noop;
+        this.progressCallback = progressCallback || noop;
+        this.successCallback = successCallback || noop;
+        this.overwrite = overwrite;
+        this.fileId = fileId;
     }
 
     /**
@@ -330,6 +401,179 @@ class MultiputUpload extends BaseMultiput {
     }
 
     /**
+     * Resume uploading the given file
+     *
+     *
+     * @param {Object} options
+     * @param {File} options.file
+     * @param {string} options.folderId - Untyped folder id (e.g. no "folder_" prefix)
+     * @param {string} [options.fileId] - Untyped file id (e.g. no "file_" prefix)
+     * @param {string} options.sessionId
+     * @param {Function} [options.errorCallback]
+     * @param {Function} [options.progressCallback]
+     * @param {Function} [options.successCallback]
+     * @return {void}
+     */
+    resume({
+        file,
+        folderId,
+        errorCallback,
+        progressCallback,
+        sessionId,
+        successCallback,
+        overwrite = true,
+        fileId,
+    }: {
+        errorCallback?: Function,
+        file: File,
+        fileId: ?string,
+        folderId: string,
+        overwrite?: boolean,
+        progressCallback?: Function,
+        sessionId: string,
+        successCallback?: Function,
+    }): void {
+        this.setFileInfo({ file, folderId, errorCallback, progressCallback, successCallback, overwrite, fileId });
+        this.sessionId = sessionId;
+
+        if (!this.sha1Worker) {
+            this.sha1Worker = createWorker();
+        }
+        this.sha1Worker.addEventListener('message', this.onWorkerMessage);
+
+        this.getSessionInfo();
+    }
+
+    /**
+     * Get session information from API.
+     * Uses session info to commit a complete session or continue an in-progress session.
+     *
+     * @private
+     * @return {void}
+     */
+    getSessionInfo = async (): Promise<any> => {
+        const uploadUrl = this.getBaseUploadUrl();
+        const sessionUrl = `${uploadUrl}/files/upload_sessions/${this.sessionId}`;
+        try {
+            const response = await this.xhr.get({ url: sessionUrl });
+            this.getSessionSuccessHandler(response.data);
+        } catch (error) {
+            this.getSessionErrorHandler(error);
+        }
+    };
+
+    /**
+     * Handles a getSessionInfo success and either commits the session or continues to process
+     * the parts that still need to be uploaded.
+     *
+     * @param response
+     * @return {void}
+     */
+    getSessionSuccessHandler(data: any): void {
+        const { total_parts, part_size, session_endpoints } = data;
+
+        // Set session information gotten from API response
+        this.partSize = part_size;
+        this.sessionEndpoints = {
+            ...this.sessionEndpoints,
+            uploadPart: session_endpoints.upload_part,
+            listParts: session_endpoints.list_parts,
+            commit: session_endpoints.commit,
+            abort: session_endpoints.abort,
+            logEvent: session_endpoints.log_event,
+        };
+
+        // Reset uploading process for parts that were in progress when the upload failed
+        let nextUploadIndex = this.firstUnuploadedPartIndex;
+        while (this.numPartsUploading > 0 || this.numPartsDigestComputing > 0) {
+            const part = this.parts[nextUploadIndex];
+            if (part && part.state === PART_STATE_UPLOADING) {
+                part.state = PART_STATE_DIGEST_READY;
+                part.numUploadRetriesPerformed = 0;
+                part.timing = {};
+                part.uploadedBytes = 0;
+
+                this.numPartsUploading -= 1;
+                this.numPartsDigestReady += 1;
+            } else if (part && part.state === PART_STATE_COMPUTING_DIGEST) {
+                part.state = PART_STATE_NOT_STARTED;
+                part.numDigestRetriesPerformed = 0;
+                part.timing = {};
+
+                this.numPartsDigestComputing -= 1;
+                this.numPartsNotStarted += 1;
+            }
+            nextUploadIndex += 1;
+        }
+
+        if (this.numPartsUploaded === total_parts) {
+            // Commit sessions that have all the parts of the file uploaded
+            this.commitSession();
+        } else {
+            this.processNextParts();
+        }
+    }
+
+    /**
+     * Handle error from getting upload session.
+     * Restart uploads without valid sessions from the beginning of the upload process.
+     *
+     * @param error
+     * @return {void}
+     */
+    getSessionErrorHandler(error: Error): void {
+        if (this.isDestroyed()) {
+            return;
+        }
+
+        const errorData = this.getErrorResponse(error);
+        if (this.numResumeRetries > this.config.retries) {
+            this.errorCallback(errorData);
+            return;
+        }
+
+        if (errorData && errorData.status === 429) {
+            let retryAfterMs = DEFAULT_RETRY_DELAY_MS;
+            if (errorData.headers) {
+                const retryAfterSec = parseInt(
+                    errorData.headers['retry-after'] || errorData.headers.get('Retry-After'),
+                    10,
+                );
+                if (!Number.isNaN(retryAfterSec)) {
+                    retryAfterMs = retryAfterSec * MS_IN_S;
+                }
+            }
+            this.retryTimeout = setTimeout(this.getSessionInfo, retryAfterMs);
+            this.numResumeRetries += 1;
+        } else if (errorData && errorData.status >= 500) {
+            this.retryTimeout = setTimeout(this.getSessionInfo, 2 ** this.numResumeRetries * MS_IN_S);
+            this.numResumeRetries += 1;
+        } else {
+            // Restart upload process for errors resulting from invalid session
+            this.parts.forEach(part => {
+                part.cancel();
+            });
+            this.reset();
+
+            // Abort session
+            clearTimeout(this.createSessionTimeout);
+            clearTimeout(this.commitSessionTimeout);
+            this.abortSession();
+            // Restart the uploading process from the beginning
+            const uploadOptions: Object = {
+                file: this.file,
+                folderId: this.folderId,
+                errorCallback: this.errorCallback,
+                progressCallback: this.progressCallback,
+                successCallback: this.successCallback,
+                overwrite: this.overwrite,
+                fileId: this.fileId,
+            };
+            this.upload(uploadOptions);
+        }
+    }
+
+    /**
      * Session error handler.
      * Retries the create session request or fails the upload.
      *
@@ -340,7 +584,9 @@ class MultiputUpload extends BaseMultiput {
      * @return {Promise}
      */
     async sessionErrorHandler(error: ?Error, logEventType: string, logMessage?: string): Promise<any> {
-        this.destroy();
+        if (!this.isResumableUploadsEnabled) {
+            this.destroy();
+        }
         const errorData = this.getErrorResponse(error);
         this.errorCallback(errorData);
 
@@ -358,10 +604,13 @@ class MultiputUpload extends BaseMultiput {
                 this.config.retries,
                 this.config.initialRetryDelayMs,
             );
-
-            this.abortSession();
+            if (!this.isResumableUploadsEnabled) {
+                this.abortSession();
+            }
         } catch (err) {
-            this.abortSession();
+            if (!this.isResumableUploadsEnabled) {
+                this.abortSession();
+            }
         }
     }
 

--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -470,7 +470,7 @@ class MultiputUpload extends BaseMultiput {
      * @return {void}
      */
     getSessionSuccessHandler(data: any): void {
-        const { total_parts, part_size, session_endpoints } = data;
+        const { part_size, session_endpoints } = data;
 
         // Set session information gotten from API response
         this.partSize = part_size;
@@ -506,12 +506,7 @@ class MultiputUpload extends BaseMultiput {
             nextUploadIndex += 1;
         }
 
-        if (this.numPartsUploaded === total_parts) {
-            // Commit sessions that have all the parts of the file uploaded
-            this.commitSession();
-        } else {
-            this.processNextParts();
-        }
+        this.processNextParts();
     }
 
     /**

--- a/src/api/uploads/__tests__/MultiputUpload-test.js
+++ b/src/api/uploads/__tests__/MultiputUpload-test.js
@@ -437,18 +437,6 @@ describe('api/uploads/MultiputUpload', () => {
             };
         });
 
-        test('should commit if all parts have been uploaded', () => {
-            // Setup
-            multiputUploadTest.numPartsUploaded = 25;
-
-            // Expectations
-            multiputUploadTest.commitSession = jest.fn();
-
-            // Execute
-            multiputUploadTest.getSessionSuccessHandler(response.data);
-            expect(multiputUploadTest.commitSession).toHaveBeenCalled();
-        });
-
         test('should call processNextParts if some parts are not uploaded', () => {
             // Setup
             multiputUploadTest.numPartsUploaded = 20;

--- a/src/api/uploads/__tests__/MultiputUpload-test.js
+++ b/src/api/uploads/__tests__/MultiputUpload-test.js
@@ -4,6 +4,7 @@ import * as uploadUtil from '../../../utils/uploads';
 import MultiputUpload from '../MultiputUpload';
 import MultiputPart, {
     PART_STATE_UPLOADED,
+    PART_STATE_UPLOADING,
     PART_STATE_COMPUTING_DIGEST,
     PART_STATE_DIGEST_READY,
     PART_STATE_NOT_STARTED,
@@ -418,6 +419,148 @@ describe('api/uploads/MultiputUpload', () => {
         });
     });
 
+    describe('getSessionSuccessHandler()', () => {
+        let response;
+        beforeEach(() => {
+            response = {
+                data: {
+                    total_parts: 25,
+                    part_size: multiputUploadTest.partSize,
+                    session_endpoints: {
+                        uploadPart: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
+                        listParts: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/parts',
+                        commit: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/commit',
+                        abort: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123',
+                        logEvent: 'https://upload.box.com/api/2.0/files/content?upload_session_id=123/log',
+                    },
+                },
+            };
+        });
+
+        test('should commit if all parts have been uploaded', () => {
+            // Setup
+            multiputUploadTest.numPartsUploaded = 25;
+
+            // Expectations
+            multiputUploadTest.commitSession = jest.fn();
+
+            // Execute
+            multiputUploadTest.getSessionSuccessHandler(response.data);
+            expect(multiputUploadTest.commitSession).toHaveBeenCalled();
+        });
+
+        test('should call processNextParts if some parts are not uploaded', () => {
+            // Setup
+            multiputUploadTest.numPartsUploaded = 20;
+
+            multiputUploadTest.processNextParts = jest.fn();
+
+            // Execute
+            multiputUploadTest.getSessionSuccessHandler(response.data);
+            expect(multiputUploadTest.processNextParts).toHaveBeenCalled();
+        });
+
+        test('should set parts that were in uploading state back to digest ready', () => {
+            // Setup
+            multiputUploadTest.numPartsUploaded = 20;
+            multiputUploadTest.numPartsUploading = 2;
+            multiputUploadTest.numPartsDigestReady = 0;
+            multiputUploadTest.firstUnuploadedPartIndex = 0;
+            multiputUploadTest.parts = [
+                { state: PART_STATE_UPLOADING, numUploadRetriesPerformed: 2, uploadedBytes: 5 },
+                { state: PART_STATE_UPLOADED, numUploadRetriesPerformed: 2, uploadedBytes: 5 },
+                { state: PART_STATE_UPLOADING, numUploadRetriesPerformed: 2, uploadedBytes: 5 },
+            ];
+
+            multiputUploadTest.processNextParts = jest.fn();
+
+            // Execute
+            multiputUploadTest.getSessionSuccessHandler(response.data);
+            expect(multiputUploadTest.numPartsUploading).toBe(0);
+            expect(multiputUploadTest.numPartsDigestReady).toBe(2);
+            expect(multiputUploadTest.parts[0].state).toBe(PART_STATE_DIGEST_READY);
+            expect(multiputUploadTest.parts[0].numUploadRetriesPerformed).toBe(0);
+            expect(multiputUploadTest.parts[0].uploadedBytes).toBe(0);
+            expect(multiputUploadTest.parts[0].timing).toStrictEqual({});
+
+            expect(multiputUploadTest.parts[1].state).toBe(PART_STATE_UPLOADED);
+            expect(multiputUploadTest.parts[1].numUploadRetriesPerformed).toBe(2);
+            expect(multiputUploadTest.parts[1].uploadedBytes).toBe(5);
+
+            expect(multiputUploadTest.parts[2].state).toBe(PART_STATE_DIGEST_READY);
+            expect(multiputUploadTest.parts[2].numUploadRetriesPerformed).toBe(0);
+            expect(multiputUploadTest.parts[2].uploadedBytes).toBe(0);
+            expect(multiputUploadTest.parts[2].timing).toStrictEqual({});
+
+            expect(multiputUploadTest.processNextParts).toHaveBeenCalled();
+        });
+
+        test('should set parts that were in digest computing state back to not started', () => {
+            // Setup
+            multiputUploadTest.numPartsUploaded = 20;
+            multiputUploadTest.numPartsDigestComputing = 1;
+            multiputUploadTest.numPartsNotStarted = 4;
+            multiputUploadTest.firstUnuploadedPartIndex = 0;
+            multiputUploadTest.parts = [{ state: PART_STATE_COMPUTING_DIGEST, numDigestRetriesPerformed: 3 }];
+
+            multiputUploadTest.processNextParts = jest.fn();
+
+            // Execute
+            multiputUploadTest.getSessionSuccessHandler(response.data);
+            expect(multiputUploadTest.numPartsDigestComputing).toBe(0);
+            expect(multiputUploadTest.numPartsNotStarted).toBe(5);
+            expect(multiputUploadTest.parts[0].state).toBe(PART_STATE_NOT_STARTED);
+            expect(multiputUploadTest.parts[0].numDigestRetriesPerformed).toBe(0);
+            expect(multiputUploadTest.parts[0].timing).toStrictEqual({});
+            expect(multiputUploadTest.processNextParts).toHaveBeenCalled();
+        });
+    });
+
+    describe('getSessionErrorHandler()', () => {
+        test('should noop when isDestroyed', () => {
+            multiputUploadTest.destroyed = true;
+            multiputUploadTest.getErrorResponse = jest.fn();
+            multiputUploadTest.abortSession = jest.fn();
+            multiputUploadTest.upload = jest.fn();
+
+            multiputUploadTest.getSessionErrorHandler();
+            expect(multiputUploadTest.getErrorResponse).not.toHaveBeenCalled();
+            expect(multiputUploadTest.abortSession).not.toHaveBeenCalled();
+            expect(multiputUploadTest.upload).not.toHaveBeenCalled();
+        });
+
+        test('should retry on network error', () => {
+            multiputUploadTest.numResumeRetries = 1;
+            multiputUploadTest.getErrorResponse = jest.fn(error => error.response);
+            multiputUploadTest.abortSession = jest.fn();
+            multiputUploadTest.upload = jest.fn();
+            multiputUploadTest.getSessionInfo = jest.fn();
+
+            const error = { response: { status: 500 } };
+
+            multiputUploadTest.getSessionErrorHandler(error);
+            expect(multiputUploadTest.getErrorResponse).toHaveBeenCalledWith(error);
+            expect(multiputUploadTest.abortSession).not.toHaveBeenCalled();
+            expect(multiputUploadTest.upload).not.toHaveBeenCalled();
+            expect(multiputUploadTest.numResumeRetries).toBe(2);
+        });
+
+        test('should restart upload process on error due to invalid session ID', () => {
+            multiputUploadTest.numResumeRetries = 0;
+            multiputUploadTest.getErrorResponse = jest.fn(error => error.response);
+            multiputUploadTest.abortSession = jest.fn();
+            multiputUploadTest.upload = jest.fn();
+
+            const goneError = { response: { status: 410 } };
+
+            multiputUploadTest.getSessionErrorHandler(goneError);
+            expect(multiputUploadTest.getErrorResponse).toHaveBeenCalledWith(goneError);
+            expect(multiputUploadTest.abortSession).toHaveBeenCalled();
+            expect(multiputUploadTest.upload).toHaveBeenCalled();
+            expect(multiputUploadTest.numResumeRetries).toBe(0);
+        });
+    });
+
     describe('createSessionErrorHandler()', () => {
         test('should should noop when isDestroyed', () => {
             multiputUploadTest.destroyed = true;
@@ -715,6 +858,40 @@ describe('api/uploads/MultiputUpload', () => {
             expect(multiputUploadTest.commitSession).toHaveBeenCalled();
             expect(multiputUploadTest.updateFirstUnuploadedPartIndex).not.toHaveBeenCalled();
             expect(multiputUploadTest.uploadNextPart).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('commitSession()', () => {
+        beforeEach(() => {
+            multiputUploadTest.xhr.post = jest.fn().mockResolvedValue();
+            multiputUploadTest.sessionEndpoints.commit =
+                'https://upload.box.com/api/2.0/files/content?upload_session_id=123/commit';
+        });
+
+        test('should noop when isDestroyed', () => {
+            multiputUploadTest.destroyed = true;
+
+            multiputUploadTest.commitSession();
+
+            expect(multiputUploadTest.xhr.post).not.toHaveBeenCalled();
+        });
+
+        test('should commit session with file sha1 included in header', () => {
+            multiputUploadTest.parts = [];
+            multiputUploadTest.fileSha1 = '123456789';
+            const postData = {
+                url: multiputUploadTest.sessionEndpoints.commit,
+                data: { parts: [], attributes: {} },
+                headers: {
+                    Digest: `sha=${multiputUploadTest.fileSha1}`,
+                    'X-Box-Client-Event-Info':
+                        '{"avg_part_read_time":null,"avg_part_digest_time":null,"avg_file_digest_time":null,"avg_part_upload_time":null}',
+                },
+            };
+
+            multiputUploadTest.commitSession();
+
+            expect(multiputUploadTest.xhr.post).toHaveBeenCalledWith(postData);
         });
     });
 

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -598,13 +598,17 @@ class ContentUploader extends Component<Props, State> {
      * @return {UploadAPI} - Instance of Upload API
      */
     getUploadAPI(file: File, uploadAPIOptions?: UploadItemAPIOptions) {
-        const { chunked } = this.props;
+        const { chunked, isResumableUploadsEnabled } = this.props;
         const { size } = file;
         const factory = this.createAPIFactory(uploadAPIOptions);
 
         if (chunked && size > CHUNKED_UPLOAD_MIN_SIZE_BYTES) {
             if (isMultiputSupported()) {
-                return factory.getChunkedUploadAPI();
+                const chunkedUploadAPI = factory.getChunkedUploadAPI();
+                if (isResumableUploadsEnabled) {
+                    chunkedUploadAPI.isResumableUploadsEnabled = true;
+                }
+                return chunkedUploadAPI;
             }
 
             /* eslint-disable no-console */
@@ -707,6 +711,43 @@ class ContentUploader extends Component<Props, State> {
         items[items.indexOf(item)] = item;
 
         api.upload(uploadOptions);
+
+        this.updateViewAndCollection(items);
+    }
+
+    /**
+     * Helper to resume uploading a single file.
+     *
+     * @param {UploadItem} item - Upload item object
+     * @return {void}
+     */
+    resumeFile(item: UploadItem) {
+        const { overwrite, rootFolderId } = this.props;
+        const { api, file, options } = item;
+
+        if (this.numItemsUploading >= UPLOAD_CONCURRENCY) {
+            return;
+        }
+
+        this.numItemsUploading += 1;
+
+        const resumeOptions: Object = {
+            file,
+            folderId: options && options.folderId ? options.folderId : rootFolderId,
+            errorCallback: error => this.handleUploadError(item, error),
+            progressCallback: event => this.handleUploadProgress(item, event),
+            successCallback: entries => this.handleUploadSuccess(item, entries),
+            overwrite,
+            sessionId: api && api.sessionId ? api.sessionId : null,
+            fileId: options && options.fileId ? options.fileId : null,
+        };
+
+        item.status = STATUS_IN_PROGRESS;
+        delete item.error;
+        const { items } = this.state;
+        items[items.indexOf(item)] = item;
+
+        api.resume(resumeOptions);
 
         this.updateViewAndCollection(items);
     }
@@ -907,7 +948,11 @@ class ContentUploader extends Component<Props, State> {
      * @return {void}
      */
     onClick = (item: UploadItem) => {
-        const { status } = item;
+        const { chunked, isResumableUploadsEnabled } = this.props;
+        const { status, file } = item;
+        const isChunkedUpload = chunked && file.size > CHUNKED_UPLOAD_MIN_SIZE_BYTES && isMultiputSupported();
+        const isResumable = isResumableUploadsEnabled && isChunkedUpload && item.api.sessionId;
+
         switch (status) {
             case STATUS_IN_PROGRESS:
             case STATUS_STAGED:
@@ -916,8 +961,12 @@ class ContentUploader extends Component<Props, State> {
                 this.removeFileFromUploadQueue(item);
                 break;
             case STATUS_ERROR:
-                this.resetFile(item);
-                this.uploadFile(item);
+                if (isResumable) {
+                    this.resumeFile(item);
+                } else {
+                    this.resetFile(item);
+                    this.uploadFile(item);
+                }
                 break;
             default:
                 break;

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -131,7 +131,7 @@ class ContentUploader extends Component<Props, State> {
         onMinimize: noop,
         onCancel: noop,
         isFolderUploadEnabled: false,
-        isResumableUploadsEnabled: true,
+        isResumableUploadsEnabled: false,
         dataTransferItems: [],
         isDraggingItemsToUploadsManager: false,
     };

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -724,12 +724,13 @@ class ContentUploader extends Component<Props, State> {
     resumeFile(item: UploadItem) {
         const { overwrite, rootFolderId } = this.props;
         const { api, file, options } = item;
+        const { items } = this.state;
 
-        if (this.numItemsUploading >= UPLOAD_CONCURRENCY) {
+        const numItemsUploading = items.filter(item_t => item_t.status === STATUS_IN_PROGRESS).length;
+
+        if (numItemsUploading >= UPLOAD_CONCURRENCY) {
             return;
         }
-
-        this.numItemsUploading += 1;
 
         const resumeOptions: Object = {
             file,
@@ -744,7 +745,6 @@ class ContentUploader extends Component<Props, State> {
 
         item.status = STATUS_IN_PROGRESS;
         delete item.error;
-        const { items } = this.state;
         items[items.indexOf(item)] = item;
 
         api.resume(resumeOptions);

--- a/src/elements/content-uploader/__tests__/ContentUploader-test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader-test.js
@@ -102,6 +102,19 @@ describe('elements/content-uploader/ContentUploader', () => {
         });
     });
 
+    describe('resumeFile()', () => {
+        test('should call resume from api and call updateViewAndCollection', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            const item = { api: {} };
+            item.api.resume = jest.fn();
+            instance.updateViewAndCollection = jest.fn();
+            instance.resumeFile(item);
+            expect(item.api.resume).toBeCalled();
+            expect(instance.updateViewAndCollection).toBeCalled();
+        });
+    });
+
     describe('isDone', () => {
         test('should be true if all items are complete or staged', () => {
             const wrapper = getWrapper();
@@ -150,7 +163,7 @@ describe('elements/content-uploader/ContentUploader', () => {
 
         beforeEach(() => {
             jest.spyOn(global.console, 'warn').mockImplementation();
-            wrapper = getWrapper();
+            wrapper = getWrapper({ isResumableUploadsEnabled: false });
             instance = wrapper.instance();
             getPlainUploadAPI = jest.fn();
             getChunkedUploadAPI = jest.fn();


### PR DESCRIPTION
Allow single uploads that are being uploaded in parts via the Chunked Upload API to be resumed from the middle of an existing upload session rather than restarting from the beginning with a new upload session, using the retry button on each individual item in the uploads manager.

**Note:** This PR is for a portion of the changes being made in [this PR](https://github.com/box/box-ui-elements/pull/1497), with the changes being made for multiple file resuming and some of the refactoring from that original PR separated out to be merged later, so that more incremental changes can be merged in to minimize impact, and each smaller section can be tested by QA separately.