### PR TITLE
fix(uploads): reset item error after retry

### DIFF
--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -768,6 +768,7 @@ class ContentUploader extends Component<Props, State> {
         item.api = this.getUploadAPI(file, options);
         item.progress = 0;
         item.status = STATUS_PENDING;
+        delete item.error;
 
         const { items } = this.state;
         items[items.indexOf(item)] = item;

--- a/src/elements/content-uploader/__tests__/ContentUploader-test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader-test.js
@@ -103,6 +103,37 @@ describe('elements/content-uploader/ContentUploader', () => {
         });
     });
 
+    describe('resetFile()', () => {
+        test('should call getUploadAPI and updateViewAndCollection', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            const item = { api: { cancel: jest.fn() }, file: { size: 10 } };
+            instance.getUploadAPI = jest.fn();
+            instance.updateViewAndCollection = jest.fn();
+
+            instance.resetFile(item);
+            expect(instance.getUploadAPI).toBeCalled();
+            expect(instance.updateViewAndCollection).toBeCalled();
+        });
+
+        test('should reset progress, status, and existing item error', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            const item = {
+                api: { cancel: jest.fn() },
+                file: { size: 10 },
+                progress: 85,
+                status: STATUS_ERROR,
+                error: { name: 'testerror' },
+            };
+
+            instance.resetFile(item);
+            expect(item.progress).toBe(0);
+            expect(item.status).toBe(STATUS_PENDING);
+            expect(item.error).toBeUndefined();
+        });
+    });
+
     describe('resumeFile()', () => {
         test('should call resume from api and call updateViewAndCollection', () => {
             const wrapper = getWrapper();


### PR DESCRIPTION
After an upload fails and has an error tied to the item, this error is currently never removed when retrying an upload. If this error exists when the retried upload finishes, the status of the item in the uploads manager is not set to completed, and so the item will continue to show the loading bar in the uploads manager (and because it is in a staged state, cannot be removed from the uploads manager due to the remove button being disabled). This PR removes the error after an upload is retried, so that the uploads manager will show the upload as completed after it finishes.