### PR TITLE
fix(select-field): Enable arrow scrolling in select fields

### DIFF
--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -38,6 +38,8 @@ type Props = {
     error?: React.Node,
     /** The select button is disabled if true */
     isDisabled?: boolean,
+    /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
+    isScrollable?: boolean,
     multiple: boolean,
     /** Function will be called with an array of all selected options after user selects a new option */
     onChange: Function,
@@ -49,8 +51,6 @@ type Props = {
     options: Array<SelectOptionProp>,
     /** The select button text shown when no options are selected. */
     placeholder?: string | React.Element<any>,
-    /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
-    scrollable?: boolean,
     /** The currently selected option values (can be empty) */
     selectedValues: Array<SelectOptionValueProp>,
     /** Array of ordered indices indicating where to insert separators (ex. index 2 means insert a separator after option 2) */
@@ -72,9 +72,9 @@ class BaseSelectField extends React.Component<Props, State> {
     static defaultProps = {
         buttonProps: {},
         isDisabled: false,
+        isScrollable: false,
         multiple: false,
         options: [],
-        scrollable: false,
         selectedValues: [],
         separatorIndices: [],
     };
@@ -366,7 +366,7 @@ class BaseSelectField extends React.Component<Props, State> {
     };
 
     render() {
-        const { className, multiple, scrollable } = this.props;
+        const { className, multiple, isScrollable } = this.props;
         const { isOpen } = this.state;
 
         // @TODO: Need invariants on specific conditions.
@@ -397,7 +397,7 @@ class BaseSelectField extends React.Component<Props, State> {
                     >
                         <ul
                             className={classNames('overlay', {
-                                [OVERLAY_SCROLLABLE_CLASS]: scrollable,
+                                [OVERLAY_SCROLLABLE_CLASS]: isScrollable,
                             })}
                             id={this.selectFieldID}
                             role="listbox"

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -8,7 +8,7 @@ import IconCheck from '../../icons/general/IconCheck';
 import SelectButton from '../select-button';
 import DatalistItem from '../datalist-item';
 import type { SelectOptionValueProp, SelectOptionProp } from './props';
-import { OVERLAY_WRAPPER_CLASS } from '../../constants';
+import { BASE_SELECT_FIELD_OFFSET_TOP_PADDING, OVERLAY_WRAPPER_CLASS } from '../../constants';
 
 import './SelectField.scss';
 
@@ -85,6 +85,24 @@ class BaseSelectField extends React.Component<Props, State> {
             isOpen: false,
             shouldScrollIntoView: false,
         };
+
+        this.fieldRef = React.createRef();
+    }
+
+    componentDidMount() {
+        this.calculateOffsetTopValue();
+    }
+
+    /**
+     * Calculate this field's distance from the top.
+     * This allows us to create an overflow container for the field's dropdown menu that is navigable using both
+     * the mouse and arrow keys and will always fit within the current viewport.
+     */
+    calculateOffsetTopValue() {
+        this.offsetTopValue =
+            window.pageYOffset +
+            this.fieldRef.current.getBoundingClientRect().top +
+            BASE_SELECT_FIELD_OFFSET_TOP_PADDING;
     }
 
     setActiveItem = (index: number, shouldScrollIntoView?: boolean = true) => {
@@ -382,6 +400,7 @@ class BaseSelectField extends React.Component<Props, State> {
                 className={classNames(className, 'select-container')}
                 onBlur={this.handleBlur}
                 onKeyDown={this.handleKeyDown}
+                ref={this.fieldRef}
             >
                 <div className="select-field">
                     {this.renderSelectButton()}
@@ -396,6 +415,7 @@ class BaseSelectField extends React.Component<Props, State> {
                             role="listbox"
                             // preventDefault on mousedown so blur doesn't happen before click
                             onMouseDown={event => event.preventDefault()}
+                            style={{ maxHeight: `calc(100vh - ${this.offsetTopValue}px)` }}
                             {...listboxProps}
                         >
                             {this.renderSelectOptions()}

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -8,7 +8,7 @@ import IconCheck from '../../icons/general/IconCheck';
 import SelectButton from '../select-button';
 import DatalistItem from '../datalist-item';
 import type { SelectOptionValueProp, SelectOptionProp } from './props';
-import { BASE_SELECT_FIELD_OFFSET_TOP_PADDING, OVERLAY_WRAPPER_CLASS } from '../../constants';
+import { OVERLAY_WRAPPER_CLASS } from '../../constants';
 
 import './SelectField.scss';
 
@@ -85,24 +85,6 @@ class BaseSelectField extends React.Component<Props, State> {
             isOpen: false,
             shouldScrollIntoView: false,
         };
-
-        this.fieldRef = React.createRef();
-    }
-
-    componentDidMount() {
-        this.calculateOffsetTopValue();
-    }
-
-    /**
-     * Calculate this field's distance from the top.
-     * This allows us to create an overflow container for the field's dropdown menu that is navigable using both
-     * the mouse and arrow keys and will always fit within the current viewport.
-     */
-    calculateOffsetTopValue() {
-        this.offsetTopValue =
-            window.pageYOffset +
-            this.fieldRef.current.getBoundingClientRect().top +
-            BASE_SELECT_FIELD_OFFSET_TOP_PADDING;
     }
 
     setActiveItem = (index: number, shouldScrollIntoView?: boolean = true) => {
@@ -400,7 +382,6 @@ class BaseSelectField extends React.Component<Props, State> {
                 className={classNames(className, 'select-container')}
                 onBlur={this.handleBlur}
                 onKeyDown={this.handleKeyDown}
-                ref={this.fieldRef}
             >
                 <div className="select-field">
                     {this.renderSelectButton()}
@@ -415,7 +396,6 @@ class BaseSelectField extends React.Component<Props, State> {
                             role="listbox"
                             // preventDefault on mousedown so blur doesn't happen before click
                             onMouseDown={event => event.preventDefault()}
-                            style={{ maxHeight: `calc(100vh - ${this.offsetTopValue}px)` }}
                             {...listboxProps}
                         >
                             {this.renderSelectOptions()}

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -49,6 +49,8 @@ type Props = {
     options: Array<SelectOptionProp>,
     /** The select button text shown when no options are selected. */
     placeholder?: string | React.Element<any>,
+    /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
+    scrollable?: boolean,
     /** The currently selected option values (can be empty) */
     selectedValues: Array<SelectOptionValueProp>,
     /** Array of ordered indices indicating where to insert separators (ex. index 2 means insert a separator after option 2) */
@@ -64,12 +66,15 @@ type State = {
     shouldScrollIntoView: boolean,
 };
 
+export const OVERLAY_SCROLLABLE_CLASS = 'bdl-SelectField-overlay--scrollable';
+
 class BaseSelectField extends React.Component<Props, State> {
     static defaultProps = {
         buttonProps: {},
         isDisabled: false,
         multiple: false,
         options: [],
+        scrollable: false,
         selectedValues: [],
         separatorIndices: [],
     };
@@ -361,7 +366,7 @@ class BaseSelectField extends React.Component<Props, State> {
     };
 
     render() {
-        const { className, multiple } = this.props;
+        const { className, multiple, scrollable } = this.props;
         const { isOpen } = this.state;
 
         // @TODO: Need invariants on specific conditions.
@@ -391,7 +396,9 @@ class BaseSelectField extends React.Component<Props, State> {
                         })}
                     >
                         <ul
-                            className="overlay"
+                            className={classNames('overlay', {
+                                [OVERLAY_SCROLLABLE_CLASS]: scrollable,
+                            })}
                             id={this.selectFieldID}
                             role="listbox"
                             // preventDefault on mousedown so blur doesn't happen before click

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -3,7 +3,7 @@
 .select-field {
     .overlay {
         min-width: 100%;
-        max-height: calc(100vh - 260px);
+        min-height: 34px;
         overflow-y: auto;
     }
 

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -3,8 +3,6 @@
 .select-field {
     .overlay {
         min-width: 100%;
-        max-height: 340px; // show at most 12 items in the dropdown menu
-        overflow-y: auto;
     }
 
     li[role='separator'] {
@@ -25,4 +23,9 @@
     height: 16px;
     margin-left: -5px;
     text-align: left;
+}
+
+.bdl-SelectField-overlay--scrollable {
+    max-height: 340px; // show at most 12 items in the dropdown menu
+    overflow-y: auto;
 }

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -3,6 +3,8 @@
 .select-field {
     .overlay {
         min-width: 100%;
+        max-height: calc(100vh - 260px);
+        overflow-y: auto;
     }
 
     li[role='separator'] {

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -3,7 +3,7 @@
 .select-field {
     .overlay {
         min-width: 100%;
-        min-height: 34px;
+        max-height: 340px; // show at most 12 items in the dropdown menu
         overflow-y: auto;
     }
 

--- a/src/components/select-field/SingleSelectField.js
+++ b/src/components/select-field/SingleSelectField.js
@@ -14,6 +14,8 @@ type Props = {
     onChange: Function,
     /** The placeholder text for the field  */
     placeholder?: string | React.Node,
+    /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
+    scrollable?: boolean,
     /** Function will be called with the selected option after user selects a new option */
     selectedValue?: SelectOptionValueProp,
 };

--- a/src/components/select-field/SingleSelectField.js
+++ b/src/components/select-field/SingleSelectField.js
@@ -10,12 +10,12 @@ type Props = {
     fieldType?: string,
     /** The select field is disabled if true */
     isDisabled?: boolean,
+    /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
+    isScrollable?: boolean,
     /** The currently selected option value */
     onChange: Function,
     /** The placeholder text for the field  */
     placeholder?: string | React.Node,
-    /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
-    scrollable?: boolean,
     /** Function will be called with the selected option after user selects a new option */
     selectedValue?: SelectOptionValueProp,
 };

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 
 import { scrollIntoView } from '../../../utils/dom';
 import BaseSelectField from '../BaseSelectField';
-import { BASE_SELECT_FIELD_OFFSET_TOP_PADDING } from '../../../constants';
 
 const sandbox = sinon.sandbox.create();
 
@@ -33,7 +32,6 @@ describe('components/select-field/BaseSelectField', () => {
                 options={options}
                 {...props}
             />,
-            { disableLifecycleMethods: true },
         );
 
     describe('renderButtonText()', () => {
@@ -855,42 +853,6 @@ describe('components/select-field/BaseSelectField', () => {
                 .withArgs(options[index]); // audio + video
 
             instance.selectMultiOption(index);
-        });
-    });
-
-    describe('componentDidMount()', () => {
-        test('should set the value of offsetTopValue', () => {
-            const wrapper = shallowRenderSelectField({
-                defaultValue: '',
-                selectedValues: [''],
-            });
-            const instance = wrapper.instance();
-            instance.calculateOffsetTopValue = jest.fn();
-            instance.componentDidMount();
-            expect(instance.calculateOffsetTopValue).toHaveBeenCalled();
-        });
-    });
-
-    describe('calculateOffsetTopValue()', () => {
-        test('should set the value of this.offsetTopValue', () => {
-            global.pageYOffset = 200;
-            const mockBoundingRectTop = 100;
-            const wrapper = shallowRenderSelectField({
-                defaultValue: '',
-                selectedValues: [''],
-            });
-            const instance = wrapper.instance();
-            instance.fieldRef = {
-                current: {
-                    getBoundingClientRect: jest.fn().mockReturnValue({
-                        top: mockBoundingRectTop,
-                    }),
-                },
-            };
-            instance.calculateOffsetTopValue();
-            expect(instance.offsetTopValue).toEqual(
-                global.pageYOffset + mockBoundingRectTop + BASE_SELECT_FIELD_OFFSET_TOP_PADDING,
-            );
         });
     });
 });

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -220,9 +220,9 @@ describe('components/select-field/BaseSelectField', () => {
         });
 
         test.each([[true, true], [false, false]])(
-            'should apply the correct CSS classes to the overlay element when scrollable is %s',
-            (scrollable, result) => {
-                const wrapper = shallowRenderSelectField({ scrollable });
+            'should apply the correct CSS classes to the overlay element when isScrollable is %s',
+            (isScrollable, result) => {
+                const wrapper = shallowRenderSelectField({ isScrollable });
                 const overlay = wrapper.find('.overlay');
                 expect(overlay.hasClass(OVERLAY_SCROLLABLE_CLASS)).toBe(result);
             },

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 
 import { scrollIntoView } from '../../../utils/dom';
 import BaseSelectField from '../BaseSelectField';
+import { BASE_SELECT_FIELD_OFFSET_TOP_PADDING } from '../../../constants';
 
 const sandbox = sinon.sandbox.create();
 
@@ -32,6 +33,7 @@ describe('components/select-field/BaseSelectField', () => {
                 options={options}
                 {...props}
             />,
+            { disableLifecycleMethods: true },
         );
 
     describe('renderButtonText()', () => {
@@ -853,6 +855,42 @@ describe('components/select-field/BaseSelectField', () => {
                 .withArgs(options[index]); // audio + video
 
             instance.selectMultiOption(index);
+        });
+    });
+
+    describe('componentDidMount()', () => {
+        test('should set the value of offsetTopValue', () => {
+            const wrapper = shallowRenderSelectField({
+                defaultValue: '',
+                selectedValues: [''],
+            });
+            const instance = wrapper.instance();
+            instance.calculateOffsetTopValue = jest.fn();
+            instance.componentDidMount();
+            expect(instance.calculateOffsetTopValue).toHaveBeenCalled();
+        });
+    });
+
+    describe('calculateOffsetTopValue()', () => {
+        test('should set the value of this.offsetTopValue', () => {
+            global.pageYOffset = 200;
+            const mockBoundingRectTop = 100;
+            const wrapper = shallowRenderSelectField({
+                defaultValue: '',
+                selectedValues: [''],
+            });
+            const instance = wrapper.instance();
+            instance.fieldRef = {
+                current: {
+                    getBoundingClientRect: jest.fn().mockReturnValue({
+                        top: mockBoundingRectTop,
+                    }),
+                },
+            };
+            instance.calculateOffsetTopValue();
+            expect(instance.offsetTopValue).toEqual(
+                global.pageYOffset + mockBoundingRectTop + BASE_SELECT_FIELD_OFFSET_TOP_PADDING,
+            );
         });
     });
 });

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 
 import { scrollIntoView } from '../../../utils/dom';
-import BaseSelectField from '../BaseSelectField';
+import BaseSelectField, { OVERLAY_SCROLLABLE_CLASS } from '../BaseSelectField';
 
 const sandbox = sinon.sandbox.create();
 
@@ -218,6 +218,15 @@ describe('components/select-field/BaseSelectField', () => {
 
             expect(overlay.prop('aria-multiselectable')).toBe(true);
         });
+
+        test.each([[true, true], [false, false]])(
+            'should apply the correct CSS classes to the overlay element when scrollable is %s',
+            (scrollable, result) => {
+                const wrapper = shallowRenderSelectField({ scrollable });
+                const overlay = wrapper.find('.overlay');
+                expect(overlay.hasClass(OVERLAY_SCROLLABLE_CLASS)).toBe(result);
+            },
+        );
     });
 
     describe('onBlur', () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -420,3 +420,4 @@ export const KEYS = {
 
 /* ----------------- Other ----------------------- */
 export const ONE_HOUR_MS = 3600000; // 60 * 60 * 1000
+export const BASE_SELECT_FIELD_OFFSET_TOP_PADDING = 75;

--- a/src/constants.js
+++ b/src/constants.js
@@ -420,4 +420,3 @@ export const KEYS = {
 
 /* ----------------- Other ----------------------- */
 export const ONE_HOUR_MS = 3600000; // 60 * 60 * 1000
-export const BASE_SELECT_FIELD_OFFSET_TOP_PADDING = 75;

--- a/src/features/metadata-instance-editor/fields/EnumField.js
+++ b/src/features/metadata-instance-editor/fields/EnumField.js
@@ -53,6 +53,7 @@ const EnumField = ({ dataKey, dataValue, displayName, description, intl, onChang
                         }
                     }}
                     options={selectOptions}
+                    scrollable
                     selectedValue={
                         // Conditional to make flow happy, dataValue should never be an array
                         Array.isArray(dataValue) ? dataValue.join(', ') : dataValue || defaultValue

--- a/src/features/metadata-instance-editor/fields/EnumField.js
+++ b/src/features/metadata-instance-editor/fields/EnumField.js
@@ -45,6 +45,7 @@ const EnumField = ({ dataKey, dataValue, displayName, description, intl, onChang
             <Label text={displayName}>
                 {!!description && <i className="metadata-instance-editor-field-enum-desc">{description}</i>}
                 <SingleSelectField
+                    isScrollable
                     onChange={(option: Option) => {
                         if (option.isSelectable) {
                             onChange(dataKey, option.value);
@@ -53,7 +54,6 @@ const EnumField = ({ dataKey, dataValue, displayName, description, intl, onChang
                         }
                     }}
                     options={selectOptions}
-                    scrollable
                     selectedValue={
                         // Conditional to make flow happy, dataValue should never be an array
                         Array.isArray(dataValue) ? dataValue.join(', ') : dataValue || defaultValue

--- a/src/features/metadata-instance-editor/fields/MultiSelectField.js
+++ b/src/features/metadata-instance-editor/fields/MultiSelectField.js
@@ -36,6 +36,7 @@ const MultiSelectField = ({
             <Label text={displayName}>
                 {!!description && <i className="metadata-instance-editor-field-multi-select-desc">{description}</i>}
                 <MultiSelect
+                    isScrollable
                     onChange={(selectedOptions: Array<SelectOptionProp>) => {
                         if (selectedOptions.length) {
                             onChange(dataKey, selectedOptions.map(({ value }) => value));
@@ -48,7 +49,6 @@ const MultiSelectField = ({
                         value: option.key,
                     }))}
                     placeholder={placeholder}
-                    scrollable
                     selectedValues={dataValue}
                 />
             </Label>

--- a/src/features/metadata-instance-editor/fields/MultiSelectField.js
+++ b/src/features/metadata-instance-editor/fields/MultiSelectField.js
@@ -48,6 +48,7 @@ const MultiSelectField = ({
                         value: option.key,
                     }))}
                     placeholder={placeholder}
+                    scrollable
                     selectedValues={dataValue}
                 />
             </Label>

--- a/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/EnumField.test.js.snap
+++ b/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/EnumField.test.js.snap
@@ -31,6 +31,7 @@ exports[`features/metadata-instance-editor/fields/EnumField should correctly ren
           },
         ]
       }
+      scrollable={true}
       selectedValue="value"
     />
   </Label>
@@ -73,6 +74,7 @@ exports[`features/metadata-instance-editor/fields/EnumField should correctly ren
           },
         ]
       }
+      scrollable={true}
       selectedValue="value"
     />
   </Label>

--- a/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/EnumField.test.js.snap
+++ b/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/EnumField.test.js.snap
@@ -6,6 +6,7 @@ exports[`features/metadata-instance-editor/fields/EnumField should correctly ren
 >
   <Label>
     <SingleSelectField
+      isScrollable={true}
       onChange={[Function]}
       options={
         Array [
@@ -31,7 +32,6 @@ exports[`features/metadata-instance-editor/fields/EnumField should correctly ren
           },
         ]
       }
-      scrollable={true}
       selectedValue="value"
     />
   </Label>
@@ -49,6 +49,7 @@ exports[`features/metadata-instance-editor/fields/EnumField should correctly ren
       description
     </i>
     <SingleSelectField
+      isScrollable={true}
       onChange={[Function]}
       options={
         Array [
@@ -74,7 +75,6 @@ exports[`features/metadata-instance-editor/fields/EnumField should correctly ren
           },
         ]
       }
-      scrollable={true}
       selectedValue="value"
     />
   </Label>

--- a/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/MultiSelectField.test.js.snap
+++ b/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/MultiSelectField.test.js.snap
@@ -6,6 +6,7 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
 >
   <Label>
     <MultiSelectField
+      isScrollable={true}
       onChange={[Function]}
       options={Array []}
       placeholder={
@@ -14,7 +15,6 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
           id="boxui.metadataInstanceEditor.fieldMultiSelectValue"
         />
       }
-      scrollable={true}
       selectedValues={
         Array [
           "value",
@@ -36,6 +36,7 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
       description
     </i>
     <MultiSelectField
+      isScrollable={true}
       onChange={[Function]}
       options={Array []}
       placeholder={
@@ -44,7 +45,6 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
           id="boxui.metadataInstanceEditor.fieldMultiSelectValue"
         />
       }
-      scrollable={true}
       selectedValues={
         Array [
           "value",

--- a/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/MultiSelectField.test.js.snap
+++ b/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/MultiSelectField.test.js.snap
@@ -14,6 +14,7 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
           id="boxui.metadataInstanceEditor.fieldMultiSelectValue"
         />
       }
+      scrollable={true}
       selectedValues={
         Array [
           "value",
@@ -43,6 +44,7 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
           id="boxui.metadataInstanceEditor.fieldMultiSelectValue"
         />
       }
+      scrollable={true}
       selectedValues={
         Array [
           "value",


### PR DESCRIPTION
This PR sets a maximum height for the `SelectField` component, which enables arrow key scrolling in dropdown menus.

**Chrome**
<img width="341" alt="buie-arrow-scroll-in-select-fields-chrome" src="https://user-images.githubusercontent.com/2956895/66881124-a41e2b80-ef7a-11e9-90dd-791aa8000672.png">

**Firefox**
<img width="341" alt="buie-arrow-scroll-in-select-fields-firefox" src="https://user-images.githubusercontent.com/2956895/66881125-a41e2b80-ef7a-11e9-9c7c-93a8b05c0121.png">

**Safari**
<img width="341" alt="buie-arrow-scroll-in-select-fields-safari" src="https://user-images.githubusercontent.com/2956895/66881126-a4b6c200-ef7a-11e9-8a68-c0f340033cf4.png">

**IE11**
<img width="342" alt="buie-arrow-scroll-in-select-fields-ie11" src="https://user-images.githubusercontent.com/2956895/66881682-8c47a700-ef7c-11e9-92e6-ac5faeb5c4bd.png">
 
**In a large viewport**
<img width="341" alt="buie-arrow-scroll-in-select-fields-large-viewport" src="https://user-images.githubusercontent.com/2956895/66881129-a7191c00-ef7a-11e9-94c6-a6389e4147fd.png">

**In a small viewport**
<img width="326" alt="buie-arrow-scroll-in-select-fields-small-viewport" src="https://user-images.githubusercontent.com/2956895/66881131-a7191c00-ef7a-11e9-9b88-ed3c963d32d1.png">

**With fields above the expanded field**
<img width="341" alt="buie-arrow-scroll-in-select-fields-third-field" src="https://user-images.githubusercontent.com/2956895/67247673-f2b64480-f416-11e9-85e7-bfc2bc04c62b.png">
