### PR TITLE
feat(security): adding SecurityBadge component

### DIFF
--- a/src/features/classification/ClassifiedBadge.js
+++ b/src/features/classification/ClassifiedBadge.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import Tooltip from '../../components/tooltip';
 import IconSecurityClassification from '../../icons/general/IconSecurityClassification';
+import { SecurityBadge } from '../security';
 import { bdlYellorange } from '../../styles/variables';
 import type { Position } from '../../components/tooltip';
 import './ClassifiedBadge.scss';
@@ -15,10 +16,11 @@ type Props = {
 
 const ClassifiedBadge = ({ name, tooltipPosition = 'bottom-center', tooltipText }: Props) => (
     <Tooltip isDisabled={!tooltipText} position={tooltipPosition} text={tooltipText} isTabbable={false}>
-        <h1 className="bdl-ClassifiedBadge">
-            <IconSecurityClassification color={bdlYellorange} height={10} width={10} strokeWidth={3} />
-            <span className="bdl-ClassifiedBadge-name">{name}</span>
-        </h1>
+        <SecurityBadge
+            className="bdl-ClassifiedBadge"
+            message={name}
+            icon={<IconSecurityClassification color={bdlYellorange} height={10} width={10} strokeWidth={3} />}
+        />
     </Tooltip>
 );
 

--- a/src/features/classification/ClassifiedBadge.js
+++ b/src/features/classification/ClassifiedBadge.js
@@ -3,10 +3,9 @@ import * as React from 'react';
 
 import Tooltip from '../../components/tooltip';
 import IconSecurityClassification from '../../icons/general/IconSecurityClassification';
-import { SecurityBadge } from '../security';
+import SecurityBadge from '../security';
 import { bdlYellorange } from '../../styles/variables';
 import type { Position } from '../../components/tooltip';
-import './ClassifiedBadge.scss';
 
 type Props = {
     name: string,

--- a/src/features/classification/ClassifiedBadge.scss
+++ b/src/features/classification/ClassifiedBadge.scss
@@ -1,5 +1,0 @@
-.bdl-ClassifiedBadge {
-    .bdl-SecurityBadge-name {
-        margin-left: 5px;
-    }
-}

--- a/src/features/classification/ClassifiedBadge.scss
+++ b/src/features/classification/ClassifiedBadge.scss
@@ -1,17 +1,5 @@
-@import '../../styles/variables';
-@import './mixins';
-
-.bdl-ClassifiedBadge,
-.bdl-ClassifiedBadge:hover {
-    @include bdl-ClassificationBadge;
-
-    background-color: $bdl-yellorange-10;
-    border-color: $bdl-yellorange;
-}
-
-.bdl-ClassifiedBadge-name {
-    @include bdl-ClassificationBadge-name;
-
-    color: $bdl-gray !important; // To inhibit overriding
-    text-transform: uppercase;
+.bdl-ClassifiedBadge {
+    .bdl-SecurityBadge-name {
+        margin-left: 5px;
+    }
 }

--- a/src/features/classification/__tests__/__snapshots__/ClassifiedBadge-test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/ClassifiedBadge-test.js.snap
@@ -10,21 +10,18 @@ exports[`features/classification/ClassifiedBadge should render a classified badg
   text="fubar"
   theme="default"
 >
-  <h1
+  <SecurityBadge
     className="bdl-ClassifiedBadge"
-  >
-    <IconSecurityClassification
-      color="#f5b31b"
-      height={10}
-      strokeWidth={3}
-      width={10}
-    />
-    <span
-      className="bdl-ClassifiedBadge-name"
-    >
-      Confidential
-    </span>
-  </h1>
+    icon={
+      <IconSecurityClassification
+        color="#f5b31b"
+        height={10}
+        strokeWidth={3}
+        width={10}
+      />
+    }
+    message="Confidential"
+  />
 </Tooltip>
 `;
 
@@ -37,20 +34,17 @@ exports[`features/classification/ClassifiedBadge should render a classified badg
   position="bottom-center"
   theme="default"
 >
-  <h1
+  <SecurityBadge
     className="bdl-ClassifiedBadge"
-  >
-    <IconSecurityClassification
-      color="#f5b31b"
-      height={10}
-      strokeWidth={3}
-      width={10}
-    />
-    <span
-      className="bdl-ClassifiedBadge-name"
-    >
-      Confidential
-    </span>
-  </h1>
+    icon={
+      <IconSecurityClassification
+        color="#f5b31b"
+        height={10}
+        strokeWidth={3}
+        width={10}
+      />
+    }
+    message="Confidential"
+  />
 </Tooltip>
 `;

--- a/src/features/security/README.md
+++ b/src/features/security/README.md
@@ -1,0 +1,18 @@
+### Description
+Renders a security badge with a message and optional custom icon.
+
+### Examples
+
+**Security Badge with message**
+```jsx
+<SecurityBadge message="Lorem Ipsum" />
+```
+
+**Security Badge with custom class and icon**
+```jsx
+<SecurityBadge
+    className="bdl-CustomClass"
+    message="Lorem Ipsum"
+    icon={<IconSecurityClassification />}
+/>
+```

--- a/src/features/security/SecurityBadge.js
+++ b/src/features/security/SecurityBadge.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+import classNames from 'classnames';
+
+import IconAlertDefault from '../../icons/general/IconAlertDefault';
+import { bdlYellorange } from '../../styles/variables';
+import './SecurityBadge.scss';
+
+type Props = {
+    className?: string,
+    icon?: React.Node,
+    message: string,
+};
+
+const SecurityBadge = ({ className, icon, message, ...rest }: Props) => {
+    const iconElement = icon || <IconAlertDefault color={bdlYellorange} height={22} width={22} strokeWidth={3} />;
+
+    return (
+        <h1 className={classNames('bdl-SecurityBadge', className)} {...rest}>
+            {iconElement}
+            <span className="bdl-SecurityBadge-name">{message}</span>
+        </h1>
+    );
+};
+
+export default SecurityBadge;

--- a/src/features/security/SecurityBadge.js
+++ b/src/features/security/SecurityBadge.js
@@ -12,15 +12,15 @@ type Props = {
     message: string,
 };
 
-const SecurityBadge = ({ className, icon, message, ...rest }: Props) => {
-    const iconElement = icon || <IconAlertDefault color={bdlYellorange} height={22} width={22} strokeWidth={3} />;
+const SecurityBadge = ({ className, icon, message, ...rest }: Props) => (
+    <h1 className={classNames('bdl-SecurityBadge', className)} {...rest}>
+        {icon}
+        <span className="bdl-SecurityBadge-name">{message}</span>
+    </h1>
+);
 
-    return (
-        <h1 className={classNames('bdl-SecurityBadge', className)} {...rest}>
-            {iconElement}
-            <span className="bdl-SecurityBadge-name">{message}</span>
-        </h1>
-    );
+SecurityBadge.defaultProps = {
+    icon: <IconAlertDefault color={bdlYellorange} height={22} width={22} strokeWidth={3} />,
 };
 
 export default SecurityBadge;

--- a/src/features/security/SecurityBadge.scss
+++ b/src/features/security/SecurityBadge.scss
@@ -1,0 +1,25 @@
+@import '../../styles/variables';
+@import './mixins';
+
+.bdl-SecurityBadge,
+.bdl-SecurityBadge:hover {
+    @include bdl-SecurityBadge;
+
+    background-color: $bdl-yellorange-10;
+    border-color: $bdl-yellorange;
+}
+
+.bdl-SecurityBadge {
+    .icon-alert-default {
+        width: 16px;
+        height: 16px;
+    }
+}
+
+.bdl-SecurityBadge-name {
+    @include bdl-SecurityBadge-name;
+
+    margin-left: 0;
+    color: $bdl-gray !important; // To inhibit overriding
+    text-transform: uppercase;
+}

--- a/src/features/security/SecurityBadge.scss
+++ b/src/features/security/SecurityBadge.scss
@@ -13,13 +13,13 @@
     .icon-alert-default {
         width: 16px;
         height: 16px;
+        margin: 0 -3px;
     }
 }
 
 .bdl-SecurityBadge-name {
     @include bdl-SecurityBadge-name;
 
-    margin-left: 0;
     color: $bdl-gray !important; // To inhibit overriding
     text-transform: uppercase;
 }

--- a/src/features/security/__tests__/SecurityBadge-test.js
+++ b/src/features/security/__tests__/SecurityBadge-test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import SecurityBadge from '../SecurityBadge';
+
+describe('features/security/SecurityBadge', () => {
+    const getWrapper = (props = {}) => shallow(<SecurityBadge {...props} />);
+
+    test('should render a classified badge with default icon (IconAlertDefault)', () => {
+        const wrapper = getWrapper({
+            message: 'Suspicious',
+        });
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render a classified badge with a custom icon', () => {
+        const wrapper = getWrapper({
+            icon: <span>Custom Icon</span>,
+            message: 'Suspicious',
+        });
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render custom class when provided', () => {
+        const wrapper = getWrapper({
+            className: 'custom',
+            message: 'Suspicious',
+        });
+        expect(wrapper.props().className).toBe('bdl-SecurityBadge custom');
+    });
+});

--- a/src/features/security/__tests__/__snapshots__/SecurityBadge-test.js.snap
+++ b/src/features/security/__tests__/__snapshots__/SecurityBadge-test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`features/security/SecurityBadge should render a classified badge with a custom icon 1`] = `
+<h1
+  className="bdl-SecurityBadge"
+>
+  <span>
+    Custom Icon
+  </span>
+  <span
+    className="bdl-SecurityBadge-name"
+  >
+    Suspicious
+  </span>
+</h1>
+`;
+
+exports[`features/security/SecurityBadge should render a classified badge with default icon (IconAlertDefault) 1`] = `
+<h1
+  className="bdl-SecurityBadge"
+>
+  <IconAlertDefault
+    color="#f5b31b"
+    height={22}
+    strokeWidth={3}
+    width={22}
+  />
+  <span
+    className="bdl-SecurityBadge-name"
+  >
+    Suspicious
+  </span>
+</h1>
+`;

--- a/src/features/security/_mixins.scss
+++ b/src/features/security/_mixins.scss
@@ -1,6 +1,6 @@
 @import '../../styles/variables';
 
-@mixin bdl-ClassificationBadge {
+@mixin bdl-SecurityBadge {
     display: inline-flex;
     align-items: center;
     margin: 0;
@@ -9,7 +9,7 @@
     border-radius: $bdl-border-radius-size;
 }
 
-@mixin bdl-ClassificationBadge-name {
+@mixin bdl-SecurityBadge-name {
     margin-left: 5px;
     font-weight: bold;
     font-size: 10px !important; // To inhibit overriding

--- a/src/features/security/index.js
+++ b/src/features/security/index.js
@@ -1,3 +1,2 @@
 // @flow
-// eslint-disable-next-line import/prefer-default-export
-export { default as SecurityBadge } from './SecurityBadge';
+export { default } from './SecurityBadge';

--- a/src/features/security/index.js
+++ b/src/features/security/index.js
@@ -1,0 +1,3 @@
+// @flow
+// eslint-disable-next-line import/prefer-default-export
+export { default as SecurityBadge } from './SecurityBadge';


### PR DESCRIPTION
This update will move out the actual badge markup from the `ClassifiedBadge` to a slightly more re-usable `SecurityBadge` component. This will allow us to use the same look and feel of classification with other security-related badges.

<img width="171" alt="Screen Shot 2019-10-07 at 4 39 50 PM" src="https://user-images.githubusercontent.com/1322503/66356923-b7e5e400-e921-11e9-81db-26e7faef9323.png">

<img width="196" alt="Screen Shot 2019-10-07 at 4 41 02 PM" src="https://user-images.githubusercontent.com/1322503/66356924-b7e5e400-e921-11e9-9a50-b998eea159d0.png">

