### PR TITLE
refactor(react): Rename deprecated React lifecycle methods

### DIFF
--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -40,7 +40,7 @@ class Avatar extends React.PureComponent<Props, State> {
         hasImageErrored: false,
     };
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         if (this.state.hasImageErrored && this.props.avatarUrl !== nextProps.avatarUrl) {
             this.setState({
                 hasImageErrored: false,

--- a/src/components/context-menu/ContextMenu.js
+++ b/src/components/context-menu/ContextMenu.js
@@ -37,12 +37,12 @@ class ContextMenu extends React.Component<Props, State> {
         targetOffset: '',
     };
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this.menuID = uniqueId('contextmenu');
         this.menuTargetID = uniqueId('contextmenutarget');
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         // if the menu becomes disabled while it is open, we should close it
         if (!this.props.isDisabled && nextProps.isDisabled && this.state.isOpen) {
             this.handleMenuClose();

--- a/src/components/context-menu/__tests__/ContextMenu-test.js
+++ b/src/components/context-menu/__tests__/ContextMenu-test.js
@@ -194,7 +194,7 @@ describe('components/context-menu/ContextMenu', () => {
         });
     });
 
-    describe('componentWillReceiveProps()', () => {
+    describe('UNSAFE_componentWillReceiveProps()', () => {
         test('should close menu when context menu becomes disabled and the menu is currently open', () => {
             const wrapper = shallow(
                 <ContextMenu>
@@ -207,7 +207,7 @@ describe('components/context-menu/ContextMenu', () => {
             const instance = wrapper.instance();
             sandbox.mock(instance).expects('handleMenuClose');
 
-            instance.componentWillReceiveProps({ isDisabled: true });
+            instance.UNSAFE_componentWillReceiveProps({ isDisabled: true });
         });
     });
 

--- a/src/components/datalist-item/DatalistItem.js
+++ b/src/components/datalist-item/DatalistItem.js
@@ -24,13 +24,13 @@ class DatalistItem extends React.Component<Props> {
         this.id = uniqueId('datalistitem');
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         if (this.props.isActive) {
             this.setActiveItemID();
         }
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         if (nextProps.isActive && !this.props.isActive) {
             this.setActiveItemID();
         }

--- a/src/components/datalist-item/__tests__/DatalistItem-test.js
+++ b/src/components/datalist-item/__tests__/DatalistItem-test.js
@@ -55,7 +55,7 @@ describe('components/datalist-item/DatalistItem', () => {
     });
 
     describe('setActiveItemID()', () => {
-        test('should call setActiveItemID() in componentWillMount() when isActive is true', () => {
+        test('should call setActiveItemID() in UNSAFE_componentWillMount() when isActive is true', () => {
             const setActiveItemIDSpy = sandbox.spy();
             shallow(
                 <DatalistItem isActive setActiveItemID={setActiveItemIDSpy}>

--- a/src/components/date-picker/DatePicker.js
+++ b/src/components/date-picker/DatePicker.js
@@ -205,7 +205,7 @@ class DatePicker extends React.Component<Props> {
         }
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { value: nextValue, minDate: nextMinDate, maxDate: nextMaxDate } = nextProps;
         const { value, minDate, maxDate, isTextInputAllowed } = this.props;
 

--- a/src/components/date-picker/__tests__/DatePicker-test.js.fixme
+++ b/src/components/date-picker/__tests__/DatePicker-test.js.fixme
@@ -514,7 +514,7 @@ describe('components/date-picker/DatePicker', () => {
             });
         });
 
-        describe('componentWillReceiveProps()', () => {
+        describe('UNSAFE_componentWillReceiveProps()', () => {
             test('should call setDate() when value changes', () => {
                 const wrapper = renderDatepicker();
                 const nextValue = new Date(123);

--- a/src/components/dropdown-menu/DropdownMenu.js
+++ b/src/components/dropdown-menu/DropdownMenu.js
@@ -39,7 +39,7 @@ class DropdownMenu extends React.Component<Props, State> {
         isOpen: false,
     };
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this.menuID = uniqueId('menu');
         this.menuButtonID = uniqueId('menubutton');
     }

--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -189,7 +189,7 @@ class Flyout extends React.Component<Props, State> {
         };
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this.overlayID = uniqueId('overlay');
         this.overlayButtonID = uniqueId('flyoutbutton');
     }

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -86,7 +86,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
      * @param {object} nextProps Props the component is receiving
      * @returns {void}
      */
-    componentWillReceiveProps(nextProps: Props, nextState: State) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props, nextState: State) {
         const { contacts: newContacts } = nextProps;
         const { contacts: currentContacts } = this.props;
         const { activeMention } = nextState;

--- a/src/components/form-elements/form/Form.js
+++ b/src/components/form-elements/form/Form.js
@@ -61,7 +61,7 @@ class Form extends Component {
         };
     }
 
-    componentWillUpdate(nextProps, nextState) {
+    UNSAFE_componentWillUpdate(nextProps, nextState) {
         if (nextProps.formValidityState) {
             Object.keys(nextProps.formValidityState).forEach(key => {
                 if (nextState.registeredInputs[key]) {

--- a/src/components/form-elements/text-area/TextArea.js
+++ b/src/components/form-elements/text-area/TextArea.js
@@ -48,7 +48,7 @@ class TextArea extends React.Component<Props, State> {
         };
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         // If a new value is passed by prop, set it
         if (nextProps.value !== this.props.value) {
             this.setState({

--- a/src/components/form-elements/text-input/TextInput.js
+++ b/src/components/form-elements/text-input/TextInput.js
@@ -60,7 +60,7 @@ class TextInput extends React.Component<Props, State> {
         };
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         // If a new value is passed by prop, set it
         if (nextProps.value !== this.props.value) {
             this.setState({

--- a/src/components/hotkeys/HotkeyHelpModal.js
+++ b/src/components/hotkeys/HotkeyHelpModal.js
@@ -49,7 +49,7 @@ class HotkeyHelpModal extends Component {
         };
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         if (!nextProps.isOpen) {
             return;
         }

--- a/src/components/hotkeys/__tests__/HotkeyHelpModal-test.js
+++ b/src/components/hotkeys/__tests__/HotkeyHelpModal-test.js
@@ -50,7 +50,7 @@ describe('components/hotkeys/components/HotkeyHelpModal', () => {
         });
     });
 
-    describe('componentWillReceiveProps()', () => {
+    describe('UNSAFE_componentWillReceiveProps()', () => {
         test('should set state.currentType when state.currentType is null', () => {
             const wrapper = getWrapper();
             wrapper.setState({ currentType: null });
@@ -67,7 +67,7 @@ describe('components/hotkeys/components/HotkeyHelpModal', () => {
 
             wrapper.setProps({ isOpen: true });
 
-            // should've been called once in constructor and once in componentWillReceiveProps
+            // should've been called once in constructor and once in UNSAFE_componentWillReceiveProps
             expect(HotkeyServiceMock.getActiveHotkeys.calledTwice).toBe(true);
             expect(HotkeyServiceMock.getActiveTypes.calledTwice).toBe(true);
         });

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -47,7 +47,7 @@ class Menu extends React.Component<Props> {
         this.setInitialFocusIndex();
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         if (nextProps.isSubmenu && !nextProps.isHidden && this.props.isHidden) {
             // If updating submenu, use the upcoming props instead of current props.
             this.setMenuItemEls();

--- a/src/components/menu/__tests__/Menu-test.js
+++ b/src/components/menu/__tests__/Menu-test.js
@@ -122,7 +122,7 @@ describe('components/menu/Menu', () => {
         });
     });
 
-    describe('componentWillReceiveProps()', () => {
+    describe('UNSAFE_componentWillReceiveProps()', () => {
         test('should call setInitialFocusIndex() when isSubmenu is true and isHidden changes from false to true', () => {
             const wrapper = shallow(
                 <Menu className="awesome-menu" isHidden>
@@ -133,7 +133,7 @@ describe('components/menu/Menu', () => {
             const instance = wrapper.instance();
             instance.setInitialFocusIndex = sandbox.mock();
 
-            instance.componentWillReceiveProps({
+            instance.UNSAFE_componentWillReceiveProps({
                 isHidden: false,
                 isSubmenu: true,
             });

--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -35,7 +35,7 @@ class ModalDialog extends React.Component<Props> {
         closeButtonProps: {},
     };
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this.modalID = uniqueId('modal');
     }
 

--- a/src/components/search-form/SearchForm.js
+++ b/src/components/search-form/SearchForm.js
@@ -71,7 +71,7 @@ class SearchForm extends React.Component<Props, State> {
         isEmpty: true,
     };
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         const { value } = nextProps;
         // update state if input is controlled and becomes empty
         if (typeof value !== 'undefined' && !value.trim()) {

--- a/src/components/search-form/__tests__/SearchForm-test.js
+++ b/src/components/search-form/__tests__/SearchForm-test.js
@@ -104,7 +104,7 @@ describe('components/search-form/SearchForm', () => {
         expect(searchActions.find('.clear-button').prop('onClick')).toEqual(onClearHandler);
     });
 
-    describe('componentWillReceiveProps()', () => {
+    describe('UNSAFE_componentWillReceiveProps()', () => {
         test('should set isEmpty state to true when controlled input becomes empty', () => {
             const wrapper = shallow(<SearchForm intl={intlShape} value="test" />).shallow();
             wrapper.setState({ isEmpty: false });

--- a/src/components/selector-dropdown/__tests__/SelectorDropdown-test.js
+++ b/src/components/selector-dropdown/__tests__/SelectorDropdown-test.js
@@ -479,7 +479,7 @@ describe('components/selector-dropdown/SelectorDropdown', () => {
         });
     });
 
-    describe('componentWillReceiveProps()', () => {
+    describe('UNSAFE_componentWillReceiveProps()', () => {
         [
             // No Children
             {

--- a/src/components/tab-view/TabViewPrimitive.js
+++ b/src/components/tab-view/TabViewPrimitive.js
@@ -49,7 +49,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
         }
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { focusedIndex, isDynamic, selectedIndex } = nextProps;
         if (isDynamic) {
             if (focusedIndex !== this.props.focusedIndex) {

--- a/src/components/tab-view/__tests__/TabViewPrimitive-test.js
+++ b/src/components/tab-view/__tests__/TabViewPrimitive-test.js
@@ -393,11 +393,11 @@ describe('components/tab-view/TabViewPrimitive', () => {
                 });
             });
 
-            describe('componentWillReceiveProps', () => {
+            describe('UNSAFE_componentWillReceiveProps', () => {
                 test('should do nothing if it is not dynamic', () => {
                     const instance = component.instance();
                     instance.scrollToTab = sinon.mock();
-                    instance.componentWillReceiveProps({
+                    instance.UNSAFE_componentWillReceiveProps({
                         focusedIndex: 0,
                         isDynamic: false,
                         selectedIndex: 0,
@@ -409,7 +409,7 @@ describe('components/tab-view/TabViewPrimitive', () => {
                     const instance = component.instance();
                     instance.scrollToTab = sinon.mock();
                     const focusedIndex = 2;
-                    instance.componentWillReceiveProps({
+                    instance.UNSAFE_componentWillReceiveProps({
                         focusedIndex,
                         isDynamic: true,
                         selectedIndex: component.props().selectedIndex,
@@ -421,7 +421,7 @@ describe('components/tab-view/TabViewPrimitive', () => {
                     const instance = component.instance();
                     instance.scrollToTab = sinon.mock();
                     const selectedIndex = 2;
-                    instance.componentWillReceiveProps({
+                    instance.UNSAFE_componentWillReceiveProps({
                         focusedIndex: component.props().focusedIndex,
                         isDynamic: true,
                         selectedIndex,
@@ -434,7 +434,7 @@ describe('components/tab-view/TabViewPrimitive', () => {
                 test('should not call focusOnTabElment if component is not dynamic', () => {
                     const instance = component.instance();
                     instance.focusOnTabElement = sinon.mock();
-                    instance.componentWillReceiveProps({
+                    instance.UNSAFE_componentWillReceiveProps({
                         focusedIndex: 0,
                         isDynamic: false,
                     });

--- a/src/components/table/__tests__/makeSelectable-test.js.fixme
+++ b/src/components/table/__tests__/makeSelectable-test.js.fixme
@@ -34,7 +34,7 @@ describe('components/table/makeSelectable', () => {
         });
     });
 
-    describe('componentWillUpdate()', () => {
+    describe('UNSAFE_componentWillUpdate()', () => {
         test('should call onFocus handler when focused index changes', () => {
             const onFocus = jest.fn();
             const wrapper = getWrapper({

--- a/src/components/table/makeSelectable.js
+++ b/src/components/table/makeSelectable.js
@@ -69,7 +69,7 @@ function makeSelectable(BaseTable) {
             document.addEventListener('keypress', this.handleKeyboardSearch);
         }
 
-        componentWillUpdate(nextProps, nextState) {
+        UNSAFE_componentWillUpdate(nextProps, nextState) {
             if (nextState.focusedIndex !== this.state.focusedIndex && this.props.onFocus) {
                 this.props.onFocus(nextState.focusedIndex);
             }

--- a/src/elements/common/KeyBinder.js
+++ b/src/elements/common/KeyBinder.js
@@ -85,7 +85,7 @@ class KeyBinder extends PureComponent<Props, State> {
      * @inheritdoc
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props): void {
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void {
         const { id, scrollToColumn, scrollToRow }: Props = nextProps;
         const { id: prevId }: Props = this.props;
         const { scrollToColumn: prevScrollToColumn, scrollToRow: prevScrollToRow }: State = this.state;

--- a/src/elements/common/progress-bar/ProgressBar.js
+++ b/src/elements/common/progress-bar/ProgressBar.js
@@ -52,7 +52,7 @@ class ProgressBar extends PureComponent<Props, State> {
      *
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         this.clearTimeoutAndInterval();
         const { percent }: Props = nextProps;
         this.setState({ percent }, this.startProgress);

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -303,7 +303,7 @@ class ContentExplorer extends Component<Props, State> {
      * @inheritdoc
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { currentFolderId }: Props = nextProps;
         const {
             currentCollection: { id },

--- a/src/elements/content-open-with/ContentOpenWith.js
+++ b/src/elements/content-open-with/ContentOpenWith.js
@@ -328,7 +328,7 @@ class ContentOpenWith extends PureComponent<Props, State> {
      * @private
      * @return {void}
      */
-    componentWillReceiveProps(): void {
+    UNSAFE_componentWillReceiveProps(): void {
         /* no-op */
     }
 

--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -258,7 +258,7 @@ class ContentPicker extends Component<Props, State> {
      * @inheritdoc
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { currentFolderId }: Props = nextProps;
         const {
             currentCollection: { id },

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -49,7 +49,7 @@ class CommentForm extends React.Component<Props, State> {
         commentEditorState: createMentionSelectorState(this.props.tagged_message),
     };
 
-    componentWillReceiveProps(nextProps: Props): void {
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void {
         const { isOpen } = nextProps;
 
         if (isOpen !== this.props.isOpen && !isOpen) {

--- a/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.js
+++ b/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.js
@@ -32,7 +32,7 @@ class ActivityMessage extends React.Component<Props, State> {
         isTranslation: false,
     };
 
-    componentWillReceiveProps(nextProps: Props): void {
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void {
         const { translatedTaggedMessage, translationFailed } = nextProps;
         if (translatedTaggedMessage || translationFailed) {
             this.setState({ isLoading: false });

--- a/src/elements/content-sidebar/skills/keywords/EditableKeywords.js
+++ b/src/elements/content-sidebar/skills/keywords/EditableKeywords.js
@@ -57,7 +57,7 @@ class EditableKeywords extends React.PureComponent<Props, State> {
      * @param {Object} nextProps - component props
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props): void {
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void {
         this.setState({ pills: getPills(nextProps.keywords), keyword: '' });
     }
 

--- a/src/elements/content-sidebar/skills/transcript/Transcript.js
+++ b/src/elements/content-sidebar/skills/transcript/Transcript.js
@@ -55,7 +55,7 @@ class Transcript extends React.PureComponent<Props, State> {
      * @private
      * @return {void}
      */
-    componentWillReceiveProps(): void {
+    UNSAFE_componentWillReceiveProps(): void {
         const wasEditing = typeof this.state.isEditingIndex === 'number';
         this.setState({
             isEditingIndex: wasEditing ? -1 : undefined,

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -184,7 +184,7 @@ class ContentUploader extends Component<Props, State> {
      * @param {Props} nextProps
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { files, dataTransferItems, useUploadsManager } = nextProps;
 
         const hasFiles = Array.isArray(files) && files.length > 0;

--- a/src/elements/content-uploader/ProgressBar.js
+++ b/src/elements/content-uploader/ProgressBar.js
@@ -39,7 +39,7 @@ class ProgressBar extends PureComponent<Props, State> {
      *
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { percent } = nextProps;
         this.setState({ percent });
     }

--- a/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
+++ b/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
@@ -115,7 +115,7 @@ class ContentExplorerModalContainer extends Component {
         };
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         const { initialFoldersPath } = this.props;
 
         if (nextProps.initialFoldersPath !== initialFoldersPath) {

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -135,7 +135,7 @@ class ContentExplorer extends Component {
         document.addEventListener('click', this.handleDocumentClick, true);
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         const { initialFoldersPath } = this.props;
 
         if (nextProps.initialFoldersPath !== initialFoldersPath) {

--- a/src/features/item-details/EditableDescription.js
+++ b/src/features/item-details/EditableDescription.js
@@ -29,7 +29,7 @@ class EditableDescription extends React.PureComponent<Props, State> {
         };
     }
 
-    componentWillReceiveProps(nextProps: Props): void {
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void {
         this.setState({ value: nextProps.value });
     }
 

--- a/src/features/item-details/EditableURL.js
+++ b/src/features/item-details/EditableURL.js
@@ -32,7 +32,7 @@ class EditableURL extends React.Component<Props, State> {
         value: this.props.value,
     };
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { value } = nextProps;
         if (value !== this.props.value) {
             this.setState({ value });

--- a/src/features/item-details/__tests__/EditableURL-test.js
+++ b/src/features/item-details/__tests__/EditableURL-test.js
@@ -13,7 +13,7 @@ describe('features/item-details/EditableURL', () => {
             />,
         );
 
-    describe('componentWillReceiveProps()', () => {
+    describe('UNSAFE_componentWillReceiveProps()', () => {
         test('should update state value when prop value changes', () => {
             const value = 'http://box.com';
             const wrapper = getWrapper();

--- a/src/features/metadata-instance-editor/CustomInstance.js
+++ b/src/features/metadata-instance-editor/CustomInstance.js
@@ -32,7 +32,7 @@ class CustomInstance extends React.PureComponent<Props, State> {
         };
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         this.setState({
             isAddFieldVisible: false,
             properties: { ...nextProps.data },

--- a/src/features/metadata-instance-editor/Instance.js
+++ b/src/features/metadata-instance-editor/Instance.js
@@ -99,7 +99,7 @@ class Instance extends React.PureComponent<Props, State> {
         this.fieldKeyToTypeMap = createFieldKeyToTypeMap(props.template.fields);
     }
 
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         const { hasError, isDirty }: Props = nextProps;
         const { isEditing }: State = this.state;
 

--- a/src/features/metadata-instance-editor/TemplateDropdown.js
+++ b/src/features/metadata-instance-editor/TemplateDropdown.js
@@ -70,7 +70,7 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
      * @param {Object} nextProps - next props
      * @return {void}
      */
-    componentWillReceiveProps(nextProps: Props) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         this.setState({
             templates: getAvailableTemplates(nextProps.templates, nextProps.usedTemplates),
         });

--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
@@ -152,7 +152,7 @@ class SharedLinkSettingsModal extends Component {
         };
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         const { expirationError, passwordError, vanityNameError } = nextProps;
 
         if (

--- a/src/features/shared-link-settings-modal/__tests__/SharedLinkSettingsModal-test.js
+++ b/src/features/shared-link-settings-modal/__tests__/SharedLinkSettingsModal-test.js
@@ -61,7 +61,7 @@ describe('features/shared-link-settings-modal/SharedLinkSettingsModal', () => {
             />,
         );
 
-    describe('componentWillReceiveProps()', () => {
+    describe('UNSAFE_componentWillReceiveProps()', () => {
         test('should update errors in state when error props change', () => {
             const wrapper = getWrapper({ expirationError: 'first error' });
 

--- a/src/icons/accessible-svg/AccessibleSVG.js
+++ b/src/icons/accessible-svg/AccessibleSVG.js
@@ -10,7 +10,7 @@ type Props = {
 };
 
 class AccessibleSVG extends React.Component<Props> {
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this.id = uniqueId('icon');
     }
 


### PR DESCRIPTION
Renames `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate` to their `UNSAFE_*` equivalents