### PR TITLE
fix(pill-selector-dropdown): fix aria attributes

### DIFF
--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.js
@@ -243,16 +243,16 @@ class PillSelectorDropdown extends React.Component<Props, State> {
         } = this.props;
 
         return (
-            <SelectorDropdown
-                className={classNames('pill-selector-wrapper', className)}
-                dividerIndex={dividerIndex}
-                onEnter={this.handleEnter}
-                onSelect={this.handleSelect}
-                overlayTitle={overlayTitle}
-                scrollBoundarySelector={dropdownScrollBoundarySelector}
-                shouldSetActiveItemOnOpen={shouldSetActiveItemOnOpen}
-                selector={
-                    <Label text={label}>
+            <Label text={label}>
+                <SelectorDropdown
+                    className={classNames('pill-selector-wrapper', className)}
+                    dividerIndex={dividerIndex}
+                    onEnter={this.handleEnter}
+                    onSelect={this.handleSelect}
+                    overlayTitle={overlayTitle}
+                    scrollBoundarySelector={dropdownScrollBoundarySelector}
+                    shouldSetActiveItemOnOpen={shouldSetActiveItemOnOpen}
+                    selector={
                         <PillSelector
                             onChange={noop} // fix console error
                             onCompositionEnd={this.handleCompositionEnd}
@@ -274,11 +274,11 @@ class PillSelectorDropdown extends React.Component<Props, State> {
                             validator={validator}
                             value={this.state.inputValue}
                         />
-                    </Label>
-                }
-            >
-                {children}
-            </SelectorDropdown>
+                    }
+                >
+                    {children}
+                </SelectorDropdown>
+            </Label>
         );
     }
 }

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
@@ -1,16 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/pill-selector-dropdown/PillSelectorDropdown render() should render disabled pill selector 1`] = `
-<SelectorDropdown
-  className="pill-selector-wrapper"
-  onEnter={[Function]}
-  onSelect={[Function]}
-  selector={
-    <Label
-      text=""
-    >
+<Label
+  text=""
+>
+  <SelectorDropdown
+    className="pill-selector-wrapper"
+    onEnter={[Function]}
+    onSelect={[Function]}
+    selector={
       <PillSelector
         allowInvalidPills={false}
+        aria-label="test"
         disabled={true}
         error=""
         inputProps={Object {}}
@@ -20,14 +21,21 @@ exports[`components/pill-selector-dropdown/PillSelectorDropdown render() should 
         onCompositionStart={[Function]}
         onInput={[Function]}
         onPaste={[Function]}
-        onRemove={[Function]}
+        onRemove={[MockFunction]}
         placeholder=""
         selectedOptions={Array []}
         validator={[Function]}
         value=""
       />
-    </Label>
-  }
-  shouldSetActiveItemOnOpen={false}
-/>
+    }
+    shouldSetActiveItemOnOpen={false}
+  >
+    <div>
+      Option 1
+    </div>
+    <div>
+      Option 2
+    </div>
+  </SelectorDropdown>
+</Label>
 `;


### PR DESCRIPTION
Recommend ignoring whitespace to review. The main change is to move the `<Label>` outside of the `<SelectorDropdown>` so that the `<PillSelector>` is the root of the `selector` prop. This is needed in order to properly pass the `aria-*` attributes to the `textfield`.