### PR TITLE
feat(react): Add text for max version history

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -480,6 +480,8 @@ be.sidebarVersions.toggle = Toggle Actions Menu
 be.sidebarVersions.uploadedBy = Uploaded by {name}
 # Text displayed if a version exceeds the user's maximum allowed version count
 be.sidebarVersions.versionLimitExceeded = You are limited to the last {versionLimit, number} {versionLimit, plural, one {version} other {versions}}.
+# Max supported entries for version history
+be.sidebarVersions.versionMaxEntries = Version history is limited to the last {maxVersions} entries.
 # Text to display in the version badge.
 be.sidebarVersions.versionNumberBadge = V{versionNumber}
 # Label given to the version badge for screen readers.

--- a/src/elements/content-sidebar/versions/VersionsSidebar.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebar.js
@@ -11,8 +11,11 @@ import messages from './messages';
 import SidebarContent from '../SidebarContent';
 import VersionsMenu from './VersionsMenu';
 import { BackButton } from '../../common/nav-button';
+import { DEFAULT_FETCH_END } from '../../../constants';
 import { LoadingIndicatorWrapper } from '../../../components/loading-indicator';
 import './VersionsSidebar.scss';
+
+const MAX_VERSIONS = DEFAULT_FETCH_END;
 
 type Props = {
     error?: MessageDescriptor,
@@ -25,8 +28,7 @@ type Props = {
 };
 
 const VersionsSidebar = ({ error, isLoading, parentName, versions, ...rest }: Props) => {
-    const MAX_VERSIONS = 1000;
-    const maxVersions = versions.length >= 1000;
+    const showLimit = versions.length >= MAX_VERSIONS;
     const showVersions = !!versions.length;
     const showEmpty = !isLoading && !showVersions;
     const showError = !!error;
@@ -61,8 +63,8 @@ const VersionsSidebar = ({ error, isLoading, parentName, versions, ...rest }: Pr
                         <VersionsMenu versions={versions} {...rest} />
                     </div>
                 )}
-                {maxVersions && (
-                    <div className="bcs-Versions-max-entries">
+                {showLimit && (
+                    <div className="bcs-Versions-max-entries" data-testid="max-versions">
                         <FormattedMessage
                             {...messages.versionMaxEntries}
                             values={{

--- a/src/elements/content-sidebar/versions/VersionsSidebar.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebar.js
@@ -64,7 +64,7 @@ const VersionsSidebar = ({ error, isLoading, parentName, versions, ...rest }: Pr
                     </div>
                 )}
                 {showLimit && (
-                    <div className="bcs-Versions-max-entries" data-testid="max-versions">
+                    <div className="bcs-Versions-maxEntries" data-testid="max-versions">
                         <FormattedMessage
                             {...messages.versionMaxEntries}
                             values={{

--- a/src/elements/content-sidebar/versions/VersionsSidebar.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebar.js
@@ -25,6 +25,8 @@ type Props = {
 };
 
 const VersionsSidebar = ({ error, isLoading, parentName, versions, ...rest }: Props) => {
+    const MAX_VERSIONS = 1000;
+    const maxVersions = versions.length >= 1000;
     const showVersions = !!versions.length;
     const showEmpty = !isLoading && !showVersions;
     const showError = !!error;
@@ -57,6 +59,16 @@ const VersionsSidebar = ({ error, isLoading, parentName, versions, ...rest }: Pr
                 {showVersions && (
                     <div className="bcs-Versions-menu">
                         <VersionsMenu versions={versions} {...rest} />
+                    </div>
+                )}
+                {maxVersions && (
+                    <div className="bcs-Versions-max-entries">
+                        <FormattedMessage
+                            {...messages.versionMaxEntries}
+                            values={{
+                                maxVersions: MAX_VERSIONS,
+                            }}
+                        />
                     </div>
                 )}
             </LoadingIndicatorWrapper>

--- a/src/elements/content-sidebar/versions/VersionsSidebar.scss
+++ b/src/elements/content-sidebar/versions/VersionsSidebar.scss
@@ -27,7 +27,7 @@
 }
 
 .bcs-Versions-empty,
-.bcs-Versions-max-entries {
+.bcs-Versions-maxEntries {
     padding-top: 10px;
     text-align: center;
 }

--- a/src/elements/content-sidebar/versions/VersionsSidebar.scss
+++ b/src/elements/content-sidebar/versions/VersionsSidebar.scss
@@ -26,7 +26,8 @@
     padding-left: 25px;
 }
 
-.bcs-Versions-empty {
+.bcs-Versions-empty,
+.bcs-Versions-max-entries {
     padding-top: 10px;
     text-align: center;
 }

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebar-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebar-test.js
@@ -27,5 +27,12 @@ describe('elements/content-sidebar/versions/VersionsSidebar', () => {
             expect(wrapper.exists(InlineError)).toBe(true);
             expect(wrapper).toMatchSnapshot();
         });
+
+        test('should show max versions text if max versions provided', () => {
+            const versions = Array.from({ length: 1000 }).map((item, index) => ({ id: index }));
+            const wrapper = getWrapper({ versions });
+
+            expect(wrapper.find('.bcs-Versions-max-entries').length).toEqual(1);
+        });
     });
 });

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebar-test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebar-test.js
@@ -32,7 +32,7 @@ describe('elements/content-sidebar/versions/VersionsSidebar', () => {
             const versions = Array.from({ length: 1000 }).map((item, index) => ({ id: index }));
             const wrapper = getWrapper({ versions });
 
-            expect(wrapper.find('.bcs-Versions-max-entries').length).toEqual(1);
+            expect(wrapper.exists('[data-testid="max-versions"]')).toBe(true);
         });
     });
 });

--- a/src/elements/content-sidebar/versions/messages.js
+++ b/src/elements/content-sidebar/versions/messages.js
@@ -132,6 +132,11 @@ const messages = defineMessages({
         defaultMessage: 'Unknown',
         description: 'Name displayed for unknown or deleted users.',
     },
+    versionMaxEntries: {
+        id: 'be.sidebarVersions.versionMaxEntries',
+        defaultMessage: 'Version history is limited to the last {maxVersions} entries.',
+        description: 'Max supported entries for version history',
+    },
 });
 
 export default messages;


### PR DESCRIPTION
This will show a message if a user has reached the max version history of 1,000 entries. **The screen shot shows a max history of 2, but that is just for demonstration purposes. Actual message is set to a length of 1,000.**
<img width="350" alt="Screen Shot 2019-09-23 at 10 22 15 AM" src="https://user-images.githubusercontent.com/7842095/65451114-64d54280-ddf3-11e9-8726-01cbd5d9c425.png">
