### PR TITLE
fix(unfied-share-modal): shared link access levels

### DIFF
--- a/src/features/unified-share-modal/SharedLinkAccessMenu.js
+++ b/src/features/unified-share-modal/SharedLinkAccessMenu.js
@@ -12,15 +12,15 @@ import type { ItemType } from '../../common/types/core';
 import SharedLinkAccessLabel from './SharedLinkAccessLabel';
 import { ANYONE_WITH_LINK, ANYONE_IN_COMPANY, PEOPLE_IN_ITEM } from './constants';
 import messages from './messages';
-import type { accessLevelType, allowedAccessLevelsType } from './flowTypes';
+import type { accessLevelType, accessLevelsDisabledReasonType, allowedAccessLevelsType } from './flowTypes';
 
 const accessLevels = [ANYONE_WITH_LINK, ANYONE_IN_COMPANY, PEOPLE_IN_ITEM];
 
 type Props = {
     accessLevel?: accessLevelType,
+    accessLevelsDisabledReason: accessLevelsDisabledReasonType,
     allowedAccessLevels: allowedAccessLevelsType,
     changeAccessLevel: (newAccessLevel: accessLevelType) => Promise<{ accessLevel: accessLevelType }>,
-    classificationName?: string,
     enterpriseName?: string,
     itemType: ItemType,
     onDismissTooltip: () => void,
@@ -35,6 +35,7 @@ type Props = {
 
 class SharedLinkAccessMenu extends React.Component<Props> {
     static defaultProps = {
+        accessLevelsDisabledReason: {},
         allowedAccessLevels: {},
         trackingProps: {},
     };
@@ -53,16 +54,27 @@ class SharedLinkAccessMenu extends React.Component<Props> {
     };
 
     renderMenu() {
-        const { accessLevel, allowedAccessLevels, classificationName, enterpriseName, itemType } = this.props;
-
+        const { accessLevel, accessLevelsDisabledReason, allowedAccessLevels, enterpriseName, itemType } = this.props;
         return (
             <Menu className="usm-share-access-menu">
                 {accessLevels.map(level => {
                     const isDisabled = !allowedAccessLevels[level];
-                    const isDisabledByClassification = isDisabled && classificationName;
-                    let menuItem = null;
-                    if (!isDisabled || isDisabledByClassification) {
-                        menuItem = (
+                    const isDisabledByPolicy = accessLevelsDisabledReason[level] === 'access_policy';
+
+                    // If an access level is disabled for reasons other than access policy enforcement
+                    // then we just don't show that menu item. If it is disabled because of an access policy
+                    // instead, then we show the menu item in a disabled state and with a tooltip.
+                    if (isDisabled && !isDisabledByPolicy) {
+                        return null;
+                    }
+
+                    return (
+                        <Tooltip
+                            isDisabled={!isDisabledByPolicy}
+                            key={`tooltip-${level}`}
+                            position="top-center"
+                            text={<FormattedMessage {...messages.disabledShareLinkPermission} />}
+                        >
                             <SelectMenuItem
                                 key={level}
                                 isDisabled={isDisabled}
@@ -76,27 +88,8 @@ class SharedLinkAccessMenu extends React.Component<Props> {
                                     itemType={itemType}
                                 />
                             </SelectMenuItem>
-                        );
-                    }
-                    if (menuItem && isDisabledByClassification) {
-                        return (
-                            <Tooltip
-                                key={`tooltip-${level}`}
-                                position="top-center"
-                                text={
-                                    <FormattedMessage
-                                        {...messages.disabledShareLinkPermission}
-                                        values={{
-                                            classification: classificationName,
-                                        }}
-                                    />
-                                }
-                            >
-                                {menuItem}
-                            </Tooltip>
-                        );
-                    }
-                    return menuItem;
+                        </Tooltip>
+                    );
                 })}
             </Menu>
         );

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -40,7 +40,6 @@ type Props = {
     changeSharedLinkPermissionLevel: (
         newPermissionLevel: permissionLevelType,
     ) => Promise<{ permissionLevel: permissionLevelType }>,
-    classificationName?: string,
     intl: IntlShape,
     item: itemtype,
     itemType: ItemType,
@@ -74,7 +73,6 @@ class SharedLinkSection extends React.Component<Props> {
             autofocusSharedLink,
             changeSharedLinkAccessLevel,
             changeSharedLinkPermissionLevel,
-            classificationName,
             item,
             itemType,
             onDismissTooltip,
@@ -87,6 +85,7 @@ class SharedLinkSection extends React.Component<Props> {
         } = this.props;
         const {
             accessLevel,
+            accessLevelsDisabledReason,
             allowedAccessLevels,
             canChangeAccessLevel,
             enterpriseName,
@@ -160,9 +159,9 @@ class SharedLinkSection extends React.Component<Props> {
                 <div className="shared-link-access-row">
                     <SharedLinkAccessMenu
                         accessLevel={accessLevel}
+                        accessLevelsDisabledReason={accessLevelsDisabledReason}
                         allowedAccessLevels={allowedAccessLevels}
                         changeAccessLevel={changeSharedLinkAccessLevel}
-                        classificationName={classificationName}
                         enterpriseName={enterpriseName}
                         itemType={itemType}
                         onDismissTooltip={() => onDismissTooltip('shared-link-access-menu')}

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -53,8 +53,6 @@ type Props = {
     changeSharedLinkPermissionLevel: (
         newPermissionLevel: permissionLevelType,
     ) => Promise<{ permissionLevel: permissionLevelType }>,
-    /** If item is classified this property contains the classification name */
-    classificationName?: string,
     /** Message warning about restrictions regarding inviting collaborators to the item */
     collaborationRestrictionWarning: React.Node,
     /** List of existing collaborators */
@@ -655,7 +653,6 @@ class UnifiedShareModal extends React.Component<Props, State> {
         const {
             changeSharedLinkAccessLevel,
             changeSharedLinkPermissionLevel,
-            classificationName,
             focusSharedLinkOnLoad,
             item,
             onSettingsClick,
@@ -724,7 +721,6 @@ class UnifiedShareModal extends React.Component<Props, State> {
                                 triggerCopyOnLoad={focusSharedLinkOnLoad}
                                 changeSharedLinkAccessLevel={changeSharedLinkAccessLevel}
                                 changeSharedLinkPermissionLevel={changeSharedLinkPermissionLevel}
-                                classificationName={classificationName}
                                 intl={intl}
                                 item={item}
                                 itemType={item.type}

--- a/src/features/unified-share-modal/__tests__/SharedLinkAccessMenu.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkAccessMenu.test.js
@@ -31,7 +31,7 @@ describe('features/unified-share-modal/SharedLinkAccessMenu', () => {
                 submitting: false,
             },
         ].forEach(({ submitting }) => {
-            test('should render correct menu', () => {
+            test(`should render correct menu when submitting is ${submitting}`, () => {
                 const sharedLinkAccessMenu = getWrapper({ submitting });
                 expect(sharedLinkAccessMenu).toMatchSnapshot();
             });
@@ -39,6 +39,32 @@ describe('features/unified-share-modal/SharedLinkAccessMenu', () => {
 
         test('should render tooltipContent if provided', () => {
             const sharedLinkAccessMenu = getWrapper({ tooltipContent: 'Hello, world!' });
+            expect(sharedLinkAccessMenu).toMatchSnapshot();
+        });
+
+        test('should render no access level menu items if disabled by something other than access policy', () => {
+            const sharedLinkAccessMenu = getWrapper({
+                allowedAccessLevels: {
+                    peopleInThisItem: true,
+                    peopleInYourCompany: false,
+                    peopleWithTheLink: false,
+                },
+            });
+            expect(sharedLinkAccessMenu).toMatchSnapshot();
+        });
+
+        test('should render tooltips for access level menu items if disabled by access policy', () => {
+            const sharedLinkAccessMenu = getWrapper({
+                accessLevelsDisabledReason: {
+                    peopleInYourCompany: 'access_policy',
+                    peopleWithTheLink: 'access_policy',
+                },
+                allowedAccessLevels: {
+                    peopleInThisItem: true,
+                    peopleInYourCompany: false,
+                    peopleWithTheLink: false,
+                },
+            });
             expect(sharedLinkAccessMenu).toMatchSnapshot();
         });
     });

--- a/src/features/unified-share-modal/__tests__/SharedLinkAccessMenu.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkAccessMenu.test.js
@@ -23,18 +23,13 @@ describe('features/unified-share-modal/SharedLinkAccessMenu', () => {
         );
 
     describe('render()', () => {
-        [
-            {
-                submitting: true,
-            },
-            {
-                submitting: false,
-            },
-        ].forEach(({ submitting }) => {
-            test(`should render correct menu when submitting is ${submitting}`, () => {
-                const sharedLinkAccessMenu = getWrapper({ submitting });
-                expect(sharedLinkAccessMenu).toMatchSnapshot();
-            });
+        test.each`
+            submitting
+            ${true}
+            ${false}
+        `('should render correct menu when submitting is $submitting', ({ submitting }) => {
+            const sharedLinkAccessMenu = getWrapper({ submitting });
+            expect(sharedLinkAccessMenu).toMatchSnapshot();
         });
 
         test('should render tooltipContent if provided', () => {

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu.test.js.snap
@@ -1,6 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/unified-share-modal/SharedLinkAccessMenu render() should render correct menu 1`] = `
+exports[`features/unified-share-modal/SharedLinkAccessMenu render() should render correct menu when submitting is false 1`] = `
+<Tooltip
+  className="usm-ftux-tooltip"
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isDisabled={false}
+  isShown={false}
+  onDismiss={[Function]}
+  position="middle-left"
+  showCloseButton={true}
+  text={null}
+  theme="callout"
+>
+  <DropdownMenu
+    constrainToScrollParent={false}
+    constrainToWindow={true}
+    isRightAligned={false}
+  >
+    <PlainButton
+      className="lnk"
+      disabled={false}
+    >
+      <MenuToggle>
+        <SharedLinkAccessLabel
+          accessLevel="peopleInYourCompany"
+          enterpriseName="Box"
+          hasDescription={false}
+          itemType="folder"
+        />
+      </MenuToggle>
+    </PlainButton>
+    <Menu
+      className="usm-share-access-menu"
+      isHidden={false}
+      isSubmenu={false}
+    />
+  </DropdownMenu>
+</Tooltip>
+`;
+
+exports[`features/unified-share-modal/SharedLinkAccessMenu render() should render correct menu when submitting is true 1`] = `
 <Tooltip
   className="usm-ftux-tooltip"
   constrainToScrollParent={false}
@@ -35,112 +75,12 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       className="usm-share-access-menu"
       isHidden={false}
       isSubmenu={false}
-    >
-      <Tooltip
-        constrainToScrollParent={false}
-        constrainToWindow={true}
-        isDisabled={false}
-        key="tooltip-peopleWithTheLink"
-        position="top-center"
-        text={
-          <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
-            id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
-          />
-        }
-        theme="default"
-      >
-        <SelectMenuItem
-          isDisabled={true}
-          isSelected={false}
-          key="peopleWithTheLink"
-          onClick={[Function]}
-        >
-          <SharedLinkAccessLabel
-            accessLevel="peopleWithTheLink"
-            enterpriseName="Box"
-            hasDescription={true}
-            itemType="folder"
-          />
-        </SelectMenuItem>
-      </Tooltip>
-      <Tooltip
-        constrainToScrollParent={false}
-        constrainToWindow={true}
-        isDisabled={false}
-        key="tooltip-peopleInYourCompany"
-        position="top-center"
-        text={
-          <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
-            id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
-          />
-        }
-        theme="default"
-      >
-        <SelectMenuItem
-          isDisabled={true}
-          isSelected={true}
-          key="peopleInYourCompany"
-          onClick={[Function]}
-        >
-          <SharedLinkAccessLabel
-            accessLevel="peopleInYourCompany"
-            enterpriseName="Box"
-            hasDescription={true}
-            itemType="folder"
-          />
-        </SelectMenuItem>
-      </Tooltip>
-      <Tooltip
-        constrainToScrollParent={false}
-        constrainToWindow={true}
-        isDisabled={false}
-        key="tooltip-peopleInThisItem"
-        position="top-center"
-        text={
-          <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
-            id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
-          />
-        }
-        theme="default"
-      >
-        <SelectMenuItem
-          isDisabled={true}
-          isSelected={false}
-          key="peopleInThisItem"
-          onClick={[Function]}
-        >
-          <SharedLinkAccessLabel
-            accessLevel="peopleInThisItem"
-            enterpriseName="Box"
-            hasDescription={true}
-            itemType="folder"
-          />
-        </SelectMenuItem>
-      </Tooltip>
-    </Menu>
+    />
   </DropdownMenu>
 </Tooltip>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessMenu render() should render correct menu 2`] = `
+exports[`features/unified-share-modal/SharedLinkAccessMenu render() should render no access level menu items if disabled by something other than access policy 1`] = `
 <Tooltip
   className="usm-ftux-tooltip"
   constrainToScrollParent={false}
@@ -179,90 +119,19 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
-        isDisabled={false}
-        key="tooltip-peopleWithTheLink"
-        position="top-center"
-        text={
-          <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
-            id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
-          />
-        }
-        theme="default"
-      >
-        <SelectMenuItem
-          isDisabled={true}
-          isSelected={false}
-          key="peopleWithTheLink"
-          onClick={[Function]}
-        >
-          <SharedLinkAccessLabel
-            accessLevel="peopleWithTheLink"
-            enterpriseName="Box"
-            hasDescription={true}
-            itemType="folder"
-          />
-        </SelectMenuItem>
-      </Tooltip>
-      <Tooltip
-        constrainToScrollParent={false}
-        constrainToWindow={true}
-        isDisabled={false}
-        key="tooltip-peopleInYourCompany"
-        position="top-center"
-        text={
-          <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
-            id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
-          />
-        }
-        theme="default"
-      >
-        <SelectMenuItem
-          isDisabled={true}
-          isSelected={true}
-          key="peopleInYourCompany"
-          onClick={[Function]}
-        >
-          <SharedLinkAccessLabel
-            accessLevel="peopleInYourCompany"
-            enterpriseName="Box"
-            hasDescription={true}
-            itemType="folder"
-          />
-        </SelectMenuItem>
-      </Tooltip>
-      <Tooltip
-        constrainToScrollParent={false}
-        constrainToWindow={true}
-        isDisabled={false}
+        isDisabled={true}
         key="tooltip-peopleInThisItem"
         position="top-center"
         text={
           <FormattedMessage
             defaultMessage="This option isn’t available for this item due to a security restriction or classification."
             id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
           />
         }
         theme="default"
       >
         <SelectMenuItem
-          isDisabled={true}
+          isDisabled={false}
           isSelected={false}
           key="peopleInThisItem"
           onClick={[Function]}
@@ -315,6 +184,46 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       className="usm-share-access-menu"
       isHidden={false}
       isSubmenu={false}
+    />
+  </DropdownMenu>
+</Tooltip>
+`;
+
+exports[`features/unified-share-modal/SharedLinkAccessMenu render() should render tooltips for access level menu items if disabled by access policy 1`] = `
+<Tooltip
+  className="usm-ftux-tooltip"
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isDisabled={false}
+  isShown={false}
+  onDismiss={[Function]}
+  position="middle-left"
+  showCloseButton={true}
+  text={null}
+  theme="callout"
+>
+  <DropdownMenu
+    constrainToScrollParent={false}
+    constrainToWindow={true}
+    isRightAligned={false}
+  >
+    <PlainButton
+      className="lnk"
+      disabled={false}
+    >
+      <MenuToggle>
+        <SharedLinkAccessLabel
+          accessLevel="peopleInYourCompany"
+          enterpriseName="Box"
+          hasDescription={false}
+          itemType="folder"
+        />
+      </MenuToggle>
+    </PlainButton>
+    <Menu
+      className="usm-share-access-menu"
+      isHidden={false}
+      isSubmenu={false}
     >
       <Tooltip
         constrainToScrollParent={false}
@@ -326,11 +235,6 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
           <FormattedMessage
             defaultMessage="This option isn’t available for this item due to a security restriction or classification."
             id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
           />
         }
         theme="default"
@@ -359,11 +263,6 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
           <FormattedMessage
             defaultMessage="This option isn’t available for this item due to a security restriction or classification."
             id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
           />
         }
         theme="default"
@@ -385,24 +284,19 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
       <Tooltip
         constrainToScrollParent={false}
         constrainToWindow={true}
-        isDisabled={false}
+        isDisabled={true}
         key="tooltip-peopleInThisItem"
         position="top-center"
         text={
           <FormattedMessage
             defaultMessage="This option isn’t available for this item due to a security restriction or classification."
             id="boxui.unifiedShare.disabledShareLinkPermission"
-            values={
-              Object {
-                "classification": "Internal",
-              }
-            }
           />
         }
         theme="default"
       >
         <SelectMenuItem
-          isDisabled={true}
+          isDisabled={false}
           isSelected={false}
           key="peopleInThisItem"
           onClick={[Function]}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -124,6 +124,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
   >
     <SharedLinkAccessMenu
       accessLevel="peopleInYourCompany"
+      accessLevelsDisabledReason={Object {}}
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       enterpriseName="Box"
@@ -267,6 +268,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
   >
     <SharedLinkAccessMenu
       accessLevel="peopleInYourCompany"
+      accessLevelsDisabledReason={Object {}}
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       enterpriseName="Box"
@@ -441,6 +443,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
   >
     <SharedLinkAccessMenu
       accessLevel="peopleInYourCompany"
+      accessLevelsDisabledReason={Object {}}
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       enterpriseName="Box"
@@ -618,6 +621,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
     className="shared-link-access-row"
   >
     <SharedLinkAccessMenu
+      accessLevelsDisabledReason={Object {}}
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       itemType="file"
@@ -754,6 +758,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   >
     <SharedLinkAccessMenu
       accessLevel="peopleInYourCompany"
+      accessLevelsDisabledReason={Object {}}
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       enterpriseName="Box"
@@ -884,6 +889,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   >
     <SharedLinkAccessMenu
       accessLevel="peopleInYourCompany"
+      accessLevelsDisabledReason={Object {}}
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       enterpriseName="Box"
@@ -1039,6 +1045,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
   >
     <SharedLinkAccessMenu
       accessLevel="peopleInThisItem"
+      accessLevelsDisabledReason={Object {}}
       allowedAccessLevels={Object {}}
       changeAccessLevel={[Function]}
       enterpriseName="Box"

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -29,6 +29,12 @@ export type allowedAccessLevelsType = {
     peopleWithTheLink?: boolean,
 };
 
+export type accessLevelsDisabledReasonType = {
+    peopleInThisItem?: 'access_policy' | null,
+    peopleInYourCompany?: 'access_policy' | null,
+    peopleWithTheLink?: 'access_policy' | null,
+};
+
 export type contactType = {
     email?: string,
     id: number | string,
@@ -123,6 +129,7 @@ export type trackingPropsType = {
 // this type is a strict subset of the SharedLinkRecord data returned from the server
 export type sharedLinkType = {
     accessLevel: accessLevelType,
+    accessLevelsDisabledReason?: accessLevelsDisabledReasonType,
     allowedAccessLevels: allowedAccessLevelsType,
     canChangeAccessLevel: boolean,
     enterpriseName: string,


### PR DESCRIPTION
When creating shared links, this changes the access level drop down to show menu items in a disabled state if disabled by an access policy. Before such happened just based on the fact that some classification existed or not, which is incorrect since you can just have classifications without any applicable policies.

Additionally a small cleanup/refactor of the menu generation.

When access levels are disabled due to a policy
<img width="500" alt="Screen Shot 2019-09-26 at 1 33 43 PM" src="https://user-images.githubusercontent.com/1075325/65728516-11235d00-e070-11e9-9570-1606ee431d40.png">

When access levels are disabled but due to other reasons
<img width="477" alt="Screen Shot 2019-09-26 at 1 31 05 PM" src="https://user-images.githubusercontent.com/1075325/65728518-11bbf380-e070-11e9-956f-f47f14f4f3ef.png">
