### PR TITLE
fix(modal): move close button after header for better screen reader a11y

### DIFF
--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -112,12 +112,12 @@ class ModalDialog extends React.Component<Props> {
 
         return (
             <div ref={modalRef} className={classNames('modal-dialog', className)} {...divProps}>
-                {this.renderCloseButton()}
                 <div className="modal-header">
                     <h2 className="modal-title" id={`${this.modalID}-label`}>
                         {title}
                     </h2>
                 </div>
+                {this.renderCloseButton()}
                 {this.renderContent()}
             </div>
         );


### PR DESCRIPTION
This looks visually the same (due to absolute positioning), but results in the screen reader reading the title of the modal before saying "Close button" (for browsers like Chrome that read the contents of the modal... it seems Safari doesn't read it all out).