### PR TITLE
refactor(avatar): Convert Avatar to hooks implementation

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -28,15 +28,17 @@ A published version of the style guide can be seen at https://opensource.box.com
 
 ### Webpack Setup
 
-`box-ui-elements` must use the same `react` and `react-dom` instances as the parent application for React hooks to work properly. Application repositories must add the following webpack `resolve` configuration to satify this requirement:
+`box-ui-elements` must use the same `react` and `react-dom` instances as the parent application for React hooks to work properly. Application repositories must add the following webpack `resolve` alias configuration to satify this requirement:
 
 ```js
 // webpack.config.js
 {
     ...
     resolve: {
-        'react': path.resolve('node_modules/react'),
-        'react-dom': path.resolve('node_modules/react-dom'),
+        alias: {
+            'react': path.resolve('node_modules/react'),
+            'react-dom': path.resolve('node_modules/react-dom'),
+        }
     }
     ...
 }

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -26,6 +26,40 @@ A published version of the style guide can be seen at https://opensource.box.com
 
 ## Testing UI Elements in a Parent Project
 
+### Webpack Setup
+
+`box-ui-elements` must use the same `react` and `react-dom` instances as the parent application for React hooks to work properly. Application repositories must add the following webpack `resolve` configuration to satify this requirement:
+
+```js
+// webpack.config.js
+{
+    ...
+    resolve: {
+        'react': path.resolve('node_modules/react'),
+        'react-dom': path.resolve('node_modules/react-dom'),
+    }
+    ...
+}
+```
+
+This will ensure that `box-ui-elements` does not use it's own `react` and `react-dom` modules when linked. Improper setup is the primary reason for "**Invalid Hook**" errors due to React version mismatch.
+
+We also recommend using `yarn resolutions` to fix the version of `react` and `react-dom` in your application:
+
+```js
+// package.json
+{
+    ...
+    "resolutions": {
+        "react": "16.9.0",
+        "react-dom": "16.9.0"
+    },
+    ...
+}
+```
+
+### Linking `box-ui-elements`
+
 To test the Box UI Elements with your own project use local Yarn linking.
 
 1. In the UI Elements project run `yarn link` as a one time setup.
@@ -48,6 +82,19 @@ To test the Box UI Elements with your own project use local Yarn linking.
 - `yarn release` to run a release.
 
 For more script commands see `package.json`. Test coverage reports are available under reports/coverage.
+
+## Best Practices
+
+### `import * as React from 'react'`
+
+You should always use this syntax over `import React, { ... } from 'react'` because it automatically includes flow types.
+
+Consequently, you must use the `React` prefix for related functions and components.
+
+- ~~`Component`~~ => `React.Component`
+- ~~`useState`~~ => `React.useState`
+
+For more information, please see https://flow.org/en/docs/react/components/#toc-class-components
 
 ## Useful Plugins
 
@@ -74,4 +121,49 @@ Under most circumstances you should be using the style guide as mentioned earlie
 
 ## Unit Testing
 
-The project is setup with Jest for unit testing. For debugging follow instructions provided in the [jest documentation](https://jestjs.io/docs/en/troubleshooting).
+### `jest` and `enzyme`
+
+The project uses the `jest` testing framework and `enzyme` for component testing.
+
+Please refer to the relevant documentation pages for tutorials and troubleshooting:
+
+- Jest: https://jestjs.io
+- Enzyme: https://airbnb.io/enzyme/
+
+### Testing Hooks with `enzyme`
+
+Most hooks can be tested with `shallow` rendering except for lifecycle hooks such as `useEffect` and `useLayoutEffect`.
+
+To test a `useEffect` hook, you must use `act()` from `react-dom/test-utils` and `mount()` from `enzyme`.
+
+```jsx
+import { act } from 'react-dom/test-utils';
+
+test('something happens', () => {
+    let wrapper;
+
+    // Perform initial render
+    act(() => {
+        wrapper = mount(<SomeComponent foo="bar">Content</SomeComponent>);
+    });
+
+    // Assert
+    expect(wrapper...);
+
+    // Perform re-render
+    act(() => {
+        // Update props to exercise lifecycle methods
+        wrapper.setProps({
+            foo: 'baz'
+        });
+    });
+
+    // Update wrapper - This must be after act()
+    wrapper.update();
+
+    // Assert
+    expect(wrapper...);
+}
+```
+
+See [React Testing Recipes](https://reactjs.org/docs/testing-recipes.html) for more examples.

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
@@ -30,50 +30,36 @@ type Props = {
     size?: $Keys<typeof SIZES>,
 };
 
-type State = {
-    /** boolean to determine if image did not load correctly */
-    hasImageErrored: boolean,
-};
+function Avatar({ avatarUrl, className, name, id, size = '' }: Props) {
+    const [hasImageErrored, setHasImageErrored] = useState(false);
+    const classes = classNames(['avatar', className, { [`avatar--${size}`]: SIZES[size] }]);
 
-class Avatar extends React.PureComponent<Props, State> {
-    state = {
-        hasImageErrored: false,
-    };
+    // Reset hasImageErrored state when avatarUrl changes
+    useEffect(() => {
+        setHasImageErrored(false);
+    }, [avatarUrl]);
 
-    componentDidUpdate(prevProps: Props, prevState: State): void {
-        if (prevState.hasImageErrored && prevProps.avatarUrl !== this.props.avatarUrl) {
-            this.setState({
-                hasImageErrored: false,
-            });
-        }
-    }
-
-    onImageError = () => {
-        this.setState({
-            hasImageErrored: true,
-        });
-    };
-
-    render() {
-        const { avatarUrl, className, name, id, size = '' }: Props = this.props;
-        const { hasImageErrored }: State = this.state;
-        const classes = classNames(['avatar', className, { [`avatar--${size}`]: SIZES[size] }]);
-
-        let avatar;
-        if (avatarUrl && !hasImageErrored) {
-            avatar = <AvatarImage onError={this.onImageError} url={avatarUrl} />;
-        } else if (name) {
-            avatar = <AvatarInitials id={id} name={name} />;
-        } else {
-            avatar = <UnknownUserAvatar className="avatar-icon" />;
-        }
-
-        return (
-            <span className={classes} role="presentation">
-                {avatar}
-            </span>
+    let avatar;
+    if (avatarUrl && !hasImageErrored) {
+        avatar = (
+            <AvatarImage
+                onError={() => {
+                    setHasImageErrored(true);
+                }}
+                url={avatarUrl}
+            />
         );
+    } else if (name) {
+        avatar = <AvatarInitials id={id} name={name} />;
+    } else {
+        avatar = <UnknownUserAvatar className="avatar-icon" />;
     }
+
+    return (
+        <span className={classes} role="presentation">
+            {avatar}
+        </span>
+    );
 }
 
 export default Avatar;

--- a/src/components/avatar/Avatar.js
+++ b/src/components/avatar/Avatar.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
 import classNames from 'classnames';
 import AvatarImage from './AvatarImage';
 import AvatarInitials from './AvatarInitials';
@@ -31,11 +31,11 @@ type Props = {
 };
 
 function Avatar({ avatarUrl, className, name, id, size = '' }: Props) {
-    const [hasImageErrored, setHasImageErrored] = useState(false);
+    const [hasImageErrored, setHasImageErrored] = React.useState(false);
     const classes = classNames(['avatar', className, { [`avatar--${size}`]: SIZES[size] }]);
 
     // Reset hasImageErrored state when avatarUrl changes
-    useEffect(() => {
+    React.useEffect(() => {
         setHasImageErrored(false);
     }, [avatarUrl]);
 

--- a/src/components/avatar/__tests__/Avatar-test.js
+++ b/src/components/avatar/__tests__/Avatar-test.js
@@ -1,6 +1,12 @@
 import React from 'react';
-
+import { act } from 'react-dom/test-utils';
 import Avatar from '../Avatar';
+
+function MockAvatarImage() {
+    return <div className="avatar-image" />;
+}
+
+jest.mock('../AvatarImage', () => MockAvatarImage);
 
 const testDataURI = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
@@ -22,7 +28,7 @@ describe('components/avatar/Avatar', () => {
 
     test('should render an AvatarImage when avatarUrl is passed in', () => {
         const wrapper = shallow(<Avatar avatarUrl={testDataURI} />);
-        const avatarImage = wrapper.find('AvatarImage');
+        const avatarImage = wrapper.find(MockAvatarImage);
         expect(avatarImage.length).toEqual(1);
         expect(avatarImage.prop('url')).toEqual(testDataURI);
     });
@@ -52,9 +58,9 @@ describe('components/avatar/Avatar', () => {
     test('should fall back to AvatarInitials when there is an error in AvatarImage', () => {
         const wrapper = shallow(<Avatar avatarUrl="http://foo.bar/baz123_invalid" id="1" name="hello world" />);
 
-        wrapper.instance().onImageError();
-        expect(wrapper.state('hasImageErrored')).toEqual(true);
-        wrapper.update();
+        const avatarImage = wrapper.find(MockAvatarImage);
+        avatarImage.prop('onError')();
+
         const avatarInitials = wrapper.find('AvatarInitials');
         expect(avatarInitials.length).toEqual(1);
     });
@@ -66,18 +72,27 @@ describe('components/avatar/Avatar', () => {
             avatarUrl: 'http://foo.bar/baz123_invalid',
         };
 
-        const wrapper = shallow(<Avatar {...props} />);
+        let wrapper;
+        act(() => {
+            wrapper = mount(<Avatar {...props} />);
+        });
+        expect(wrapper.find(MockAvatarImage).length).toEqual(1);
 
-        wrapper.instance().onImageError();
-        expect(wrapper.state('hasImageErrored')).toEqual(true);
-
-        wrapper.setProps({
-            ...props,
-            avatarUrl: 'http://foo.bar/baz123_invalid_new',
+        act(() => {
+            const avatarImage = wrapper.find(MockAvatarImage);
+            avatarImage.prop('onError')();
         });
         wrapper.update();
+        expect(wrapper.find(MockAvatarImage).length).toEqual(0);
+        expect(wrapper.find('AvatarInitials').length).toEqual(1);
 
-        expect(wrapper.state('hasImageErrored')).toEqual(false);
-        expect(wrapper.find('AvatarImage').length).toEqual(1);
+        act(() => {
+            wrapper.setProps({
+                ...props,
+                avatarUrl: 'http://foo.bar/baz123_invalid_new',
+            });
+        });
+        wrapper.update();
+        expect(wrapper.find(MockAvatarImage).length).toEqual(1);
     });
 });


### PR DESCRIPTION
Refactoring `Avatar` to use hooks (take 2). The first iteration worked fine but due to a few libraries using their own version of React (and also during node_module linking), this was reverted.

Now with `yarn resolutions`, we can avoid having duplicate React instances and multiple versions of react.