### PR TITLE
fix: slight adjust in check mark alignment

### DIFF
--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -18,9 +18,9 @@
 }
 
 .select-option-check-icon {
-    position: relative;
-    left: -5px;
     flex: none;
-    width: 16px;
+    width: 20px;
     height: 16px;
+    margin-left: -5px;
+    text-align: left;
 }

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -18,7 +18,9 @@
 }
 
 .select-option-check-icon {
+    position: relative;
+    left: -5px;
     flex: none;
-    width: 20px;
+    width: 16px;
     height: 16px;
 }


### PR DESCRIPTION
Does not change menu item padding

**Before**
<img width="209" alt="Screen Shot 2019-10-21 at 4 43 32 PM" src="https://user-images.githubusercontent.com/1075325/67251706-bf7ab200-f424-11e9-8862-56456f152bd7.png"><img width="177" alt="Screen Shot 2019-10-21 at 4 43 23 PM" src="https://user-images.githubusercontent.com/1075325/67251704-bf7ab200-f424-11e9-9738-2f094b174cb3.png"><img width="154" alt="Screen Shot 2019-10-21 at 4 47 44 PM" src="https://user-images.githubusercontent.com/1075325/67251799-24360c80-f425-11e9-89fc-72db29d503b4.png">


**After**
<img width="188" alt="Screen Shot 2019-10-21 at 5 08 17 PM" src="https://user-images.githubusercontent.com/1075325/67251877-724b1000-f425-11e9-9ed7-93124c130470.png"><img width="167" alt="Screen Shot 2019-10-21 at 5 08 25 PM" src="https://user-images.githubusercontent.com/1075325/67251879-724b1000-f425-11e9-8513-6479251a9afc.png"><img width="159" alt="Screen Shot 2019-10-21 at 4 47 27 PM" src="https://user-images.githubusercontent.com/1075325/67251830-357f1900-f425-11e9-81cc-7c5781810724.png">

