### PR TITLE
fix(sidebar): remove unwanted parentheses in empty state

### DIFF
--- a/src/elements/content-sidebar/activity-feed/activity-feed/EmptyState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/EmptyState.js
@@ -23,7 +23,6 @@ const EmptyState = ({ showCommentMessage }: Props): React.Node => (
                 </aside>
             ) : null}
         </div>
-        )
     </div>
 );
 


### PR DESCRIPTION
<img width="171" alt="Screen Shot 2019-09-25 at 11 25 59 AM" src="https://user-images.githubusercontent.com/21349325/65628916-4607b500-df87-11e9-9e9b-b4675db455bf.png">
