### PR TITLE
fix(subheader): Add logic around grid view

### DIFF
--- a/src/elements/common/sub-header/SubHeaderRight.js
+++ b/src/elements/common/sub-header/SubHeaderRight.js
@@ -38,20 +38,20 @@ const SubHeaderRight = ({
     gridMaxColumns,
     gridMinColumns,
     maxGridColumnCountForWidth,
-    onGridViewSliderChange,
     onCreate,
-    onViewModeChange,
+    onGridViewSliderChange,
     onSortChange,
     onUpload,
+    onViewModeChange,
     view,
     viewMode,
 }: Props) => {
     const { sortBy, sortDirection, items = [] }: Collection = currentCollection;
+    const hasGridView: boolean = !!gridColumnCount;
     const hasItems: boolean = items.length > 0;
     const isFolder: boolean = view === VIEW_FOLDER;
     const showSort: boolean = isFolder && hasItems;
     const showAdd: boolean = (!!canUpload || !!canCreateNewFolder) && isFolder;
-
     return (
         <div className="be-sub-header-right">
             {hasItems && viewMode === VIEW_MODE_GRID && (
@@ -63,7 +63,9 @@ const SubHeaderRight = ({
                     onChange={onGridViewSliderChange}
                 />
             )}
-            {hasItems && <ViewModeChangeButton viewMode={viewMode} onViewModeChange={onViewModeChange} />}
+            {hasItems && hasGridView && (
+                <ViewModeChangeButton viewMode={viewMode} onViewModeChange={onViewModeChange} />
+            )}
             {showSort && !!sortBy && !!sortDirection && (
                 <Sort onSortChange={onSortChange} sortBy={sortBy} sortDirection={sortDirection} />
             )}

--- a/src/elements/common/sub-header/__tests__/SubHeaderRight-test.js
+++ b/src/elements/common/sub-header/__tests__/SubHeaderRight-test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Add from '../Add';
+import GridViewSlider from '../../../../components/grid-view/GridViewSlider';
+import SubHeaderRight from '../SubHeaderRight';
+import ViewModeChangeButton from '../ViewModeChangeButton';
+import { VIEW_FOLDER, VIEW_MODE_GRID } from '../../../../constants';
+
+const getWrapper = props => shallow(<SubHeaderRight {...props} />);
+
+describe('Elements/SubHeader/SubHeaderRight', () => {
+    const currentCollection = {
+        sortBy: '',
+        sortDirection: '',
+        items: ['123'],
+    };
+
+    test.each([[VIEW_FOLDER, false], [VIEW_MODE_GRID, true]])(
+        '%s shows grid view slider %s',
+        (viewMode, expectation) => {
+            const wrapper = getWrapper({ viewMode, currentCollection });
+
+            expect(wrapper.exists(GridViewSlider)).toBe(expectation);
+        },
+    );
+
+    test.each([[0, 0], [1, 1]])('should show %i grid view buttons on toolbar', (columns, expectation) => {
+        const wrapper = getWrapper({ gridColumnCount: columns, currentCollection });
+        expect(wrapper.find(ViewModeChangeButton).length).toEqual(expectation);
+    });
+
+    test.each([[VIEW_FOLDER, true], [VIEW_MODE_GRID, false]])(
+        'Add button with %s on toolbar should be %s',
+        (view, expectation) => {
+            const wrapper = getWrapper({
+                canUpload: expectation,
+                canCreateNewFolder: expectation,
+                view,
+                currentCollection,
+            });
+            expect(wrapper.exists(Add)).toBe(expectation);
+        },
+    );
+});


### PR DESCRIPTION
This change removes the view change (grid view) button unless there is a provided `gridColumnCount` prop. Content Picker was showing the grid view button when it doesn't support grid view.