### PR TITLE
fix(sidebar): Limit maximum height of additional tabs in sidebar nav

### DIFF
--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -49,55 +49,62 @@ const SidebarNav = ({
 }: Props) => (
     <div className="bcs-SidebarNav" aria-label={intl.formatMessage(messages.sidebarNavLabel)} role="tablist">
         <div className="bcs-SidebarNav-tabs">
-            {hasActivity && (
-                <SidebarNavButton
-                    data-resin-target={SIDEBAR_NAV_TARGETS.ACTIVITY}
-                    data-testid="sidebaractivity"
-                    isOpen={isOpen}
-                    sidebarView={SIDEBAR_VIEW_ACTIVITY}
-                    onNavigate={onNavigate}
-                    tooltip={<FormattedMessage {...messages.sidebarActivityTitle} />}
-                >
-                    <IconChatRound />
-                </SidebarNavButton>
+            <div className="bcs-SidebarNav-main">
+                {hasActivity && (
+                    <SidebarNavButton
+                        data-resin-target={SIDEBAR_NAV_TARGETS.ACTIVITY}
+                        data-testid="sidebaractivity"
+                        isOpen={isOpen}
+                        sidebarView={SIDEBAR_VIEW_ACTIVITY}
+                        onNavigate={onNavigate}
+                        tooltip={<FormattedMessage {...messages.sidebarActivityTitle} />}
+                    >
+                        <IconChatRound />
+                    </SidebarNavButton>
+                )}
+                {hasDetails && (
+                    <SidebarNavButton
+                        data-resin-target={SIDEBAR_NAV_TARGETS.DETAILS}
+                        data-testid="sidebardetails"
+                        isOpen={isOpen}
+                        sidebarView={SIDEBAR_VIEW_DETAILS}
+                        onNavigate={onNavigate}
+                        tooltip={<FormattedMessage {...messages.sidebarDetailsTitle} />}
+                    >
+                        <IconDocInfo />
+                    </SidebarNavButton>
+                )}
+                {hasSkills && (
+                    <SidebarNavButton
+                        data-resin-target={SIDEBAR_NAV_TARGETS.SKILLS}
+                        data-testid="sidebarskills"
+                        isOpen={isOpen}
+                        sidebarView={SIDEBAR_VIEW_SKILLS}
+                        onNavigate={onNavigate}
+                        tooltip={<FormattedMessage {...messages.sidebarSkillsTitle} />}
+                    >
+                        <IconMagicWand />
+                    </SidebarNavButton>
+                )}
+                {hasMetadata && (
+                    <SidebarNavButton
+                        data-resin-target={SIDEBAR_NAV_TARGETS.METADATA}
+                        data-testid="sidebarmetadata"
+                        isOpen={isOpen}
+                        sidebarView={SIDEBAR_VIEW_METADATA}
+                        onNavigate={onNavigate}
+                        tooltip={<FormattedMessage {...messages.sidebarMetadataTitle} />}
+                    >
+                        <IconMetadataThick />
+                    </SidebarNavButton>
+                )}
+            </div>
+
+            {hasAdditionalTabs && (
+                <div className="bcs-SidebarNav-overflow">
+                    <AdditionalTabs key={fileId} tabs={additionalTabs} />
+                </div>
             )}
-            {hasDetails && (
-                <SidebarNavButton
-                    data-resin-target={SIDEBAR_NAV_TARGETS.DETAILS}
-                    data-testid="sidebardetails"
-                    isOpen={isOpen}
-                    sidebarView={SIDEBAR_VIEW_DETAILS}
-                    onNavigate={onNavigate}
-                    tooltip={<FormattedMessage {...messages.sidebarDetailsTitle} />}
-                >
-                    <IconDocInfo />
-                </SidebarNavButton>
-            )}
-            {hasSkills && (
-                <SidebarNavButton
-                    data-resin-target={SIDEBAR_NAV_TARGETS.SKILLS}
-                    data-testid="sidebarskills"
-                    isOpen={isOpen}
-                    sidebarView={SIDEBAR_VIEW_SKILLS}
-                    onNavigate={onNavigate}
-                    tooltip={<FormattedMessage {...messages.sidebarSkillsTitle} />}
-                >
-                    <IconMagicWand />
-                </SidebarNavButton>
-            )}
-            {hasMetadata && (
-                <SidebarNavButton
-                    data-resin-target={SIDEBAR_NAV_TARGETS.METADATA}
-                    data-testid="sidebarmetadata"
-                    isOpen={isOpen}
-                    sidebarView={SIDEBAR_VIEW_METADATA}
-                    onNavigate={onNavigate}
-                    tooltip={<FormattedMessage {...messages.sidebarMetadataTitle} />}
-                >
-                    <IconMetadataThick />
-                </SidebarNavButton>
-            )}
-            {hasAdditionalTabs && <AdditionalTabs key={fileId} tabs={additionalTabs} />}
         </div>
         <div className="bcs-SidebarNav-footer">
             <SidebarToggle isOpen={isOpen} />

--- a/src/elements/content-sidebar/SidebarNav.scss
+++ b/src/elements/content-sidebar/SidebarNav.scss
@@ -20,7 +20,7 @@
 
     .bcs-SidebarNav-overflow {
         display: flex;
-        flex: 1 1 0;
+        flex: 1 1 1px; // IE11 doesn't support flex-basis of 0
         flex-direction: column;
         overflow: hidden;
 
@@ -31,14 +31,8 @@
             display: block;
             flex: 0 0 1px;
             height: 1px;
-            margin-left: auto;
-            margin-right: auto;
+            margin: 0 auto;
             width: 44px;
-        }
-
-        &::before {
-            margin-bottom: 16px;
-            margin-top: 16px;
         }
 
         .bdl-AdditionalTab {
@@ -47,7 +41,10 @@
 
         .bdl-AdditionalTabs {
             flex: 1 1 100%;
-            overflow: auto;
+            overflow-x: hidden;
+            overflow-y: auto;
+            padding-bottom: 16px;
+            padding-top: 16px;
         }
     }
 

--- a/src/elements/content-sidebar/SidebarNav.scss
+++ b/src/elements/content-sidebar/SidebarNav.scss
@@ -8,10 +8,53 @@
         justify-content: space-between;
     }
 
+    .bcs-SidebarNav-tabs {
+        display: flex;
+        flex: 1 1 100%;
+        flex-direction: column;
+    }
+
+    .bcs-SidebarNav-main {
+        flex: 0 1 auto;
+    }
+
+    .bcs-SidebarNav-overflow {
+        display: flex;
+        flex: 1 1 0;
+        flex-direction: column;
+        overflow: hidden;
+
+        &::after,
+        &::before {
+            background: $bdl-gray-10;
+            content: '';
+            display: block;
+            flex: 0 0 1px;
+            height: 1px;
+            margin-left: auto;
+            margin-right: auto;
+            width: 44px;
+        }
+
+        &::before {
+            margin-bottom: 16px;
+            margin-top: 16px;
+        }
+
+        .bdl-AdditionalTab {
+            flex-shrink: 0;
+        }
+
+        .bdl-AdditionalTabs {
+            flex: 1 1 100%;
+            overflow: auto;
+        }
+    }
+
     .bcs-SidebarNav-footer {
         align-items: center;
         display: flex;
-        height: 60px;
+        flex: 0 0 60px;
         justify-content: center;
 
         // Need to add these overriding styles because there is a specificity issue with .btn-plain

--- a/src/elements/content-sidebar/additional-tabs/AdditionalTabs.scss
+++ b/src/elements/content-sidebar/additional-tabs/AdditionalTabs.scss
@@ -1,10 +1,4 @@
-@import '../../../styles/variables';
-
-.bdl-AdditionalTabs::before {
-    background: $bdl-gray-10;
-    content: '';
-    display: block;
-    height: 1px;
-    margin: 16px auto;
-    width: 44px;
+.bdl-AdditionalTabs {
+    display: flex;
+    flex-direction: column;
 }

--- a/src/elements/content-sidebar/additional-tabs/AdditionalTabsLoading.js
+++ b/src/elements/content-sidebar/additional-tabs/AdditionalTabsLoading.js
@@ -7,8 +7,6 @@
 import * as React from 'react';
 import AdditionalTabPlaceholder from './AdditionalTabPlaceholder';
 import MoreTabPlaceholder from './MoreTabPlaceholder';
-
-import './AdditionalTabs.scss';
 import './AdditionalTabsLoading.scss';
 
 // Loading layout for the sidebar's additional tabs

--- a/src/elements/content-sidebar/additional-tabs/MoreTabPlaceholder.js
+++ b/src/elements/content-sidebar/additional-tabs/MoreTabPlaceholder.js
@@ -7,7 +7,6 @@
 import * as React from 'react';
 import { bdlGray10 } from '../../../styles/variables';
 import IconEllipsis from '../../../icons/general/IconEllipsis';
-import './AdditionalTabs.scss';
 
 const MoreTabPlaceholder = () => {
     return (


### PR DESCRIPTION
Currently, previewing a file with a high number of recommended apps with a short (>500px) viewport causes the preview header to overflow off the top of the screen. This change resolves the issue by allowing the recommended apps section to shrink and scroll.