### PR TITLE
fix(sidebar): Fix deeplinking for version history sidebar

### DIFF
--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -159,7 +159,10 @@ class SidebarPanels extends React.Component<Props> {
                 {hasActivity && (
                     <Route
                         exact
-                        path={`/${SIDEBAR_VIEW_ACTIVITY}/:activeFeedEntryType(comments|tasks)?/:activeFeedEntryId?`}
+                        path={[
+                            `/${SIDEBAR_VIEW_ACTIVITY}`,
+                            `/${SIDEBAR_VIEW_ACTIVITY}/:activeFeedEntryType(comments|tasks)/:activeFeedEntryId?`,
+                        ]}
                         render={({ match }) => {
                             const matchEntryType = match.params.activeFeedEntryType;
                             const activeFeedEntryType = matchEntryType

--- a/src/elements/content-sidebar/__tests__/__snapshots__/SidebarPanels-test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/SidebarPanels-test.js.snap
@@ -4,7 +4,12 @@ exports[`elements/content-sidebar/SidebarPanels render activity sidebar should r
 <Switch>
   <Route
     exact={true}
-    path="/activity/:activeFeedEntryType(comments|tasks)?/:activeFeedEntryId?"
+    path={
+      Array [
+        "/activity",
+        "/activity/:activeFeedEntryType(comments|tasks)/:activeFeedEntryId?",
+      ]
+    }
     render={[Function]}
   />
   <Route


### PR DESCRIPTION
I guess regex + optional parameters don't work.