### PR TITLE
build(i18n): Update babel to build i18n/json for local development

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,22 +15,28 @@ module.exports = {
         '@babel/plugin-transform-object-assign',
         '@babel/plugin-proposal-class-properties',
         '@babel/plugin-proposal-object-rest-spread',
+        [
+            'react-intl',
+            {
+                enforceDescriptions: true,
+                messagesDir: './i18n/json',
+            },
+        ],
     ],
     env: {
         dev: {
-            plugins: ['flow-react-proptypes'],
-        },
-        npm: {
             plugins: [
-                ['react-remove-properties', { properties: ['data-testid'] }],
+                'flow-react-proptypes',
                 [
                     'react-intl',
                     {
-                        enforceDescriptions: true,
-                        messagesDir: './i18n/json',
+                        enforceDescriptions: false,
                     },
                 ],
             ],
+        },
+        npm: {
+            plugins: [['react-remove-properties', { properties: ['data-testid'] }]],
         },
         production: {
             plugins: [['react-remove-properties', { properties: ['data-resin-target', 'data-testid'] }]],
@@ -39,12 +45,6 @@ module.exports = {
             plugins: [
                 '@babel/plugin-transform-modules-commonjs',
                 'dynamic-import-node', // https://github.com/facebook/jest/issues/5920
-                [
-                    'react-intl',
-                    {
-                        enforceDescriptions: false,
-                    },
-                ],
             ],
         },
     },


### PR DESCRIPTION
Message files are currently built along the following path, with the responsible script on top and associated files below:
```
Developer         -> build:*:es -> build:i18n (for both)
src/*/messages.js -> i18n/json  -> i18n/*.properties -> i18n/*.js
```

Unfortunately, the second step was failing silently for scripts such as `yarn start:npm` due to a misconfigured Babel environment setting. Even with this change, it will still be necessary to run `yarn build:i18n` manually after changing a message. The watcher doesn't run it automatically.