### PR TITLE
fix(arrow-stepper): Fix arrow stepper in KeyBinding component

### DIFF
--- a/src/elements/common/KeyBinder.js
+++ b/src/elements/common/KeyBinder.js
@@ -28,6 +28,9 @@ type Props = {
 
 type State = {
     focusOnRender: boolean,
+    prevId: number,
+    prevScrollToColumn: number,
+    prevScrollToRow: number,
     scrollToColumn: number,
     scrollToRow: number,
 };
@@ -57,6 +60,45 @@ class KeyBinder extends PureComponent<Props, State> {
     };
 
     /**
+     * Resets scroll position if props change
+     * @private
+     * @inheritdoc
+     * @return {State|null}
+     */
+    static getDerivedStateFromProps(props: Props, state: State): void {
+        const { prevId, prevScrollToColumn, prevScrollToRow }: State = state;
+        const { id, scrollToColumn: scrollToColumnProp, scrollToRow: scrollToRowProp }: Props = props;
+
+        if (id !== prevId) {
+            return {
+                focusOnRender: false,
+                prevId: id,
+                prevScrollToColumn: 0,
+                prevScrollToRow: 0,
+                scrollToColumn: 0,
+                scrollToRow: 0,
+            };
+        }
+
+        const newState = {};
+
+        if (prevScrollToColumn !== scrollToColumnProp && prevScrollToRow !== scrollToRowProp) {
+            newState.prevScrollToColumn = scrollToColumnProp;
+            newState.prevScrollToRow = scrollToRowProp;
+            newState.scrollToColumn = scrollToColumnProp;
+            newState.scrollToRow = scrollToRowProp;
+        } else if (scrollToRowProp !== prevScrollToRow) {
+            newState.prevScrollToRow = scrollToRowProp;
+            newState.scrollToRow = scrollToRowProp;
+        } else if (scrollToColumnProp !== prevScrollToColumn) {
+            newState.prevScrollToColumn = scrollToColumnProp;
+            newState.scrollToColumn = scrollToColumnProp;
+        }
+
+        return Object.keys(newState).length ? newState : null;
+    }
+
+    /**
      * [constructor]
      *
      * @private
@@ -65,51 +107,20 @@ class KeyBinder extends PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
 
+        const { id, scrollToRow, scrollToColumn }: Props = props;
         this.state = {
-            scrollToColumn: props.scrollToColumn,
-            scrollToRow: props.scrollToRow,
             focusOnRender: false,
+            prevId: id,
+            prevScrollToColumn: scrollToColumn,
+            prevScrollToRow: scrollToRow,
+            scrollToColumn,
+            scrollToRow,
         };
 
         this.columnStartIndex = 0;
         this.columnStopIndex = 0;
         this.rowStartIndex = 0;
         this.rowStopIndex = 0;
-    }
-
-    /**
-     * Resets scroll states and sets new states if
-     * needed specially when collection changes
-     *
-     * @private
-     * @inheritdoc
-     * @return {void}
-     */
-    componentDidUpdate(prevProps: Props, prevState: State): void {
-        const { id, scrollToColumn, scrollToRow }: Props = this.props;
-        const { id: prevId }: Props = prevProps;
-        const { scrollToColumn: prevScrollToColumn, scrollToRow: prevScrollToRow }: State = prevState;
-        const newState = {};
-
-        if (id !== prevId) {
-            // Only when the entire collection changes
-            // like folder navigate, reset the scroll states
-            newState.scrollToColumn = 0;
-            newState.scrollToRow = 0;
-            newState.focusOnRender = false;
-        } else if (prevScrollToColumn !== scrollToColumn && prevScrollToRow !== scrollToRow) {
-            newState.scrollToColumn = scrollToColumn;
-            newState.scrollToRow = scrollToRow;
-        } else if (prevScrollToColumn !== scrollToColumn) {
-            newState.scrollToColumn = scrollToColumn;
-        } else if (prevScrollToRow !== scrollToRow) {
-            newState.scrollToRow = scrollToRow;
-        }
-
-        // Only update the state if there is something to set
-        if (Object.keys(newState).length) {
-            this.setState(newState);
-        }
     }
 
     /**

--- a/src/elements/common/KeyBinder.js
+++ b/src/elements/common/KeyBinder.js
@@ -28,7 +28,7 @@ type Props = {
 
 type State = {
     focusOnRender: boolean,
-    prevId: number,
+    prevId: string | void,
     prevScrollToColumn: number,
     prevScrollToRow: number,
     scrollToColumn: number,
@@ -65,7 +65,7 @@ class KeyBinder extends PureComponent<Props, State> {
      * @inheritdoc
      * @return {State|null}
      */
-    static getDerivedStateFromProps(props: Props, state: State): void {
+    static getDerivedStateFromProps(props: Props, state: State) {
         const { prevId, prevScrollToColumn, prevScrollToRow }: State = state;
         const { id, scrollToColumn: scrollToColumnProp, scrollToRow: scrollToRowProp }: Props = props;
 

--- a/src/elements/common/__tests__/KeyBinder.js
+++ b/src/elements/common/__tests__/KeyBinder.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import KeyBinder from '../KeyBinder';
+
+describe('KeyBinder', () => {
+    let onScrollToChangeMock;
+    let getEvent;
+    let wrapper;
+
+    beforeEach(() => {
+        onScrollToChangeMock = jest.fn();
+        wrapper = shallow(
+            <KeyBinder
+                id="123"
+                onScrollToChange={onScrollToChangeMock}
+                rowCount={10}
+                items={[]}
+                columnCount={10}
+                scrollToRow={0}
+                scrollToColumn={0}
+            >
+                {() => {}}
+            </KeyBinder>,
+        );
+        getEvent = type => {
+            return {
+                key: type,
+                stopPropagation: jest.fn(),
+                preventDefault: jest.fn(),
+            };
+        };
+    });
+
+    test('it should update scrollToRow when props change', () => {
+        wrapper.setProps({ scrollToRow: 5 });
+        expect(wrapper.state('scrollToRow')).toEqual(5);
+    });
+
+    test('it should update scrollToColumn when props change', () => {
+        wrapper.setProps({ scrollToColumn: 5 });
+        expect(wrapper.state('scrollToColumn')).toEqual(5);
+    });
+
+    test('it should update scrollToColumn and scrollToRow when props change', () => {
+        wrapper.setProps({ scrollToColumn: 5, scrollToRow: 5 });
+        expect(wrapper.state('scrollToColumn')).toEqual(5);
+        expect(wrapper.state('scrollToRow')).toEqual(5);
+    });
+
+    test.each`
+        eventType       | scrollType          | result
+        ${'ArrowUp'}    | ${'scrollToRow'}    | ${2}
+        ${'ArrowDown'}  | ${'scrollToRow'}    | ${8}
+        ${'ArrowLeft'}  | ${'scrollToColumn'} | ${2}
+        ${'ArrowRight'} | ${'scrollToColumn'} | ${8}
+    `('Arrow Handlers', ({ eventType, scrollType, result }) => {
+        const event = getEvent(eventType);
+
+        wrapper.setProps({ [`${scrollType}`]: 5 });
+        wrapper.simulate('keyDown', event);
+        wrapper.simulate('keyDown', event);
+        wrapper.simulate('keyDown', event);
+        expect(onScrollToChangeMock).toBeCalled();
+        expect(wrapper.state(scrollType)).toEqual(result);
+    });
+});

--- a/src/elements/common/__tests__/KeyBinder.js
+++ b/src/elements/common/__tests__/KeyBinder.js
@@ -4,12 +4,15 @@ import KeyBinder from '../KeyBinder';
 
 describe('KeyBinder', () => {
     let onScrollToChangeMock;
-    let getEvent;
-    let wrapper;
-
-    beforeEach(() => {
-        onScrollToChangeMock = jest.fn();
-        wrapper = shallow(
+    const getEvent = type => {
+        return {
+            key: type,
+            stopPropagation: jest.fn(),
+            preventDefault: jest.fn(),
+        };
+    };
+    const getWrapper = props => {
+        return shallow(
             <KeyBinder
                 id="123"
                 onScrollToChange={onScrollToChangeMock}
@@ -18,30 +21,34 @@ describe('KeyBinder', () => {
                 columnCount={10}
                 scrollToRow={0}
                 scrollToColumn={0}
+                {...props}
             >
                 {() => {}}
             </KeyBinder>,
         );
-        getEvent = type => {
-            return {
-                key: type,
-                stopPropagation: jest.fn(),
-                preventDefault: jest.fn(),
-            };
-        };
+    };
+
+    beforeEach(() => {
+        onScrollToChangeMock = jest.fn();
     });
 
-    test('it should update scrollToRow when props change', () => {
+    test('should update scrollToRow when props change', () => {
+        const wrapper = getWrapper();
+
         wrapper.setProps({ scrollToRow: 5 });
         expect(wrapper.state('scrollToRow')).toEqual(5);
     });
 
-    test('it should update scrollToColumn when props change', () => {
+    test('should update scrollToColumn when props change', () => {
+        const wrapper = getWrapper();
+
         wrapper.setProps({ scrollToColumn: 5 });
         expect(wrapper.state('scrollToColumn')).toEqual(5);
     });
 
-    test('it should update scrollToColumn and scrollToRow when props change', () => {
+    test('should update scrollToColumn and scrollToRow when props change', () => {
+        const wrapper = getWrapper();
+
         wrapper.setProps({ scrollToColumn: 5, scrollToRow: 5 });
         expect(wrapper.state('scrollToColumn')).toEqual(5);
         expect(wrapper.state('scrollToRow')).toEqual(5);
@@ -53,13 +60,15 @@ describe('KeyBinder', () => {
         ${'ArrowDown'}  | ${'scrollToRow'}    | ${8}
         ${'ArrowLeft'}  | ${'scrollToColumn'} | ${2}
         ${'ArrowRight'} | ${'scrollToColumn'} | ${8}
-    `('Arrow Handlers', ({ eventType, scrollType, result }) => {
+    `('should exercise the $eventType key for $scrollType', ({ eventType, scrollType, result }) => {
         const event = getEvent(eventType);
+        const wrapper = getWrapper({ [`${scrollType}`]: 5 });
+        const instance = wrapper.instance();
 
-        wrapper.setProps({ [`${scrollType}`]: 5 });
-        wrapper.simulate('keyDown', event);
-        wrapper.simulate('keyDown', event);
-        wrapper.simulate('keyDown', event);
+        instance.onKeyDown(event);
+        instance.onKeyDown(event);
+        instance.onKeyDown(event);
+
         expect(onScrollToChangeMock).toBeCalled();
         expect(wrapper.state(scrollType)).toEqual(result);
     });


### PR DESCRIPTION
Move from `componentDidUpdate` to use the  `getDerivedStateFromProps` function. This also adds tests for the arrow keys and prop updates.