### PR TITLE
fix(versions): Update version actions to avoid unnecessary buttons

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsItemAction.js
+++ b/src/elements/content-sidebar/versions/VersionsItemAction.js
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react';
-import PlainButton from '../../../components/plain-button';
+import { MenuItem } from '../../../components/menu';
 import './VersionsItemAction.scss';
 
 type Props = {
@@ -16,19 +16,15 @@ type Props = {
 };
 
 const VersionsItemAction = ({ action, children, fileId, isCurrent, ...rest }: Props) => (
-    <li className="bcs-VersionsItemAction">
-        <PlainButton // Button element is required to trigger resin events
-            className="bcs-VersionsItemAction-button menu-item"
-            data-resin-iscurrent={isCurrent}
-            data-resin-itemid={fileId}
-            data-resin-target={action}
-            role="menuitem"
-            type="button"
-            {...rest}
-        >
-            {children}
-        </PlainButton>
-    </li>
+    <MenuItem
+        className="bcs-VersionsItemAction"
+        data-resin-iscurrent={isCurrent}
+        data-resin-itemid={fileId}
+        data-resin-target={action}
+        {...rest}
+    >
+        {children}
+    </MenuItem>
 );
 
 export default VersionsItemAction;

--- a/src/elements/content-sidebar/versions/VersionsItemAction.scss
+++ b/src/elements/content-sidebar/versions/VersionsItemAction.scss
@@ -9,7 +9,3 @@
         stroke: $bdl-gray;
     }
 }
-
-.bcs-VersionsItemAction-button {
-    width: 100%;
-}


### PR DESCRIPTION
I've confirmed that Resin events are still firing as expected with this change; the buttons were never necessary.