### PR TITLE
fix(activity-feed): fix long user names in tasks/comments in Edge

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/Comment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.js
@@ -172,7 +172,7 @@ class Comment extends React.Component<Props, State> {
                                 )}
                             </TetherComponent>
                         )}
-                        <div>
+                        <div className="bcs-Comment-headline">
                             <UserLink
                                 data-resin-target={ACTIVITY_TARGETS.PROFILE}
                                 id={createdByUser.id}

--- a/src/elements/content-sidebar/activity-feed/comment/Comment.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/Comment.scss
@@ -16,6 +16,14 @@
     }
 }
 
+.bcs-Comment-headline {
+    // target only Edge because this breaks other browsers
+    // but fixes Edge
+    @supports (-ms-ime-align: auto) {
+        word-break: break-all;
+    }
+}
+
 // tethered styles for delete confirmation modal
 .bcs-Comment-deleteConfirmationModal {
     z-index: $overlay-z-index;

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/__snapshots__/Comment-test.js.snap
@@ -61,7 +61,9 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
           </MenuItem>
         </MediaMenu>
       </TetherComponent>
-      <div>
+      <div
+        className="bcs-Comment-headline"
+      >
         <UserLink
           data-resin-target="activityfeed-profilelink"
           id={10}
@@ -105,7 +107,9 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should correctly 
       />
     </MediaFigure>
     <MediaBody>
-      <div>
+      <div
+        className="bcs-Comment-headline"
+      >
         <UserLink
           data-resin-target="activityfeed-profilelink"
           id={10}
@@ -150,7 +154,9 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render an 
       />
     </MediaFigure>
     <MediaBody>
-      <div>
+      <div
+        className="bcs-Comment-headline"
+      >
         <UserLink
           data-resin-target="activityfeed-profilelink"
           id={10}
@@ -198,7 +204,9 @@ exports[`elements/content-sidebar/ActivityFeed/comment/Comment should render com
       />
     </MediaFigure>
     <MediaBody>
-      <div>
+      <div
+        className="bcs-Comment-headline"
+      >
         <UserLink
           data-resin-target="activityfeed-profilelink"
           id={10}

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.js
@@ -323,7 +323,7 @@ class Task extends React.Component<Props, State> {
                                 )}
                             </TetherComponent>
                         )}
-                        <div>
+                        <div className="bcs-Task-headline">
                             <FormattedMessage
                                 {...getMessageForTask(!!currentUserAssignment, task_type)}
                                 values={{

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -25,6 +25,14 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
     border-width: 2px;
 }
 
+.bcs-Task-headline {
+    // target only Edge because this breaks other browsers
+    // but fixes Edge
+    @supports (-ms-ime-align: auto) {
+        word-break: break-all;
+    }
+}
+
 .bcs-Task-statusContainer {
     margin-top: 2 * $bcs-task-grid;
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task-test.js.snap
@@ -82,7 +82,9 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
           </MenuItem>
         </MediaMenu>
       </TetherComponent>
-      <div>
+      <div
+        className="bcs-Task-headline"
+      >
         <FormattedMessage
           defaultMessage="{user} assigned you a Task"
           id="be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineGeneralCurrentUser"


### PR DESCRIPTION
Follow-up to https://github.com/box/box-ui-elements/pull/1602 that fixes long username wrapping in Edge. Sorry in advance for the browser targeting, but I tried and tried and couldn't find a better way that didn't break other browsers and fixed Edge... :(