### PR TITLE
fix(usm): "Link Settings" should not line wrap

### DIFF
--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -181,6 +181,7 @@
             .shared-link-settings-btn {
                 margin-left: 5px;
                 color: $primary-color;
+                white-space: nowrap;
             }
         }
     }


### PR DESCRIPTION
<img width="479" alt="Screen Shot 2019-10-17 at 1 45 47 PM" src="https://user-images.githubusercontent.com/380408/67046202-a9978500-f0e4-11e9-8321-fa3f742e6d3e.png">

<img width="492" alt="Screen Shot 2019-10-17 at 1 45 43 PM" src="https://user-images.githubusercontent.com/380408/67046224-b4eab080-f0e4-11e9-9564-e765a4230a67.png">

