### PR TITLE
feat(tasks): handle new error message with title and description

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -94,8 +94,14 @@ be.contentSidebar.activityFeed.task.taskEditMenuItem = Modify task
 be.contentSidebar.activityFeed.taskForm.taskAnyCheckboxLabel = Only one assignee is required to complete this task
 # Text in tooltip explaining completion rule for an any assignee task.
 be.contentSidebar.activityFeed.taskForm.taskAnyInfoTooltip = By default, all assignees are required to take action before a task is complete. Selecting this option will require only one assignee to complete this task.
+# Warning message showing that, while the task was updated, not all assignees (1+) were removed
+be.contentSidebar.activityFeed.taskForm.taskApprovalAssigneeRemovalWarningMessage = Unable to remove assignee(s) because the task is now approved.
 # Title shown above error message when a task creation fails
 be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle = Error
+# Title shown above warning message when a task create/edit partially fails
+be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle = Task Updated with Errors
+# Warning message showing that, while the task was updated, not all assignees (1+) were removed
+be.contentSidebar.activityFeed.taskForm.taskGeneralAssigneeRemovalWarningMessage = Unable to remove assignee(s) because the task is now completed.
 # Error message when a task edit fails
 be.contentSidebar.activityFeed.taskForm.taskUpdateErrorMessage = An error occurred while modifying this task. Please try again.
 # label for cancel button in create task popup

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -562,11 +562,6 @@ class Feed extends Base {
                 });
             })
             .then(() => {
-                return Promise.all(
-                    task.removedAssignees.map(assignee => this.deleteTaskCollaborator(file, task, assignee)),
-                );
-            })
-            .then(() => {
                 return new Promise((resolve, reject) => {
                     this.tasksNewAPI.getTask({
                         file,
@@ -580,10 +575,6 @@ class Feed extends Base {
                                 task.id,
                             );
 
-                            if (!this.isDestroyed()) {
-                                successCallback();
-                            }
-
                             resolve();
                         },
                         errorCallback: (e: ElementsXhrError) => {
@@ -593,6 +584,17 @@ class Feed extends Base {
                         },
                     });
                 });
+            })
+            .then(() => {
+                return Promise.all(
+                    task.removedAssignees.map(assignee => this.deleteTaskCollaborator(file, task, assignee)),
+                );
+            })
+            .then(() => {
+                // everything succeeded, so call the passed in success callback
+                if (!this.isDestroyed()) {
+                    successCallback();
+                }
             })
             .catch((e: ElementsXhrError) => {
                 this.updateFeedItem({ isPending: false }, task.id);

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -552,11 +552,6 @@ class Feed extends Base {
 
         Promise.all(task.addedAssignees.map(assignee => this.createTaskCollaborator(file, task, assignee)))
             .then(() => {
-                return Promise.all(
-                    task.removedAssignees.map(assignee => this.deleteTaskCollaborator(file, task, assignee)),
-                );
-            })
-            .then(() => {
                 this.tasksNewAPI.updateTask({
                     file,
                     task,
@@ -578,6 +573,11 @@ class Feed extends Base {
                         this.feedErrorCallback(false, e, ERROR_CODE_UPDATE_TASK);
                     },
                 });
+            })
+            .then(() => {
+                return Promise.all(
+                    task.removedAssignees.map(assignee => this.deleteTaskCollaborator(file, task, assignee)),
+                );
             })
             .catch((e: ElementsXhrError) => {
                 this.updateFeedItem({ isPending: false }, task.id);

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -545,7 +545,7 @@ class Feed extends Base {
             throw getBadItemError();
         }
 
-        let shouldCloseModal = true;
+        let updatedWithoutError = true;
         let removeAssigneeError;
 
         this.file = file;
@@ -567,7 +567,7 @@ class Feed extends Base {
             await Promise.all(
                 task.removedAssignees.map(assignee => this.deleteTaskCollaborator(file, task, assignee)),
             ).catch((e: ElementsXhrError) => {
-                shouldCloseModal = false;
+                updatedWithoutError = false;
                 removeAssigneeError = e;
             });
 
@@ -584,7 +584,7 @@ class Feed extends Base {
                             task.id,
                         );
 
-                        if (!shouldCloseModal) {
+                        if (!updatedWithoutError) {
                             this.feedErrorCallback(false, removeAssigneeError, ERROR_CODE_UPDATE_TASK);
                         }
 
@@ -599,7 +599,7 @@ class Feed extends Base {
             });
 
             // everything succeeded, so call the passed in success callback
-            if (!this.isDestroyed() && shouldCloseModal) {
+            if (!this.isDestroyed() && updatedWithoutError) {
                 successCallback();
             }
         } catch (e) {

--- a/src/api/__tests__/Feed-test.js
+++ b/src/api/__tests__/Feed-test.js
@@ -788,7 +788,7 @@ describe('api/Feed', () => {
 
             await new Promise(r => setTimeout(r, 0));
 
-            expect(feed.tasksNewAPI.updateTask).not.toBeCalled();
+            expect(feed.tasksNewAPI.updateTask).toBeCalled();
             expect(feed.updateFeedItem).toBeCalled();
             expect(mockErrorCallback).toBeCalled();
         });

--- a/src/api/__tests__/Feed-test.js
+++ b/src/api/__tests__/Feed-test.js
@@ -711,8 +711,10 @@ describe('api/Feed', () => {
             feed.updateFeedItem = jest.fn();
         });
 
-        test('should throw if no file id', () => {
-            expect(() => feed.updateTaskNew({})).toThrow(fileError);
+        test('should throw if no file id', async () => {
+            expect.assertions(1);
+            const updatedTask = feed.updateTaskNew({});
+            await expect(updatedTask).rejects.toEqual(Error(fileError));
         });
 
         test('should call the error handling when unable to create new task collaborator', async () => {
@@ -816,7 +818,7 @@ describe('api/Feed', () => {
 
             expect(feed.tasksNewAPI.updateTask).toBeCalled();
             expect(feed.tasksNewAPI.getTask).toBeCalled();
-            expect(feed.updateFeedItem).toBeCalled();
+            expect(feed.updateFeedItem).toBeCalledTimes(2);
             expect(successCallback).toBeCalled();
         });
 

--- a/src/api/__tests__/Feed-test.js
+++ b/src/api/__tests__/Feed-test.js
@@ -717,7 +717,10 @@ describe('api/Feed', () => {
 
         test('should call the error handling when unable to create new task collaborator', async () => {
             const mockErrorCallback = jest.fn();
+            const mockSuccessCallback = jest.fn();
+
             feed.createTaskCollaborator = jest.fn().mockRejectedValue(new Error('forced rejection'));
+            feed.deleteTaskCollaborator = jest.fn().mockResolvedValue();
 
             const task = {
                 id: '1',
@@ -745,17 +748,20 @@ describe('api/Feed', () => {
                 ],
             };
 
-            feed.updateTaskNew(file, task, jest.fn(), mockErrorCallback);
+            feed.updateTaskNew(file, task, mockSuccessCallback, mockErrorCallback);
 
             await new Promise(r => setTimeout(r, 0));
 
             expect(feed.tasksNewAPI.updateTask).not.toBeCalled();
+            expect(feed.tasksNewAPI.getTask).not.toBeCalled();
+            expect(feed.deleteTaskCollaborator).not.toBeCalled();
             expect(feed.updateFeedItem).toBeCalled();
             expect(mockErrorCallback).toBeCalled();
         });
 
         test('should call the error handling when unable to delete existing task collaborator', async () => {
             const mockErrorCallback = jest.fn();
+            const mockSuccessCallback = jest.fn();
             feed.deleteTaskCollaborator = jest.fn().mockRejectedValue(new Error('forced rejection'));
 
             const task = {
@@ -784,11 +790,12 @@ describe('api/Feed', () => {
                 ],
             };
 
-            feed.updateTaskNew(file, task, jest.fn(), mockErrorCallback);
+            feed.updateTaskNew(file, task, mockSuccessCallback, mockErrorCallback);
 
             await new Promise(r => setTimeout(r, 0));
 
             expect(feed.tasksNewAPI.updateTask).toBeCalled();
+            expect(feed.tasksNewAPI.getTask).toBeCalled();
             expect(feed.updateFeedItem).toBeCalled();
             expect(mockErrorCallback).toBeCalled();
         });
@@ -808,6 +815,7 @@ describe('api/Feed', () => {
             await new Promise(r => setTimeout(r, 0));
 
             expect(feed.tasksNewAPI.updateTask).toBeCalled();
+            expect(feed.tasksNewAPI.getTask).toBeCalled();
             expect(feed.updateFeedItem).toBeCalled();
             expect(successCallback).toBeCalled();
         });

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskError.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskError.js
@@ -10,7 +10,7 @@ import getProp from 'lodash/get';
 import messages from './messages';
 import apiMessages from '../../../../api/messages';
 import { TASK_EDIT_MODE_EDIT } from '../../../../constants';
-import InlineError from '../../../../components/inline-error/InlineError';
+import InlineNotice from '../../../../components/inline-notice/InlineNotice';
 
 import type { TaskType, TaskEditMode } from '../../../../common/types/tasks';
 
@@ -45,9 +45,9 @@ const TaskError = ({ editMode, error, taskType }: Props) => {
     }
 
     return (
-        <InlineError title={<FormattedMessage {...errorTitle} />}>
+        <InlineNotice type="error" title={<FormattedMessage {...errorTitle} />}>
             <FormattedMessage {...errorMessage} />
-        </InlineError>
+        </InlineNotice>
     );
 };
 

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskError.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskError.js
@@ -5,7 +5,7 @@
 
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
-import get from 'lodash/get';
+import getProp from 'lodash/get';
 
 import messages from './messages';
 import apiMessages from '../../../../api/messages';
@@ -20,12 +20,15 @@ type Props = {
     taskType: TaskType,
 };
 
-function TaskError(props: Props) {
-    const { editMode, error, taskType } = props;
+const TaskError = ({ editMode, error, taskType }: Props) => {
     const isEditMode = editMode === TASK_EDIT_MODE_EDIT;
-    const isForbiddenErrorOnEdit = get(error, 'status') === 403 && isEditMode;
+    const isForbiddenErrorOnEdit = getProp(error, 'status') === 403 && isEditMode;
     const errorTitle = isForbiddenErrorOnEdit ? messages.taskEditWarningTitle : messages.taskCreateErrorTitle;
     let errorMessage = isEditMode ? messages.taskUpdateErrorMessage : apiMessages.taskCreateErrorMessage;
+
+    if (!error) {
+        return null;
+    }
 
     // error message changes when a forbidden operation occurs while editing a task
     if (isForbiddenErrorOnEdit) {
@@ -40,15 +43,12 @@ function TaskError(props: Props) {
                 return null;
         }
     }
-    if (!error) {
-        return null;
-    }
 
     return (
         <InlineError title={<FormattedMessage {...errorTitle} />}>
             <FormattedMessage {...errorMessage} />
         </InlineError>
     );
-}
+};
 
 export default TaskError;

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskError.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskError.js
@@ -1,0 +1,54 @@
+/**
+ * @flow
+ * @file Component for in-modal error messages for tasks
+ */
+
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+import get from 'lodash/get';
+
+import messages from './messages';
+import apiMessages from '../../../../api/messages';
+import { TASK_EDIT_MODE_EDIT } from '../../../../constants';
+import InlineError from '../../../../components/inline-error/InlineError';
+
+import type { TaskType, TaskEditMode } from '../../../../common/types/tasks';
+
+type Props = {
+    editMode?: TaskEditMode,
+    error?: { status: number },
+    taskType: TaskType,
+};
+
+function TaskError(props: Props) {
+    const { editMode, error, taskType } = props;
+    const isEditMode = editMode === TASK_EDIT_MODE_EDIT;
+    const isForbiddenErrorOnEdit = get(error, 'status') === 403 && isEditMode;
+    const errorTitle = isForbiddenErrorOnEdit ? messages.taskEditWarningTitle : messages.taskCreateErrorTitle;
+    let errorMessage = isEditMode ? messages.taskUpdateErrorMessage : apiMessages.taskCreateErrorMessage;
+
+    // error message changes when a forbidden operation occurs while editing a task
+    if (isForbiddenErrorOnEdit) {
+        switch (taskType) {
+            case 'GENERAL':
+                errorMessage = messages.taskGeneralAssigneeRemovalWarningMessage;
+                break;
+            case 'APPROVAL':
+                errorMessage = messages.taskApprovalAssigneeRemovalWarningMessage;
+                break;
+            default:
+                return null;
+        }
+    }
+    if (!error) {
+        return null;
+    }
+
+    return (
+        <InlineError title={<FormattedMessage {...errorTitle} />}>
+            <FormattedMessage {...errorMessage} />
+        </InlineError>
+    );
+}
+
+export default TaskError;

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -39,7 +39,7 @@ import type {
 import './TaskForm.scss';
 
 type TaskFormProps = {|
-    error?: any,
+    error?: { status: number },
     isDisabled?: boolean,
     onCancel: () => any,
     onSubmitError: (e: ElementsXhrError) => any,
@@ -333,6 +333,8 @@ class TaskForm extends React.Component<Props, State> {
             ? messages.tasksAddTaskFormSubmitLabel
             : messages.tasksEditTaskFormSubmitLabel;
 
+        // TODO: use `error` to determine if this came from 403 on update task - remove assignees
+        // make a little function to pick the message
         const taskErrorMessage = isCreateEditMode
             ? apiMessages.taskCreateErrorMessage
             : messages.taskUpdateErrorMessage;

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -5,7 +5,7 @@
 
 import * as React from 'react';
 import noop from 'lodash/noop';
-import get from 'lodash/get';
+import getProp from 'lodash/get';
 import classNames from 'classnames';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import commonMessages from '../../../../common/messages';
@@ -335,7 +335,7 @@ class TaskForm extends React.Component<Props, State> {
         const shouldShowCompletionRule = approvers.length > 0;
         const isCompletionRuleCheckboxDisabled = approvers.length <= 1;
         const isCompletionRuleCheckboxChecked = completionRule === TASK_COMPLETION_RULE_ANY;
-        const isForbiddenErrorOnEdit = isLoading || !!(get(error, 'status') === 403 && !isCreateEditMode);
+        const isForbiddenErrorOnEdit = isLoading || (getProp(error, 'status') === 403 && !isCreateEditMode);
 
         return (
             <div className={inputContainerClassNames} data-resin-component="taskform">

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskError-test.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskError-test.js
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import TaskError from '../TaskError';
+
+describe('components/content-sidebar/activity-feed/task-form/TaskError', () => {
+    test.each([
+        ['GENERAL', 'EDIT', undefined, 0],
+        ['GENERAL', 'EDIT', { status: 403 }, 1],
+        ['GENERAL', 'EDIT', { status: 404 }, 1],
+        ['GENERAL', 'CREATE', undefined, 0],
+        ['GENERAL', 'CREATE', { status: 403 }, 1],
+        ['GENERAL', 'CREATE', { status: 404 }, 1],
+        ['APPROVAL', 'EDIT', undefined, 0],
+        ['APPROVAL', 'EDIT', { status: 403 }, 1],
+        ['APPROVAL', 'EDIT', { status: 404 }, 1],
+        ['APPROVAL', 'CREATE', undefined, 0],
+        ['APPROVAL', 'CREATE', { status: 403 }, 1],
+        ['APPROVAL', 'CREATE', { status: 404 }, 1],
+    ])(
+        'when type is %s and edit mode is %s, with error obj %o, we show the proper inline error',
+        (taskType, editMode, error) => {
+            const wrapper = mount(<TaskError taskType={taskType} editMode={editMode} error={error} />);
+            expect(wrapper).toMatchSnapshot();
+        },
+    );
+});

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskForm-test.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskForm-test.js
@@ -191,13 +191,31 @@ describe('components/ContentSidebar/ActivityFeed/task-form/TaskForm', () => {
         expect(wrapper.find('PillSelectorDropdown').hasClass('scrollable'));
     });
 
-    test('should show inline error when error prop is passed', () => {
-        const wrapper = render({
-            createTask: jest.fn(),
-            error: 'error',
-        });
-        expect(wrapper.find('.inline-alert').length).toBe(1);
-    });
+    test.each([
+        ['GENERAL', 'EDIT', undefined, 0],
+        ['GENERAL', 'EDIT', { status: 403 }, 1],
+        ['GENERAL', 'EDIT', { status: 404 }, 1],
+        ['GENERAL', 'CREATE', undefined, 0],
+        ['GENERAL', 'CREATE', { status: 403 }, 1],
+        ['GENERAL', 'CREATE', { status: 404 }, 1],
+        ['APPROVAL', 'EDIT', undefined, 0],
+        ['APPROVAL', 'EDIT', { status: 403 }, 1],
+        ['APPROVAL', 'EDIT', { status: 404 }, 1],
+        ['APPROVAL', 'CREATE', undefined, 0],
+        ['APPROVAL', 'CREATE', { status: 403 }, 1],
+        ['APPROVAL', 'CREATE', { status: 404 }, 1],
+    ])(
+        'when type is %s and edit mode is %s, with error obj %o, we show the proper inline error',
+        (taskType, editMode, error, alertCount) => {
+            const wrapper = render({
+                createTask: jest.fn(),
+                error,
+                taskType,
+                editMode,
+            });
+            expect(wrapper.find('.inline-alert').length).toBe(alertCount);
+        },
+    );
 
     describe('handleDueDateChange()', () => {
         test('should set the approval date to be one millisecond before midnight of the next day', async () => {

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskForm-test.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/TaskForm-test.js
@@ -191,32 +191,6 @@ describe('components/ContentSidebar/ActivityFeed/task-form/TaskForm', () => {
         expect(wrapper.find('PillSelectorDropdown').hasClass('scrollable'));
     });
 
-    test.each([
-        ['GENERAL', 'EDIT', undefined, 0],
-        ['GENERAL', 'EDIT', { status: 403 }, 1],
-        ['GENERAL', 'EDIT', { status: 404 }, 1],
-        ['GENERAL', 'CREATE', undefined, 0],
-        ['GENERAL', 'CREATE', { status: 403 }, 1],
-        ['GENERAL', 'CREATE', { status: 404 }, 1],
-        ['APPROVAL', 'EDIT', undefined, 0],
-        ['APPROVAL', 'EDIT', { status: 403 }, 1],
-        ['APPROVAL', 'EDIT', { status: 404 }, 1],
-        ['APPROVAL', 'CREATE', undefined, 0],
-        ['APPROVAL', 'CREATE', { status: 403 }, 1],
-        ['APPROVAL', 'CREATE', { status: 404 }, 1],
-    ])(
-        'when type is %s and edit mode is %s, with error obj %o, we show the proper inline error',
-        (taskType, editMode, error, alertCount) => {
-            const wrapper = render({
-                createTask: jest.fn(),
-                error,
-                taskType,
-                editMode,
-            });
-            expect(wrapper.find('.inline-alert').length).toBe(alertCount);
-        },
-    );
-
     describe('handleDueDateChange()', () => {
         test('should set the approval date to be one millisecond before midnight of the next day', async () => {
             // Midnight on December 3rd GMT

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskError-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskError-test.js.snap
@@ -10,25 +10,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="APPROVAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Error"
         id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Error"
           id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="An error occurred while creating this task. Please try again."
@@ -38,7 +39,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 
@@ -52,25 +53,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="APPROVAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Error"
         id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Error"
           id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="An error occurred while creating this task. Please try again."
@@ -80,7 +82,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 
@@ -101,25 +103,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="APPROVAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Task Updated with Errors"
         id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Task Updated with Errors"
           id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="Unable to remove assignee(s) because the task is now approved."
@@ -129,7 +132,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 
@@ -143,25 +146,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="APPROVAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Error"
         id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Error"
           id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="An error occurred while modifying this task. Please try again."
@@ -171,7 +175,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 
@@ -192,25 +196,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="GENERAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Error"
         id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Error"
           id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="An error occurred while creating this task. Please try again."
@@ -220,7 +225,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 
@@ -234,25 +239,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="GENERAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Error"
         id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Error"
           id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="An error occurred while creating this task. Please try again."
@@ -262,7 +268,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 
@@ -283,25 +289,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="GENERAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Task Updated with Errors"
         id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Task Updated with Errors"
           id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="Unable to remove assignee(s) because the task is now completed."
@@ -311,7 +318,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 
@@ -325,25 +332,26 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
   }
   taskType="GENERAL"
 >
-  <InlineError
+  <InlineNotice
     title={
       <FormattedMessage
         defaultMessage="Error"
         id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
       />
     }
+    type="error"
   >
     <div
-      className="inline-alert inline-alert-visible inline-alert-error "
+      className="inline-alert inline-alert-visible inline-alert-error"
     >
-      <b>
+      <strong>
         <FormattedMessage
           defaultMessage="Error"
           id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
         >
           <div />
         </FormattedMessage>
-      </b>
+      </strong>
       <div>
         <FormattedMessage
           defaultMessage="An error occurred while modifying this task. Please try again."
@@ -353,7 +361,7 @@ exports[`components/content-sidebar/activity-feed/task-form/TaskError when type 
         </FormattedMessage>
       </div>
     </div>
-  </InlineError>
+  </InlineNotice>
 </TaskError>
 `;
 

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskError-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskError-test.js.snap
@@ -1,0 +1,365 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is APPROVAL and edit mode is CREATE, with error obj { status: 403 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="CREATE"
+  error={
+    Object {
+      "status": 403,
+    }
+  }
+  taskType="APPROVAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Error"
+        id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Error"
+          id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="An error occurred while creating this task. Please try again."
+          id="be.api.taskCreateErrorMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is APPROVAL and edit mode is CREATE, with error obj { status: 404 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="CREATE"
+  error={
+    Object {
+      "status": 404,
+    }
+  }
+  taskType="APPROVAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Error"
+        id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Error"
+          id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="An error occurred while creating this task. Please try again."
+          id="be.api.taskCreateErrorMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is APPROVAL and edit mode is CREATE, with error obj undefined, we show the proper inline error 1`] = `
+<TaskError
+  editMode="CREATE"
+  taskType="APPROVAL"
+/>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is APPROVAL and edit mode is EDIT, with error obj { status: 403 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="EDIT"
+  error={
+    Object {
+      "status": 403,
+    }
+  }
+  taskType="APPROVAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Task Updated with Errors"
+        id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Task Updated with Errors"
+          id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="Unable to remove assignee(s) because the task is now approved."
+          id="be.contentSidebar.activityFeed.taskForm.taskApprovalAssigneeRemovalWarningMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is APPROVAL and edit mode is EDIT, with error obj { status: 404 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="EDIT"
+  error={
+    Object {
+      "status": 404,
+    }
+  }
+  taskType="APPROVAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Error"
+        id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Error"
+          id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="An error occurred while modifying this task. Please try again."
+          id="be.contentSidebar.activityFeed.taskForm.taskUpdateErrorMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is APPROVAL and edit mode is EDIT, with error obj undefined, we show the proper inline error 1`] = `
+<TaskError
+  editMode="EDIT"
+  taskType="APPROVAL"
+/>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is GENERAL and edit mode is CREATE, with error obj { status: 403 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="CREATE"
+  error={
+    Object {
+      "status": 403,
+    }
+  }
+  taskType="GENERAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Error"
+        id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Error"
+          id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="An error occurred while creating this task. Please try again."
+          id="be.api.taskCreateErrorMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is GENERAL and edit mode is CREATE, with error obj { status: 404 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="CREATE"
+  error={
+    Object {
+      "status": 404,
+    }
+  }
+  taskType="GENERAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Error"
+        id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Error"
+          id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="An error occurred while creating this task. Please try again."
+          id="be.api.taskCreateErrorMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is GENERAL and edit mode is CREATE, with error obj undefined, we show the proper inline error 1`] = `
+<TaskError
+  editMode="CREATE"
+  taskType="GENERAL"
+/>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is GENERAL and edit mode is EDIT, with error obj { status: 403 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="EDIT"
+  error={
+    Object {
+      "status": 403,
+    }
+  }
+  taskType="GENERAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Task Updated with Errors"
+        id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Task Updated with Errors"
+          id="be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="Unable to remove assignee(s) because the task is now completed."
+          id="be.contentSidebar.activityFeed.taskForm.taskGeneralAssigneeRemovalWarningMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is GENERAL and edit mode is EDIT, with error obj { status: 404 }, we show the proper inline error 1`] = `
+<TaskError
+  editMode="EDIT"
+  error={
+    Object {
+      "status": 404,
+    }
+  }
+  taskType="GENERAL"
+>
+  <InlineError
+    title={
+      <FormattedMessage
+        defaultMessage="Error"
+        id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+      />
+    }
+  >
+    <div
+      className="inline-alert inline-alert-visible inline-alert-error "
+    >
+      <b>
+        <FormattedMessage
+          defaultMessage="Error"
+          id="be.contentSidebar.activityFeed.taskForm.taskCreateErrorTitle"
+        >
+          <div />
+        </FormattedMessage>
+      </b>
+      <div>
+        <FormattedMessage
+          defaultMessage="An error occurred while modifying this task. Please try again."
+          id="be.contentSidebar.activityFeed.taskForm.taskUpdateErrorMessage"
+        >
+          <div />
+        </FormattedMessage>
+      </div>
+    </div>
+  </InlineError>
+</TaskError>
+`;
+
+exports[`components/content-sidebar/activity-feed/task-form/TaskError when type is GENERAL and edit mode is EDIT, with error obj undefined, we show the proper inline error 1`] = `
+<TaskError
+  editMode="EDIT"
+  taskType="GENERAL"
+/>
+`;

--- a/src/elements/content-sidebar/activity-feed/task-form/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/messages.js
@@ -12,10 +12,25 @@ const messages = defineMessages({
         description: 'Title shown above error message when a task creation fails',
         defaultMessage: 'Error',
     },
+    taskEditWarningTitle: {
+        id: 'be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle',
+        description: 'Title shown above warning message when a task create/edit partially fails',
+        defaultMessage: 'Task Updated with Errors',
+    },
     taskUpdateErrorMessage: {
         id: 'be.contentSidebar.activityFeed.taskForm.taskUpdateErrorMessage',
         description: 'Error message when a task edit fails',
         defaultMessage: 'An error occurred while modifying this task. Please try again.',
+    },
+    taskApprovalAssigneeRemovalWarningMessage: {
+        id: 'be.contentSidebar.activityFeed.taskForm.taskApprovalAssigneeRemovalWarningMessage',
+        description: 'Warning message showing that, while the task was updated, not all assignees (1+) were removed',
+        defaultMessage: 'Unable to remove assignee(s) because the task is now approved.',
+    },
+    taskGeneralAssigneeRemovalWarningMessage: {
+        id: 'be.contentSidebar.activityFeed.taskForm.taskGeneralAssigneeRemovalWarningMessage',
+        description: 'Warning message showing that, while the task was updated, not all assignees (1+) were removed',
+        defaultMessage: 'Unable to remove assignee(s) because the task is now completed.',
     },
     tasksAddTaskFormSelectAssigneesLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSelectAssigneesLabel',


### PR DESCRIPTION
add support for handling race conditions that can occur when altering a task in a certain way. 

- if a task is being edited to follow the "any" completion rule, any existing approvers/completers could trigger the rule stating that the task is done.
- we need to make sure that we perform the checks in a better sequence to preserve changes to tasks, collaborators, and status in the safest order possible
- re-sequencing the work such that task details are updated before removals
- adding new message for any attempts to remove assignees **after** a task is updated to "any" status