### PR TITLE
feat(classification): updated ui for classification

### DIFF
--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -853,7 +853,7 @@ type ErrorContextProps = {
 type ElementsErrorCallback = (e: ElementsXhrError, code: string, contextInfo?: Object) => void;
 
 type ClassificationInfo = {
-    advisoryMessage?: string,
+    definition?: string,
     name: string,
 };
 

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -598,6 +598,8 @@ boxui.checkboxTooltip.iconInfoText = Info
 boxui.classification.add = Add
 # Header for classification section in sidebar
 boxui.classification.classification = Classification
+# Header displayed above the classification definition
+boxui.classification.definition = Definition
 # Button to edit classification on an item
 boxui.classification.edit = Edit
 # Default message for classification in the sidebar when there is none

--- a/src/elements/content-sidebar/__tests__/DetailsSidebar-test.js
+++ b/src/elements/content-sidebar/__tests__/DetailsSidebar-test.js
@@ -71,7 +71,7 @@ describe('elements/content-sidebar/DetailsSidebar', () => {
         test('should render DetailsSidebar with all components', () => {
             const wrapper = getWrapper(
                 {
-                    classification: { advisoryMessage: 'message', name: 'name' },
+                    classification: { definition: 'message', name: 'name' },
                     hasProperties: true,
                     hasNotices: true,
                     hasAccessStats: true,

--- a/src/elements/content-sidebar/__tests__/SidebarClassification-test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarClassification-test.js
@@ -29,7 +29,7 @@ describe('elements/content-sidebar/SidebarClassification', () => {
             const props = {
                 classification: {
                     name: 'Public',
-                    advisoryMessage: 'message',
+                    definition: 'message',
                 },
                 file: {
                     permissions: {
@@ -51,7 +51,7 @@ describe('elements/content-sidebar/SidebarClassification', () => {
             const wrapper = getWrapper({
                 classification: {
                     name: 'Public',
-                    advisoryMessage: 'message',
+                    definition: 'message',
                 },
                 onEdit: jest.fn(),
                 intl: {
@@ -68,7 +68,7 @@ describe('elements/content-sidebar/SidebarClassification', () => {
             const wrapper = getWrapper({
                 classification: {
                     name: 'Public',
-                    advisoryMessage: 'message',
+                    definition: 'message',
                 },
                 onEdit: null,
                 file: {

--- a/src/elements/content-sidebar/__tests__/__snapshots__/DetailsSidebar-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/DetailsSidebar-test.js.snap
@@ -46,7 +46,7 @@ exports[`elements/content-sidebar/DetailsSidebar render() should render DetailsS
   <SidebarClassification
     classification={
       Object {
-        "advisoryMessage": "message",
+        "definition": "message",
         "name": "name",
       }
     }

--- a/src/elements/content-sidebar/__tests__/__snapshots__/SidebarClassification-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/SidebarClassification-test.js.snap
@@ -25,7 +25,7 @@ exports[`elements/content-sidebar/SidebarClassification render() should render c
   }
 >
   <Classification
-    advisoryMessage="message"
+    definition="message"
     messageStyle="inline"
     name="Public"
   />
@@ -51,7 +51,7 @@ exports[`elements/content-sidebar/SidebarClassification render() should render c
   }
 >
   <Classification
-    advisoryMessage="message"
+    definition="message"
     messageStyle="inline"
     name="Public"
   />
@@ -77,7 +77,7 @@ exports[`elements/content-sidebar/SidebarClassification render() should render c
   }
 >
   <Classification
-    advisoryMessage="message"
+    definition="message"
     messageStyle="inline"
     name="Public"
   />

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import Label from '../../components/label/Label';
 import ClassifiedBadge from './ClassifiedBadge';
 import messages from './messages';
 import './Classification.scss';
@@ -10,15 +11,15 @@ const STYLE_INLINE: 'inline' = 'inline';
 const STYLE_TOOLTIP: 'tooltip' = 'tooltip';
 
 type Props = {
-    advisoryMessage?: string,
     className?: string,
+    definition?: string,
     messageStyle?: typeof STYLE_INLINE | typeof STYLE_TOOLTIP,
     name?: string,
 };
 
-const Classification = ({ advisoryMessage, className = '', messageStyle, name }: Props) => {
+const Classification = ({ definition, className = '', messageStyle, name }: Props) => {
     const isClassified = !!name;
-    const hasMessage = !!advisoryMessage;
+    const hasMessage = !!definition;
 
     const isTooltipMessageEnabled = isClassified && hasMessage && messageStyle === STYLE_TOOLTIP;
     const isInlineMessageEnabled = isClassified && hasMessage && messageStyle === STYLE_INLINE;
@@ -30,10 +31,14 @@ const Classification = ({ advisoryMessage, className = '', messageStyle, name }:
             {isClassified && (
                 <ClassifiedBadge
                     name={((name: any): string)}
-                    tooltipText={isTooltipMessageEnabled ? advisoryMessage : undefined}
+                    tooltipText={isTooltipMessageEnabled ? definition : undefined}
                 />
             )}
-            {isInlineMessageEnabled && <p className="bdl-Classification-advisoryMessage">{advisoryMessage}</p>}
+            {isInlineMessageEnabled && (
+                <Label text={<FormattedMessage {...messages.definition} />}>
+                    <p className="bdl-Classification-definition">{definition}</p>
+                </Label>
+            )}
             {isNotClassifiedMessageVisible && (
                 <span className="bdl-Classification-missingMessage">
                     <FormattedMessage {...messages.missing} />
@@ -43,4 +48,5 @@ const Classification = ({ advisoryMessage, className = '', messageStyle, name }:
     );
 };
 
+export { STYLE_INLINE, STYLE_TOOLTIP };
 export default Classification;

--- a/src/features/classification/Classification.scss
+++ b/src/features/classification/Classification.scss
@@ -1,7 +1,14 @@
 @import '../../styles/variables';
 
-.bdl-Classification-advisoryMessage {
-    margin-top: 5px;
+.bdl-Classification {
+    .label {
+        font-weight: normal;
+        margin-top: 12px;
+    }
+}
+
+.bdl-Classification-definition {
+    margin-top: 3px;
 }
 
 .bdl-Classification-missingMessage {

--- a/src/features/classification/ClassifiedBadge.js
+++ b/src/features/classification/ClassifiedBadge.js
@@ -16,7 +16,7 @@ type Props = {
 const ClassifiedBadge = ({ name, tooltipPosition = 'bottom-center', tooltipText }: Props) => (
     <Tooltip isDisabled={!tooltipText} position={tooltipPosition} text={tooltipText}>
         <h1 className="bdl-ClassifiedBadge">
-            <IconSecurityClassification color={bdlYellorange} height={10} width={10} />
+            <IconSecurityClassification color={bdlYellorange} height={10} width={10} strokeWidth={3} />
             <span className="bdl-ClassifiedBadge-name">{name}</span>
         </h1>
     </Tooltip>

--- a/src/features/classification/README.md
+++ b/src/features/classification/README.md
@@ -1,21 +1,21 @@
 ### Description
-Renders a classification badge and advisory message.
+Renders a classification badge with classification definition.
 
 ### Examples
 
-**Classification with advisory message**
+**Classification with definition**
 ```jsx
 <Classification
-    advisoryMessage="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+    definition="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
     messageStyle="inline"
     name="Confidential"
 />
 ```
 
-**Classification with advisory message in a tooltip**
+**Classification with definition in a tooltip**
 ```jsx
 <Classification
-    advisoryMessage="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+    definition="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
     messageStyle="tooltip"
     name="Confidential"
 />

--- a/src/features/classification/__tests__/Classification-test.js
+++ b/src/features/classification/__tests__/Classification-test.js
@@ -6,7 +6,7 @@ import ClassifiedBadge from '../ClassifiedBadge';
 describe('features/classification/Classification', () => {
     const getWrapper = (props = {}) => shallow(<Classification {...props} />);
 
-    test('should render a classified badge with no advisory message', () => {
+    test('should render a classified badge with no definition', () => {
         const wrapper = getWrapper({
             name: 'Confidential',
         });
@@ -16,7 +16,7 @@ describe('features/classification/Classification', () => {
     test('should render empty when classification does not exist but is editable', () => {
         const wrapper = getWrapper();
         expect(wrapper.find(ClassifiedBadge).length).toBe(0);
-        expect(wrapper.find('.bdl-Classification-advisoryMessage').length).toBe(0);
+        expect(wrapper.find('.bdl-Classification-definition').length).toBe(0);
         expect(wrapper.find('.bdl-Classification-missingMessage').length).toBe(0);
     });
 
@@ -27,19 +27,19 @@ describe('features/classification/Classification', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should render a classified badge with an inline advisory message', () => {
+    test('should render a classified badge with an inline definition', () => {
         const wrapper = getWrapper({
             name: 'Confidential',
-            advisoryMessage: 'fubar',
+            definition: 'fubar',
             messageStyle: 'inline',
         });
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should render a classified badge with advisory message in tooltip', () => {
+    test('should render a classified badge with definition in tooltip', () => {
         const wrapper = getWrapper({
             name: 'Confidential',
-            advisoryMessage: 'fubar',
+            definition: 'fubar',
             messageStyle: 'tooltip',
         });
         expect(wrapper).toMatchSnapshot();

--- a/src/features/classification/__tests__/__snapshots__/Classification-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification-test.js.snap
@@ -1,6 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/classification/Classification should render a classified badge with advisory message in tooltip 1`] = `
+exports[`features/classification/Classification should render a classified badge with an inline definition 1`] = `
+<article
+  className="bdl-Classification "
+>
+  <ClassifiedBadge
+    name="Confidential"
+  />
+  <Label
+    text={
+      <FormattedMessage
+        defaultMessage="Definition"
+        id="boxui.classification.definition"
+      />
+    }
+  >
+    <p
+      className="bdl-Classification-definition"
+    >
+      fubar
+    </p>
+  </Label>
+</article>
+`;
+
+exports[`features/classification/Classification should render a classified badge with definition in tooltip 1`] = `
 <article
   className="bdl-Classification "
 >
@@ -11,22 +35,7 @@ exports[`features/classification/Classification should render a classified badge
 </article>
 `;
 
-exports[`features/classification/Classification should render a classified badge with an inline advisory message 1`] = `
-<article
-  className="bdl-Classification "
->
-  <ClassifiedBadge
-    name="Confidential"
-  />
-  <p
-    className="bdl-Classification-advisoryMessage"
-  >
-    fubar
-  </p>
-</article>
-`;
-
-exports[`features/classification/Classification should render a classified badge with no advisory message 1`] = `
+exports[`features/classification/Classification should render a classified badge with no definition 1`] = `
 <article
   className="bdl-Classification "
 >

--- a/src/features/classification/__tests__/__snapshots__/ClassifiedBadge-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/ClassifiedBadge-test.js.snap
@@ -15,6 +15,7 @@ exports[`features/classification/ClassifiedBadge should render a classified badg
     <IconSecurityClassification
       color="#f5b31b"
       height={10}
+      strokeWidth={3}
       width={10}
     />
     <span
@@ -40,6 +41,7 @@ exports[`features/classification/ClassifiedBadge should render a classified badg
     <IconSecurityClassification
       color="#f5b31b"
       height={10}
+      strokeWidth={3}
       width={10}
     />
     <span

--- a/src/features/classification/messages.js
+++ b/src/features/classification/messages.js
@@ -11,6 +11,11 @@ const messages = defineMessages({
         description: 'Header for classification section in sidebar',
         id: 'boxui.classification.classification',
     },
+    definition: {
+        defaultMessage: 'Definition',
+        description: 'Header displayed above the classification definition',
+        id: 'boxui.classification.definition',
+    },
     edit: {
         defaultMessage: 'Edit',
         description: 'Button to edit classification on an item',

--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
@@ -354,7 +354,7 @@ class SharedLinkSettingsModal extends Component {
             <span className="bdl-SharedLinkSettingsModal-title">
                 <FormattedMessage {...messages.modalTitle} />
                 <Classification
-                    advisoryMessage={bannerPolicy ? bannerPolicy.body : undefined}
+                    definition={bannerPolicy ? bannerPolicy.body : undefined}
                     messageStyle="tooltip"
                     name={classification}
                     className="bdl-SharedLinkSettingsModal-classification"

--- a/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal-test.js.snap
+++ b/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal-test.js.snap
@@ -9,8 +9,8 @@ exports[` 1`] = `
     id="boxui.share.sharedLinkSettings.modalTitle"
   />
   <Classification
-    advisoryMessage="test"
     className="bdl-SharedLinkSettingsModal-classification"
+    definition="test"
     messageStyle="tooltip"
     name="internal"
   />

--- a/src/features/unified-share-modal/UnifiedShareModalTitle.js
+++ b/src/features/unified-share-modal/UnifiedShareModalTitle.js
@@ -56,7 +56,7 @@ const UnifiedShareModalTitle = ({ isEmailLinkSectionExpanded, showCollaboratorLi
         <span className="bdl-UnifiedShareModalTitle">
             {title}
             <Classification
-                advisoryMessage={bannerPolicy ? bannerPolicy.body : undefined}
+                definition={bannerPolicy ? bannerPolicy.body : undefined}
                 messageStyle="tooltip"
                 name={classification}
                 className="bdl-UnifiedShareModalTitle-classification"

--- a/src/features/unified-share-modal/__tests__/UnifiedShareModal-test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareModal-test.js
@@ -33,7 +33,7 @@ describe('features/unified-share-modal/UnifiedShareModal', () => {
     const getWrapper = (props = {}) =>
         shallow(
             <UnifiedShareModal
-                classification={{ advisoryMessage: undefined, name: undefined }}
+                classification={{ definition: undefined, name: undefined }}
                 collaborationRestrictionWarning=""
                 getInitialData={jest.fn().mockImplementation(() => Promise.resolve('test'))}
                 intl={intl}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModalTitle-test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModalTitle-test.js.snap
@@ -14,8 +14,8 @@ exports[`features/unified-share-modal/HeaderTitle should render classifiction la
     }
   />
   <Classification
-    advisoryMessage="test"
     className="bdl-UnifiedShareModalTitle-classification"
+    definition="test"
     messageStyle="tooltip"
     name="internal"
   />

--- a/test/sidebar.html
+++ b/test/sidebar.html
@@ -112,7 +112,7 @@
                         hasAccessStats: true,
                         hasClassification: true,
                         classification: {
-                            advisoryMessage:
+                            definition:
                                 "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
                             name: 'confidential',
                         },
@@ -158,8 +158,7 @@
                     },
                     hasActivityFeed: true,
                     hasSkills: true,
-                    features: {
-                    },
+                    features: {},
                 });
                 if (refreshOnComplete) window.location.reload();
             }


### PR DESCRIPTION
BREAKING CHANGE: Also changes advisoryMessage prop to definition to keep terminology consistent

UI will now show a "Definition" label on top of the definition text:

<img width="255" alt="Screen Shot 2019-08-22 at 2 30 07 PM" src="https://user-images.githubusercontent.com/1322503/63551208-5f7d9300-c4e9-11e9-8a80-38fd25565f3a.png">
