### PR TITLE
fix(security-badge): Fixing SecurityBadge flow type

### DIFF
--- a/src/features/security/SecurityBadge.js
+++ b/src/features/security/SecurityBadge.js
@@ -9,7 +9,7 @@ import './SecurityBadge.scss';
 type Props = {
     className?: string,
     icon?: React.Node,
-    message: string,
+    message: React.Node,
 };
 
 const SecurityBadge = ({ className, icon, message, ...rest }: Props) => (


### PR DESCRIPTION
The `SecurityBadge`, unlike the `ClassifiedBadge`, should allow a `React.Node` as a message.