### PR TITLE
fix(user-link): allow wrapping of long user names

### DIFF
--- a/src/elements/content-sidebar/activity-feed/common/user-link/UserLink.scss
+++ b/src/elements/content-sidebar/activity-feed/common/user-link/UserLink.scss
@@ -4,4 +4,5 @@
 .bcs-UserLink.link {
     color: $bdl-gray;
     font-weight: bold;
+    white-space: normal;
 }


### PR DESCRIPTION
Allow long user names to wrap in comments and tasks.

Before:
<img width="324" alt="Screen Shot 2019-09-09 at 10 47 48 AM" src="https://user-images.githubusercontent.com/1280912/64554517-6f221780-d2f0-11e9-8c24-3f56264245c1.png">

After:
<img width="306" alt="Screen Shot 2019-09-09 at 10 48 03 AM" src="https://user-images.githubusercontent.com/1280912/64554531-747f6200-d2f0-11e9-89f8-81dc96e05a5f.png">
