### PR TITLE
fix(tooltip): color contrast and layout fixes

### DIFF
--- a/src/components/tooltip/Tooltip.scss
+++ b/src/components/tooltip/Tooltip.scss
@@ -61,7 +61,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
 
     .tooltip-close-button {
         position: absolute;
-        top: 10px;
+        top: 9px;
         right: 3px;
         cursor: pointer;
 

--- a/src/components/tooltip/Tooltip.scss
+++ b/src/components/tooltip/Tooltip.scss
@@ -37,12 +37,12 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
     }
 
     &.is-error {
-        color: $bdl-watermelon-red;
+        color: $bdl-gray;
         background-color: $bdl-watermelon-red-10;
-        border: 1px solid $bdl-watermelon-red;
+        border: 1px solid $bdl-watermelon-red-50;
 
         .tooltip-close-button .icon-close .fill-color {
-            fill: $bdl-watermelon-red;
+            fill: $bdl-gray;
         }
     }
 
@@ -56,13 +56,13 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
     }
 
     &.with-close-button {
-        padding-right: 24px;
+        padding-right: 28px;
     }
 
     .tooltip-close-button {
         position: absolute;
-        top: 4px;
-        right: 0;
+        top: 10px;
+        right: 3px;
         cursor: pointer;
 
         .icon-close {


### PR DESCRIPTION
Old error tooltip with low color contrast text and misaligned close button (when shown):
![Screen Shot 2019-10-24 at 2 32 29 PM](https://user-images.githubusercontent.com/1280912/67527145-27bad500-f66b-11e9-843b-065b9155aa6f.png)


New error tooltip with better color contrast and improved layout of close button (when shown):
![Screen Shot 2019-10-24 at 2 22 24 PM](https://user-images.githubusercontent.com/1280912/67527040-ddd1ef00-f66a-11e9-8b23-5ef47eae5dab.png)
