### PR TITLE
refactor(css): Replace CSS class names with prefixed class names

### DIFF
--- a/examples/styles/FlyoutExamples.scss
+++ b/examples/styles/FlyoutExamples.scss
@@ -11,11 +11,11 @@ button.amsterdam-survey-button {
         fill: $white;
     }
 
-    &.btn-plain {
-        background: $box-blue;
-        border-radius: 4px;
+    &.bdl-PlainButton {
+        width: 40px;
         height: 40px;
         margin-right: 100px;
-        width: 40px;
+        background: $box-blue;
+        border-radius: 4px;
     }
 }

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -4,6 +4,12 @@ be.accessStatsPermissionsError = Sorry, you do not have permission to see the ac
 be.activityFeed.fullDateTime = {time, date, full} at {time, time, short}
 # Error message for feed item API errors
 be.activityFeedItemApiError = There was a problem loading the activity feed. Please refresh the page or try again later.
+# Text to show when comment no longer exists
+be.activitySidebar.activityFeed.commentMissingError = This comment no longer exists
+# Error title
+be.activitySidebar.activityFeed.feedInlineErrorTitle = Error
+# Text to show when a task no longer exists
+be.activitySidebar.activityFeed.taskMissingError = This task no longer exists
 # Label for add action
 be.add = Add
 # Text to display when app is disabled by applied access policy
@@ -167,13 +173,13 @@ be.contentSidebar.addTask = Add Task
 # label for menu item that opens approval task popup
 be.contentSidebar.addTask.approval = Approval Task
 # description for menu item that opens approval task popup
-be.contentSidebar.addTask.approval.description = Request an approval to move work forward
+be.contentSidebar.addTask.approval.description = Assignees will be responsible for approving or rejecting tasks
 # title for approval task popup
 be.contentSidebar.addTask.approval.title = Create Approval Task
 # label for menu item that opens general task popup
 be.contentSidebar.addTask.general = General Task
 # description for menu item that opens general task popup
-be.contentSidebar.addTask.general.description = Keep track of work that needs to get done
+be.contentSidebar.addTask.general.description = Assignees will be responsible for marking tasks as complete
 # title for general task popup
 be.contentSidebar.addTask.general.title = Create General Task
 # title for when editing an existing approval task
@@ -300,6 +306,8 @@ be.loadingState = Please wait while the items load...
 be.logo = Logo
 # Indicator on the footer that max items have been selected.
 be.max = max
+# Message shown when there are no items for provided metadata query.
+be.metadataState = There are no items in this folder.
 # Text for modified date with modified prefix.
 be.modifiedDate = Modified {date}
 # Text for modified date with user with modified prefix.
@@ -442,6 +450,8 @@ be.sidebarVersions.delete = Delete
 be.sidebarVersions.deleteError = File version could not be deleted.
 # Message displayed for a deleted version. {name} is the user who performed the action.
 be.sidebarVersions.deletedBy = Deleted by {name}
+# Tooltip message for actions disabled by retention policy.
+be.sidebarVersions.disabledByRetention = Disabled by retention policy
 # Label for the version download action.
 be.sidebarVersions.download = Download
 # Error message for the version download action.
@@ -458,6 +468,8 @@ be.sidebarVersions.priorWeek = Last Week
 be.sidebarVersions.promote = Make Current
 # Error message for the version promote action.
 be.sidebarVersions.promoteError = File version could not be made current.
+# Message displayed for a restored version. {name} is the user who performed the action.
+be.sidebarVersions.promotedBy = Promoted from v{versionPromoted} by {name}
 # Label for the version restore action.
 be.sidebarVersions.restore = Restore
 # Error message for the version restored action.
@@ -478,10 +490,18 @@ be.sidebarVersions.toggle = Toggle Actions Menu
 be.sidebarVersions.uploadedBy = Uploaded by {name}
 # Text displayed if a version exceeds the user's maximum allowed version count
 be.sidebarVersions.versionLimitExceeded = You are limited to the last {versionLimit, number} {versionLimit, plural, one {version} other {versions}}.
+# Max supported entries for version history
+be.sidebarVersions.versionMaxEntries = Version history is limited to the last {maxVersions} entries.
 # Text to display in the version badge.
 be.sidebarVersions.versionNumberBadge = V{versionNumber}
 # Label given to the version badge for screen readers.
 be.sidebarVersions.versionNumberLabel = Version number {versionNumber}
+# Message describing when the version will be deleted due to an applied retention policy.
+be.sidebarVersions.versionRetentionDelete = Will be deleted {time} by retention policy.
+# Message describing that the version retention policy is indefinite and will not expire.
+be.sidebarVersions.versionRetentionIndefinite = Retained indefinitely by retention policy.
+# Message describing when the version retention policy will expire.
+be.sidebarVersions.versionRetentionRemove = Retention policy expires on {time}.
 # Name displayed for unknown or deleted users.
 be.sidebarVersions.versionUserUnknown = Unknown
 # Header to display for group of versions created today
@@ -568,16 +588,18 @@ be.uploadsProvidedFolderNameInvalidMessage = Provided folder name, {name}, could
 be.uploadsRetryButtonTooltip = Retry upload
 # Error message shown when account storage limit has been reached
 be.uploadsStorageLimitErrorMessage = Account storage limit reached
-# Message displayed in the activity feed for a deleted version. {name} is the user who performed the action. { version_number } is the file version string.
-be.versionDeleted = {name} deleted version {version_number}
-# Message displayed in the activity feed to represent the range of versions uploaded by multiple users. { numberOfCollaborators } is a number and { versions } is a range of versions.
-be.versionMultipleUsersUploaded = {numberOfCollaborators} collaborators uploaded versions {versions}
-# Message displayed in the activity feed for a restored version. {name} is the user who performed the action. { version_number } is the file version string.
-be.versionRestored = {name} restored version {version_number}
-# Message displayed in the activity feed to represent the range of versions uploaded by a single user. { name } is the user who uploaded. { versions } is a range of versions.
-be.versionUploadCollapsed = {name} uploaded versions {versions}
-# Message displayed in the activity feed for a newly uploaded version. {name} is the user who performed the action. { version_number } is the file version string.
-be.versionUploaded = {name} uploaded version {version_number}
+# Message displayed in the activity feed for a deleted version. {name} is the user who performed the action. {version_number} is the file version string.
+be.versionDeleted = {name} deleted v{version_number}
+# Message displayed in the activity feed to represent the range of versions uploaded by multiple users. {numberOfCollaborators} is a number and {versions} is a range of versions.
+be.versionMultipleUsersUploaded = {numberOfCollaborators} collaborators uploaded v{versions}
+# Message displayed in the activity feed for a promoted version. {name} is the user who performed the action. {version_promoted} is the originating file version string. {version_number} is the file version string.
+be.versionPromoted = {name} promoted v{version_promoted} to v{version_number}
+# Message displayed in the activity feed for a restored version. {name} is the user who performed the action. {version_number} is the file version string.
+be.versionRestored = {name} restored v{version_number}
+# Message displayed in the activity feed to represent the range of versions uploaded by a single user. {name} is the user who uploaded. {versions} is a range of versions.
+be.versionUploadCollapsed = {name} uploaded v{versions}
+# Message displayed in the activity feed for a newly uploaded version. {name} is the user who performed the action. {version_number} is the file version string.
+be.versionUploaded = {name} uploaded v{version_number}
 # Shown instead of yesterdays date.
 be.yesterday = yesterday
 # The label for the comments category of access stats
@@ -966,6 +988,8 @@ boxui.readableTime.eventTimeDate = {time, date, medium} at {time, time, short}
 boxui.readableTime.eventTimeDateShort = {date} at {time, time, short}
 # The time that an event occurred today
 boxui.readableTime.eventTimeToday = Today at {time, time, short}
+# The time that an event occurred at a given date with the weekday included
+boxui.readableTime.eventTimeWeekdayLong = {weekday}, {time, date, medium}
 # The time that an event occurred yesterday
 boxui.readableTime.eventTimeYesterday = Yesterday at {time, time, short}
 # Title for a clear button
@@ -1360,41 +1384,3 @@ boxui.validation.requiredError = Required Field
 boxui.validation.tooLongError = Input cannot exceed {max} characters
 # Error message for when an input value is too short. {min} is the minimum length
 boxui.validation.tooShortError = Input must be at least {min} characters
-# Badge text indicating version is the current version (must be lower case)
-boxui.versionHistoryModal.current = current
-# Label given to the current badge for screen readers
-boxui.versionHistoryModal.currentVersionLabel = This is the current version of the file
-# Description of a version that has been deleted
-boxui.versionHistoryModal.deletedByInfo = Removed on {deleted, date, full} by {deleterUserName}.
-# Description of a version that will be permanently deleted
-boxui.versionHistoryModal.deletedPermanentlyByInfo = Removed on {deleted, date, full} by {deleterUserName}. Per your company settings, this version will be removed permanently on {deletedPermanentlyBy, date, full}.
-# Button text for downloading a version
-boxui.versionHistoryModal.download = Download
-# Button text for restoring a version as current
-boxui.versionHistoryModal.makeCurrent = Make Current
-# Button text for removing/deleting a version
-boxui.versionHistoryModal.remove = Remove
-# Button text for restoring a version
-boxui.versionHistoryModal.restore = Restore
-# Description of a version that has been restored
-boxui.versionHistoryModal.restoredByInfo = Restored on {restored, date, full} by {restorerUserName}.
-# Description of a version that has been restored from a now unavailable previous version.
-boxui.versionHistoryModal.restoredFromPreviousVersionInfo = Restored on {restored, date, full} from a previous version by {restorerUserName}.
-# Description of a version that has been restored. {versionNumber} is the version number of the original file version restored.
-boxui.versionHistoryModal.restoredFromVersionInfo = Restored on {restored, date, full} from V{versionNumber} by {restorerUserName}.
-# Text displayed when a version is retained and will be deleted on a certain date
-boxui.versionHistoryModal.retainedAndDeletedOn = Will be deleted {dispositionDate, date, full} by retention policy.
-# Text displayed when a version is retained indefinitely
-boxui.versionHistoryModal.retainedIndefinitely = Retained indefinitely by retention policy.
-# Text displayed when a version is retained until a certain date
-boxui.versionHistoryModal.retainedUntil = Retained until {dispositionDate, date, full} by retention policy.
-# Title of the version history modal
-boxui.versionHistoryModal.title = Version History
-# Description of a version that has been uploaded
-boxui.versionHistoryModal.uploadedInfo = Uploaded on {uploaded, date, full} at {uploaded, time, short} by {uploaderUserName}.
-# Text displayed instead of button actions
-boxui.versionHistoryModal.versionLimitExceeded = You can restore the most recent {versionLimit} versions of any file.
-# Badge text showing current version number
-boxui.versionHistoryModal.versionNumberBadge = V{versionNumber}
-# Label given to the version badge for screen readers
-boxui.versionHistoryModal.versionNumberLabel = Version number {versionNumber}

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -110,17 +110,17 @@ be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle = Task Updated with
 be.contentSidebar.activityFeed.taskForm.taskGeneralAssigneeRemovalWarningMessage = Unable to remove assignee(s) because the task is now completed.
 # Error message when a task edit fails
 be.contentSidebar.activityFeed.taskForm.taskUpdateErrorMessage = An error occurred while modifying this task. Please try again.
-# label for cancel button in create task popup
+# bdl-Label for cancel button in create task popup
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormCancelLabel = Cancel
-# label for task create form due date input
+# bdl-Label for task create form due date input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormDueDateLabel = Due Date
-# label for task create form message input
+# bdl-Label for task create form message input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormMessageLabel = Message
-# label for task create form assignee input
+# bdl-Label for task create form assignee input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSelectAssigneesLabel = Select Assignees
-# label for create button in create task modal in create mode
+# bdl-Label for create button in create task modal in create mode
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSubmitLabel = Create
-# label for edit button in create task modal in edit mode
+# bdl-Label for edit button in create task modal in edit mode
 be.contentSidebar.activityFeed.taskForm.tasksEditTaskFormSubmitLabel = Update
 # Title for checkmark icon indicating someone completed a task
 be.contentSidebar.activityFeed.taskNew.taskAssignmentCompleted = Completed
@@ -168,15 +168,15 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedStatusCompleted = Completed {dat
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel = Status: {taskStatus}
 # Rejected task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusRejected = Rejected {dateTime}
-# label for button that opens task popup
+# bdl-Label for button that opens task popup
 be.contentSidebar.addTask = Add Task
-# label for menu item that opens approval task popup
+# bdl-Label for menu item that opens approval task popup
 be.contentSidebar.addTask.approval = Approval Task
 # description for menu item that opens approval task popup
 be.contentSidebar.addTask.approval.description = Assignees will be responsible for approving or rejecting tasks
 # title for approval task popup
 be.contentSidebar.addTask.approval.title = Create Approval Task
-# label for menu item that opens general task popup
+# bdl-Label for menu item that opens general task popup
 be.contentSidebar.addTask.general = General Task
 # description for menu item that opens general task popup
 be.contentSidebar.addTask.general.description = Assignees will be responsible for marking tasks as complete
@@ -290,7 +290,7 @@ be.itemName = Name
 be.itemOwner = Owner
 # Label for item size attribute.
 be.itemSize = Size
-# label for item uploader.
+# bdl-Label for item uploader.
 be.itemUploader = Uploader
 # Label for keywords/topics skill section in the preview sidebar
 be.keywordSkill = Topics

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -4,12 +4,6 @@ be.accessStatsPermissionsError = Sorry, you do not have permission to see the ac
 be.activityFeed.fullDateTime = {time, date, full} at {time, time, short}
 # Error message for feed item API errors
 be.activityFeedItemApiError = There was a problem loading the activity feed. Please refresh the page or try again later.
-# Text to show when comment no longer exists
-be.activitySidebar.activityFeed.commentMissingError = This comment no longer exists
-# Error title
-be.activitySidebar.activityFeed.feedInlineErrorTitle = Error
-# Text to show when a task no longer exists
-be.activitySidebar.activityFeed.taskMissingError = This task no longer exists
 # Label for add action
 be.add = Add
 # Text to display when app is disabled by applied access policy
@@ -110,17 +104,17 @@ be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle = Task Updated with
 be.contentSidebar.activityFeed.taskForm.taskGeneralAssigneeRemovalWarningMessage = Unable to remove assignee(s) because the task is now completed.
 # Error message when a task edit fails
 be.contentSidebar.activityFeed.taskForm.taskUpdateErrorMessage = An error occurred while modifying this task. Please try again.
-# bdl-Label for cancel button in create task popup
+# label for cancel button in create task popup
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormCancelLabel = Cancel
-# bdl-Label for task create form due date input
+# label for task create form due date input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormDueDateLabel = Due Date
-# bdl-Label for task create form message input
+# label for task create form message input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormMessageLabel = Message
-# bdl-Label for task create form assignee input
+# label for task create form assignee input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSelectAssigneesLabel = Select Assignees
-# bdl-Label for create button in create task modal in create mode
+# label for create button in create task modal in create mode
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSubmitLabel = Create
-# bdl-Label for edit button in create task modal in edit mode
+# label for edit button in create task modal in edit mode
 be.contentSidebar.activityFeed.taskForm.tasksEditTaskFormSubmitLabel = Update
 # Title for checkmark icon indicating someone completed a task
 be.contentSidebar.activityFeed.taskNew.taskAssignmentCompleted = Completed
@@ -168,18 +162,18 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedStatusCompleted = Completed {dat
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel = Status: {taskStatus}
 # Rejected task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusRejected = Rejected {dateTime}
-# bdl-Label for button that opens task popup
+# label for button that opens task popup
 be.contentSidebar.addTask = Add Task
-# bdl-Label for menu item that opens approval task popup
+# label for menu item that opens approval task popup
 be.contentSidebar.addTask.approval = Approval Task
 # description for menu item that opens approval task popup
-be.contentSidebar.addTask.approval.description = Assignees will be responsible for approving or rejecting tasks
+be.contentSidebar.addTask.approval.description = Request an approval to move work forward
 # title for approval task popup
 be.contentSidebar.addTask.approval.title = Create Approval Task
-# bdl-Label for menu item that opens general task popup
+# label for menu item that opens general task popup
 be.contentSidebar.addTask.general = General Task
 # description for menu item that opens general task popup
-be.contentSidebar.addTask.general.description = Assignees will be responsible for marking tasks as complete
+be.contentSidebar.addTask.general.description = Keep track of work that needs to get done
 # title for general task popup
 be.contentSidebar.addTask.general.title = Create General Task
 # title for when editing an existing approval task
@@ -290,7 +284,7 @@ be.itemName = Name
 be.itemOwner = Owner
 # Label for item size attribute.
 be.itemSize = Size
-# bdl-Label for item uploader.
+# label for item uploader.
 be.itemUploader = Uploader
 # Label for keywords/topics skill section in the preview sidebar
 be.keywordSkill = Topics
@@ -306,8 +300,6 @@ be.loadingState = Please wait while the items load...
 be.logo = Logo
 # Indicator on the footer that max items have been selected.
 be.max = max
-# Message shown when there are no items for provided metadata query.
-be.metadataState = There are no items in this folder.
 # Text for modified date with modified prefix.
 be.modifiedDate = Modified {date}
 # Text for modified date with user with modified prefix.
@@ -450,8 +442,6 @@ be.sidebarVersions.delete = Delete
 be.sidebarVersions.deleteError = File version could not be deleted.
 # Message displayed for a deleted version. {name} is the user who performed the action.
 be.sidebarVersions.deletedBy = Deleted by {name}
-# Tooltip message for actions disabled by retention policy.
-be.sidebarVersions.disabledByRetention = Disabled by retention policy
 # Label for the version download action.
 be.sidebarVersions.download = Download
 # Error message for the version download action.
@@ -468,8 +458,6 @@ be.sidebarVersions.priorWeek = Last Week
 be.sidebarVersions.promote = Make Current
 # Error message for the version promote action.
 be.sidebarVersions.promoteError = File version could not be made current.
-# Message displayed for a restored version. {name} is the user who performed the action.
-be.sidebarVersions.promotedBy = Promoted from v{versionPromoted} by {name}
 # Label for the version restore action.
 be.sidebarVersions.restore = Restore
 # Error message for the version restored action.
@@ -490,18 +478,10 @@ be.sidebarVersions.toggle = Toggle Actions Menu
 be.sidebarVersions.uploadedBy = Uploaded by {name}
 # Text displayed if a version exceeds the user's maximum allowed version count
 be.sidebarVersions.versionLimitExceeded = You are limited to the last {versionLimit, number} {versionLimit, plural, one {version} other {versions}}.
-# Max supported entries for version history
-be.sidebarVersions.versionMaxEntries = Version history is limited to the last {maxVersions} entries.
 # Text to display in the version badge.
 be.sidebarVersions.versionNumberBadge = V{versionNumber}
 # Label given to the version badge for screen readers.
 be.sidebarVersions.versionNumberLabel = Version number {versionNumber}
-# Message describing when the version will be deleted due to an applied retention policy.
-be.sidebarVersions.versionRetentionDelete = Will be deleted {time} by retention policy.
-# Message describing that the version retention policy is indefinite and will not expire.
-be.sidebarVersions.versionRetentionIndefinite = Retained indefinitely by retention policy.
-# Message describing when the version retention policy will expire.
-be.sidebarVersions.versionRetentionRemove = Retention policy expires on {time}.
 # Name displayed for unknown or deleted users.
 be.sidebarVersions.versionUserUnknown = Unknown
 # Header to display for group of versions created today
@@ -588,18 +568,16 @@ be.uploadsProvidedFolderNameInvalidMessage = Provided folder name, {name}, could
 be.uploadsRetryButtonTooltip = Retry upload
 # Error message shown when account storage limit has been reached
 be.uploadsStorageLimitErrorMessage = Account storage limit reached
-# Message displayed in the activity feed for a deleted version. {name} is the user who performed the action. {version_number} is the file version string.
-be.versionDeleted = {name} deleted v{version_number}
-# Message displayed in the activity feed to represent the range of versions uploaded by multiple users. {numberOfCollaborators} is a number and {versions} is a range of versions.
-be.versionMultipleUsersUploaded = {numberOfCollaborators} collaborators uploaded v{versions}
-# Message displayed in the activity feed for a promoted version. {name} is the user who performed the action. {version_promoted} is the originating file version string. {version_number} is the file version string.
-be.versionPromoted = {name} promoted v{version_promoted} to v{version_number}
-# Message displayed in the activity feed for a restored version. {name} is the user who performed the action. {version_number} is the file version string.
-be.versionRestored = {name} restored v{version_number}
-# Message displayed in the activity feed to represent the range of versions uploaded by a single user. {name} is the user who uploaded. {versions} is a range of versions.
-be.versionUploadCollapsed = {name} uploaded v{versions}
-# Message displayed in the activity feed for a newly uploaded version. {name} is the user who performed the action. {version_number} is the file version string.
-be.versionUploaded = {name} uploaded v{version_number}
+# Message displayed in the activity feed for a deleted version. {name} is the user who performed the action. { version_number } is the file version string.
+be.versionDeleted = {name} deleted version {version_number}
+# Message displayed in the activity feed to represent the range of versions uploaded by multiple users. { numberOfCollaborators } is a number and { versions } is a range of versions.
+be.versionMultipleUsersUploaded = {numberOfCollaborators} collaborators uploaded versions {versions}
+# Message displayed in the activity feed for a restored version. {name} is the user who performed the action. { version_number } is the file version string.
+be.versionRestored = {name} restored version {version_number}
+# Message displayed in the activity feed to represent the range of versions uploaded by a single user. { name } is the user who uploaded. { versions } is a range of versions.
+be.versionUploadCollapsed = {name} uploaded versions {versions}
+# Message displayed in the activity feed for a newly uploaded version. {name} is the user who performed the action. { version_number } is the file version string.
+be.versionUploaded = {name} uploaded version {version_number}
 # Shown instead of yesterdays date.
 be.yesterday = yesterday
 # The label for the comments category of access stats
@@ -988,8 +966,6 @@ boxui.readableTime.eventTimeDate = {time, date, medium} at {time, time, short}
 boxui.readableTime.eventTimeDateShort = {date} at {time, time, short}
 # The time that an event occurred today
 boxui.readableTime.eventTimeToday = Today at {time, time, short}
-# The time that an event occurred at a given date with the weekday included
-boxui.readableTime.eventTimeWeekdayLong = {weekday}, {time, date, medium}
 # The time that an event occurred yesterday
 boxui.readableTime.eventTimeYesterday = Yesterday at {time, time, short}
 # Title for a clear button
@@ -1384,3 +1360,41 @@ boxui.validation.requiredError = Required Field
 boxui.validation.tooLongError = Input cannot exceed {max} characters
 # Error message for when an input value is too short. {min} is the minimum length
 boxui.validation.tooShortError = Input must be at least {min} characters
+# Badge text indicating version is the current version (must be lower case)
+boxui.versionHistoryModal.current = current
+# Label given to the current badge for screen readers
+boxui.versionHistoryModal.currentVersionLabel = This is the current version of the file
+# Description of a version that has been deleted
+boxui.versionHistoryModal.deletedByInfo = Removed on {deleted, date, full} by {deleterUserName}.
+# Description of a version that will be permanently deleted
+boxui.versionHistoryModal.deletedPermanentlyByInfo = Removed on {deleted, date, full} by {deleterUserName}. Per your company settings, this version will be removed permanently on {deletedPermanentlyBy, date, full}.
+# Button text for downloading a version
+boxui.versionHistoryModal.download = Download
+# Button text for restoring a version as current
+boxui.versionHistoryModal.makeCurrent = Make Current
+# Button text for removing/deleting a version
+boxui.versionHistoryModal.remove = Remove
+# Button text for restoring a version
+boxui.versionHistoryModal.restore = Restore
+# Description of a version that has been restored
+boxui.versionHistoryModal.restoredByInfo = Restored on {restored, date, full} by {restorerUserName}.
+# Description of a version that has been restored from a now unavailable previous version.
+boxui.versionHistoryModal.restoredFromPreviousVersionInfo = Restored on {restored, date, full} from a previous version by {restorerUserName}.
+# Description of a version that has been restored. {versionNumber} is the version number of the original file version restored.
+boxui.versionHistoryModal.restoredFromVersionInfo = Restored on {restored, date, full} from V{versionNumber} by {restorerUserName}.
+# Text displayed when a version is retained and will be deleted on a certain date
+boxui.versionHistoryModal.retainedAndDeletedOn = Will be deleted {dispositionDate, date, full} by retention policy.
+# Text displayed when a version is retained indefinitely
+boxui.versionHistoryModal.retainedIndefinitely = Retained indefinitely by retention policy.
+# Text displayed when a version is retained until a certain date
+boxui.versionHistoryModal.retainedUntil = Retained until {dispositionDate, date, full} by retention policy.
+# Title of the version history modal
+boxui.versionHistoryModal.title = Version History
+# Description of a version that has been uploaded
+boxui.versionHistoryModal.uploadedInfo = Uploaded on {uploaded, date, full} at {uploaded, time, short} by {uploaderUserName}.
+# Text displayed instead of button actions
+boxui.versionHistoryModal.versionLimitExceeded = You can restore the most recent {versionLimit} versions of any file.
+# Badge text showing current version number
+boxui.versionHistoryModal.versionNumberBadge = V{versionNumber}
+# Label given to the version badge for screen readers
+boxui.versionHistoryModal.versionNumberLabel = Version number {versionNumber}

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -110,17 +110,17 @@ be.contentSidebar.activityFeed.taskForm.taskEditWarningTitle = Task Updated with
 be.contentSidebar.activityFeed.taskForm.taskGeneralAssigneeRemovalWarningMessage = Unable to remove assignee(s) because the task is now completed.
 # Error message when a task edit fails
 be.contentSidebar.activityFeed.taskForm.taskUpdateErrorMessage = An error occurred while modifying this task. Please try again.
-# bdl-Label for cancel button in create task popup
+# label for cancel button in create task popup
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormCancelLabel = Cancel
-# bdl-Label for task create form due date input
+# label for task create form due date input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormDueDateLabel = Due Date
-# bdl-Label for task create form message input
+# label for task create form message input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormMessageLabel = Message
-# bdl-Label for task create form assignee input
+# label for task create form assignee input
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSelectAssigneesLabel = Select Assignees
-# bdl-Label for create button in create task modal in create mode
+# label for create button in create task modal in create mode
 be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSubmitLabel = Create
-# bdl-Label for edit button in create task modal in edit mode
+# label for edit button in create task modal in edit mode
 be.contentSidebar.activityFeed.taskForm.tasksEditTaskFormSubmitLabel = Update
 # Title for checkmark icon indicating someone completed a task
 be.contentSidebar.activityFeed.taskNew.taskAssignmentCompleted = Completed
@@ -168,15 +168,15 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedStatusCompleted = Completed {dat
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel = Status: {taskStatus}
 # Rejected task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusRejected = Rejected {dateTime}
-# bdl-Label for button that opens task popup
+# label for button that opens task popup
 be.contentSidebar.addTask = Add Task
-# bdl-Label for menu item that opens approval task popup
+# label for menu item that opens approval task popup
 be.contentSidebar.addTask.approval = Approval Task
 # description for menu item that opens approval task popup
 be.contentSidebar.addTask.approval.description = Assignees will be responsible for approving or rejecting tasks
 # title for approval task popup
 be.contentSidebar.addTask.approval.title = Create Approval Task
-# bdl-Label for menu item that opens general task popup
+# label for menu item that opens general task popup
 be.contentSidebar.addTask.general = General Task
 # description for menu item that opens general task popup
 be.contentSidebar.addTask.general.description = Assignees will be responsible for marking tasks as complete
@@ -290,7 +290,7 @@ be.itemName = Name
 be.itemOwner = Owner
 # Label for item size attribute.
 be.itemSize = Size
-# bdl-Label for item uploader.
+# label for item uploader.
 be.itemUploader = Uploader
 # Label for keywords/topics skill section in the preview sidebar
 be.keywordSkill = Topics

--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -27,17 +27,17 @@ const writeFile = promisify(fs.writeFile);
 */
 
 const conversionMap = {
-    // 'btn': 'bdl-Button',
-    // 'btn-group': 'bdl-ButtonGroup',
-    // 'btn-plain': 'bdl-PlainButton',
-    // 'btn-primary': 'bdl-Button--primary',
-    // 'is-disabled': 'bdl-is-disabled',
-    // 'label': 'bdl-Label',
-    // 'pill': 'bdl-Pill',
-    // 'pill-error': 'bdl-Pill--error',
-    // 'select-button': 'bdl-SelectButton',
-    // 'toggle': 'bdl-Toggle',
-    // 'tooltip': 'bdl-Tooltip',
+    'btn': 'bdl-Button',
+    'btn-group': 'bdl-ButtonGroup',
+    'btn-plain': 'bdl-PlainButton',
+    'btn-primary': 'bdl-Button--primary',
+    'is-disabled': 'bdl-is-disabled',
+    'label': 'bdl-Label',
+    'pill': 'bdl-Pill',
+    'pill-error': 'bdl-Pill--error',
+    'select-button': 'bdl-SelectButton',
+    'toggle': 'bdl-Toggle',
+    'tooltip': 'bdl-Tooltip',
 };
 const scssPrefix = '.';
 const jsPrefixes = ["'", '"', '`'];

--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -27,17 +27,17 @@ const writeFile = promisify(fs.writeFile);
 */
 
 const conversionMap = {
-    // 'btn': 'bdl-Button',
-    // 'btn-group': 'bdl-ButtonGroup',
-    // 'btn-plain': 'bdl-Button--plain',
-    // 'btn-primary': 'bdl-Button--primary',
-    // 'is-disabled': 'bdl-is-disabled',
-    // 'label': 'bdl-Label',
-    // 'pill': 'bdl-Pill',
-    // 'pill-error': 'bdl-Pill--error',
-    // 'select-button': 'bdl-SelectButton',
-    // 'toggle': 'bdl-Toggle',
-    // 'tooltip': 'bdl-Tooltip',
+    'btn': 'bdl-Button',
+    'btn-group': 'bdl-ButtonGroup',
+    'btn-plain': 'bdl-Button--plain',
+    'btn-primary': 'bdl-Button--primary',
+    'is-disabled': 'bdl-is-disabled',
+    'label': 'bdl-Label',
+    'pill': 'bdl-Pill',
+    'pill-error': 'bdl-Pill--error',
+    'select-button': 'bdl-SelectButton',
+    'toggle': 'bdl-Toggle',
+    'tooltip': 'bdl-Tooltip',
 };
 const scssPrefix = '.';
 const jsPrefixes = ["'", '"', '`'];

--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -27,17 +27,17 @@ const writeFile = promisify(fs.writeFile);
 */
 
 const conversionMap = {
-    'btn': 'bdl-Button',
-    'btn-group': 'bdl-ButtonGroup',
-    'btn-plain': 'bdl-PlainButton',
-    'btn-primary': 'bdl-PrimaryButton',
-    'is-disabled': 'bdl-is-disabled',
-    'label': 'bdl-Label',
-    'pill': 'bdl-Pill',
-    'pill-error': 'bdl-Pill--error',
-    'select-button': 'bdl-SelectButton',
-    'toggle': 'bdl-Toggle',
-    'tooltip': 'bdl-Tooltip',
+    // 'btn': 'bdl-Button',
+    // 'btn-group': 'bdl-ButtonGroup',
+    // 'btn-plain': 'bdl-PlainButton',
+    // 'btn-primary': 'bdl-PrimaryButton',
+    // 'is-disabled': 'bdl-is-disabled',
+    // 'label': 'bdl-Label',
+    // 'pill': 'bdl-Pill',
+    // 'pill-error': 'bdl-Pill--error',
+    // 'select-button': 'bdl-SelectButton',
+    // 'toggle': 'bdl-Toggle',
+    // 'tooltip': 'bdl-Tooltip',
 };
 const scssPrefix = '.';
 const jsPrefixes = ["'", '"', '`'];

--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -30,7 +30,7 @@ const conversionMap = {
     // 'btn': 'bdl-Button',
     // 'btn-group': 'bdl-ButtonGroup',
     // 'btn-plain': 'bdl-PlainButton',
-    // 'btn-primary': 'bdl-PrimaryButton',
+    // 'btn-primary': 'bdl-Button--primary',
     // 'is-disabled': 'bdl-is-disabled',
     // 'label': 'bdl-Label',
     // 'pill': 'bdl-Pill',

--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -29,8 +29,8 @@ const writeFile = promisify(fs.writeFile);
 const conversionMap = {
     'btn': 'bdl-Button',
     'btn-group': 'bdl-ButtonGroup',
-    'btn-plain': 'bdl-Button--plain',
-    'btn-primary': 'bdl-Button--primary',
+    'btn-plain': 'bdl-PlainButton',
+    'btn-primary': 'bdl-PrimaryButton',
     'is-disabled': 'bdl-is-disabled',
     'label': 'bdl-Label',
     'pill': 'bdl-Pill',

--- a/src/components/button-group/ButtonGroup.js
+++ b/src/components/button-group/ButtonGroup.js
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const ButtonGroup = ({ children, className = '', isDisabled }: Props) => (
-    <div className={`btn-group ${className} ${isDisabled ? 'is-disabled' : ''}`}>{children}</div>
+    <div className={`btn-group ${className} ${isDisabled ? 'bdl-is-disabled' : ''}`}>{children}</div>
 );
 
 export default ButtonGroup;

--- a/src/components/button-group/ButtonGroup.js
+++ b/src/components/button-group/ButtonGroup.js
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const ButtonGroup = ({ children, className = '', isDisabled }: Props) => (
-    <div className={`btn-group ${className} ${isDisabled ? 'bdl-is-disabled' : ''}`}>{children}</div>
+    <div className={`bdl-ButtonGroup ${className} ${isDisabled ? 'bdl-is-disabled' : ''}`}>{children}</div>
 );
 
 export default ButtonGroup;

--- a/src/components/button-group/ButtonGroup.scss
+++ b/src/components/button-group/ButtonGroup.scss
@@ -3,19 +3,19 @@
 /**************************************
  * Button Group
  **************************************/
-.btn-group {
+.bdl-ButtonGroup {
     position: relative;
 
     .toggle-overlay {
         display: inline;
 
-        > .btn {
+        > .bdl-Button {
             margin-left: 0;
             padding-right: 11px;
             padding-left: 11px;
             border-radius: 0 4px 4px 0;
 
-            &.btn-primary {
+            &.bdl-Button--primary {
                 border-left-color: darken($primary-color, 10%);
             }
         }
@@ -39,11 +39,11 @@
         }
     }
 
-    > .btn {
+    > .bdl-Button {
         margin: 5px 0 5px -1px;
         border-radius: 0;
 
-        &.btn-primary {
+        &.bdl-Button--primary {
             margin: 5px 0;
             border-right-color: darken($primary-color, 10%);
 
@@ -60,17 +60,17 @@
         }
     }
 
-    > .btn:first-child {
+    > .bdl-Button:first-child {
         border-top-left-radius: 4px;
         border-bottom-left-radius: 4px;
     }
 
-    > .btn:last-child {
+    > .bdl-Button:last-child {
         border-top-right-radius: 4px;
         border-bottom-right-radius: 4px;
     }
 
-    > .btn.is-selected {
+    > .bdl-Button.is-selected {
         z-index: 2; /* place on top of siblings */
         color: $bdl-gray-80;
         background-color: $bdl-gray-10;
@@ -78,12 +78,12 @@
         box-shadow: none;
     }
 
-    > .btn:focus {
+    > .bdl-Button:focus {
         z-index: 3; /* place on top of all other buttons for accessibility */
     }
 
-    &.is-disabled {
-        > .btn {
+    &.bdl-is-disabled {
+        > .bdl-Button {
             color: $bdl-gray-62;
             background-color: $bdl-gray-02;
             border: 1px solid $bdl-gray-30;
@@ -92,7 +92,7 @@
             opacity: .4;
         }
 
-        > .btn-primary {
+        > .bdl-Button--primary {
             color: $white;
             background-color: $primary-color;
             border-color: $primary-color;

--- a/src/components/button-group/ButtonGroup.scss
+++ b/src/components/button-group/ButtonGroup.scss
@@ -15,7 +15,7 @@
             padding-left: 11px;
             border-radius: 0 4px 4px 0;
 
-            &.bdl-Button--primary {
+            &.bdl-PrimaryButton {
                 border-left-color: darken($primary-color, 10%);
             }
         }
@@ -43,11 +43,11 @@
         margin: 5px 0 5px -1px;
         border-radius: 0;
 
-        &.bdl-Button--primary {
+        &.bdl-PrimaryButton {
             margin: 5px 0;
             border-right-color: darken($primary-color, 10%);
 
-            &.is-selected {
+            &.bdl-is-selected {
                 color: $white;
                 background-color: darken($primary-color, 8%);
                 border-color: darken($primary-color, 15%);
@@ -70,7 +70,7 @@
         border-bottom-right-radius: 4px;
     }
 
-    > .bdl-Button.is-selected {
+    > .bdl-Button.bdl-is-selected {
         z-index: 2; /* place on top of siblings */
         color: $bdl-gray-80;
         background-color: $bdl-gray-10;
@@ -92,7 +92,7 @@
             opacity: .4;
         }
 
-        > .bdl-Button--primary {
+        > .bdl-PrimaryButton {
             color: $white;
             background-color: $primary-color;
             border-color: $primary-color;

--- a/src/components/button-group/ButtonGroup.scss
+++ b/src/components/button-group/ButtonGroup.scss
@@ -15,7 +15,7 @@
             padding-left: 11px;
             border-radius: 0 4px 4px 0;
 
-            &.bdl-PrimaryButton {
+            &.bdl-Button--primary {
                 border-left-color: darken($primary-color, 10%);
             }
         }
@@ -43,7 +43,7 @@
         margin: 5px 0 5px -1px;
         border-radius: 0;
 
-        &.bdl-PrimaryButton {
+        &.bdl-Button--primary {
             margin: 5px 0;
             border-right-color: darken($primary-color, 10%);
 
@@ -92,7 +92,7 @@
             opacity: .4;
         }
 
-        > .bdl-PrimaryButton {
+        > .bdl-Button--primary {
             color: $white;
             background-color: $primary-color;
             border-color: $primary-color;

--- a/src/components/button-group/__test__/ButtonGroup.test.js
+++ b/src/components/button-group/__test__/ButtonGroup.test.js
@@ -14,7 +14,7 @@ describe('components/button-group/ButtonGroup', () => {
             </ButtonGroup>,
         );
 
-        expect(wrapper.find('.btn-group')).toBeTruthy();
-        expect(wrapper.find('.btn').length).toBe(3);
+        expect(wrapper.find('.bdl-ButtonGroup')).toBeTruthy();
+        expect(wrapper.find('.bdl-Button').length).toBe(3);
     });
 });

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -58,7 +58,7 @@ class Button extends React.Component<Props> {
             {
                 'bdl-is-disabled': isDisabled,
                 'bdl-is-loading': isLoading,
-                'is-selected': isSelected,
+                'bdl-is-selected': isSelected,
             },
             className,
         );

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -25,7 +25,7 @@ class Button extends React.Component<Props> {
 
     handleClick = (event: SyntheticEvent<HTMLButtonElement>) => {
         const { isDisabled, onClick } = this.props;
-        if (isDisabled || (this.btnElement && this.btnElement.classList.contains('is-disabled'))) {
+        if (isDisabled || (this.btnElement && this.btnElement.classList.contains('bdl-is-disabled'))) {
             event.preventDefault();
             event.stopPropagation();
             return;
@@ -54,10 +54,10 @@ class Button extends React.Component<Props> {
         }
 
         const styleClassName = classNames(
-            'btn',
+            'bdl-Button',
             {
-                'is-disabled': isDisabled,
-                'is-loading': isLoading,
+                'bdl-is-disabled': isDisabled,
+                'bdl-is-loading': isLoading,
                 'is-selected': isSelected,
             },
             className,
@@ -77,8 +77,8 @@ class Button extends React.Component<Props> {
                 type={type}
                 {...buttonProps}
             >
-                <span className="btn-content">{children}</span>
-                {isLoading && <LoadingIndicator className="btn-loading-indicator" />}
+                <span className="bdl-Button-content">{children}</span>
+                {isLoading && <LoadingIndicator className="bdl-Button-loadingIndicator" />}
             </button>
         );
         if (showRadar) {

--- a/src/components/button/__tests__/Button.test.js
+++ b/src/components/button/__tests__/Button.test.js
@@ -16,15 +16,15 @@ describe('components/button/Button', () => {
         const wrapper = shallow(<Button>{children}</Button>);
 
         expect(wrapper.hasClass('btn')).toBe(true);
-        expect(wrapper.find('.btn-content').length).toEqual(1);
+        expect(wrapper.find('.bdl-Button-content').length).toEqual(1);
         expect(wrapper.text()).toEqual(children);
     });
 
     test('should correctly render loading indicator, disable button and hide button content if button is in loading state', () => {
         const wrapper = shallow(<Button isLoading>Test</Button>);
 
-        expect(wrapper.find('.btn-loading-indicator').length).toEqual(1);
-        expect(wrapper.hasClass('is-loading')).toBe(true);
+        expect(wrapper.find('.bdl-Button-loadingIndicator').length).toEqual(1);
+        expect(wrapper.hasClass('bdl-is-loading')).toBe(true);
     });
 
     test('simulates click events', () => {
@@ -57,7 +57,7 @@ describe('components/button/Button', () => {
         sinon.assert.calledOnce(stopPropagation);
     });
 
-    test('should not call onClick when className has is-disabled', () => {
+    test('should not call onClick when className has bdl-is-disabled', () => {
         const onClickHandler = sinon.spy();
         const preventDefault = sinon.spy();
         const stopPropagation = sinon.spy();

--- a/src/components/button/__tests__/Button.test.js
+++ b/src/components/button/__tests__/Button.test.js
@@ -15,7 +15,7 @@ describe('components/button/Button', () => {
 
         const wrapper = shallow(<Button>{children}</Button>);
 
-        expect(wrapper.hasClass('btn')).toBe(true);
+        expect(wrapper.hasClass('bdl-Button')).toBe(true);
         expect(wrapper.find('.bdl-Button-content').length).toEqual(1);
         expect(wrapper.text()).toEqual(children);
     });
@@ -33,10 +33,10 @@ describe('components/button/Button', () => {
         const wrapper = shallow(<Button onClick={onClickHandler} />);
 
         const contains = sinon.stub();
-        contains.withArgs('is-disabled').returns(false);
+        contains.withArgs('bdl-is-disabled').returns(false);
         wrapper.instance().btnElement = { classList: { contains } };
 
-        wrapper.find('button').simulate('click');
+        wrapper.find('.bdl-Button').simulate('click');
         expect(onClickHandler.calledOnce).toBe(true);
     });
 
@@ -48,10 +48,10 @@ describe('components/button/Button', () => {
         const wrapper = shallow(<Button isDisabled onClick={onClickHandler} />);
 
         const contains = sinon.stub();
-        contains.withArgs('is-disabled').returns(true);
+        contains.withArgs('bdl-is-disabled').returns(true);
         wrapper.instance().btnElement = { classList: { contains } };
 
-        wrapper.find('button').simulate('click', { preventDefault, stopPropagation });
+        wrapper.find('.bdl-Button').simulate('click', { preventDefault, stopPropagation });
         sinon.assert.notCalled(onClickHandler);
         sinon.assert.calledOnce(preventDefault);
         sinon.assert.calledOnce(stopPropagation);
@@ -65,10 +65,10 @@ describe('components/button/Button', () => {
         const wrapper = shallow(<Button className="is-disabled" onClick={onClickHandler} />);
 
         const contains = sinon.stub();
-        contains.withArgs('is-disabled').returns(true);
+        contains.withArgs('bdl-is-disabled').returns(true);
         wrapper.instance().btnElement = { classList: { contains } };
 
-        wrapper.find('button').simulate('click', { preventDefault, stopPropagation });
+        wrapper.find('.bdl-Button').simulate('click', { preventDefault, stopPropagation });
         sinon.assert.notCalled(onClickHandler);
         sinon.assert.calledOnce(preventDefault);
         sinon.assert.calledOnce(stopPropagation);

--- a/src/components/button/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/button/__tests__/__snapshots__/Button.test.js.snap
@@ -15,7 +15,7 @@ exports[`components/button/Button should render a RadarAnimation if showRadar is
     type="submit"
   >
     <span
-      className="btn-content"
+      className="bdl-Button-content"
     >
       Test
     </span>

--- a/src/components/button/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/components/button/__tests__/__snapshots__/Button.test.js.snap
@@ -10,7 +10,7 @@ exports[`components/button/Button should render a RadarAnimation if showRadar is
   position="middle-right"
 >
   <button
-    className="btn"
+    className="bdl-Button"
     onClick={[Function]}
     type="submit"
   >

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -69,8 +69,8 @@ const Checkbox = ({
     );
 
     return (
-        <div className={`checkbox-container ${className} ${isDisabled ? 'is-disabled' : ''}`}>
-            {fieldLabel && <div className="label">{fieldLabel}</div>}
+        <div className={`checkbox-container ${className} ${isDisabled ? 'bdl-is-disabled' : ''}`}>
+            {fieldLabel && <div className="label bdl-Label">{fieldLabel}</div>}
             {tooltip ? <CheckboxTooltip label={checkboxLabel} tooltip={tooltip} /> : checkboxLabel}
             {description ? <div className="checkbox-description">{description}</div> : null}
             {subsection ? <div className="checkbox-subsection">{subsection}</div> : null}

--- a/src/components/checkbox/Checkbox.js
+++ b/src/components/checkbox/Checkbox.js
@@ -70,7 +70,7 @@ const Checkbox = ({
 
     return (
         <div className={`checkbox-container ${className} ${isDisabled ? 'bdl-is-disabled' : ''}`}>
-            {fieldLabel && <div className="label bdl-Label">{fieldLabel}</div>}
+            {fieldLabel && <div className="bdl-Label">{fieldLabel}</div>}
             {tooltip ? <CheckboxTooltip label={checkboxLabel} tooltip={tooltip} /> : checkboxLabel}
             {description ? <div className="checkbox-description">{description}</div> : null}
             {subsection ? <div className="checkbox-subsection">{subsection}</div> : null}

--- a/src/components/checkbox/Checkbox.scss
+++ b/src/components/checkbox/Checkbox.scss
@@ -89,11 +89,11 @@
 .checkbox-container {
     margin: 0 0 20px;
 
-    &.is-disabled .checkbox-label {
+    &.bdl-is-disabled .checkbox-label {
         color: $bdl-gray-50;
     }
 
-    > .label {
+    > .bdl-Label {
         margin: 8px 0;
     }
 }

--- a/src/components/checkbox/__tests__/Checkbox.test.js
+++ b/src/components/checkbox/__tests__/Checkbox.test.js
@@ -25,7 +25,7 @@ describe('components/checkbox/Checkbox', () => {
         ).toEqual('checkbox-pointer-target');
         expect(wrapper.find('label').text()).toEqual('Check things');
         expect(wrapper.find('input').prop('checked')).toBeFalsy();
-        expect(wrapper.find('.label').length).toBe(0);
+        expect(wrapper.find('.bdl-Label').length).toBe(0);
     });
 
     test('should pass rest of props to input', () => {
@@ -79,7 +79,7 @@ describe('components/checkbox/Checkbox', () => {
         const fieldLabel = 'Label';
         wrapper.setProps({ fieldLabel });
 
-        const label = wrapper.find('.label');
+        const label = wrapper.find('.bdl-Label');
         expect(label.length).toBe(1);
         expect(label.contains(fieldLabel)).toBe(true);
     });

--- a/src/components/collapsible/Collapsible.scss
+++ b/src/components/collapsible/Collapsible.scss
@@ -31,7 +31,7 @@
         transition: transform $bdl-transition-duration-200ms;
     }
 
-    .btn-plain.collapsible-card-title {
+    .bdl-Button--plain.collapsible-card-title {
         position: relative;
         display: flex;
         align-items: center;
@@ -55,12 +55,12 @@
             background-color: $white;
         }
 
-        .btn-plain.collapsible-card-title,
+        .bdl-Button--plain.collapsible-card-title,
         .collapsible-card-content {
             padding: 10px;
         }
 
-        &.is-open .btn-plain.collapsible-card-title {
+        &.is-open .bdl-Button--plain.collapsible-card-title {
             border-bottom: 1px solid $bdl-gray-10;
         }
 
@@ -70,7 +70,7 @@
     }
 
     &:not(.is-bordered) {
-        .btn-plain.collapsible-card-title {
+        .bdl-Button--plain.collapsible-card-title {
             border-bottom: 1px solid $bdl-gray-10;
 
             &:hover,

--- a/src/components/collapsible/Collapsible.scss
+++ b/src/components/collapsible/Collapsible.scss
@@ -31,7 +31,7 @@
         transition: transform $bdl-transition-duration-200ms;
     }
 
-    .bdl-Button--plain.collapsible-card-title {
+    .bdl-PlainButton.collapsible-card-title {
         position: relative;
         display: flex;
         align-items: center;
@@ -55,12 +55,12 @@
             background-color: $white;
         }
 
-        .bdl-Button--plain.collapsible-card-title,
+        .bdl-PlainButton.collapsible-card-title,
         .collapsible-card-content {
             padding: 10px;
         }
 
-        &.is-open .bdl-Button--plain.collapsible-card-title {
+        &.is-open .bdl-PlainButton.collapsible-card-title {
             border-bottom: 1px solid $bdl-gray-10;
         }
 
@@ -70,7 +70,7 @@
     }
 
     &:not(.is-bordered) {
-        .bdl-Button--plain.collapsible-card-title {
+        .bdl-PlainButton.collapsible-card-title {
             border-bottom: 1px solid $bdl-gray-10;
 
             &:hover,

--- a/src/components/date-picker/DatePicker.js
+++ b/src/components/date-picker/DatePicker.js
@@ -383,7 +383,7 @@ class DatePicker extends React.Component<Props> {
         const { formatMessage } = intl;
         const classes = classNames(className, 'date-picker-wrapper', {
             'show-clear-btn': !!value,
-            'show-error': !!error,
+            'bdl-show-error': !!error,
         });
 
         const resinTargetAttr = resinTarget ? { [RESIN_TAG_TARGET]: resinTarget } : {};

--- a/src/components/date-picker/DatePicker.js
+++ b/src/components/date-picker/DatePicker.js
@@ -383,7 +383,7 @@ class DatePicker extends React.Component<Props> {
         const { formatMessage } = intl;
         const classes = classNames(className, 'date-picker-wrapper', {
             'show-clear-btn': !!value,
-            'bdl-show-error': !!error,
+            'bdl-has-error': !!error,
         });
 
         const resinTargetAttr = resinTarget ? { [RESIN_TAG_TARGET]: resinTarget } : {};

--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -97,7 +97,7 @@
         }
     }
 
-    &.show-clear-btn.show-error {
+    &.show-clear-btn.bdl-show-error {
         .date-picker-clear-btn,
         .date-picker-clear-btn:hover,
         .date-picker-clear-btn:active {

--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -30,7 +30,7 @@
         text-overflow: ellipsis;
     }
 
-    .date-picker-input:focus ~ .tooltip,
+    .date-picker-input:focus ~ .bdl-Tooltip,
     .date-picker-unix-time-input {
         display: none;
     }

--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -97,7 +97,7 @@
         }
     }
 
-    &.show-clear-btn.bdl-show-error {
+    &.show-clear-btn.bdl-has-error {
         .date-picker-clear-btn,
         .date-picker-clear-btn:hover,
         .date-picker-clear-btn:active {

--- a/src/components/date-picker/_pikaday.scss
+++ b/src/components/date-picker/_pikaday.scss
@@ -170,7 +170,7 @@
 }
 
 .pika-button:hover,
-.is-selected .pika-button {
+.bdl-is-selected .pika-button {
     color: $white;
     font-weight: bold;
     background-color: $primary-color;

--- a/src/components/date-picker/_pikaday.scss
+++ b/src/components/date-picker/_pikaday.scss
@@ -91,7 +91,7 @@
     text-indent: -999px;
     cursor: pointer;
 
-    &.is-disabled {
+    &.bdl-is-disabled {
         cursor: default;
         opacity: .2;
     }
@@ -178,7 +178,7 @@
     cursor: pointer;
 }
 
-.is-disabled .pika-button,
+.bdl-is-disabled .pika-button,
 .is-outside-current-month .pika-button {
     cursor: default;
     opacity: .3;

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -88,7 +88,7 @@ class DraftJSEditor extends React.Component<Props> {
         const classes = classNames({
             'draft-js-editor': true,
             'bdl-is-disabled': isDisabled,
-            'bdl-show-error': !!error,
+            'bdl-has-error': !!error,
         });
 
         let a11yProps = {};

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -88,7 +88,7 @@ class DraftJSEditor extends React.Component<Props> {
         const classes = classNames({
             'draft-js-editor': true,
             'bdl-is-disabled': isDisabled,
-            'show-error': !!error,
+            'bdl-show-error': !!error,
         });
 
         let a11yProps = {};

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -87,7 +87,7 @@ class DraftJSEditor extends React.Component<Props> {
 
         const classes = classNames({
             'draft-js-editor': true,
-            'is-disabled': isDisabled,
+            'bdl-is-disabled': isDisabled,
             'show-error': !!error,
         });
 

--- a/src/components/draft-js-editor/DraftJSEditor.scss
+++ b/src/components/draft-js-editor/DraftJSEditor.scss
@@ -4,7 +4,7 @@
     margin: 8px 10px;
 }
 
-.is-disabled .public-DraftStyleDefault-block {
+.bdl-is-disabled .public-DraftStyleDefault-block {
     width: 262px;
     padding: 8px 10px;
     border: 1px solid $bdl-gray-20;

--- a/src/components/dropdown-menu/MenuToggle.scss
+++ b/src/components/dropdown-menu/MenuToggle.scss
@@ -23,11 +23,11 @@
         }
     }
 
-    .btn-primary & .fill-color {
+    .bdl-Button--primary & .fill-color {
         fill: $white;
     }
 
-    .lnk.is-disabled & .fill-color {
+    .lnk.bdl-is-disabled & .fill-color {
         fill: $bdl-gray-50;
     }
 }

--- a/src/components/dropdown-menu/MenuToggle.scss
+++ b/src/components/dropdown-menu/MenuToggle.scss
@@ -23,7 +23,7 @@
         }
     }
 
-    .bdl-Button--primary & .fill-color {
+    .bdl-PrimaryButton & .fill-color {
         fill: $white;
     }
 

--- a/src/components/dropdown-menu/MenuToggle.scss
+++ b/src/components/dropdown-menu/MenuToggle.scss
@@ -23,7 +23,7 @@
         }
     }
 
-    .bdl-PrimaryButton & .fill-color {
+    .bdl-Button--primary & .fill-color {
         fill: $white;
     }
 

--- a/src/components/fieldset/Fieldset.js
+++ b/src/components/fieldset/Fieldset.js
@@ -11,7 +11,7 @@ type Props = {
 
 const Fieldset = ({ children, className = '', title, ...rest }: Props) => (
     <fieldset className={`fieldset ${className}`} {...rest}>
-        <legend className="label">{title}</legend>
+        <legend className="label bdl-Label">{title}</legend>
         {children}
     </fieldset>
 );

--- a/src/components/fieldset/Fieldset.js
+++ b/src/components/fieldset/Fieldset.js
@@ -11,7 +11,7 @@ type Props = {
 
 const Fieldset = ({ children, className = '', title, ...rest }: Props) => (
     <fieldset className={`fieldset ${className}`} {...rest}>
-        <legend className="label bdl-Label">{title}</legend>
+        <legend className="bdl-Label">{title}</legend>
         {children}
     </fieldset>
 );

--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -360,7 +360,7 @@ class Flyout extends React.Component<Props, State> {
         const tetherPosition = positions[position];
 
         if (elements.length !== 2) {
-            throw new Error('Flyout must have exactly two children: A button component and a <Overlay>');
+            throw new Error('Flyout must have exactly two children: A button component and an <Overlay>');
         }
 
         const overlayButton = elements[0];

--- a/src/components/form-elements/text-area/__tests__/TextArea.test.js
+++ b/src/components/form-elements/text-area/__tests__/TextArea.test.js
@@ -30,14 +30,14 @@ describe('components/form-elements/text-area/TextArea', () => {
         const wrapper = mount(<TextArea className="coverage" isRequired label="label" name="input" />);
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
     });
 
     test('should mark required fields valid when not empty', () => {
         const wrapper = mount(<TextArea isRequired label="label" name="textarea" value="baba" />);
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should correctly validate when change event is fired', () => {
@@ -45,7 +45,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
 
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'a' });
         textarea.simulate('blur');
@@ -55,7 +55,7 @@ describe('components/form-elements/text-area/TextArea', () => {
             },
         });
 
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should set an textarea as valid when the validityFn returns an void', () => {
@@ -145,7 +145,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
 
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'abba' });
 
@@ -157,7 +157,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should validate onChange when textarea is already in error state', () => {
@@ -165,7 +165,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
 
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
 
         const textareaEl = textarea.getDOMNode();
         textareaEl.value = 'a';
@@ -174,7 +174,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-area-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should set validity state when set validity state handler is called with custom error', () => {

--- a/src/components/form-elements/text-area/__tests__/TextArea.test.js
+++ b/src/components/form-elements/text-area/__tests__/TextArea.test.js
@@ -30,14 +30,14 @@ describe('components/form-elements/text-area/TextArea', () => {
         const wrapper = mount(<TextArea className="coverage" isRequired label="label" name="input" />);
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeTruthy();
     });
 
     test('should mark required fields valid when not empty', () => {
         const wrapper = mount(<TextArea isRequired label="label" name="textarea" value="baba" />);
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should correctly validate when change event is fired', () => {
@@ -45,7 +45,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
 
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'a' });
         textarea.simulate('blur');
@@ -55,7 +55,7 @@ describe('components/form-elements/text-area/TextArea', () => {
             },
         });
 
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should set an textarea as valid when the validityFn returns an void', () => {
@@ -145,7 +145,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
 
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'abba' });
 
@@ -157,7 +157,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should validate onChange when textarea is already in error state', () => {
@@ -165,7 +165,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         const textarea = wrapper.find('textarea');
         textarea.simulate('blur');
 
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeTruthy();
 
         const textareaEl = textarea.getDOMNode();
         textareaEl.value = 'a';
@@ -174,7 +174,7 @@ describe('components/form-elements/text-area/TextArea', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-area-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-area-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should set validity state when set validity state handler is called with custom error', () => {

--- a/src/components/form-elements/text-input/__tests__/TextInput.test.js
+++ b/src/components/form-elements/text-input/__tests__/TextInput.test.js
@@ -30,14 +30,14 @@ describe('components/form-elements/text-input/TextInput', () => {
         const wrapper = mount(<TextInput className="coverage" isRequired label="label" name="input" />);
         const input = wrapper.find('input');
         input.simulate('blur');
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeTruthy();
     });
 
     test('should mark required fields valid when not empty', () => {
         const wrapper = mount(<TextInput isRequired label="label" name="input" value="baba" />);
         const input = wrapper.find('input');
         input.simulate('blur');
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should correctly validate when change event is fired', () => {
@@ -45,7 +45,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const input = wrapper.find('input');
         input.simulate('blur');
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'a' });
         input.simulate('blur');
@@ -55,7 +55,7 @@ describe('components/form-elements/text-input/TextInput', () => {
             currentTarget: inputEl,
         });
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should mark email fields invalid when invalid', () => {
@@ -69,7 +69,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const wrapper = mount(<TextInput label="label" name="input" type="email" value="bob@bob.com" />);
         const input = wrapper.find('input');
         input.simulate('blur');
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should mark url fields invalid when invalid', () => {
@@ -79,7 +79,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         instance.checkValidity();
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeTruthy();
     });
 
     test('should mark url fields valid when valid', () => {
@@ -89,7 +89,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         instance.checkValidity();
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeFalsy();
         expect(wrapper.state('errorMessage')).toBeFalsy();
     });
 
@@ -184,7 +184,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const input = wrapper.find('input');
         input.simulate('blur');
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'abba' });
 
@@ -196,7 +196,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should validate onChange when input is already in error state', () => {
@@ -204,7 +204,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const input = wrapper.find('input');
         input.simulate('blur');
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeTruthy();
 
         const inputEl = input.getDOMNode();
         inputEl.value = 'a';
@@ -213,7 +213,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-has-error')).toBeFalsy();
     });
 
     test('should set validity state when set validity state handler is called with custom error', () => {

--- a/src/components/form-elements/text-input/__tests__/TextInput.test.js
+++ b/src/components/form-elements/text-input/__tests__/TextInput.test.js
@@ -30,14 +30,14 @@ describe('components/form-elements/text-input/TextInput', () => {
         const wrapper = mount(<TextInput className="coverage" isRequired label="label" name="input" />);
         const input = wrapper.find('input');
         input.simulate('blur');
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
     });
 
     test('should mark required fields valid when not empty', () => {
         const wrapper = mount(<TextInput isRequired label="label" name="input" value="baba" />);
         const input = wrapper.find('input');
         input.simulate('blur');
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should correctly validate when change event is fired', () => {
@@ -45,7 +45,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const input = wrapper.find('input');
         input.simulate('blur');
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'a' });
         input.simulate('blur');
@@ -55,7 +55,7 @@ describe('components/form-elements/text-input/TextInput', () => {
             currentTarget: inputEl,
         });
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should mark email fields invalid when invalid', () => {
@@ -69,7 +69,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const wrapper = mount(<TextInput label="label" name="input" type="email" value="bob@bob.com" />);
         const input = wrapper.find('input');
         input.simulate('blur');
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should mark url fields invalid when invalid', () => {
@@ -79,7 +79,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         instance.checkValidity();
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
     });
 
     test('should mark url fields valid when valid', () => {
@@ -89,7 +89,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         instance.checkValidity();
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
         expect(wrapper.state('errorMessage')).toBeFalsy();
     });
 
@@ -184,7 +184,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const input = wrapper.find('input');
         input.simulate('blur');
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
 
         wrapper.setProps({ value: 'abba' });
 
@@ -196,7 +196,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should validate onChange when input is already in error state', () => {
@@ -204,7 +204,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         const input = wrapper.find('input');
         input.simulate('blur');
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeTruthy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeTruthy();
 
         const inputEl = input.getDOMNode();
         inputEl.value = 'a';
@@ -213,7 +213,7 @@ describe('components/form-elements/text-input/TextInput', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find('.text-input-container').hasClass('show-error')).toBeFalsy();
+        expect(wrapper.find('.text-input-container').hasClass('bdl-show-error')).toBeFalsy();
     });
 
     test('should set validity state when set validity state handler is called with custom error', () => {

--- a/src/components/grid-view/GridView.scss
+++ b/src/components/grid-view/GridView.scss
@@ -12,7 +12,7 @@
         margin-right: 0;
         padding: 5px 10px;
 
-        .btn-content {
+        .bdl-Button-content {
             display: flex;
             align-items: center;
             justify-content: center;

--- a/src/components/label/InfoIconWithTooltip.js
+++ b/src/components/label/InfoIconWithTooltip.js
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const InfoIconWithTooltip = ({ className = '', iconProps, tooltipText }: Props) => (
-    <span key="infoIcon" className={`${className} tooltip-icon-container`}>
+    <span key="infoIcon" className={`${className} bdl-Tooltip-iconContainer`}>
         <Tooltip position="top-center" text={tooltipText}>
             <span className="info-icon-container">
                 <IconInfo height={16} width={16} {...iconProps} />

--- a/src/components/label/InfoIconWithTooltip.js
+++ b/src/components/label/InfoIconWithTooltip.js
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const InfoIconWithTooltip = ({ className = '', iconProps, tooltipText }: Props) => (
-    <span key="infoIcon" className={`${className} bdl-Tooltip-iconContainer`}>
+    <span key="infoIcon" className={`${className} bdl-InfoIconWithTooltip`}>
         <Tooltip position="top-center" text={tooltipText}>
             <span className="info-icon-container">
                 <IconInfo height={16} width={16} {...iconProps} />

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -33,7 +33,7 @@ type Props = {
 
 const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hideLabel, children }: Props) => {
     const labelContent = [
-        <span key="labelText">{text}</span>,
+        <span key="label bdl-LabelText">{text}</span>,
         showOptionalText ? <OptionalFormattedMessage key="optionalMessage" /> : null,
     ];
 

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -11,7 +11,7 @@ import HiddenLabel from './HiddenLabel';
 import './Label.scss';
 
 const OptionalFormattedMessage = () => (
-    <span className="bdl-Label-optionalText">
+    <span className="bdl-label-optional">
         (<FormattedMessage {...commonMessages.optional} />)
     </span>
 );

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -11,7 +11,7 @@ import HiddenLabel from './HiddenLabel';
 import './Label.scss';
 
 const OptionalFormattedMessage = () => (
-    <span className="bdl-label-optional">
+    <span className="bdl-Label-optional">
         (<FormattedMessage {...commonMessages.optional} />)
     </span>
 );
@@ -41,7 +41,7 @@ const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hi
         labelContent.push(
             <InfoIconWithTooltip
                 key="infoTooltip"
-                iconProps={{ className: 'bdl-Tooltip-icon', ...infoIconProps }}
+                iconProps={{ className: 'bdl-Label-infoIcon', ...infoIconProps }}
                 tooltipText={infoTooltip}
             />,
         );

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -11,7 +11,7 @@ import HiddenLabel from './HiddenLabel';
 import './Label.scss';
 
 const OptionalFormattedMessage = () => (
-    <span className="bdl-Label--optional">
+    <span className="bdl-Label-optionalText">
         (<FormattedMessage {...commonMessages.optional} />)
     </span>
 );
@@ -33,7 +33,7 @@ type Props = {
 
 const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hideLabel, children }: Props) => {
     const labelContent = [
-        <span key="label bdl-LabelText">{text}</span>,
+        <span key="labelText">{text}</span>,
         showOptionalText ? <OptionalFormattedMessage key="optionalMessage" /> : null,
     ];
 

--- a/src/components/label/Label.js
+++ b/src/components/label/Label.js
@@ -11,7 +11,7 @@ import HiddenLabel from './HiddenLabel';
 import './Label.scss';
 
 const OptionalFormattedMessage = () => (
-    <span className="label-optional">
+    <span className="bdl-Label--optional">
         (<FormattedMessage {...commonMessages.optional} />)
     </span>
 );
@@ -41,7 +41,7 @@ const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hi
         labelContent.push(
             <InfoIconWithTooltip
                 key="infoTooltip"
-                iconProps={{ className: 'tooltip-icon', ...infoIconProps }}
+                iconProps={{ className: 'bdl-Tooltip-icon', ...infoIconProps }}
                 tooltipText={infoTooltip}
             />,
         );

--- a/src/components/label/Label.scss
+++ b/src/components/label/Label.scss
@@ -9,14 +9,14 @@
     color: $bdl-gray-62;
     font-weight: bold;
 
-    .label-optional {
+    .bdl-Label--optional {
         padding-left: 3px;
     }
 
-    .tooltip-icon-container {
+    .bdl-Tooltip-iconContainer {
         padding-left: 3px;
 
-        .tooltip-icon {
+        .bdl-Tooltip-icon {
             position: relative;
             top: 3px;
         }

--- a/src/components/label/Label.scss
+++ b/src/components/label/Label.scss
@@ -4,7 +4,7 @@
  * Label
  **************************************/
 
-.label {
+.bdl-Label {
     display: block;
     color: $bdl-gray-62;
     font-weight: bold;

--- a/src/components/label/Label.scss
+++ b/src/components/label/Label.scss
@@ -9,7 +9,7 @@
     color: $bdl-gray-62;
     font-weight: bold;
 
-    .bdl-Label--optional {
+    .bdl-Label-optionalText {
         padding-left: 3px;
     }
 

--- a/src/components/label/Label.scss
+++ b/src/components/label/Label.scss
@@ -9,11 +9,11 @@
     color: $bdl-gray-62;
     font-weight: bold;
 
-    .bdl-Label-optionalText {
+    .bdl-label-optional {
         padding-left: 3px;
     }
 
-    .bdl-Tooltip-iconContainer {
+    .bdl-InfoIconWithTooltip {
         padding-left: 3px;
 
         .bdl-Tooltip-icon {

--- a/src/components/label/Label.scss
+++ b/src/components/label/Label.scss
@@ -9,14 +9,14 @@
     color: $bdl-gray-62;
     font-weight: bold;
 
-    .bdl-label-optional {
+    .bdl-Label-optional {
         padding-left: 3px;
     }
 
     .bdl-InfoIconWithTooltip {
         padding-left: 3px;
 
-        .bdl-Tooltip-icon {
+        .bdl-Label-infoIcon {
             position: relative;
             top: 3px;
         }

--- a/src/components/label/LabelPrimitive.js
+++ b/src/components/label/LabelPrimitive.js
@@ -11,7 +11,7 @@ type Props = {
 const LabelPrimitive = ({ children, className, labelContent, ...rest }: Props) => (
     // eslint-disable-next-line jsx-a11y/label-has-for
     <label>
-        <span className={classNames('label bdl-Label', className)} {...rest}>
+        <span className={classNames('bdl-Label', className)} {...rest}>
             {labelContent}
         </span>
         {children}

--- a/src/components/label/LabelPrimitive.js
+++ b/src/components/label/LabelPrimitive.js
@@ -11,7 +11,7 @@ type Props = {
 const LabelPrimitive = ({ children, className, labelContent, ...rest }: Props) => (
     // eslint-disable-next-line jsx-a11y/label-has-for
     <label>
-        <span className={classNames('label', className)} {...rest}>
+        <span className={classNames('label bdl-Label', className)} {...rest}>
             {labelContent}
         </span>
         {children}

--- a/src/components/label/__tests__/Label.test.js
+++ b/src/components/label/__tests__/Label.test.js
@@ -45,10 +45,10 @@ describe('components/label/Label', () => {
             </Label>,
         );
 
-        expect(wrapper.find('.label-optional').length).toEqual(1);
+        expect(wrapper.find('.bdl-Label--optional').length).toEqual(1);
 
         // Make sure text 'optional' appears in parentheses like '(optional)'
-        expect(/.*\(.*\).*/.test(wrapper.find('.label-optional').html())).toEqual(true);
+        expect(/.*\(.*\).*/.test(wrapper.find('.bdl-Label--optional').html())).toEqual(true);
     });
 
     describe('with infoToolTip', () => {

--- a/src/components/label/__tests__/Label.test.js
+++ b/src/components/label/__tests__/Label.test.js
@@ -45,10 +45,10 @@ describe('components/label/Label', () => {
             </Label>,
         );
 
-        expect(wrapper.find('.bdl-Label-optionalText').length).toEqual(1);
+        expect(wrapper.find('.bdl-label-optional').length).toEqual(1);
 
         // Make sure text 'optional' appears in parentheses like '(optional)'
-        expect(/.*\(.*\).*/.test(wrapper.find('.bdl-Label-optionalText').html())).toEqual(true);
+        expect(/.*\(.*\).*/.test(wrapper.find('.bdl-label-optional').html())).toEqual(true);
     });
 
     describe('with infoToolTip', () => {

--- a/src/components/label/__tests__/Label.test.js
+++ b/src/components/label/__tests__/Label.test.js
@@ -45,10 +45,10 @@ describe('components/label/Label', () => {
             </Label>,
         );
 
-        expect(wrapper.find('.bdl-Label--optional').length).toEqual(1);
+        expect(wrapper.find('.bdl-Label-optionalText').length).toEqual(1);
 
         // Make sure text 'optional' appears in parentheses like '(optional)'
-        expect(/.*\(.*\).*/.test(wrapper.find('.bdl-Label--optional').html())).toEqual(true);
+        expect(/.*\(.*\).*/.test(wrapper.find('.bdl-Label-optionalText').html())).toEqual(true);
     });
 
     describe('with infoToolTip', () => {

--- a/src/components/label/__tests__/Label.test.js
+++ b/src/components/label/__tests__/Label.test.js
@@ -45,10 +45,10 @@ describe('components/label/Label', () => {
             </Label>,
         );
 
-        expect(wrapper.find('.bdl-label-optional').length).toEqual(1);
+        expect(wrapper.find('.bdl-Label-optional').length).toEqual(1);
 
         // Make sure text 'optional' appears in parentheses like '(optional)'
-        expect(/.*\(.*\).*/.test(wrapper.find('.bdl-label-optional').html())).toEqual(true);
+        expect(/.*\(.*\).*/.test(wrapper.find('.bdl-Label-optional').html())).toEqual(true);
     });
 
     describe('with infoToolTip', () => {

--- a/src/components/label/__tests__/LabelPrimitive.test.js
+++ b/src/components/label/__tests__/LabelPrimitive.test.js
@@ -16,7 +16,7 @@ describe('components/label/LabelPrimitive', () => {
         expect(wrapper.find('span.bdl-Label').length).toEqual(1);
         expect(wrapper.find('.bdl-Label').prop('children')).toEqual(labelContent);
         expect(wrapper.find('input').length).toEqual(1);
-        expect(wrapper.find('.bdl-Label-optionalText').length).toEqual(0);
+        expect(wrapper.find('.bdl-label-optional').length).toEqual(0);
     });
 
     test('should set the passed classNames', () => {

--- a/src/components/label/__tests__/LabelPrimitive.test.js
+++ b/src/components/label/__tests__/LabelPrimitive.test.js
@@ -16,7 +16,7 @@ describe('components/label/LabelPrimitive', () => {
         expect(wrapper.find('span.bdl-Label').length).toEqual(1);
         expect(wrapper.find('.bdl-Label').prop('children')).toEqual(labelContent);
         expect(wrapper.find('input').length).toEqual(1);
-        expect(wrapper.find('.bdl-Label--optional').length).toEqual(0);
+        expect(wrapper.find('.bdl-Label-optionalText').length).toEqual(0);
     });
 
     test('should set the passed classNames', () => {

--- a/src/components/label/__tests__/LabelPrimitive.test.js
+++ b/src/components/label/__tests__/LabelPrimitive.test.js
@@ -16,7 +16,7 @@ describe('components/label/LabelPrimitive', () => {
         expect(wrapper.find('span.bdl-Label').length).toEqual(1);
         expect(wrapper.find('.bdl-Label').prop('children')).toEqual(labelContent);
         expect(wrapper.find('input').length).toEqual(1);
-        expect(wrapper.find('.bdl-label-optional').length).toEqual(0);
+        expect(wrapper.find('.bdl-Label-optional').length).toEqual(0);
     });
 
     test('should set the passed classNames', () => {

--- a/src/components/label/__tests__/LabelPrimitive.test.js
+++ b/src/components/label/__tests__/LabelPrimitive.test.js
@@ -13,10 +13,10 @@ describe('components/label/LabelPrimitive', () => {
         );
 
         expect(wrapper.find('label').length).toEqual(1);
-        expect(wrapper.find('span.label').length).toEqual(1);
-        expect(wrapper.find('.label').prop('children')).toEqual(labelContent);
+        expect(wrapper.find('span.bdl-Label').length).toEqual(1);
+        expect(wrapper.find('.bdl-Label').prop('children')).toEqual(labelContent);
         expect(wrapper.find('input').length).toEqual(1);
-        expect(wrapper.find('.label-optional').length).toEqual(0);
+        expect(wrapper.find('.bdl-Label--optional').length).toEqual(0);
     });
 
     test('should set the passed classNames', () => {
@@ -28,7 +28,7 @@ describe('components/label/LabelPrimitive', () => {
             </LabelPrimitive>,
         );
 
-        expect(wrapper.find('.label').prop('className')).toEqual('label this is a test');
+        expect(wrapper.find('.bdl-Label').prop('className')).toEqual('bdl-Label this is a test');
     });
 
     test('should fire passed mouse enter handler', () => {
@@ -44,7 +44,7 @@ describe('components/label/LabelPrimitive', () => {
             </LabelPrimitive>,
         );
 
-        const label = wrapper.find('.label');
+        const label = wrapper.find('.bdl-Label');
         label.simulate('mouseEnter');
 
         expect(firedCount).toEqual(1);
@@ -63,7 +63,7 @@ describe('components/label/LabelPrimitive', () => {
             </LabelPrimitive>,
         );
 
-        const label = wrapper.find('.label');
+        const label = wrapper.find('.bdl-Label');
         label.simulate('mouseLeave');
 
         expect(firedCount).toEqual(1);

--- a/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip.test.js.snap
+++ b/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`components/label/InfoIconWithTooltip should render correctly 1`] = `
 <span
-  className="test-class bdl-Tooltip-iconContainer"
+  className="test-class bdl-InfoIconWithTooltip"
   key="infoIcon"
 >
   <Tooltip

--- a/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip.test.js.snap
+++ b/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`components/label/InfoIconWithTooltip should render correctly 1`] = `
 <span
-  className="test-class tooltip-icon-container"
+  className="test-class bdl-Tooltip-iconContainer"
   key="infoIcon"
 >
   <Tooltip

--- a/src/components/link/LinkButton.js
+++ b/src/components/link/LinkButton.js
@@ -8,6 +8,8 @@ type Props = {
     className?: string,
 };
 
-const LinkButton = ({ className = '', ...rest }: Props) => <LinkBase className={`btn ${className}`} {...rest} />;
+const LinkButton = ({ className = '', ...rest }: Props) => (
+    <LinkBase className={`btn bdl-Button ${className}`} {...rest} />
+);
 
 export default LinkButton;

--- a/src/components/link/LinkButton.js
+++ b/src/components/link/LinkButton.js
@@ -8,8 +8,6 @@ type Props = {
     className?: string,
 };
 
-const LinkButton = ({ className = '', ...rest }: Props) => (
-    <LinkBase className={`btn bdl-Button ${className}`} {...rest} />
-);
+const LinkButton = ({ className = '', ...rest }: Props) => <LinkBase className={`bdl-Button ${className}`} {...rest} />;
 
 export default LinkButton;

--- a/src/components/link/LinkPrimaryButton.js
+++ b/src/components/link/LinkPrimaryButton.js
@@ -9,7 +9,7 @@ type Props = {
 };
 
 const LinkPrimaryButton = ({ className = '', ...rest }: Props) => (
-    <LinkButton className={`bdl-PrimaryButton ${className}`} {...rest} />
+    <LinkButton className={`bdl-Button--primary ${className}`} {...rest} />
 );
 
 export default LinkPrimaryButton;

--- a/src/components/link/LinkPrimaryButton.js
+++ b/src/components/link/LinkPrimaryButton.js
@@ -9,7 +9,7 @@ type Props = {
 };
 
 const LinkPrimaryButton = ({ className = '', ...rest }: Props) => (
-    <LinkButton className={`btn-primary ${className}`} {...rest} />
+    <LinkButton className={`bdl-PrimaryButton ${className}`} {...rest} />
 );
 
 export default LinkPrimaryButton;

--- a/src/components/link/__tests__/Link.test.js
+++ b/src/components/link/__tests__/Link.test.js
@@ -113,7 +113,7 @@ describe('components/link/Link', () => {
         const wrapper = mount(<LinkPrimaryButton>a link</LinkPrimaryButton>);
 
         expect(wrapper.find('a').hasClass('btn')).toBe(true);
-        expect(wrapper.find('a').hasClass('btn-primary')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-PrimaryButton')).toBe(true);
         expect(wrapper.find('a').prop('children')).toEqual('a link');
         expect(wrapper.find('a').prop('href')).toEqual('#');
     });
@@ -122,7 +122,7 @@ describe('components/link/Link', () => {
         const wrapper = mount(<LinkPrimaryButton href="foo">a link</LinkPrimaryButton>);
 
         expect(wrapper.find('a').hasClass('btn')).toBe(true);
-        expect(wrapper.find('a').hasClass('btn-primary')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-PrimaryButton')).toBe(true);
         expect(wrapper.find('a').prop('children')).toEqual('a link');
         expect(wrapper.find('a').prop('href')).toEqual('foo');
     });

--- a/src/components/link/__tests__/Link.test.js
+++ b/src/components/link/__tests__/Link.test.js
@@ -85,7 +85,7 @@ describe('components/link/Link', () => {
     test('should correctly render LinkButton', () => {
         const wrapper = mount(<LinkButton>a link</LinkButton>);
 
-        expect(wrapper.find('a').hasClass('btn')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-Button')).toBe(true);
         expect(wrapper.find('a').prop('children')).toEqual('a link');
         expect(wrapper.find('a').prop('href')).toEqual('#');
     });
@@ -93,7 +93,7 @@ describe('components/link/Link', () => {
     test('should correctly render LinkButton with proper href', () => {
         const wrapper = mount(<LinkButton href="foo">a link</LinkButton>);
 
-        expect(wrapper.find('a').hasClass('btn')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-Button')).toBe(true);
         expect(wrapper.find('a').prop('children')).toEqual('a link');
         expect(wrapper.find('a').prop('href')).toEqual('foo');
     });
@@ -112,8 +112,8 @@ describe('components/link/Link', () => {
     test('should correctly render LinkPrimaryButton', () => {
         const wrapper = mount(<LinkPrimaryButton>a link</LinkPrimaryButton>);
 
-        expect(wrapper.find('a').hasClass('btn')).toBe(true);
-        expect(wrapper.find('a').hasClass('bdl-PrimaryButton')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-Button')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-Button--primary')).toBe(true);
         expect(wrapper.find('a').prop('children')).toEqual('a link');
         expect(wrapper.find('a').prop('href')).toEqual('#');
     });
@@ -121,8 +121,8 @@ describe('components/link/Link', () => {
     test('should correctly render LinkPrimaryButton with proper href', () => {
         const wrapper = mount(<LinkPrimaryButton href="foo">a link</LinkPrimaryButton>);
 
-        expect(wrapper.find('a').hasClass('btn')).toBe(true);
-        expect(wrapper.find('a').hasClass('bdl-PrimaryButton')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-Button')).toBe(true);
+        expect(wrapper.find('a').hasClass('bdl-Button--primary')).toBe(true);
         expect(wrapper.find('a').prop('children')).toEqual('a link');
         expect(wrapper.find('a').prop('href')).toEqual('foo');
     });

--- a/src/components/loading-indicator/Crawler.scss
+++ b/src/components/loading-indicator/Crawler.scss
@@ -21,7 +21,7 @@
     animation: crawler .66s infinite ease-in-out;
 }
 
-.bdl-PrimaryButton .crawler div {
+.bdl-Button--primary .crawler div {
     background-color: $white;
 }
 

--- a/src/components/loading-indicator/Crawler.scss
+++ b/src/components/loading-indicator/Crawler.scss
@@ -37,7 +37,7 @@
     transform: scale(2);
 }
 
-.is-loading .crawler div {
+.bdl-is-loading .crawler div {
     transform: translateZ(0);
     will-change: transform, opacity;
 }

--- a/src/components/loading-indicator/Crawler.scss
+++ b/src/components/loading-indicator/Crawler.scss
@@ -21,7 +21,7 @@
     animation: crawler .66s infinite ease-in-out;
 }
 
-.btn-primary .crawler div {
+.bdl-Button--primary .crawler div {
     background-color: $white;
 }
 

--- a/src/components/loading-indicator/Crawler.scss
+++ b/src/components/loading-indicator/Crawler.scss
@@ -21,7 +21,7 @@
     animation: crawler .66s infinite ease-in-out;
 }
 
-.bdl-Button--primary .crawler div {
+.bdl-PrimaryButton .crawler div {
     background-color: $white;
 }
 

--- a/src/components/media/Media.scss
+++ b/src/components/media/Media.scss
@@ -30,12 +30,12 @@
     // float is used to reflow content instead of pushing it to the left
     float: right;
 
-    // overrides for .btn-plain's margin resets on focus states
+    // overrides for .bdl-Button--plain's margin resets on focus states
     &,
-    &.btn-plain,
-    &.btn-plain:active,
-    &.btn-plain:hover,
-    &.btn-plain:focus {
+    &.bdl-Button--plain,
+    &.bdl-Button--plain:active,
+    &.bdl-Button--plain:hover,
+    &.bdl-Button--plain:focus {
         margin-bottom: 5px;
         margin-left: 10px;
     }

--- a/src/components/media/Media.scss
+++ b/src/components/media/Media.scss
@@ -30,12 +30,12 @@
     // float is used to reflow content instead of pushing it to the left
     float: right;
 
-    // overrides for .bdl-Button--plain's margin resets on focus states
+    // overrides for .bdl-PlainButton's margin resets on focus states
     &,
-    &.bdl-Button--plain,
-    &.bdl-Button--plain:active,
-    &.bdl-Button--plain:hover,
-    &.bdl-Button--plain:focus {
+    &.bdl-PlainButton,
+    &.bdl-PlainButton:active,
+    &.bdl-PlainButton:hover,
+    &.bdl-PlainButton:focus {
         margin-bottom: 5px;
         margin-left: 10px;
     }

--- a/src/components/media/__tests__/__snapshots__/Media.test.js.snap
+++ b/src/components/media/__tests__/__snapshots__/Media.test.js.snap
@@ -18,7 +18,7 @@ exports[`components/Media compound component 1`] = `
     <button
       aria-expanded="false"
       aria-haspopup="true"
-      class="bdl-Button--plain bdl-Media-menu"
+      class="bdl-PlainButton bdl-Media-menu"
       id="menubutton2"
       type="button"
     >

--- a/src/components/media/__tests__/__snapshots__/Media.test.js.snap
+++ b/src/components/media/__tests__/__snapshots__/Media.test.js.snap
@@ -18,7 +18,7 @@ exports[`components/Media compound component 1`] = `
     <button
       aria-expanded="false"
       aria-haspopup="true"
-      class="btn-plain bdl-Media-menu"
+      class="bdl-Button--plain bdl-Media-menu"
       id="menubutton2"
       type="button"
     >

--- a/src/components/menu/Menu.scss
+++ b/src/components/menu/Menu.scss
@@ -40,9 +40,9 @@
     cursor: pointer;
 
     &,
-    &.bdl-Button--plain,
-    &.bdl-Button--plain:hover,
-    &.bdl-Button--plain:active {
+    &.bdl-PlainButton,
+    &.bdl-PlainButton:hover,
+    &.bdl-PlainButton:active {
         padding: 5px 35px 5px 15px;
     }
 
@@ -62,7 +62,7 @@
         padding-left: 30px;
 
         /* checkmark */
-        &.is-selected::before {
+        &.bdl-is-selected::before {
             position: absolute;
             top: 8px;
             left: 14px;

--- a/src/components/menu/Menu.scss
+++ b/src/components/menu/Menu.scss
@@ -40,9 +40,9 @@
     cursor: pointer;
 
     &,
-    &.btn-plain,
-    &.btn-plain:hover,
-    &.btn-plain:active {
+    &.bdl-Button--plain,
+    &.bdl-Button--plain:hover,
+    &.bdl-Button--plain:active {
         padding: 5px 35px 5px 15px;
     }
 

--- a/src/components/menu/MenuItem.js
+++ b/src/components/menu/MenuItem.js
@@ -38,7 +38,7 @@ class MenuItem extends React.Component<Props> {
 
         menuItemProps.className = classNames('menu-item', className, {
             'is-select-item': isSelectItem,
-            'is-selected': isSelected,
+            'bdl-is-selected': isSelected,
         });
         menuItemProps.role = isSelectItem ? 'menuitemradio' : 'menuitem';
         menuItemProps.tabIndex = -1;

--- a/src/components/menu/MenuLinkItem.js
+++ b/src/components/menu/MenuLinkItem.js
@@ -18,7 +18,7 @@ const MenuLinkItem = ({ children, isSelected = false, isSelectItem = false, ...r
     const linkProps: Object = {
         className: classNames('menu-item', linkEl.props.className, {
             'is-select-item': isSelectItem,
-            'is-selected': isSelected,
+            'bdl-is-selected': isSelected,
         }),
         role: isSelectItem ? 'menuitemradio' : 'menuitem',
         tabIndex: -1,

--- a/src/components/menu/__tests__/MenuItem.test.js
+++ b/src/components/menu/__tests__/MenuItem.test.js
@@ -40,7 +40,7 @@ describe('components/menu/MenuItem', () => {
                 </MenuItem>,
             );
 
-            expect(wrapper.hasClass('is-selected')).toBe(true);
+            expect(wrapper.hasClass('bdl-is-selected')).toBe(true);
             expect(wrapper.prop('aria-checked')).toBe(true);
         });
 

--- a/src/components/menu/__tests__/MenuLinkItem.test.js
+++ b/src/components/menu/__tests__/MenuLinkItem.test.js
@@ -46,7 +46,7 @@ describe('components/menu/MenuLinkItem', () => {
 
         const link = wrapper.find('a');
         expect(link.length).toBe(1);
-        expect(link.hasClass('is-selected')).toBe(true);
+        expect(link.hasClass('bdl-is-selected')).toBe(true);
         expect(link.prop('aria-checked')).toBe(true);
     });
 });

--- a/src/components/modal/Modal.scss
+++ b/src/components/modal/Modal.scss
@@ -111,11 +111,11 @@
     margin-top: 30px;
     text-align: right;
 
-    .btn:last-of-type {
+    .bdl-Button:last-of-type {
         margin-right: 0;
     }
 
-    .btn {
+    .bdl-Button {
         margin-top: 0;
         margin-bottom: 0;
     }

--- a/src/components/notification/Notification.js
+++ b/src/components/notification/Notification.js
@@ -112,7 +112,7 @@ class Notification extends React.Component<Props> {
                 {contents}
                 <button
                     aria-label={formatMessage(messages.clearNotificationButtonText)}
-                    className="close-btn"
+                    className="bdl-CloseButton"
                     onClick={this.onClose}
                     type="button"
                 >

--- a/src/components/notification/Notification.scss
+++ b/src/components/notification/Notification.scss
@@ -81,7 +81,7 @@
             border-color: $bdl-gray-10;
         }
 
-        &.close-btn {
+        &.bdl-CloseButton {
             display: flex;
             padding: 2px 7px;
             font-weight: bold;

--- a/src/components/notification/Notification.scss
+++ b/src/components/notification/Notification.scss
@@ -73,8 +73,8 @@
         flex: none;
         color: $white;
 
-        &.btn.is-disabled,
-        &.btn:not(.is-disabled) {
+        &.bdl-Button.bdl-is-disabled,
+        &.bdl-Button:not(.bdl-is-disabled) {
             margin: 0 5px;
             padding: 7px 13px;
             background-color: transparent;

--- a/src/components/pill-cloud/PillCloud.js
+++ b/src/components/pill-cloud/PillCloud.js
@@ -14,13 +14,13 @@ type Props = {
 };
 
 const PillCloud = ({ options, onSelect, selectedOptions = [], buttonProps = {} }: Props) => (
-    <div className="pill-cloud-container">
+    <div className="bdl-PillCloud">
         {options &&
             options.map(option => (
                 <Button
                     key={option.value}
-                    className={classNames('pill bdl-Pill', 'pill-cloud-button', {
-                        'is-selected': selectedOptions.find(op => isEqual(op, option)),
+                    className={classNames('bdl-Pill', 'bdl-PillCloud-button', {
+                        'bdl-is-selected': selectedOptions.find(op => isEqual(op, option)),
                     })}
                     onClick={onSelect ? () => onSelect(option) : undefined}
                     {...buttonProps}

--- a/src/components/pill-cloud/PillCloud.js
+++ b/src/components/pill-cloud/PillCloud.js
@@ -19,7 +19,7 @@ const PillCloud = ({ options, onSelect, selectedOptions = [], buttonProps = {} }
             options.map(option => (
                 <Button
                     key={option.value}
-                    className={classNames('pill', 'pill-cloud-button', {
+                    className={classNames('pill bdl-Pill', 'pill-cloud-button', {
                         'is-selected': selectedOptions.find(op => isEqual(op, option)),
                     })}
                     onClick={onSelect ? () => onSelect(option) : undefined}

--- a/src/components/pill-cloud/__tests__/PillCloud.test.js
+++ b/src/components/pill-cloud/__tests__/PillCloud.test.js
@@ -21,20 +21,20 @@ describe('components/pill-cloud/PillCloud', () => {
         ];
         const wrapper = shallow(<PillCloud options={pills} />);
 
-        expect(wrapper.find('.pill-cloud-button').length).toEqual(3);
+        expect(wrapper.find('.bdl-PillCloud-button').length).toEqual(3);
     });
 
     test('should be able to handle 0 children', () => {
         const wrapper = shallow(<PillCloud options={[]} />);
 
-        expect(wrapper.find('.pill-cloud-button').length).toEqual(0);
+        expect(wrapper.find('.bdl-PillCloud-button').length).toEqual(0);
     });
 
     test('should be able to handle 1 child', () => {
         const pills = [{ value: 1, displayText: 'Hello' }];
         const wrapper = shallow(<PillCloud options={pills} />);
 
-        expect(wrapper.find('.pill-cloud-button').length).toEqual(1);
+        expect(wrapper.find('.bdl-PillCloud-button').length).toEqual(1);
     });
 
     test('should add selected class to a selected pill when passed by reference', () => {
@@ -44,12 +44,12 @@ describe('components/pill-cloud/PillCloud', () => {
             { value: 3, displayText: 'Sir' },
         ];
         const wrapper = shallow(<PillCloud options={pills} selectedOptions={[pills[1]]} />);
-        const buttons = wrapper.find('.pill-cloud-button');
+        const buttons = wrapper.find('.bdl-PillCloud-button');
         expect(
             buttons
                 .at(1)
                 .props()
-                .className.includes('is-selected'),
+                .className.includes('bdl-is-selected'),
         ).toBeTruthy();
     });
 
@@ -60,12 +60,12 @@ describe('components/pill-cloud/PillCloud', () => {
             { value: 3, displayText: 'Sir' },
         ];
         const wrapper = shallow(<PillCloud options={pills} selectedOptions={[{ value: 3, displayText: 'Sir' }]} />);
-        const buttons = wrapper.find('.pill-cloud-button');
+        const buttons = wrapper.find('.bdl-PillCloud-button');
         expect(
             buttons
                 .at(2)
                 .props()
-                .className.includes('is-selected'),
+                .className.includes('bdl-is-selected'),
         ).toBeTruthy();
     });
 
@@ -81,6 +81,6 @@ describe('components/pill-cloud/PillCloud', () => {
             />,
         );
 
-        wrapper.find('.pill-cloud-button').simulate('click');
+        wrapper.find('.bdl-PillCloud-button').simulate('click');
     });
 });

--- a/src/components/pill-cloud/__tests__/__snapshots__/PillCloud.test.js.snap
+++ b/src/components/pill-cloud/__tests__/__snapshots__/PillCloud.test.js.snap
@@ -2,22 +2,22 @@
 
 exports[`components/pill-cloud/PillCloud should render pills 1`] = `
 <div
-  className="pill-cloud-container"
+  className="bdl-PillCloud"
 >
   <Button
-    className="pill pill-cloud-button"
+    className="bdl-Pill bdl-PillCloud-button"
     key="1"
   >
     Hello
   </Button>
   <Button
-    className="pill pill-cloud-button"
+    className="bdl-Pill bdl-PillCloud-button"
     key="2"
   >
     There
   </Button>
   <Button
-    className="pill pill-cloud-button"
+    className="bdl-Pill bdl-PillCloud-button"
     key="3"
   >
     Sir

--- a/src/components/pill-selector-dropdown/Pill.js
+++ b/src/components/pill-selector-dropdown/Pill.js
@@ -12,17 +12,17 @@ type Props = {
 };
 
 const Pill = ({ isDisabled = false, isSelected = false, isValid = true, onRemove, text }: Props) => {
-    const styles = classNames('pill bdl-Pill', {
-        'is-selected': isSelected && !isDisabled,
-        'is-invalid': !isValid,
+    const styles = classNames('bdl-Pill', {
+        'bdl-is-selected': isSelected && !isDisabled,
+        'bdl-is-invalid': !isValid,
         'bdl-is-disabled': isDisabled,
     });
     const onClick = isDisabled ? noop : onRemove;
 
     return (
         <span className={styles}>
-            <span className="pill-text">{text}</span>
-            <span aria-hidden="true" className="close-btn" onClick={onClick}>
+            <span className="bdl-Pill-text">{text}</span>
+            <span aria-hidden="true" className="bdl-CloseButton" onClick={onClick}>
                 ✕
             </span>
         </span>

--- a/src/components/pill-selector-dropdown/Pill.js
+++ b/src/components/pill-selector-dropdown/Pill.js
@@ -12,10 +12,10 @@ type Props = {
 };
 
 const Pill = ({ isDisabled = false, isSelected = false, isValid = true, onRemove, text }: Props) => {
-    const styles = classNames('pill', {
+    const styles = classNames('pill bdl-Pill', {
         'is-selected': isSelected && !isDisabled,
         'is-invalid': !isValid,
-        'is-disabled': isDisabled,
+        'bdl-is-disabled': isDisabled,
     });
     const onClick = isDisabled ? noop : onRemove;
 

--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -176,7 +176,7 @@ class PillSelector extends React.Component<Props, State> {
         } = this.props;
         const suggestedPillsEnabled = suggestedPillsData && suggestedPillsData.length > 0;
         const hasError = !!error;
-        const classes = classNames('bdl-PillSelector-inputWrapper', {
+        const classes = classNames('bdl-PillSelector', {
             'bdl-is-disabled': disabled,
             'is-focused': isFocused,
             'bdl-show-error': hasError,

--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -177,7 +177,7 @@ class PillSelector extends React.Component<Props, State> {
         const suggestedPillsEnabled = suggestedPillsData && suggestedPillsData.length > 0;
         const hasError = !!error;
         const classes = classNames('pill-selector-input-wrapper', {
-            'is-disabled': disabled,
+            'bdl-is-disabled': disabled,
             'is-focused': isFocused,
             'show-error': hasError,
             'pill-selector-suggestions-enabled': suggestedPillsEnabled,

--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -176,11 +176,11 @@ class PillSelector extends React.Component<Props, State> {
         } = this.props;
         const suggestedPillsEnabled = suggestedPillsData && suggestedPillsData.length > 0;
         const hasError = !!error;
-        const classes = classNames('pill-selector-input-wrapper', {
+        const classes = classNames('bdl-PillSelector-inputWrapper', {
             'bdl-is-disabled': disabled,
             'is-focused': isFocused,
-            'show-error': hasError,
-            'pill-selector-suggestions-enabled': suggestedPillsEnabled,
+            'bdl-show-error': hasError,
+            'bdl-PillSelector--suggestionsEnabled': suggestedPillsEnabled,
         });
         const ariaAttrs = {
             'aria-invalid': hasError,
@@ -222,7 +222,7 @@ class PillSelector extends React.Component<Props, State> {
                         {...rest}
                         {...inputProps}
                         autoComplete="off"
-                        className={classNames('pill-selector-input', className)}
+                        className={classNames('bdl-PillSelector-input', className)}
                         disabled={disabled}
                         onInput={onInput}
                         placeholder={this.getNumSelected() === 0 ? placeholder : ''}

--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -178,8 +178,8 @@ class PillSelector extends React.Component<Props, State> {
         const hasError = !!error;
         const classes = classNames('bdl-PillSelector', {
             'bdl-is-disabled': disabled,
-            'is-focused': isFocused,
-            'bdl-show-error': hasError,
+            'bdl-is-focused': isFocused,
+            'bdl-has-error': hasError,
             'bdl-PillSelector--suggestionsEnabled': suggestedPillsEnabled,
         });
         const ariaAttrs = {

--- a/src/components/pill-selector-dropdown/PillSelector.scss
+++ b/src/components/pill-selector-dropdown/PillSelector.scss
@@ -4,7 +4,7 @@
  * Pill Selector
  **************************************/
 
-.bdl-PillSelector-hiddenInput {
+.bdl-PillSelector-input--hidden {
     position: absolute;
     visibility: hidden;
 }
@@ -45,13 +45,13 @@
             }
         }
 
-        &.is-focused {
+        &.bdl-is-focused {
             border-color: $primary-color;
             outline: 0;
             box-shadow: none;
         }
 
-        &.bdl-show-error {
+        &.bdl-has-error {
             border-color: $bdl-watermelon-red;
         }
 
@@ -59,7 +59,7 @@
             min-height: $bdl-line-height * 4;
         }
 
-        &:not(.bdl-show-error) {
+        &:not(.bdl-has-error) {
             .icon-alert {
                 display: none;
             }

--- a/src/components/pill-selector-dropdown/PillSelector.scss
+++ b/src/components/pill-selector-dropdown/PillSelector.scss
@@ -35,7 +35,7 @@
             border: 1px solid darken($primary-color, 10%);
         }
 
-        &.is-disabled {
+        &.bdl-is-disabled {
             color: $bdl-gray-30;
             background-color: $bdl-gray-02;
             box-shadow: none;
@@ -77,13 +77,13 @@
             }
         }
 
-        .tooltip {
+        .bdl-Tooltip {
             top: calc(100% - 5px) !important;
             right: 10px !important;
             margin-top: 0 !important;
         }
 
-        .pills-list {
+        .bdl-Pills-list {
             margin: 0;
 
             li {

--- a/src/components/pill-selector-dropdown/PillSelector.scss
+++ b/src/components/pill-selector-dropdown/PillSelector.scss
@@ -4,16 +4,16 @@
  * Pill Selector
  **************************************/
 
-.pill-selector-hidden-input {
+.bdl-PillSelector-hiddenInput {
     position: absolute;
     visibility: hidden;
 }
 
-.pill-selector-wrapper {
+.bdl-PillSelector-wrapper {
     position: relative;
     margin: 0 0 20px;
 
-    .pill-selector-input-wrapper {
+    .bdl-PillSelector-inputWrapper {
         display: flex;
         flex-flow: row wrap;
         align-content: flex-start;
@@ -51,15 +51,15 @@
             box-shadow: none;
         }
 
-        &.show-error {
+        &.bdl-show-error {
             border-color: $bdl-watermelon-red;
         }
 
-        &.pill-selector-suggestions-enabled {
+        &.bdl-PillSelector--suggestionsEnabled {
             min-height: $bdl-line-height * 4;
         }
 
-        &:not(.show-error) {
+        &:not(.bdl-show-error) {
             .icon-alert {
                 display: none;
             }
@@ -91,7 +91,7 @@
             }
         }
 
-        .pill-selector-input {
+        .bdl-PillSelector-input {
             flex: 1;
             box-sizing: content-box !important;
             min-width: 0;

--- a/src/components/pill-selector-dropdown/PillSelector.scss
+++ b/src/components/pill-selector-dropdown/PillSelector.scss
@@ -9,11 +9,11 @@
     visibility: hidden;
 }
 
-.bdl-PillSelector-wrapper {
+.bdl-PillSelectorWrapper {
     position: relative;
     margin: 0 0 20px;
 
-    .bdl-PillSelector-inputWrapper {
+    .bdl-PillSelector {
         display: flex;
         flex-flow: row wrap;
         align-content: flex-start;
@@ -83,7 +83,7 @@
             margin-top: 0 !important;
         }
 
-        .bdl-Pills-list {
+        .bdl-PillsList {
             margin: 0;
 
             li {

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.js
@@ -245,7 +245,7 @@ class PillSelectorDropdown extends React.Component<Props, State> {
         return (
             <Label text={label}>
                 <SelectorDropdown
-                    className={classNames('pill-selector-wrapper', className)}
+                    className={classNames('bdl-PillSelector-wrapper', className)}
                     dividerIndex={dividerIndex}
                     onEnter={this.handleEnter}
                     onSelect={this.handleSelect}

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.js
@@ -245,7 +245,7 @@ class PillSelectorDropdown extends React.Component<Props, State> {
         return (
             <Label text={label}>
                 <SelectorDropdown
-                    className={classNames('bdl-PillSelector-wrapper', className)}
+                    className={classNames('bdl-PillSelectorWrapper', className)}
                     dividerIndex={dividerIndex}
                     onEnter={this.handleEnter}
                     onSelect={this.handleSelect}

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
@@ -1,8 +1,8 @@
 @import '../../styles/variables';
 @import 'PillSelector';
 
-.pill-selector-input-wrapper {
-    &.show-error {
+.bdl-PillSelector-inputWrapper {
+    &.bdl-show-error {
         border-color: $bdl-watermelon-red;
     }
 }

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
@@ -1,7 +1,7 @@
 @import '../../styles/variables';
 @import 'PillSelector';
 
-.bdl-PillSelector-inputWrapper {
+.bdl-PillSelector {
     &.bdl-show-error {
         border-color: $bdl-watermelon-red;
     }

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
@@ -2,7 +2,7 @@
 @import 'PillSelector';
 
 .bdl-PillSelector {
-    &.bdl-show-error {
+    &.bdl-has-error {
         border-color: $bdl-watermelon-red;
     }
 }

--- a/src/components/pill-selector-dropdown/SuggestedPill.js
+++ b/src/components/pill-selector-dropdown/SuggestedPill.js
@@ -44,7 +44,7 @@ const SuggestedPill = ({ email, id, name, onAdd }: Props) => {
                 onKeyDown={handleKeyPress}
                 type="button"
             >
-                <span className="pill-text suggested-pill">{name}</span>
+                <span className="bdl-Pill-text suggested-pill">{name}</span>
             </PlainButton>
         </Tooltip>
     );

--- a/src/components/pill-selector-dropdown/__tests__/Pill.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/Pill.test.js
@@ -8,17 +8,17 @@ describe('components/pill-selector-dropdown/Pill', () => {
     test('should render default component', () => {
         const wrapper = shallow(<Pill onRemove={onRemoveStub} text="box" />);
 
-        expect(wrapper.hasClass('pill')).toBe(true);
-        expect(wrapper.hasClass('is-selected')).toBe(false);
+        expect(wrapper.hasClass('bdl-Pill')).toBe(true);
+        expect(wrapper.hasClass('bdl-is-selected')).toBe(false);
         expect(wrapper.childAt(0).text()).toEqual('box');
-        expect(wrapper.childAt(1).hasClass('close-btn')).toBe(true);
-        expect(wrapper.find('.close-btn').prop('onClick')).toEqual(onRemoveStub);
+        expect(wrapper.childAt(1).hasClass('bdl-CloseButton')).toBe(true);
+        expect(wrapper.find('.bdl-CloseButton').prop('onClick')).toEqual(onRemoveStub);
     });
 
     test('should have the selected class when isSelected is true', () => {
         const wrapper = shallow(<Pill isSelected isDisabled={false} onRemove={onRemoveStub} text="box" />);
 
-        expect(wrapper.hasClass('is-selected')).toBe(true);
+        expect(wrapper.hasClass('bdl-is-selected')).toBe(true);
     });
 
     test('should generate pill with invalid class when pill is not valid', () => {
@@ -38,11 +38,11 @@ describe('components/pill-selector-dropdown/Pill', () => {
         const wrapper = shallow(<Pill onRemove={onRemoveStub} text="box" />);
 
         wrapper.setProps({ isDisabled: true });
-        wrapper.find('.close-btn').simulate('click');
+        wrapper.find('.bdl-CloseButton').simulate('click');
         expect(onRemoveStub).toHaveBeenCalledTimes(0);
 
         wrapper.setProps({ isDisabled: false });
-        wrapper.find('.close-btn').simulate('click');
+        wrapper.find('.bdl-CloseButton').simulate('click');
         expect(onRemoveStub).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
@@ -26,7 +26,7 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
                 <PillSelector onInput={onInputStub} onRemove={onRemoveStub} placeholder={placeholder} />,
             );
             const input = wrapper.find('textarea');
-            const selector = wrapper.find('.pill-selector-input-wrapper');
+            const selector = wrapper.find('.bdl-PillSelector-inputWrapper');
 
             expect(wrapper.find('Tooltip').exists()).toBe(true);
             expect(selector.length).toBe(1);
@@ -55,16 +55,16 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
             expect(wrapper.find('.is-focused').length).toBe(0);
         });
 
-        test('should add show-error class when error is given', () => {
+        test('should add bdl-show-error class when error is given', () => {
             const wrapper = shallow(<PillSelector error="hello" onInput={onInputStub} onRemove={onRemoveStub} />);
 
-            expect(wrapper.find('.show-error').length).toBe(1);
+            expect(wrapper.find('.bdl-show-error').length).toBe(1);
         });
 
-        test('should not add show-error class when error is not given', () => {
+        test('should not add bdl-show-error class when error is not given', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
 
-            expect(wrapper.find('.show-error').length).toBe(0);
+            expect(wrapper.find('.bdl-show-error').length).toBe(0);
         });
 
         test('should render pills when there are selected options using legacy text attribute', () => {
@@ -153,7 +153,7 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
             );
             const input = wrapper.find('textarea');
 
-            expect(input.hasClass('pill-selector-input')).toBe(true);
+            expect(input.hasClass('bdl-PillSelector-input')).toBe(true);
             expect(input.hasClass(className)).toBe(true);
         });
 
@@ -198,7 +198,7 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
         test('should set isFocused to false when called', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
             wrapper.setState({ isFocused: true });
-            const inputWrapper = wrapper.find('.pill-selector-input-wrapper');
+            const inputWrapper = wrapper.find('.bdl-PillSelector-inputWrapper');
             inputWrapper.simulate('blur');
             expect(wrapper.state('isFocused')).toBe(false);
         });
@@ -217,7 +217,7 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
     describe('onFocus', () => {
         test('should set isFocused to true when called', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
-            const inputWrapper = wrapper.find('.pill-selector-input-wrapper');
+            const inputWrapper = wrapper.find('.bdl-PillSelector-inputWrapper');
             inputWrapper.simulate('focus');
             expect(wrapper.state('isFocused')).toBe(true);
         });

--- a/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
@@ -41,30 +41,30 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should add is-focused class when input is focused', () => {
+        test('should add bdl-is-focused class when input is focused', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
             wrapper.setState({ isFocused: true });
 
-            expect(wrapper.find('.is-focused').length).toBe(1);
+            expect(wrapper.find('.bdl-is-focused').length).toBe(1);
         });
 
-        test('should not add is-focused class when input is not focused', () => {
+        test('should not add bdl-is-focused class when input is not focused', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
             wrapper.setState({ isFocused: false });
 
-            expect(wrapper.find('.is-focused').length).toBe(0);
+            expect(wrapper.find('.bdl-is-focused').length).toBe(0);
         });
 
-        test('should add bdl-show-error class when error is given', () => {
+        test('should add bdl-has-error class when error is given', () => {
             const wrapper = shallow(<PillSelector error="hello" onInput={onInputStub} onRemove={onRemoveStub} />);
 
-            expect(wrapper.find('.bdl-show-error').length).toBe(1);
+            expect(wrapper.find('.bdl-has-error').length).toBe(1);
         });
 
-        test('should not add bdl-show-error class when error is not given', () => {
+        test('should not add bdl-has-error class when error is not given', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
 
-            expect(wrapper.find('.bdl-show-error').length).toBe(0);
+            expect(wrapper.find('.bdl-has-error').length).toBe(0);
         });
 
         test('should render pills when there are selected options using legacy text attribute', () => {

--- a/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
@@ -26,7 +26,7 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
                 <PillSelector onInput={onInputStub} onRemove={onRemoveStub} placeholder={placeholder} />,
             );
             const input = wrapper.find('textarea');
-            const selector = wrapper.find('.bdl-PillSelector-inputWrapper');
+            const selector = wrapper.find('.bdl-PillSelector');
 
             expect(wrapper.find('Tooltip').exists()).toBe(true);
             expect(selector.length).toBe(1);
@@ -198,7 +198,7 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
         test('should set isFocused to false when called', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
             wrapper.setState({ isFocused: true });
-            const inputWrapper = wrapper.find('.bdl-PillSelector-inputWrapper');
+            const inputWrapper = wrapper.find('.bdl-PillSelector');
             inputWrapper.simulate('blur');
             expect(wrapper.state('isFocused')).toBe(false);
         });
@@ -217,7 +217,7 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
     describe('onFocus', () => {
         test('should set isFocused to true when called', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
-            const inputWrapper = wrapper.find('.bdl-PillSelector-inputWrapper');
+            const inputWrapper = wrapper.find('.bdl-PillSelector');
             inputWrapper.simulate('focus');
             expect(wrapper.state('isFocused')).toBe(true);
         });

--- a/src/components/pill-selector-dropdown/__tests__/PillSelectorDropdown.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/PillSelectorDropdown.test.js
@@ -38,7 +38,7 @@ describe('components/pill-selector-dropdown/PillSelectorDropdown', () => {
             const selectorDropdown = wrapper.find('SelectorDropdown');
 
             expect(selectorDropdown.is('SelectorDropdown')).toBe(true);
-            expect(selectorDropdown.hasClass('bdl-PillSelector-wrapper')).toBe(true);
+            expect(selectorDropdown.hasClass('bdl-PillSelectorWrapper')).toBe(true);
             expect(selectorDropdown.hasClass(className)).toBe(true);
             expect(selectorDropdown.prop('onEnter')).toEqual(instance.handleEnter);
             expect(selectorDropdown.prop('onSelect')).toEqual(instance.handleSelect);

--- a/src/components/pill-selector-dropdown/__tests__/PillSelectorDropdown.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/PillSelectorDropdown.test.js
@@ -38,7 +38,7 @@ describe('components/pill-selector-dropdown/PillSelectorDropdown', () => {
             const selectorDropdown = wrapper.find('SelectorDropdown');
 
             expect(selectorDropdown.is('SelectorDropdown')).toBe(true);
-            expect(selectorDropdown.hasClass('pill-selector-wrapper')).toBe(true);
+            expect(selectorDropdown.hasClass('bdl-PillSelector-wrapper')).toBe(true);
             expect(selectorDropdown.hasClass(className)).toBe(true);
             expect(selectorDropdown.prop('onEnter')).toEqual(instance.handleEnter);
             expect(selectorDropdown.prop('onSelect')).toEqual(instance.handleSelect);

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/Pill.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/Pill.test.js.snap
@@ -2,16 +2,16 @@
 
 exports[`components/pill-selector-dropdown/Pill should generate pill with invalid class when pill is not valid 1`] = `
 <span
-  className="pill is-selected is-invalid"
+  className="bdl-Pill bdl-is-selected bdl-is-invalid"
 >
   <span
-    className="pill-text"
+    className="bdl-Pill-text"
   >
     box
   </span>
   <span
     aria-hidden="true"
-    className="close-btn"
+    className="bdl-CloseButton"
     onClick={[MockFunction]}
   >
     ✕

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
@@ -11,7 +11,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
   theme="error"
 >
   <span
-    className="pill-selector-input-wrapper is-disabled"
+    className="pill-selector-input-wrapper bdl-is-disabled"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
@@ -11,7 +11,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
   theme="error"
 >
   <span
-    className="pill-selector-input-wrapper bdl-is-disabled"
+    className="bdl-PillSelector-inputWrapper bdl-is-disabled"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -28,7 +28,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
       aria-errormessage="errorMessage2"
       aria-invalid={false}
       autoComplete="off"
-      className="pill-selector-input"
+      className="bdl-PillSelector-input"
       disabled={true}
       onInput={[Function]}
       placeholder=""

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
@@ -11,7 +11,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
   theme="error"
 >
   <span
-    className="bdl-PillSelector-inputWrapper bdl-is-disabled"
+    className="bdl-PillSelector bdl-is-disabled"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`components/pill-selector-dropdown/PillSelectorDropdown render() should 
   text=""
 >
   <SelectorDropdown
-    className="pill-selector-wrapper"
+    className="bdl-PillSelector-wrapper"
     onEnter={[Function]}
     onSelect={[Function]}
     selector={

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`components/pill-selector-dropdown/PillSelectorDropdown render() should 
   text=""
 >
   <SelectorDropdown
-    className="bdl-PillSelector-wrapper"
+    className="bdl-PillSelectorWrapper"
     onEnter={[Function]}
     onSelect={[Function]}
     selector={

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/SuggestedPill.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/SuggestedPill.test.js.snap
@@ -16,7 +16,7 @@ exports[`components/pill-selector-dropdown/SuggestedPill render() should render 
     type="button"
   >
     <span
-      className="pill-text suggested-pill"
+      className="bdl-Pill-text suggested-pill"
     >
       Foo
     </span>

--- a/src/components/plain-button/PlainButton.js
+++ b/src/components/plain-button/PlainButton.js
@@ -22,7 +22,7 @@ const PlainButton = ({ children, className = '', getDOMRef, isDisabled = false, 
 
     return (
         // eslint-disable-next-line react/button-has-type
-        <button className={`bdl-Button--plain ${className}`} ref={getDOMRef} type={type} {...rest} {...buttonProps}>
+        <button className={`bdl-PlainButton ${className}`} ref={getDOMRef} type={type} {...rest} {...buttonProps}>
             {children}
         </button>
     );

--- a/src/components/plain-button/PlainButton.js
+++ b/src/components/plain-button/PlainButton.js
@@ -22,7 +22,7 @@ const PlainButton = ({ children, className = '', getDOMRef, isDisabled = false, 
 
     return (
         // eslint-disable-next-line react/button-has-type
-        <button className={`btn-plain ${className}`} ref={getDOMRef} type={type} {...rest} {...buttonProps}>
+        <button className={`bdl-Button--plain ${className}`} ref={getDOMRef} type={type} {...rest} {...buttonProps}>
             {children}
         </button>
     );

--- a/src/components/plain-button/__tests__/PlainButton.test.js
+++ b/src/components/plain-button/__tests__/PlainButton.test.js
@@ -10,7 +10,7 @@ describe('components/plain-button/PlainButton', () => {
 
         const wrapper = shallow(<PlainButton>{children}</PlainButton>);
 
-        expect(wrapper.hasClass('btn-plain')).toBe(true);
+        expect(wrapper.hasClass('bdl-Button--plain')).toBe(true);
         expect(wrapper.text()).toEqual(children);
     });
 

--- a/src/components/plain-button/__tests__/PlainButton.test.js
+++ b/src/components/plain-button/__tests__/PlainButton.test.js
@@ -10,7 +10,7 @@ describe('components/plain-button/PlainButton', () => {
 
         const wrapper = shallow(<PlainButton>{children}</PlainButton>);
 
-        expect(wrapper.hasClass('bdl-Button--plain')).toBe(true);
+        expect(wrapper.hasClass('bdl-PlainButton')).toBe(true);
         expect(wrapper.text()).toEqual(children);
     });
 

--- a/src/components/plain-button/__tests__/__snapshots__/PlainButton.test.js.snap
+++ b/src/components/plain-button/__tests__/__snapshots__/PlainButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`components/plain-button/PlainButton should render component correctly and prevent onClick when isDisabled is true 1`] = `
 <button
   aria-disabled={true}
-  className="btn-plain "
+  className="bdl-Button--plain "
   onClick={[Function]}
   type="submit"
 />
@@ -11,7 +11,7 @@ exports[`components/plain-button/PlainButton should render component correctly a
 
 exports[`components/plain-button/PlainButton should render component correctly and trigger onClick when isDisabled is false 1`] = `
 <button
-  className="btn-plain "
+  className="bdl-Button--plain "
   onClick={
     [MockFunction] {
       "calls": Array [

--- a/src/components/plain-button/__tests__/__snapshots__/PlainButton.test.js.snap
+++ b/src/components/plain-button/__tests__/__snapshots__/PlainButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`components/plain-button/PlainButton should render component correctly and prevent onClick when isDisabled is true 1`] = `
 <button
   aria-disabled={true}
-  className="bdl-Button--plain "
+  className="bdl-PlainButton "
   onClick={[Function]}
   type="submit"
 />
@@ -11,7 +11,7 @@ exports[`components/plain-button/PlainButton should render component correctly a
 
 exports[`components/plain-button/PlainButton should render component correctly and trigger onClick when isDisabled is false 1`] = `
 <button
-  className="bdl-Button--plain "
+  className="bdl-PlainButton "
   onClick={
     [MockFunction] {
       "calls": Array [

--- a/src/components/primary-button/PrimaryButton.js
+++ b/src/components/primary-button/PrimaryButton.js
@@ -13,7 +13,7 @@ type Props = {
 
 const PrimaryButton = ({ children, className = '', isDisabled, isSelected, isLoading, ...rest }: Props) => (
     <Button
-        className={`btn-primary ${className}`}
+        className={`bdl-PrimaryButton ${className}`}
         isDisabled={isDisabled}
         isLoading={isLoading}
         isSelected={isSelected}

--- a/src/components/primary-button/PrimaryButton.js
+++ b/src/components/primary-button/PrimaryButton.js
@@ -13,7 +13,7 @@ type Props = {
 
 const PrimaryButton = ({ children, className = '', isDisabled, isSelected, isLoading, ...rest }: Props) => (
     <Button
-        className={`bdl-PrimaryButton ${className}`}
+        className={`bdl-Button--primary ${className}`}
         isDisabled={isDisabled}
         isLoading={isLoading}
         isSelected={isSelected}

--- a/src/components/primary-button/__tests__/PrimaryButton.test.js
+++ b/src/components/primary-button/__tests__/PrimaryButton.test.js
@@ -10,7 +10,7 @@ describe('components/primary-button/PrimaryButton', () => {
         const wrapper = shallow(<PrimaryButton>{children}</PrimaryButton>);
 
         expect(wrapper.find(Button).length).toEqual(1);
-        expect(wrapper.hasClass('btn-primary')).toBe(true);
+        expect(wrapper.hasClass('bdl-PrimaryButton')).toBe(true);
         expect(wrapper.contains(children)).toBe(true);
     });
 });

--- a/src/components/primary-button/__tests__/PrimaryButton.test.js
+++ b/src/components/primary-button/__tests__/PrimaryButton.test.js
@@ -10,7 +10,7 @@ describe('components/primary-button/PrimaryButton', () => {
         const wrapper = shallow(<PrimaryButton>{children}</PrimaryButton>);
 
         expect(wrapper.find(Button).length).toEqual(1);
-        expect(wrapper.hasClass('bdl-PrimaryButton')).toBe(true);
+        expect(wrapper.hasClass('bdl-Button--primary')).toBe(true);
         expect(wrapper.contains(children)).toBe(true);
     });
 });

--- a/src/components/select-button/SelectButton.js
+++ b/src/components/select-button/SelectButton.js
@@ -15,7 +15,7 @@ type Props = {
 const SelectButton = ({ children, className = '', error, isDisabled = false, ...rest }: Props) => (
     <Tooltip isShown={!!error} position="middle-right" text={error} theme="error">
         <button
-            className={classNames(className, 'select-button', {
+            className={classNames(className, 'select-button bdl-SelectButton', {
                 'is-invalid': !!error,
             })}
             disabled={isDisabled}

--- a/src/components/select-button/SelectButton.js
+++ b/src/components/select-button/SelectButton.js
@@ -15,8 +15,8 @@ type Props = {
 const SelectButton = ({ children, className = '', error, isDisabled = false, ...rest }: Props) => (
     <Tooltip isShown={!!error} position="middle-right" text={error} theme="error">
         <button
-            className={classNames(className, 'select-button bdl-SelectButton', {
-                'is-invalid': !!error,
+            className={classNames(className, 'bdl-SelectButton', {
+                'bdl-is-invalid': !!error,
             })}
             disabled={isDisabled}
             type="button"

--- a/src/components/select-button/SelectButton.scss
+++ b/src/components/select-button/SelectButton.scss
@@ -1,7 +1,7 @@
 @import '../../styles/variables';
 
 .bdl-SelectButton {
-    &.is-invalid {
+    &.bdl-is-invalid {
         border-color: $bdl-watermelon-red;
     }
 }

--- a/src/components/select-button/SelectButton.scss
+++ b/src/components/select-button/SelectButton.scss
@@ -1,6 +1,6 @@
 @import '../../styles/variables';
 
-.select-button {
+.bdl-SelectButton {
     &.is-invalid {
         border-color: $bdl-watermelon-red;
     }

--- a/src/components/select-button/__tests__/SelectButton.test.js
+++ b/src/components/select-button/__tests__/SelectButton.test.js
@@ -8,7 +8,7 @@ describe('components/select-button/SelectButton', () => {
 
         const wrapper = shallow(<SelectButton>{children}</SelectButton>).find('button');
 
-        expect(wrapper.hasClass('select-button')).toBe(true);
+        expect(wrapper.hasClass('bdl-SelectButton')).toBe(true);
         expect(wrapper.contains(children)).toBe(true);
         expect(wrapper.prop('disabled')).toBe(false);
     });

--- a/src/components/select-button/__tests__/__snapshots__/SelectButton.test.js.snap
+++ b/src/components/select-button/__tests__/__snapshots__/SelectButton.test.js.snap
@@ -10,7 +10,7 @@ exports[`components/select-button/SelectButton should not show error tooltip on 
   theme="error"
 >
   <button
-    className="select-button"
+    className="bdl-SelectButton"
     disabled={false}
     type="button"
   >
@@ -30,7 +30,7 @@ exports[`components/select-button/SelectButton should show error tooltip on butt
   theme="error"
 >
   <button
-    className="select-button is-invalid"
+    className="bdl-SelectButton bdl-is-invalid"
     disabled={false}
     type="button"
   >

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -384,7 +384,7 @@ class BaseSelectField extends React.Component<Props, State> {
         return (
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <div
-                className={classNames(className, 'bdl-Select-container')}
+                className={classNames(className, 'bdl-Select-content')}
                 onBlur={this.handleBlur}
                 onKeyDown={this.handleKeyDown}
             >

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -384,7 +384,7 @@ class BaseSelectField extends React.Component<Props, State> {
         return (
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <div
-                className={classNames(className, 'select-container')}
+                className={classNames(className, 'bdl-Select-container')}
                 onBlur={this.handleBlur}
                 onKeyDown={this.handleKeyDown}
             >

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -191,7 +191,7 @@ describe('components/select-field/BaseSelectField', () => {
                 className,
             });
 
-            expect(wrapper.hasClass('bdl-Select-container')).toBe(true);
+            expect(wrapper.hasClass('bdl-Select-content')).toBe(true);
             expect(wrapper.hasClass(className)).toBe(true);
         });
 

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -191,7 +191,7 @@ describe('components/select-field/BaseSelectField', () => {
                 className,
             });
 
-            expect(wrapper.hasClass('select-container')).toBe(true);
+            expect(wrapper.hasClass('bdl-Select-container')).toBe(true);
             expect(wrapper.hasClass(className)).toBe(true);
         });
 

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -42,7 +42,7 @@ const Select = ({
     showLabel = true,
     ...rest
 }: Props) => {
-    const classes = classNames(className, 'bdl-Select-inputContainer', {
+    const classes = classNames(className, 'bdl-Select', {
         'bdl-show-error': !!error || showErrorOutline,
         'bdl-is-disabled': isDisabled,
     });
@@ -52,7 +52,7 @@ const Select = ({
             <Label hideLabel={!showLabel} text={label} tooltip={labelTooltip}>
                 <Tooltip isShown={!!error} position="middle-right" text={error || ''} theme="error">
                     <span className="bdl-Select-container">
-                        <span className="bdl-Select-container-inner">
+                        <span className="bdl-Select-innerContainer">
                             {/* eslint-disable-next-line jsx-a11y/no-onchange */}
                             <select disabled={isDisabled} name={name} onChange={onChange} {...rest}>
                                 {children}

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -43,7 +43,7 @@ const Select = ({
     ...rest
 }: Props) => {
     const classes = classNames(className, 'bdl-Select', {
-        'bdl-show-error': !!error || showErrorOutline,
+        'bdl-has-error': !!error || showErrorOutline,
         'bdl-is-disabled': isDisabled,
     });
 
@@ -51,8 +51,8 @@ const Select = ({
         <div className={classes}>
             <Label hideLabel={!showLabel} text={label} tooltip={labelTooltip}>
                 <Tooltip isShown={!!error} position="middle-right" text={error || ''} theme="error">
-                    <span className="bdl-Select-container">
-                        <span className="bdl-Select-innerContainer">
+                    <span className="bdl-Select-content">
+                        <span className="bdl-Select-contentBody">
                             {/* eslint-disable-next-line jsx-a11y/no-onchange */}
                             <select disabled={isDisabled} name={name} onChange={onChange} {...rest}>
                                 {children}
@@ -61,7 +61,7 @@ const Select = ({
                         </span>
                         {infoTooltip && (
                             <Tooltip position="middle-right" text={infoTooltip}>
-                                <span className="bdl-Tooltip-iconContainer">
+                                <span className="bdl-InfoIconWithTooltip">
                                     <IconInfo height={16} width={16} {...infoIconProps} />
                                 </span>
                             </Tooltip>

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -42,8 +42,8 @@ const Select = ({
     showLabel = true,
     ...rest
 }: Props) => {
-    const classes = classNames(className, 'select-input-container', {
-        'show-error': !!error || showErrorOutline,
+    const classes = classNames(className, 'bdl-Select-inputContainer', {
+        'bdl-show-error': !!error || showErrorOutline,
         'bdl-is-disabled': isDisabled,
     });
 
@@ -51,17 +51,17 @@ const Select = ({
         <div className={classes}>
             <Label hideLabel={!showLabel} text={label} tooltip={labelTooltip}>
                 <Tooltip isShown={!!error} position="middle-right" text={error || ''} theme="error">
-                    <span className="select-container">
-                        <span className="select-container-inner">
+                    <span className="bdl-Select-container">
+                        <span className="bdl-Select-container-inner">
                             {/* eslint-disable-next-line jsx-a11y/no-onchange */}
                             <select disabled={isDisabled} name={name} onChange={onChange} {...rest}>
                                 {children}
                             </select>
-                            <span className="select-overlay" />
+                            <span className="bdl-Select-overlay" />
                         </span>
                         {infoTooltip && (
                             <Tooltip position="middle-right" text={infoTooltip}>
-                                <span className="tooltip-icon-container">
+                                <span className="bdl-Tooltip-iconContainer">
                                     <IconInfo height={16} width={16} {...infoIconProps} />
                                 </span>
                             </Tooltip>

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -44,7 +44,7 @@ const Select = ({
 }: Props) => {
     const classes = classNames(className, 'select-input-container', {
         'show-error': !!error || showErrorOutline,
-        'is-disabled': isDisabled,
+        'bdl-is-disabled': isDisabled,
     });
 
     return (

--- a/src/components/select/Select.scss
+++ b/src/components/select/Select.scss
@@ -7,17 +7,17 @@
 .bdl-Select {
     margin: 0 0 20px;
 
-    .bdl-Select-container {
+    .bdl-Select-content {
         margin-top: 5px;
     }
 
-    .bdl-Tooltip-iconContainer {
+    .bdl-InfoIconWithTooltip {
         position: absolute;
         margin-top: 9px;
         margin-left: 10px;
     }
 
-    &.bdl-show-error {
+    &.bdl-has-error {
         .bdl-Select-overlay {
             border-color: $bdl-watermelon-red;
         }

--- a/src/components/select/Select.scss
+++ b/src/components/select/Select.scss
@@ -4,21 +4,21 @@
  * Select
  **************************************/
 
-.select-input-container {
+.bdl-Select-inputContainer {
     margin: 0 0 20px;
 
-    .select-container {
+    .bdl-Select-container {
         margin-top: 5px;
     }
 
-    .tooltip-icon-container {
+    .bdl-Tooltip-iconContainer {
         position: absolute;
         margin-top: 9px;
         margin-left: 10px;
     }
 
-    &.show-error {
-        .select-overlay {
+    &.bdl-show-error {
+        .bdl-Select-overlay {
             border-color: $bdl-watermelon-red;
         }
     }

--- a/src/components/select/Select.scss
+++ b/src/components/select/Select.scss
@@ -4,7 +4,7 @@
  * Select
  **************************************/
 
-.bdl-Select-inputContainer {
+.bdl-Select {
     margin: 0 0 20px;
 
     .bdl-Select-container {

--- a/src/components/select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/components/select/__tests__/__snapshots__/Select.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`components/select/Select should not show Tooltip when no error exists 1`] = `
 <div
-  className="bdl-Select-inputContainer"
+  className="bdl-Select"
 >
   <Label
     hideLabel={false}
@@ -21,7 +21,7 @@ exports[`components/select/Select should not show Tooltip when no error exists 1
         className="bdl-Select-container"
       >
         <span
-          className="bdl-Select-container-inner"
+          className="bdl-Select-innerContainer"
         >
           <select />
           <span
@@ -36,7 +36,7 @@ exports[`components/select/Select should not show Tooltip when no error exists 1
 
 exports[`components/select/Select should not show error outline if not specified 1`] = `
 <div
-  className="bdl-Select-inputContainer"
+  className="bdl-Select"
 >
   <Label
     hideLabel={false}
@@ -55,7 +55,7 @@ exports[`components/select/Select should not show error outline if not specified
         className="bdl-Select-container"
       >
         <span
-          className="bdl-Select-container-inner"
+          className="bdl-Select-innerContainer"
         >
           <select />
           <span
@@ -70,7 +70,7 @@ exports[`components/select/Select should not show error outline if not specified
 
 exports[`components/select/Select should render infoTooltip when specified 1`] = `
 <div
-  className="bdl-Select-inputContainer"
+  className="bdl-Select"
 >
   <Label
     hideLabel={false}
@@ -89,7 +89,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
         className="bdl-Select-container"
       >
         <span
-          className="bdl-Select-container-inner"
+          className="bdl-Select-innerContainer"
         >
           <select
             name="select"
@@ -124,7 +124,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
 
 exports[`components/select/Select should show Tooltip when error exists 1`] = `
 <div
-  className="bdl-Select-inputContainer bdl-show-error"
+  className="bdl-Select bdl-show-error"
 >
   <Label
     hideLabel={false}
@@ -143,7 +143,7 @@ exports[`components/select/Select should show Tooltip when error exists 1`] = `
         className="bdl-Select-container"
       >
         <span
-          className="bdl-Select-container-inner"
+          className="bdl-Select-innerContainer"
         >
           <select />
           <span
@@ -158,7 +158,7 @@ exports[`components/select/Select should show Tooltip when error exists 1`] = `
 
 exports[`components/select/Select should show error outline if specified 1`] = `
 <div
-  className="bdl-Select-inputContainer bdl-show-error"
+  className="bdl-Select bdl-show-error"
 >
   <Label
     hideLabel={false}
@@ -177,7 +177,7 @@ exports[`components/select/Select should show error outline if specified 1`] = `
         className="bdl-Select-container"
       >
         <span
-          className="bdl-Select-container-inner"
+          className="bdl-Select-innerContainer"
         >
           <select />
           <span

--- a/src/components/select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/components/select/__tests__/__snapshots__/Select.test.js.snap
@@ -18,10 +18,10 @@ exports[`components/select/Select should not show Tooltip when no error exists 1
       theme="error"
     >
       <span
-        className="bdl-Select-container"
+        className="bdl-Select-content"
       >
         <span
-          className="bdl-Select-innerContainer"
+          className="bdl-Select-contentBody"
         >
           <select />
           <span
@@ -52,10 +52,10 @@ exports[`components/select/Select should not show error outline if not specified
       theme="error"
     >
       <span
-        className="bdl-Select-container"
+        className="bdl-Select-content"
       >
         <span
-          className="bdl-Select-innerContainer"
+          className="bdl-Select-contentBody"
         >
           <select />
           <span
@@ -86,10 +86,10 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
       theme="error"
     >
       <span
-        className="bdl-Select-container"
+        className="bdl-Select-content"
       >
         <span
-          className="bdl-Select-innerContainer"
+          className="bdl-Select-contentBody"
         >
           <select
             name="select"
@@ -107,7 +107,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
           theme="default"
         >
           <span
-            className="bdl-Tooltip-iconContainer"
+            className="bdl-InfoIconWithTooltip"
           >
             <IconInfo
               height={16}
@@ -124,7 +124,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
 
 exports[`components/select/Select should show Tooltip when error exists 1`] = `
 <div
-  className="bdl-Select bdl-show-error"
+  className="bdl-Select bdl-has-error"
 >
   <Label
     hideLabel={false}
@@ -140,10 +140,10 @@ exports[`components/select/Select should show Tooltip when error exists 1`] = `
       theme="error"
     >
       <span
-        className="bdl-Select-container"
+        className="bdl-Select-content"
       >
         <span
-          className="bdl-Select-innerContainer"
+          className="bdl-Select-contentBody"
         >
           <select />
           <span
@@ -158,7 +158,7 @@ exports[`components/select/Select should show Tooltip when error exists 1`] = `
 
 exports[`components/select/Select should show error outline if specified 1`] = `
 <div
-  className="bdl-Select bdl-show-error"
+  className="bdl-Select bdl-has-error"
 >
   <Label
     hideLabel={false}
@@ -174,10 +174,10 @@ exports[`components/select/Select should show error outline if specified 1`] = `
       theme="error"
     >
       <span
-        className="bdl-Select-container"
+        className="bdl-Select-content"
       >
         <span
-          className="bdl-Select-innerContainer"
+          className="bdl-Select-contentBody"
         >
           <select />
           <span

--- a/src/components/select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/components/select/__tests__/__snapshots__/Select.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`components/select/Select should not show Tooltip when no error exists 1`] = `
 <div
-  className="select-input-container"
+  className="bdl-Select-inputContainer"
 >
   <Label
     hideLabel={false}
@@ -18,14 +18,14 @@ exports[`components/select/Select should not show Tooltip when no error exists 1
       theme="error"
     >
       <span
-        className="select-container"
+        className="bdl-Select-container"
       >
         <span
-          className="select-container-inner"
+          className="bdl-Select-container-inner"
         >
           <select />
           <span
-            className="select-overlay"
+            className="bdl-Select-overlay"
           />
         </span>
       </span>
@@ -36,7 +36,7 @@ exports[`components/select/Select should not show Tooltip when no error exists 1
 
 exports[`components/select/Select should not show error outline if not specified 1`] = `
 <div
-  className="select-input-container"
+  className="bdl-Select-inputContainer"
 >
   <Label
     hideLabel={false}
@@ -52,14 +52,14 @@ exports[`components/select/Select should not show error outline if not specified
       theme="error"
     >
       <span
-        className="select-container"
+        className="bdl-Select-container"
       >
         <span
-          className="select-container-inner"
+          className="bdl-Select-container-inner"
         >
           <select />
           <span
-            className="select-overlay"
+            className="bdl-Select-overlay"
           />
         </span>
       </span>
@@ -70,7 +70,7 @@ exports[`components/select/Select should not show error outline if not specified
 
 exports[`components/select/Select should render infoTooltip when specified 1`] = `
 <div
-  className="select-input-container"
+  className="bdl-Select-inputContainer"
 >
   <Label
     hideLabel={false}
@@ -86,16 +86,16 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
       theme="error"
     >
       <span
-        className="select-container"
+        className="bdl-Select-container"
       >
         <span
-          className="select-container-inner"
+          className="bdl-Select-container-inner"
         >
           <select
             name="select"
           />
           <span
-            className="select-overlay"
+            className="bdl-Select-overlay"
           />
         </span>
         <Tooltip
@@ -107,7 +107,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
           theme="default"
         >
           <span
-            className="tooltip-icon-container"
+            className="bdl-Tooltip-iconContainer"
           >
             <IconInfo
               height={16}
@@ -124,7 +124,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
 
 exports[`components/select/Select should show Tooltip when error exists 1`] = `
 <div
-  className="select-input-container show-error"
+  className="bdl-Select-inputContainer bdl-show-error"
 >
   <Label
     hideLabel={false}
@@ -140,14 +140,14 @@ exports[`components/select/Select should show Tooltip when error exists 1`] = `
       theme="error"
     >
       <span
-        className="select-container"
+        className="bdl-Select-container"
       >
         <span
-          className="select-container-inner"
+          className="bdl-Select-container-inner"
         >
           <select />
           <span
-            className="select-overlay"
+            className="bdl-Select-overlay"
           />
         </span>
       </span>
@@ -158,7 +158,7 @@ exports[`components/select/Select should show Tooltip when error exists 1`] = `
 
 exports[`components/select/Select should show error outline if specified 1`] = `
 <div
-  className="select-input-container show-error"
+  className="bdl-Select-inputContainer bdl-show-error"
 >
   <Label
     hideLabel={false}
@@ -174,14 +174,14 @@ exports[`components/select/Select should show error outline if specified 1`] = `
       theme="error"
     >
       <span
-        className="select-container"
+        className="bdl-Select-container"
       >
         <span
-          className="select-container-inner"
+          className="bdl-Select-container-inner"
         >
           <select />
           <span
-            className="select-overlay"
+            className="bdl-Select-overlay"
           />
         </span>
       </span>

--- a/src/components/selector-dropdown/SelectorDropdown.scss
+++ b/src/components/selector-dropdown/SelectorDropdown.scss
@@ -47,7 +47,7 @@
     .link {
         color: $bdl-gray-80 !important;
 
-        &.is-selected {
+        &.bdl-is-selected {
             background-color: fade-out($bdl-gray, .95);
         }
     }

--- a/src/components/sidebar-toggle-button/SidebarToggleButton.scss
+++ b/src/components/sidebar-toggle-button/SidebarToggleButton.scss
@@ -9,11 +9,11 @@
         fill: $bdl-gray-50;
     }
 
-    &:not(.is-disabled):hover {
+    &:not(.bdl-is-disabled):hover {
         background-color: $bdl-gray-05;
     }
 
-    &:not(.is-disabled):focus {
+    &:not(.bdl-is-disabled):focus {
         border-color: #96a0a6;
         box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
     }

--- a/src/components/sidebar-toggle-button/__tests__/__snapshots__/SidebarToggleButton.test.js.snap
+++ b/src/components/sidebar-toggle-button/__tests__/__snapshots__/SidebarToggleButton.test.js.snap
@@ -52,7 +52,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Show Sidebar"
-            className="btn-plain bdl-SidebarToggleButton bdl-is-collapsed"
+            className="bdl-Button--plain bdl-SidebarToggleButton bdl-is-collapsed"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -149,7 +149,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Show Sidebar"
-            className="btn-plain bdl-SidebarToggleButton bdl-is-collapsed"
+            className="bdl-Button--plain bdl-SidebarToggleButton bdl-is-collapsed"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -246,7 +246,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Hide Sidebar"
-            className="btn-plain bdl-SidebarToggleButton"
+            className="bdl-Button--plain bdl-SidebarToggleButton"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -341,7 +341,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Hide Sidebar"
-            className="btn-plain bdl-SidebarToggleButton"
+            className="bdl-Button--plain bdl-SidebarToggleButton"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}

--- a/src/components/sidebar-toggle-button/__tests__/__snapshots__/SidebarToggleButton.test.js.snap
+++ b/src/components/sidebar-toggle-button/__tests__/__snapshots__/SidebarToggleButton.test.js.snap
@@ -24,7 +24,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
       <TetherComponent
         attachment="middle right"
         bodyElement={<body />}
-        classPrefix="tooltip"
+        classPrefix="bdl-Tooltip"
         constraints={
           Array [
             Object {
@@ -52,7 +52,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Show Sidebar"
-            className="bdl-Button--plain bdl-SidebarToggleButton bdl-is-collapsed"
+            className="bdl-PlainButton bdl-SidebarToggleButton bdl-is-collapsed"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -121,7 +121,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
       <TetherComponent
         attachment="middle left"
         bodyElement={<body />}
-        classPrefix="tooltip"
+        classPrefix="bdl-Tooltip"
         constraints={
           Array [
             Object {
@@ -149,7 +149,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Show Sidebar"
-            className="bdl-Button--plain bdl-SidebarToggleButton bdl-is-collapsed"
+            className="bdl-PlainButton bdl-SidebarToggleButton bdl-is-collapsed"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -218,7 +218,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
       <TetherComponent
         attachment="middle left"
         bodyElement={<body />}
-        classPrefix="tooltip"
+        classPrefix="bdl-Tooltip"
         constraints={
           Array [
             Object {
@@ -246,7 +246,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Hide Sidebar"
-            className="bdl-Button--plain bdl-SidebarToggleButton"
+            className="bdl-PlainButton bdl-SidebarToggleButton"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -313,7 +313,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
       <TetherComponent
         attachment="middle right"
         bodyElement={<body />}
-        classPrefix="tooltip"
+        classPrefix="bdl-Tooltip"
         constraints={
           Array [
             Object {
@@ -341,7 +341,7 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
         >
           <button
             aria-label="Hide Sidebar"
-            className="bdl-Button--plain bdl-SidebarToggleButton"
+            className="bdl-PlainButton bdl-SidebarToggleButton"
             onBlur={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}

--- a/src/components/slide-carousel/SlideButton.js
+++ b/src/components/slide-carousel/SlideButton.js
@@ -12,7 +12,7 @@ type Props = {
 const SlideButton = ({ buttonRef, onClick, isSelected = false, ...rest }: Props) => (
     <PlainButton
         aria-selected={isSelected}
-        className={`slide-selector ${isSelected ? 'is-selected' : ''}`}
+        className={`slide-selector ${isSelected ? 'bdl-is-selected' : ''}`}
         getDOMRef={buttonRef}
         onClick={onClick}
         role="tab"

--- a/src/components/slide-carousel/SlideCarousel.scss
+++ b/src/components/slide-carousel/SlideCarousel.scss
@@ -42,7 +42,7 @@
         background: $bdl-light-blue;
     }
 
-    &.is-selected {
+    &.bdl-is-selected {
         background: $bdl-box-blue;
     }
 }

--- a/src/components/slide-carousel/__tests__/SlideButton.test.js
+++ b/src/components/slide-carousel/__tests__/SlideButton.test.js
@@ -16,14 +16,14 @@ describe('components/slide-carousel/SlideButton', () => {
 
     const getWrapper = props => shallow(<SlideButton {...defaultProps} {...props} />);
 
-    test('should have the is-selected class when selected', () => {
+    test('should have the bdl-is-selected class when selected', () => {
         const wrapper = getWrapper({ isSelected: true });
-        expect(wrapper.hasClass('is-selected')).toBe(true);
+        expect(wrapper.hasClass('bdl-is-selected')).toBe(true);
     });
 
-    test('should not have the is-selected class when not selected', () => {
+    test('should not have the bdl-is-selected class when not selected', () => {
         const wrapper = getWrapper({ isSelected: false });
-        expect(wrapper.hasClass('is-selected')).not.toBe(true);
+        expect(wrapper.hasClass('bdl-is-selected')).not.toBe(true);
     });
 
     test('should call onClick prop when clicked', () => {

--- a/src/components/tab-view/TabViewPrimitive.js
+++ b/src/components/tab-view/TabViewPrimitive.js
@@ -217,12 +217,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
                 {React.Children.map(children, (tab, i) => {
                     const buttonProps = omit(tab.props, ['className', 'children', 'title']);
 
-                    const classes = classNames(
-                        'bdl-Button',
-                        'bdl-PlainButton',
-                        'tab',
-                        i === selectedIndex ? 'bdl-is-selected' : '',
-                    );
+                    const classes = classNames('bdl-PlainButton', 'tab', i === selectedIndex ? 'bdl-is-selected' : '');
 
                     const ariaControls = `${this.tabviewID}-panel-${i + 1}`;
                     const ariaSelected = i === selectedIndex;
@@ -284,7 +279,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <div className="dynamic-tabs-bar" onKeyDown={this.handleKeyDown}>
                 <button
-                    className={classNames('bdl-Button bdl-PlainButton svg-container left-arrow', {
+                    className={classNames('bdl-PlainButton svg-container left-arrow', {
                         hidden: !this.isLeftArrowVisible(),
                     })}
                     onClick={() => onTabFocus(focusedIndex - 1)}
@@ -295,7 +290,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
                 </button>
                 <div className="dynamic-tabs-wrapper">{this.renderTabs()}</div>
                 <button
-                    className={classNames('bdl-Button bdl-PlainButton svg-container right-arrow', {
+                    className={classNames('bdl-PlainButton svg-container right-arrow', {
                         hidden: !this.isRightArrowVisible(),
                     })}
                     onClick={() => onTabFocus(focusedIndex + 1)}

--- a/src/components/tab-view/TabViewPrimitive.js
+++ b/src/components/tab-view/TabViewPrimitive.js
@@ -217,7 +217,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
                 {React.Children.map(children, (tab, i) => {
                     const buttonProps = omit(tab.props, ['className', 'children', 'title']);
 
-                    const classes = classNames('btn-plain', 'tab', i === selectedIndex ? 'is-selected' : '');
+                    const classes = classNames('bdl-Button--plain', 'tab', i === selectedIndex ? 'is-selected' : '');
 
                     const ariaControls = `${this.tabviewID}-panel-${i + 1}`;
                     const ariaSelected = i === selectedIndex;
@@ -279,7 +279,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <div className="dynamic-tabs-bar" onKeyDown={this.handleKeyDown}>
                 <button
-                    className={classNames('btn-plain svg-container left-arrow', {
+                    className={classNames('bdl-Button--plain svg-container left-arrow', {
                         hidden: !this.isLeftArrowVisible(),
                     })}
                     onClick={() => onTabFocus(focusedIndex - 1)}
@@ -290,7 +290,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
                 </button>
                 <div className="dynamic-tabs-wrapper">{this.renderTabs()}</div>
                 <button
-                    className={classNames('btn-plain svg-container right-arrow', {
+                    className={classNames('bdl-Button--plain svg-container right-arrow', {
                         hidden: !this.isRightArrowVisible(),
                     })}
                     onClick={() => onTabFocus(focusedIndex + 1)}

--- a/src/components/tab-view/TabViewPrimitive.js
+++ b/src/components/tab-view/TabViewPrimitive.js
@@ -217,7 +217,12 @@ class TabViewPrimitive extends React.Component<Props, State> {
                 {React.Children.map(children, (tab, i) => {
                     const buttonProps = omit(tab.props, ['className', 'children', 'title']);
 
-                    const classes = classNames('bdl-Button--plain', 'tab', i === selectedIndex ? 'is-selected' : '');
+                    const classes = classNames(
+                        'bdl-Button',
+                        'bdl-PlainButton',
+                        'tab',
+                        i === selectedIndex ? 'bdl-is-selected' : '',
+                    );
 
                     const ariaControls = `${this.tabviewID}-panel-${i + 1}`;
                     const ariaSelected = i === selectedIndex;
@@ -279,7 +284,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <div className="dynamic-tabs-bar" onKeyDown={this.handleKeyDown}>
                 <button
-                    className={classNames('bdl-Button--plain svg-container left-arrow', {
+                    className={classNames('bdl-Button bdl-PlainButton svg-container left-arrow', {
                         hidden: !this.isLeftArrowVisible(),
                     })}
                     onClick={() => onTabFocus(focusedIndex - 1)}
@@ -290,7 +295,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
                 </button>
                 <div className="dynamic-tabs-wrapper">{this.renderTabs()}</div>
                 <button
-                    className={classNames('bdl-Button--plain svg-container right-arrow', {
+                    className={classNames('bdl-Button bdl-PlainButton svg-container right-arrow', {
                         hidden: !this.isRightArrowVisible(),
                     })}
                     onClick={() => onTabFocus(focusedIndex + 1)}
@@ -321,7 +326,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
                             id={`${this.tabviewID}-panel-${i}`}
                             aria-labelledby={`${this.tabviewID}-tab-${i + 1}`}
                             aria-hidden={selectedIndex !== i}
-                            className={`tab-panel ${i === selectedIndex ? 'is-selected' : ''}`}
+                            className={`tab-panel ${i === selectedIndex ? 'bdl-is-selected' : ''}`}
                             role={TAB_PANEL_ROLE}
                             // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
                             tabIndex="0"

--- a/src/components/tab-view/Tabs.scss
+++ b/src/components/tab-view/Tabs.scss
@@ -64,7 +64,7 @@
             margin-bottom: 10px;
         }
 
-        &.is-selected {
+        &.bdl-is-selected {
             color: $bdl-gray;
 
             .tab-underline {
@@ -122,7 +122,7 @@
         border-bottom: 1px solid $bdl-gray-10;
     }
 
-    .tab.bdl-Button--plain:not(.bdl-is-disabled) {
+    .tab.bdl-PlainButton:not(.bdl-is-disabled) {
         &:active {
             background: transparent;
             border-bottom: 1px solid $bdl-gray-10;
@@ -146,7 +146,7 @@
     .tab-panel {
         display: none;
 
-        &.is-selected {
+        &.bdl-is-selected {
             display: block;
             height: 100%;
         }

--- a/src/components/tab-view/Tabs.scss
+++ b/src/components/tab-view/Tabs.scss
@@ -122,7 +122,7 @@
         border-bottom: 1px solid $bdl-gray-10;
     }
 
-    .tab.btn-plain:not(.is-disabled) {
+    .tab.bdl-Button--plain:not(.bdl-is-disabled) {
         &:active {
             background: transparent;
             border-bottom: 1px solid $bdl-gray-10;

--- a/src/components/tab-view/__tests__/TabViewPrimitive.test.js
+++ b/src/components/tab-view/__tests__/TabViewPrimitive.test.js
@@ -85,8 +85,8 @@ describe('components/tab-view/TabViewPrimitive', () => {
         );
 
         const tabs = component.find('.tabs').find('button');
-        expect(tabs.at(0).hasClass('is-selected')).toBe(false);
-        expect(tabs.at(1).hasClass('is-selected')).toBe(true);
+        expect(tabs.at(0).hasClass('bdl-is-selected')).toBe(false);
+        expect(tabs.at(1).hasClass('bdl-is-selected')).toBe(true);
     });
 
     test('should call onTabSelect when tab selected', () => {

--- a/src/components/text-area/TextArea.js
+++ b/src/components/text-area/TextArea.js
@@ -37,7 +37,7 @@ const TextArea = ({
 }: Props) => {
     const hasError = !!error;
     const classes = classNames(className, 'text-area-container', {
-        'show-error': hasError,
+        'bdl-show-error': hasError,
     });
 
     const errorMessageID = React.useRef(uniqueId('errorMessage')).current;

--- a/src/components/text-area/TextArea.js
+++ b/src/components/text-area/TextArea.js
@@ -37,7 +37,7 @@ const TextArea = ({
 }: Props) => {
     const hasError = !!error;
     const classes = classNames(className, 'text-area-container', {
-        'bdl-show-error': hasError,
+        'bdl-has-error': hasError,
     });
 
     const errorMessageID = React.useRef(uniqueId('errorMessage')).current;

--- a/src/components/text-area/TextArea.scss
+++ b/src/components/text-area/TextArea.scss
@@ -17,13 +17,13 @@
         font-family: inherit;
     }
 
-    &:not(.show-error) {
+    &:not(.bdl-show-error) {
         .caution {
             display: none;
         }
     }
 
-    &.show-error {
+    &.bdl-show-error {
         textarea {
             border-color: $bdl-watermelon-red;
         }

--- a/src/components/text-area/TextArea.scss
+++ b/src/components/text-area/TextArea.scss
@@ -17,13 +17,13 @@
         font-family: inherit;
     }
 
-    &:not(.bdl-show-error) {
+    &:not(.bdl-has-error) {
         .caution {
             display: none;
         }
     }
 
-    &.bdl-show-error {
+    &.bdl-has-error {
         textarea {
             border-color: $bdl-watermelon-red;
         }

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.scss
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.scss
@@ -17,7 +17,7 @@
         }
     }
 
-    .btn {
+    .bdl-Button {
         min-width: 80px;
         margin: 0;
         border-left: 0;
@@ -27,10 +27,10 @@
     }
 
     &.copy-success {
-        .btn,
-        .btn:hover,
-        .btn:active,
-        .btn:active:hover {
+        .bdl-Button,
+        .bdl-Button:hover,
+        .bdl-Button:active,
+        .bdl-Button:active:hover {
             color: $white;
             background-color: $bdl-green-light;
             border-color: $bdl-green-light;

--- a/src/components/text-input/TextInput.js
+++ b/src/components/text-input/TextInput.js
@@ -52,7 +52,7 @@ const TextInput = ({
 }: Props) => {
     const hasError = !!error;
     const classes = classNames(className, 'text-input-container', {
-        'bdl-show-error': hasError,
+        'bdl-has-error': hasError,
     });
 
     const errorMessageID = React.useRef(uniqueId('errorMessage')).current;

--- a/src/components/text-input/TextInput.js
+++ b/src/components/text-input/TextInput.js
@@ -52,7 +52,7 @@ const TextInput = ({
 }: Props) => {
     const hasError = !!error;
     const classes = classNames(className, 'text-input-container', {
-        'show-error': hasError,
+        'bdl-show-error': hasError,
     });
 
     const errorMessageID = React.useRef(uniqueId('errorMessage')).current;

--- a/src/components/text-input/TextInput.scss
+++ b/src/components/text-input/TextInput.scss
@@ -47,7 +47,7 @@
     }
 
     &.is-required,
-    &.show-error {
+    &.bdl-show-error {
         input {
             border-color: $bdl-watermelon-red;
         }

--- a/src/components/text-input/TextInput.scss
+++ b/src/components/text-input/TextInput.scss
@@ -47,7 +47,7 @@
     }
 
     &.is-required,
-    &.bdl-show-error {
+    &.bdl-has-error {
         input {
             border-color: $bdl-watermelon-red;
         }

--- a/src/components/text-input/TextInput.scss
+++ b/src/components/text-input/TextInput.scss
@@ -19,7 +19,7 @@
         margin-left: -24px;
     }
 
-    .label {
+    .bdl-Label {
         word-wrap: break-word;
     }
 

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -37,12 +37,12 @@ const Toggle = ({
     onChange,
     ...rest
 }: Props) => {
-    const classes = classNames('toggle-container', className, {
-        'is-toggle-right-aligned': isToggleRightAligned,
+    const classes = classNames('bdl-Toggle', className, {
+        'bdl-is-toggleRightAligned': isToggleRightAligned,
     });
     let toggleElements = [
-        <div key="toggle-simple-switch" className="toggle-simple-switch" />,
-        <div key="toggle-simple-label" className="toggle-simple-label">
+        <div key="bdl-Toggle-switch" className="bdl-Toggle-switch" />,
+        <div key="bdl-Toggle-labelContent" className="bdl-Toggle-labelContent">
             {label}
         </div>,
     ];
@@ -54,10 +54,10 @@ const Toggle = ({
     return (
         <div className={classes}>
             {/* eslint-disable-next-line jsx-a11y/label-has-for */}
-            <label className="toggle-simple">
+            <label className="bdl-Toggle-label">
                 <input
                     checked={isOn}
-                    className="toggle-simple-input"
+                    className="bdl-Toggle-input"
                     disabled={isDisabled}
                     name={name}
                     onBlur={onBlur}
@@ -67,7 +67,7 @@ const Toggle = ({
                 />
                 {toggleElements}
             </label>
-            {description ? <div className="toggle-simple-description">{description}</div> : null}
+            {description ? <div className="bdl-Toggle-description">{description}</div> : null}
         </div>
     );
 };

--- a/src/components/toggle/Toggle.scss
+++ b/src/components/toggle/Toggle.scss
@@ -4,93 +4,18 @@
  * Toggle
  **************************************/
 
-.toggle-container {
-    margin: 0 0 20px;
-
-    .toggle-label {
-        display: inline-block;
-        margin: 5px 10px;
-        line-height: 15px;
-        vertical-align: top;
-    }
-}
+$height: 20px;
+$width: $height * 2;
 
 .bdl-Toggle {
-    display: none;
-
-    &,
-    &::after,
-    &::before,
-    *,
-    *::after,
-    *::before,
-    & + .toggle-btn {
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-
-        &::selection {
-            background: none;
-        }
-    }
-
-    + .toggle-btn {
-        position: relative;
-        display: inline-block;
-        width: 50px;
-        height: 24px;
-        margin: 1px 0;
-        padding: 2px;
-        background: $bdl-gray-30;
-        border-radius: 40px;
-        outline: 0;
-        cursor: pointer;
-        transition: left .4s ease, background .4s ease;
-
-        &::after,
-        &::before {
-            position: relative;
-            display: block;
-            width: 26px;
-            content: '';
-        }
-
-        &::after {
-            top: -3px;
-            left: -3px;
-            height: 26px;
-            background: $white;
-            border: 1px solid $bdl-gray-62;
-            border-radius: 50%;
-            box-shadow: 0 1px 2px fade-out($black, .9);
-            transition: left .2s ease, background .2s ease;
-        }
-
-        &::before {
-            display: none;
-        }
-    }
-
-    &:checked {
-        + .toggle-btn {
-            background: $primary-color;
-
-            &::after {
-                left: 50%;
-            }
-        }
-    }
+    margin: 0 0 20px;
 }
 
 /**********************************************************
  * A simpler version of toggle that does not use ids
  * Eventually we should remove the webapp specific version
  **********************************************************/
-$height: 20px;
-$width: $height * 2;
-
-.toggle-simple {
+.bdl-Toggle-label {
     position: relative;
     display: flex;
     width: $width;
@@ -99,24 +24,24 @@ $width: $height * 2;
     outline: none;
     user-select: none;
 
-    .is-toggle-right-aligned & {
+    .bdl-is-toggleRightAligned & {
         width: 100%;
     }
 }
 
-.toggle-simple-input {
+.bdl-Toggle-input {
     position: absolute;
     left: -9999px;
     opacity: 0; // this keeps the element tab-able
 }
 
-.toggle-simple-label {
+.bdl-Toggle-labelContent {
     display: inline-block;
     min-width: 0;
     margin-left: $width + 6;
     white-space: nowrap;
 
-    .is-toggle-right-aligned & {
+    .bdl-is-toggleRightAligned & {
         flex: 1;
         margin-left: auto;
         overflow: hidden;
@@ -124,18 +49,18 @@ $width: $height * 2;
     }
 }
 
-.toggle-simple-description {
+.bdl-Toggle-description {
     margin-top: 2px;
     margin-left: $width + 6;
     color: $bdl-gray-50;
 
-    .is-toggle-right-aligned & {
+    .bdl-is-toggleRightAligned & {
         margin-right: $width + 6;
         margin-left: auto;
     }
 }
 
-.toggle-simple-switch {
+.bdl-Toggle-switch {
     display: inline-block;
 
     // NOTE: targets ie11
@@ -143,7 +68,7 @@ $width: $height * 2;
         cursor: pointer;
     }
 
-    .is-toggle-right-aligned & {
+    .bdl-is-toggleRightAligned & {
         position: relative;
         width: $width;
     }
@@ -175,7 +100,7 @@ $width: $height * 2;
         transition: margin .4s;
     }
 
-    .toggle-simple-input:checked ~ & {
+    .bdl-Toggle-input:checked ~ & {
         &::before {
             background-color: $primary-color;
         }
@@ -185,7 +110,7 @@ $width: $height * 2;
         }
     }
 
-    .toggle-simple-input:disabled ~ & {
+    .bdl-Toggle-input:disabled ~ & {
         &::before,
         &::after {
             cursor: default;
@@ -201,7 +126,7 @@ $width: $height * 2;
         }
     }
 
-    .toggle-simple-input:focus ~ & {
+    .bdl-Toggle-input:focus ~ & {
         &::after {
             border-color: $primary-color;
         }

--- a/src/components/toggle/Toggle.scss
+++ b/src/components/toggle/Toggle.scss
@@ -15,7 +15,7 @@
     }
 }
 
-.toggle {
+.bdl-Toggle {
     display: none;
 
     &,

--- a/src/components/toggle/__tests__/Toggle.test.js
+++ b/src/components/toggle/__tests__/Toggle.test.js
@@ -10,10 +10,10 @@ describe('components/toggle/Toggle', () => {
     test('should correctly render default component', () => {
         const wrapper = getWrapper();
 
-        expect(wrapper.hasClass('toggle-container')).toBeTruthy();
-        expect(wrapper.hasClass('is-toggle-right-aligned')).toBeFalsy();
+        expect(wrapper.hasClass('bdl-Toggle')).toBeTruthy();
+        expect(wrapper.hasClass('bdl-is-toggleRightAligned')).toBeFalsy();
         expect(wrapper.find('input').prop('checked')).toBeFalsy();
-        expect(wrapper.find('.toggle-simple-description').length).toBeFalsy();
+        expect(wrapper.find('.bdl-Toggle-description').length).toBeFalsy();
     });
 
     test('should put className on the container when className is passed in', () => {
@@ -44,7 +44,7 @@ describe('components/toggle/Toggle', () => {
         const wrapper = getWrapper();
         const description = 'foobar';
         wrapper.setProps({ description });
-        expect(wrapper.find('.toggle-simple-description').text()).toEqual(description);
+        expect(wrapper.find('.bdl-Toggle-description').text()).toEqual(description);
     });
 
     test('should render properly when isToggleRightAligned prop is true', () => {

--- a/src/components/toggle/__tests__/__snapshots__/Toggle.test.js.snap
+++ b/src/components/toggle/__tests__/__snapshots__/Toggle.test.js.snap
@@ -2,26 +2,26 @@
 
 exports[`components/toggle/Toggle should render properly when isToggleRightAligned prop is true 1`] = `
 <div
-  className="toggle-container is-toggle-right-aligned"
+  className="bdl-Toggle bdl-is-toggleRightAligned"
 >
   <label
-    className="toggle-simple"
+    className="bdl-Toggle-label"
   >
     <input
-      className="toggle-simple-input"
+      className="bdl-Toggle-input"
       name="toggle"
       onChange={[Function]}
       type="checkbox"
     />
     <div
-      className="toggle-simple-label"
-      key="toggle-simple-label"
+      className="bdl-Toggle-labelContent"
+      key="bdl-Toggle-labelContent"
     >
       Enter things
     </div>
     <div
-      className="toggle-simple-switch"
-      key="toggle-simple-switch"
+      className="bdl-Toggle-switch"
+      key="bdl-Toggle-switch"
     />
   </label>
 </div>
@@ -29,25 +29,25 @@ exports[`components/toggle/Toggle should render properly when isToggleRightAlign
 
 exports[`components/toggle/Toggle should render properly when random props are passed in 1`] = `
 <div
-  className="toggle-container"
+  className="bdl-Toggle"
 >
   <label
-    className="toggle-simple"
+    className="bdl-Toggle-label"
   >
     <input
-      className="toggle-simple-input"
+      className="bdl-Toggle-input"
       data-resin-target="toggle"
       name="toggle"
       onChange={[Function]}
       type="checkbox"
     />
     <div
-      className="toggle-simple-switch"
-      key="toggle-simple-switch"
+      className="bdl-Toggle-switch"
+      key="bdl-Toggle-switch"
     />
     <div
-      className="toggle-simple-label"
-      key="toggle-simple-label"
+      className="bdl-Toggle-labelContent"
+      key="bdl-Toggle-labelContent"
     >
       Enter things
     </div>

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -115,7 +115,7 @@ class Tooltip extends React.Component<Props, State> {
         this.state = { isShown: !!props.isShown, wasClosedByUser: false };
     }
 
-    tooltipID = uniqueId('bdl-Tooltip');
+    tooltipID = uniqueId('tooltip');
 
     tetherRef = React.createRef<{ position: () => {} }>();
 
@@ -244,9 +244,9 @@ class Tooltip extends React.Component<Props, State> {
         const bodyEl = bodyElement instanceof HTMLElement ? bodyElement : document.body;
 
         const classes = classNames('bdl-Tooltip', className, {
-            'is-callout': theme === CALLOUT_THEME,
+            'bdl-is-callout': theme === CALLOUT_THEME,
             'bdl-is-error': theme === ERROR_THEME,
-            'with-close-button': withCloseButton,
+            'bdl-has-closeButton': withCloseButton,
         });
 
         return (

--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -115,7 +115,7 @@ class Tooltip extends React.Component<Props, State> {
         this.state = { isShown: !!props.isShown, wasClosedByUser: false };
     }
 
-    tooltipID = uniqueId('tooltip');
+    tooltipID = uniqueId('bdl-Tooltip');
 
     tetherRef = React.createRef<{ position: () => {} }>();
 
@@ -243,9 +243,9 @@ class Tooltip extends React.Component<Props, State> {
 
         const bodyEl = bodyElement instanceof HTMLElement ? bodyElement : document.body;
 
-        const classes = classNames('tooltip', className, {
+        const classes = classNames('bdl-Tooltip', className, {
             'is-callout': theme === CALLOUT_THEME,
-            'is-error': theme === ERROR_THEME,
+            'bdl-is-error': theme === ERROR_THEME,
             'with-close-button': withCloseButton,
         });
 
@@ -253,7 +253,7 @@ class Tooltip extends React.Component<Props, State> {
             <TetherComponent
                 attachment={tetherPosition.attachment}
                 bodyElement={bodyEl}
-                classPrefix="tooltip"
+                classPrefix="bdl-Tooltip"
                 constraints={constraints}
                 enabled={showTooltip}
                 targetAttachment={tetherPosition.targetAttachment}
@@ -264,7 +264,7 @@ class Tooltip extends React.Component<Props, State> {
                     <div className={classes} id={this.tooltipID} role="tooltip">
                         {text}
                         {withCloseButton && (
-                            <PlainButton className="tooltip-close-button" onClick={this.closeTooltip}>
+                            <PlainButton className="bdl-Tooltip-closeButton" onClick={this.closeTooltip}>
                                 <IconClose />
                             </PlainButton>
                         )}

--- a/src/components/tooltip/Tooltip.scss
+++ b/src/components/tooltip/Tooltip.scss
@@ -8,7 +8,7 @@ $arrow-size: 6px;
 $horizontal-offset: 10px;
 $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
 
-.tooltip {
+.bdl-Tooltip {
     position: relative;
     max-width: 200px;
     padding: 8px $horizontal-offset;

--- a/src/components/tooltip/Tooltip.scss
+++ b/src/components/tooltip/Tooltip.scss
@@ -46,7 +46,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         }
     }
 
-    &.is-callout {
+    &.bdl-is-callout {
         background-color: $bdl-purple-rain;
         border-color: $bdl-purple-rain;
     }
@@ -55,7 +55,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         margin-left: -8px;
     }
 
-    &.with-close-button {
+    &.bdl-has-closeButton {
         padding-right: 28px;
     }
 

--- a/src/components/tooltip/Tooltip.scss
+++ b/src/components/tooltip/Tooltip.scss
@@ -28,7 +28,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         content: '';
     }
 
-    &.is-error::after {
+    &.bdl-is-error::after {
         position: absolute;
         width: 0;
         height: 0;
@@ -36,12 +36,12 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         content: '';
     }
 
-    &.is-error {
+    &.bdl-is-error {
         color: $bdl-gray;
         background-color: $bdl-watermelon-red-10;
         border: 1px solid $bdl-watermelon-red-50;
 
-        .tooltip-close-button .icon-close .fill-color {
+        .bdl-Tooltip-closeButton .icon-close .fill-color {
             fill: $bdl-gray;
         }
     }
@@ -59,7 +59,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         padding-right: 28px;
     }
 
-    .tooltip-close-button {
+    .bdl-Tooltip-closeButton {
         position: absolute;
         top: 9px;
         right: 3px;
@@ -74,7 +74,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         }
     }
 
-    .tooltip-target-attached-top.tooltip-target-attached-center > & {
+    .bdl-Tooltip-target-attached-top.bdl-Tooltip-target-attached-center > & {
         margin-bottom: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -84,7 +84,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-top-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             top: 100%;
             left: 50%;
             margin-left: -$arrow-size + 1;
@@ -92,7 +92,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         }
     }
 
-    .tooltip-target-attached-top.tooltip-target-attached-left > & {
+    .bdl-Tooltip-target-attached-top.bdl-Tooltip-target-attached-left > & {
         margin-bottom: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -101,14 +101,14 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-top-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             top: 100%;
             left: $horizontal-offset + 1;
             border-top-color: $bdl-watermelon-red-10;
         }
     }
 
-    .tooltip-target-attached-top.tooltip-target-attached-right > & {
+    .bdl-Tooltip-target-attached-top.bdl-Tooltip-target-attached-right > & {
         margin-bottom: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -117,14 +117,14 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-top-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             top: 100%;
             right: $horizontal-offset + 1;
             border-top-color: $bdl-watermelon-red-10;
         }
     }
 
-    .tooltip-target-attached-middle.tooltip-target-attached-right > & {
+    .bdl-Tooltip-target-attached-middle.bdl-Tooltip-target-attached-right > & {
         margin-left: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -134,7 +134,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-right-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             top: 50%;
             right: 100%;
             margin-top: -$arrow-size + 1;
@@ -142,7 +142,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         }
     }
 
-    .tooltip-target-attached-middle.tooltip-target-attached-left > & {
+    .bdl-Tooltip-target-attached-middle.bdl-Tooltip-target-attached-left > & {
         margin-right: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -152,7 +152,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-left-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             top: 50%;
             left: 100%;
             margin-top: -$arrow-size + 1;
@@ -160,7 +160,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         }
     }
 
-    .tooltip-target-attached-bottom.tooltip-target-attached-center > & {
+    .bdl-Tooltip-target-attached-bottom.bdl-Tooltip-target-attached-center > & {
         margin-top: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -170,7 +170,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-bottom-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             bottom: 100%;
             left: 50%;
             margin-left: -$arrow-size + 1;
@@ -178,7 +178,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
         }
     }
 
-    .tooltip-target-attached-bottom.tooltip-target-attached-left > & {
+    .bdl-Tooltip-target-attached-bottom.bdl-Tooltip-target-attached-left > & {
         margin-top: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -187,14 +187,14 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-bottom-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             bottom: 100%;
             left: $horizontal-offset + 1;
             border-bottom-color: $bdl-watermelon-red-10;
         }
     }
 
-    .tooltip-target-attached-bottom.tooltip-target-attached-right > & {
+    .bdl-Tooltip-target-attached-bottom.bdl-Tooltip-target-attached-right > & {
         margin-top: $arrow-size + $tooltip-offset;
 
         &::before {
@@ -203,7 +203,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
             border-bottom-color: inherit;
         }
 
-        &.is-error::after {
+        &.bdl-is-error::after {
             right: $horizontal-offset + 1;
             bottom: 100%;
             border-bottom-color: $bdl-watermelon-red-10;
@@ -214,7 +214,7 @@ $tooltip-offset: 4px; /* amount of space between target and tooltip arrow */
 // tooltip is a tethered element and as such attached to body
 // however the body may not have box specific classes and hence the
 // tooltip needs to manually inherit few of the body styles to look correct.
-.tooltip-element {
+.bdl-Tooltip-element {
     @include box-sizing;
     @include common-typography;
 

--- a/src/components/tooltip/__tests__/Tooltip.test.js
+++ b/src/components/tooltip/__tests__/Tooltip.test.js
@@ -212,7 +212,7 @@ describe('components/tooltip/Tooltip', () => {
                 </Tooltip>,
             );
 
-            expect(wrapper.find('[role="tooltip"]').hasClass('is-error')).toBe(true);
+            expect(wrapper.find('[role="tooltip"]').hasClass('bdl-is-error')).toBe(true);
         });
 
         test('should render children only when tooltip is disabled', () => {

--- a/src/components/tooltip/__tests__/Tooltip.test.js
+++ b/src/components/tooltip/__tests__/Tooltip.test.js
@@ -116,7 +116,7 @@ describe('components/tooltip/Tooltip', () => {
             const tooltip = wrapper.childAt(1);
             expect(wrapper.prop('enabled')).toBe(true);
             expect(tooltip.is('div')).toBe(true);
-            expect(tooltip.hasClass('tooltip')).toBe(true);
+            expect(tooltip.hasClass('bdl-Tooltip')).toBe(true);
             expect(component.prop('aria-describedby')).toEqual(tooltip.prop('id'));
             expect(tooltip.text()).toEqual('hi');
         });
@@ -200,7 +200,7 @@ describe('components/tooltip/Tooltip', () => {
             expect(component.prop('onMouseLeave')).toBeFalsy();
             expect(component.prop('tabIndex')).toBeFalsy();
             expect(tooltip.is('div')).toBe(true);
-            expect(tooltip.hasClass('tooltip')).toBe(true);
+            expect(tooltip.hasClass('bdl-Tooltip')).toBe(true);
             expect(component.prop('aria-describedby')).toEqual(tooltip.prop('id'));
             expect(tooltip.text()).toEqual('hi');
         });

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -4,7 +4,7 @@ exports[`components/tooltip/Tooltip render() should not render the close button 
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
-  classPrefix="tooltip"
+  classPrefix="bdl-Tooltip"
   constraints={
     Array [
       Object {
@@ -28,7 +28,7 @@ exports[`components/tooltip/Tooltip render() should not render with close button
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
-  classPrefix="tooltip"
+  classPrefix="bdl-Tooltip"
   constraints={
     Array [
       Object {
@@ -52,7 +52,7 @@ exports[`components/tooltip/Tooltip render() should not render with close button
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
-  classPrefix="tooltip"
+  classPrefix="bdl-Tooltip"
   constraints={
     Array [
       Object {
@@ -67,13 +67,13 @@ exports[`components/tooltip/Tooltip render() should not render with close button
   targetAttachment="top center"
 >
   <div
-    aria-describedby="tooltip3"
+    aria-describedby="bdl-Tooltip3"
   >
     Hello
   </div>
   <div
-    className="tooltip"
-    id="tooltip3"
+    className="bdl-Tooltip"
+    id="bdl-Tooltip3"
     role="tooltip"
   >
     hi
@@ -91,7 +91,7 @@ exports[`components/tooltip/Tooltip render() should render children wrapped in t
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
-  classPrefix="tooltip"
+  classPrefix="bdl-Tooltip"
   constraints={
     Array [
       Object {
@@ -122,7 +122,7 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
-  classPrefix="tooltip"
+  classPrefix="bdl-Tooltip"
   constraints={
     Array [
       Object {
@@ -137,13 +137,13 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
   targetAttachment="top center"
 >
   <div
-    aria-describedby="tooltip5"
+    aria-describedby="bdl-Tooltip5"
   >
     Hello
   </div>
   <div
-    className="tooltip is-callout"
-    id="tooltip5"
+    className="bdl-Tooltip is-callout"
+    id="bdl-Tooltip5"
     role="tooltip"
   >
     hi
@@ -155,7 +155,7 @@ exports[`components/tooltip/Tooltip render() should render with close button if 
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
-  classPrefix="tooltip"
+  classPrefix="bdl-Tooltip"
   constraints={
     Array [
       Object {
@@ -170,13 +170,13 @@ exports[`components/tooltip/Tooltip render() should render with close button if 
   targetAttachment="top center"
 >
   <div
-    aria-describedby="tooltip1"
+    aria-describedby="bdl-Tooltip1"
   >
     Hello
   </div>
   <div
-    className="tooltip with-close-button"
-    id="tooltip1"
+    className="bdl-Tooltip with-close-button"
+    id="bdl-Tooltip1"
     role="tooltip"
   >
     hi

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -67,13 +67,13 @@ exports[`components/tooltip/Tooltip render() should not render with close button
   targetAttachment="top center"
 >
   <div
-    aria-describedby="bdl-Tooltip3"
+    aria-describedby="tooltip3"
   >
     Hello
   </div>
   <div
     className="bdl-Tooltip"
-    id="bdl-Tooltip3"
+    id="tooltip3"
     role="tooltip"
   >
     hi
@@ -137,13 +137,13 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
   targetAttachment="top center"
 >
   <div
-    aria-describedby="bdl-Tooltip5"
+    aria-describedby="tooltip5"
   >
     Hello
   </div>
   <div
-    className="bdl-Tooltip is-callout"
-    id="bdl-Tooltip5"
+    className="bdl-Tooltip bdl-is-callout"
+    id="tooltip5"
     role="tooltip"
   >
     hi
@@ -170,13 +170,13 @@ exports[`components/tooltip/Tooltip render() should render with close button if 
   targetAttachment="top center"
 >
   <div
-    aria-describedby="bdl-Tooltip1"
+    aria-describedby="tooltip1"
   >
     Hello
   </div>
   <div
-    className="bdl-Tooltip with-close-button"
-    id="bdl-Tooltip1"
+    className="bdl-Tooltip bdl-has-closeButton"
+    id="tooltip1"
     role="tooltip"
   >
     hi

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -181,7 +181,7 @@ exports[`components/tooltip/Tooltip render() should render with close button if 
   >
     hi
     <PlainButton
-      className="tooltip-close-button"
+      className="bdl-Tooltip-closeButton"
       onClick={[Function]}
     >
       <IconClose />

--- a/src/elements/common/base.scss
+++ b/src/elements/common/base.scss
@@ -39,11 +39,11 @@
         }
     }
 
-    .btn-plain,
+    .bdl-Button--plain,
     input,
     textarea,
     select,
-    .select-button {
+    .bdl-SelectButton {
         font: inherit;
     }
 }

--- a/src/elements/common/base.scss
+++ b/src/elements/common/base.scss
@@ -39,7 +39,7 @@
         }
     }
 
-    .bdl-Button--plain,
+    .bdl-PlainButton,
     input,
     textarea,
     select,

--- a/src/elements/common/breadcrumbs/Breadcrumb.scss
+++ b/src/elements/common/breadcrumbs/Breadcrumb.scss
@@ -9,7 +9,7 @@
         min-width: 64px;
     }
 
-    .be & .btn-plain {
+    .be & .bdl-Button--plain {
         color: $bdl-gray-62;
 
         &:last-child {

--- a/src/elements/common/breadcrumbs/Breadcrumb.scss
+++ b/src/elements/common/breadcrumbs/Breadcrumb.scss
@@ -9,7 +9,7 @@
         min-width: 64px;
     }
 
-    .be & .bdl-Button--plain {
+    .be & .bdl-PlainButton {
         color: $bdl-gray-62;
 
         &:last-child {

--- a/src/elements/common/breadcrumbs/BreadcrumbDropdown.scss
+++ b/src/elements/common/breadcrumbs/BreadcrumbDropdown.scss
@@ -1,6 +1,6 @@
 @import '../variables';
 
-.be .bdl-Button--plain.be-breadcrumbs-drop-down {
+.be .bdl-PlainButton.be-breadcrumbs-drop-down {
     color: $bdl-gray-62;
     letter-spacing: 1.5px;
 

--- a/src/elements/common/breadcrumbs/BreadcrumbDropdown.scss
+++ b/src/elements/common/breadcrumbs/BreadcrumbDropdown.scss
@@ -1,6 +1,6 @@
 @import '../variables';
 
-.be .btn-plain.be-breadcrumbs-drop-down {
+.be .bdl-Button--plain.be-breadcrumbs-drop-down {
     color: $bdl-gray-62;
     letter-spacing: 1.5px;
 

--- a/src/elements/common/breadcrumbs/InlineBreadcrumbs.scss
+++ b/src/elements/common/breadcrumbs/InlineBreadcrumbs.scss
@@ -15,7 +15,7 @@
             min-width: 43px;
         }
 
-        .be & .btn-plain {
+        .be & .bdl-Button--plain {
             color: inherit;
             font-size: 11px;
         }

--- a/src/elements/common/breadcrumbs/InlineBreadcrumbs.scss
+++ b/src/elements/common/breadcrumbs/InlineBreadcrumbs.scss
@@ -15,7 +15,7 @@
             min-width: 43px;
         }
 
-        .be & .bdl-Button--plain {
+        .be & .bdl-PlainButton {
             color: inherit;
             font-size: 11px;
         }

--- a/src/elements/common/makePopup.js
+++ b/src/elements/common/makePopup.js
@@ -112,7 +112,7 @@ const makePopup = (kit: string) => (Wrapped: any) =>
             const wrappedProps = omit(rest, ['onCancel', 'onChoose', 'onClose', 'modal']);
             const {
                 buttonLabel = 'Missing modal.buttonLabel in options',
-                buttonClassName = 'btn bdl-Button bdl-PrimaryButton',
+                buttonClassName = 'bdl-Button bdl-Button--primary',
                 modalClassName = 'be-modal-wrapper-content',
                 overlayClassName = 'be-modal-wrapper-overlay',
             }: ModalOptions = modal;

--- a/src/elements/common/makePopup.js
+++ b/src/elements/common/makePopup.js
@@ -112,7 +112,7 @@ const makePopup = (kit: string) => (Wrapped: any) =>
             const wrappedProps = omit(rest, ['onCancel', 'onChoose', 'onClose', 'modal']);
             const {
                 buttonLabel = 'Missing modal.buttonLabel in options',
-                buttonClassName = 'btn btn-primary',
+                buttonClassName = 'btn bdl-Button btn-primary',
                 modalClassName = 'be-modal-wrapper-content',
                 overlayClassName = 'be-modal-wrapper-overlay',
             }: ModalOptions = modal;

--- a/src/elements/common/makePopup.js
+++ b/src/elements/common/makePopup.js
@@ -112,7 +112,7 @@ const makePopup = (kit: string) => (Wrapped: any) =>
             const wrappedProps = omit(rest, ['onCancel', 'onChoose', 'onClose', 'modal']);
             const {
                 buttonLabel = 'Missing modal.buttonLabel in options',
-                buttonClassName = 'btn bdl-Button btn-primary',
+                buttonClassName = 'btn bdl-Button bdl-PrimaryButton',
                 modalClassName = 'be-modal-wrapper-content',
                 overlayClassName = 'be-modal-wrapper-overlay',
             }: ModalOptions = modal;

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -224,7 +224,7 @@ const messages = defineMessages({
     },
     uploader: {
         id: 'be.itemUploader',
-        description: 'label bdl-Label for item uploader.',
+        description: 'bdl-Label for item uploader.',
         defaultMessage: 'Uploader',
     },
     interacted: {

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -224,7 +224,7 @@ const messages = defineMessages({
     },
     uploader: {
         id: 'be.itemUploader',
-        description: 'bdl-Label for item uploader.',
+        description: 'label for item uploader.',
         defaultMessage: 'Uploader',
     },
     interacted: {

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -224,7 +224,7 @@ const messages = defineMessages({
     },
     uploader: {
         id: 'be.itemUploader',
-        description: 'label for item uploader.',
+        description: 'label bdl-Label for item uploader.',
         defaultMessage: 'Uploader',
     },
     interacted: {

--- a/src/elements/common/modal.scss
+++ b/src/elements/common/modal.scss
@@ -7,7 +7,7 @@
         justify-content: center;
         padding: 15px 0 0;
 
-        .btn {
+        .bdl-Button {
             margin-left: 8px;
         }
     }

--- a/src/elements/common/nav-button/__tests__/NavButton.test.js
+++ b/src/elements/common/nav-button/__tests__/NavButton.test.js
@@ -18,14 +18,14 @@ describe('elements/common/nav-button/NavButton', () => {
         test('applies a custom activeClassName instead of the default', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton to="/activity" activeClassName="bdl-is-selected">
+                    <NavButton to="/activity" activeClassName="bdl-bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
             expect(button.hasClass('bdl-is-active')).toBe(false);
-            expect(button.hasClass('bdl-is-selected')).toBe(true);
+            expect(button.hasClass('bdl-bdl-is-selected')).toBe(true);
         });
     });
 
@@ -43,14 +43,14 @@ describe('elements/common/nav-button/NavButton', () => {
         test('does not apply its activeClassName', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton to="/details" activeClassName="bdl-is-selected">
+                    <NavButton to="/details" activeClassName="bdl-bdl-is-selected">
                         Details
                     </NavButton>
                 </MemoryRouter>,
             );
 
             expect(button.hasClass('bdl-is-active')).toBe(false);
-            expect(button.hasClass('bdl-is-selected')).toBe(false);
+            expect(button.hasClass('bdl-bdl-is-selected')).toBe(false);
         });
     });
 
@@ -92,25 +92,25 @@ describe('elements/common/nav-button/NavButton', () => {
         test('applies custom activeClassName for exact matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton exact to="/activity" activeClassName="bdl-is-selected">
+                    <NavButton exact to="/activity" activeClassName="bdl-bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-is-selected')).toBe(true);
+            expect(button.hasClass('bdl-bdl-is-selected')).toBe(true);
         });
 
         test('applies custom activeClassName for partial matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity/versions']}>
-                    <NavButton exact to="/activity" activeClassName="bdl-is-selected">
+                    <NavButton exact to="/activity" activeClassName="bdl-bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-is-selected')).toBe(false);
+            expect(button.hasClass('bdl-bdl-is-selected')).toBe(false);
         });
     });
 
@@ -166,25 +166,25 @@ describe('elements/common/nav-button/NavButton', () => {
         test('applies custom activeClassName for strict matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity/']}>
-                    <NavButton strict to="/activity/" activeClassName="bdl-is-selected">
+                    <NavButton strict to="/activity/" activeClassName="bdl-bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-is-selected')).toBe(true);
+            expect(button.hasClass('bdl-bdl-is-selected')).toBe(true);
         });
 
         test('does not apply custom activeClassName for non-strict matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton strict to="/activity/" activeClassName="bdl-is-selected">
+                    <NavButton strict to="/activity/" activeClassName="bdl-bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-is-selected')).toBe(false);
+            expect(button.hasClass('bdl-bdl-is-selected')).toBe(false);
         });
     });
 

--- a/src/elements/common/nav-button/__tests__/NavButton.test.js
+++ b/src/elements/common/nav-button/__tests__/NavButton.test.js
@@ -18,14 +18,14 @@ describe('elements/common/nav-button/NavButton', () => {
         test('applies a custom activeClassName instead of the default', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton to="/activity" activeClassName="bdl-bdl-is-selected">
+                    <NavButton to="/activity" activeClassName="bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
             expect(button.hasClass('bdl-is-active')).toBe(false);
-            expect(button.hasClass('bdl-bdl-is-selected')).toBe(true);
+            expect(button.hasClass('bdl-is-selected')).toBe(true);
         });
     });
 
@@ -43,14 +43,14 @@ describe('elements/common/nav-button/NavButton', () => {
         test('does not apply its activeClassName', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton to="/details" activeClassName="bdl-bdl-is-selected">
+                    <NavButton to="/details" activeClassName="bdl-is-selected">
                         Details
                     </NavButton>
                 </MemoryRouter>,
             );
 
             expect(button.hasClass('bdl-is-active')).toBe(false);
-            expect(button.hasClass('bdl-bdl-is-selected')).toBe(false);
+            expect(button.hasClass('bdl-is-selected')).toBe(false);
         });
     });
 
@@ -92,25 +92,25 @@ describe('elements/common/nav-button/NavButton', () => {
         test('applies custom activeClassName for exact matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton exact to="/activity" activeClassName="bdl-bdl-is-selected">
+                    <NavButton exact to="/activity" activeClassName="bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-bdl-is-selected')).toBe(true);
+            expect(button.hasClass('bdl-is-selected')).toBe(true);
         });
 
         test('applies custom activeClassName for partial matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity/versions']}>
-                    <NavButton exact to="/activity" activeClassName="bdl-bdl-is-selected">
+                    <NavButton exact to="/activity" activeClassName="bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-bdl-is-selected')).toBe(false);
+            expect(button.hasClass('bdl-is-selected')).toBe(false);
         });
     });
 
@@ -166,25 +166,25 @@ describe('elements/common/nav-button/NavButton', () => {
         test('applies custom activeClassName for strict matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity/']}>
-                    <NavButton strict to="/activity/" activeClassName="bdl-bdl-is-selected">
+                    <NavButton strict to="/activity/" activeClassName="bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-bdl-is-selected')).toBe(true);
+            expect(button.hasClass('bdl-is-selected')).toBe(true);
         });
 
         test('does not apply custom activeClassName for non-strict matches', () => {
             const button = render(
                 <MemoryRouter initialEntries={['/activity']}>
-                    <NavButton strict to="/activity/" activeClassName="bdl-bdl-is-selected">
+                    <NavButton strict to="/activity/" activeClassName="bdl-is-selected">
                         Activity
                     </NavButton>
                 </MemoryRouter>,
             );
 
-            expect(button.hasClass('bdl-bdl-is-selected')).toBe(false);
+            expect(button.hasClass('bdl-is-selected')).toBe(false);
         });
     });
 

--- a/src/elements/common/nav-button/__tests__/__snapshots__/BackButton.test.js.snap
+++ b/src/elements/common/nav-button/__tests__/__snapshots__/BackButton.test.js.snap
@@ -9,7 +9,7 @@ exports[`elements/common/nav-button/BackButton should match its snapshot 1`] = `
       type="button"
     >
       <button
-        className="btn-plain bdl-BackButton"
+        className="bdl-Button--plain bdl-BackButton"
         onClick={[Function]}
         type="button"
       >

--- a/src/elements/common/nav-button/__tests__/__snapshots__/BackButton.test.js.snap
+++ b/src/elements/common/nav-button/__tests__/__snapshots__/BackButton.test.js.snap
@@ -9,7 +9,7 @@ exports[`elements/common/nav-button/BackButton should match its snapshot 1`] = `
       type="button"
     >
       <button
-        className="bdl-Button--plain bdl-BackButton"
+        className="bdl-PlainButton bdl-BackButton"
         onClick={[Function]}
         type="button"
       >

--- a/src/elements/common/sub-header/AddButton.scss
+++ b/src/elements/common/sub-header/AddButton.scss
@@ -1,4 +1,4 @@
-.btn.be-btn-add {
+.bdl-Button.be-btn-add {
     margin-left: 7px;
     padding: 5px 6px;
 

--- a/src/elements/common/sub-header/SortButton.scss
+++ b/src/elements/common/sub-header/SortButton.scss
@@ -1,4 +1,4 @@
-.btn.be-btn-sort {
+.bdl-Button.be-btn-sort {
     padding: 7px 6px;
 
     .bce:not(.be-is-small) & {

--- a/src/elements/content-explorer/Footer.scss
+++ b/src/elements/content-explorer/Footer.scss
@@ -15,7 +15,7 @@
         flex-basis: 0;
     }
 
-    .btn-group {
+    .bdl-ButtonGroup {
         margin-right: 5px;
         margin-left: 5px;
     }

--- a/src/elements/content-explorer/ItemList.scss
+++ b/src/elements/content-explorer/ItemList.scss
@@ -43,7 +43,7 @@
         }
 
         .bce-item-coloumn,
-        .be & .bdl-Button--plain {
+        .be & .bdl-PlainButton {
             color: $dark-cerulean;
             outline: none;
         }
@@ -58,7 +58,7 @@
         }
 
         .bce-item-coloumn,
-        .be & .bdl-Button--plain {
+        .be & .bdl-PlainButton {
             color: $dark-cerulean;
         }
     }

--- a/src/elements/content-explorer/ItemList.scss
+++ b/src/elements/content-explorer/ItemList.scss
@@ -22,7 +22,7 @@
     .bce-more-options {
         opacity: 0;
 
-        .btn {
+        .bdl-Button {
             margin-left: 8px;
             background-color: transparent;
         }
@@ -43,7 +43,7 @@
         }
 
         .bce-item-coloumn,
-        .be & .btn-plain {
+        .be & .bdl-Button--plain {
             color: $dark-cerulean;
             outline: none;
         }
@@ -58,7 +58,7 @@
         }
 
         .bce-item-coloumn,
-        .be & .btn-plain {
+        .be & .bdl-Button--plain {
             color: $dark-cerulean;
         }
     }

--- a/src/elements/content-explorer/MoreOptionsCell.scss
+++ b/src/elements/content-explorer/MoreOptionsCell.scss
@@ -1,3 +1,3 @@
-.btn.bce-btn-more-options {
+.bdl-Button.bce-btn-more-options {
     letter-spacing: 1.5px;
 }

--- a/src/elements/content-open-with/ContentOpenWith.scss
+++ b/src/elements/content-open-with/ContentOpenWith.scss
@@ -3,7 +3,7 @@
 .be.bcow {
     font-family: $font;
 
-    .btn {
+    .bdl-Button {
         padding: 3px 13px 3px 10px;
     }
 

--- a/src/elements/content-open-with/ContentOpenWith.scss
+++ b/src/elements/content-open-with/ContentOpenWith.scss
@@ -7,7 +7,7 @@
         padding: 3px 13px 3px 10px;
     }
 
-    .btn-content {
+    .bdl-Button-content {
         display: flex;
         align-items: center;
     }

--- a/src/elements/content-picker/Footer.scss
+++ b/src/elements/content-picker/Footer.scss
@@ -47,7 +47,7 @@
             border-right: 0;
         }
 
-        .bdl-Button--primary svg {
+        .bdl-PrimaryButton svg {
             fill: #fff;
         }
     }

--- a/src/elements/content-picker/Footer.scss
+++ b/src/elements/content-picker/Footer.scss
@@ -47,7 +47,7 @@
             border-right: 0;
         }
 
-        .bdl-PrimaryButton svg {
+        .bdl-Button--primary svg {
             fill: #fff;
         }
     }

--- a/src/elements/content-picker/Footer.scss
+++ b/src/elements/content-picker/Footer.scss
@@ -18,7 +18,7 @@
         max-width: 100%;
         margin: 0;
 
-        .btn-content {
+        .bdl-Button-content {
             display: inline-block;
             width: 100%;
             overflow: hidden;

--- a/src/elements/content-picker/Footer.scss
+++ b/src/elements/content-picker/Footer.scss
@@ -37,17 +37,17 @@
     }
 
     .bcp-footer-actions {
-        .btn {
+        .bdl-Button {
             width: 40px;
             height: 32px;
             padding: 0;
         }
 
-        .btn:first-child {
+        .bdl-Button:first-child {
             border-right: 0;
         }
 
-        .btn-primary svg {
+        .bdl-Button--primary svg {
             fill: #fff;
         }
     }
@@ -57,7 +57,7 @@
         flex: 1 0 auto;
     }
 
-    .btn-group {
+    .bdl-ButtonGroup {
         margin-right: 5px;
         margin-left: 5px;
     }

--- a/src/elements/content-picker/ItemList.scss
+++ b/src/elements/content-picker/ItemList.scss
@@ -20,7 +20,7 @@
         background-color: $light-blue;
         border-top-color: $grey-blue;
 
-        .be & .btn-plain,
+        .be & .bdl-Button--plain,
         .be-item-label {
             color: $dark-cerulean;
             outline: none;
@@ -84,7 +84,7 @@
             }
         }
 
-        .be & .btn-plain,
+        .be & .bdl-Button--plain,
         .be-item-label {
             color: $dark-cerulean;
         }

--- a/src/elements/content-picker/ItemList.scss
+++ b/src/elements/content-picker/ItemList.scss
@@ -20,7 +20,7 @@
         background-color: $light-blue;
         border-top-color: $grey-blue;
 
-        .be & .bdl-Button--plain,
+        .be & .bdl-PlainButton,
         .be-item-label {
             color: $dark-cerulean;
             outline: none;
@@ -84,7 +84,7 @@
             }
         }
 
-        .be & .bdl-Button--plain,
+        .be & .bdl-PlainButton,
         .be-item-label {
             color: $dark-cerulean;
         }

--- a/src/elements/content-preview/__tests__/__snapshots__/PreviewNavigation.test.js.snap
+++ b/src/elements/content-preview/__tests__/__snapshots__/PreviewNavigation.test.js.snap
@@ -133,7 +133,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="bdl-Button--plain bcpr-navigate-right"
+            className="bdl-PlainButton bcpr-navigate-right"
             onClick={[Function]}
             type="button"
           >
@@ -318,7 +318,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="bdl-Button--plain bcpr-navigate-left"
+            className="bdl-PlainButton bcpr-navigate-left"
             onClick={[Function]}
             type="button"
           >
@@ -360,7 +360,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="bdl-Button--plain bcpr-navigate-right"
+            className="bdl-PlainButton bcpr-navigate-right"
             onClick={[Function]}
             type="button"
           >
@@ -535,7 +535,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="bdl-Button--plain bcpr-navigate-left"
+            className="bdl-PlainButton bcpr-navigate-left"
             onClick={[Function]}
             type="button"
           >

--- a/src/elements/content-preview/__tests__/__snapshots__/PreviewNavigation.test.js.snap
+++ b/src/elements/content-preview/__tests__/__snapshots__/PreviewNavigation.test.js.snap
@@ -133,7 +133,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="btn-plain bcpr-navigate-right"
+            className="bdl-Button--plain bcpr-navigate-right"
             onClick={[Function]}
             type="button"
           >
@@ -318,7 +318,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="btn-plain bcpr-navigate-left"
+            className="bdl-Button--plain bcpr-navigate-left"
             onClick={[Function]}
             type="button"
           >
@@ -360,7 +360,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="btn-plain bcpr-navigate-right"
+            className="bdl-Button--plain bcpr-navigate-right"
             onClick={[Function]}
             type="button"
           >
@@ -535,7 +535,7 @@ exports[`elements/content-preview/PreviewNavigation render() should render corre
           type="button"
         >
           <button
-            className="btn-plain bcpr-navigate-left"
+            className="bdl-Button--plain bcpr-navigate-left"
             onClick={[Function]}
             type="button"
           >

--- a/src/elements/content-preview/preview-header/PreviewHeader.scss
+++ b/src/elements/content-preview/preview-header/PreviewHeader.scss
@@ -98,7 +98,7 @@
     }
 }
 
-.bcpr-PreviewHeader-button.bdl-Button--plain {
+.bcpr-PreviewHeader-button.bdl-PlainButton {
     display: flex;
     align-items: center;
     padding: 5px 10px;
@@ -114,7 +114,7 @@
     }
 }
 
-.bcpr-PreviewHeader-button-close.bdl-Button--plain {
+.bcpr-PreviewHeader-button-close.bdl-PlainButton {
     font-weight: bold;
 
     .icon-close {

--- a/src/elements/content-preview/preview-header/PreviewHeader.scss
+++ b/src/elements/content-preview/preview-header/PreviewHeader.scss
@@ -61,8 +61,8 @@
         .ba-btn-annotate-draw-undo,
         button.ba-btn-annotate-draw-redo,
         button.ba-btn-annotate-draw-undo,
-        .is-disabled.ba-btn-annotate-draw-redo,
-        .is-disabled.ba-btn-annotate-draw-undo {
+        .bdl-is-disabled.ba-btn-annotate-draw-redo,
+        .bdl-is-disabled.ba-btn-annotate-draw-undo {
             margin: 5px;
             background: none;
             border: none;
@@ -98,7 +98,7 @@
     }
 }
 
-.bcpr-PreviewHeader-button.btn-plain {
+.bcpr-PreviewHeader-button.bdl-Button--plain {
     display: flex;
     align-items: center;
     padding: 5px 10px;
@@ -114,7 +114,7 @@
     }
 }
 
-.bcpr-PreviewHeader-button-close.btn-plain {
+.bcpr-PreviewHeader-button-close.bdl-Button--plain {
     font-weight: bold;
 
     .icon-close {

--- a/src/elements/content-sidebar/SidebarNav.scss
+++ b/src/elements/content-sidebar/SidebarNav.scss
@@ -54,8 +54,8 @@
         align-items: center;
         justify-content: center;
 
-        // Need to add these overriding styles because there is a specificity issue with .btn-plain
-        .btn-plain.bdl-SidebarToggleButton {
+        // Need to add these overriding styles because there is a specificity issue with .bdl-Button--plain
+        .bdl-Button--plain.bdl-SidebarToggleButton {
             height: 24px;
             margin: 0 3px;
             padding: 4px;

--- a/src/elements/content-sidebar/SidebarNav.scss
+++ b/src/elements/content-sidebar/SidebarNav.scss
@@ -54,8 +54,8 @@
         align-items: center;
         justify-content: center;
 
-        // Need to add these overriding styles because there is a specificity issue with .bdl-Button--plain
-        .bdl-Button--plain.bdl-SidebarToggleButton {
+        // Need to add these overriding styles because there is a specificity issue with .bdl-PlainButton
+        .bdl-PlainButton.bdl-SidebarToggleButton {
             height: 24px;
             margin: 0 3px;
             padding: 4px;

--- a/src/elements/content-sidebar/SidebarNavButton.js
+++ b/src/elements/content-sidebar/SidebarNavButton.js
@@ -45,10 +45,10 @@ const SidebarNavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, 
                 return (
                     <Tooltip position="middle-left" text={tooltip} isTabbable={false}>
                         <NavButton
-                            activeClassName="bdl-is-selected"
+                            activeClassName="bcs-is-selected"
                             aria-selected={isActiveValue}
                             aria-controls={`${id}-content`}
-                            className="bcs-NavButton"
+                            className="bdl-NavButton"
                             data-resin-target={dataResinTarget}
                             data-testid={dataTestId}
                             getDOMRef={ref}

--- a/src/elements/content-sidebar/SidebarNavButton.js
+++ b/src/elements/content-sidebar/SidebarNavButton.js
@@ -45,7 +45,7 @@ const SidebarNavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, 
                 return (
                     <Tooltip position="middle-left" text={tooltip} isTabbable={false}>
                         <NavButton
-                            activeClassName="bcs-is-selected"
+                            activeClassName="bcs-bdl-is-selected"
                             aria-selected={isActiveValue}
                             aria-controls={`${id}-content`}
                             className="bcs-NavButton"

--- a/src/elements/content-sidebar/SidebarNavButton.js
+++ b/src/elements/content-sidebar/SidebarNavButton.js
@@ -45,7 +45,7 @@ const SidebarNavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, 
                 return (
                     <Tooltip position="middle-left" text={tooltip} isTabbable={false}>
                         <NavButton
-                            activeClassName="bcs-bdl-is-selected"
+                            activeClassName="bdl-is-selected"
                             aria-selected={isActiveValue}
                             aria-controls={`${id}-content`}
                             className="bcs-NavButton"

--- a/src/elements/content-sidebar/SidebarNavButton.scss
+++ b/src/elements/content-sidebar/SidebarNavButton.scss
@@ -15,7 +15,7 @@
         pointer-events: none;
     }
 
-    &.bcs-bdl-is-selected {
+    &.bdl-is-selected {
         &::before {
             background-color: $blue;
         }
@@ -28,7 +28,7 @@
     &:hover {
         background-color: $bdl-gray-05;
 
-        &:not(.bcs-bdl-is-selected) svg .fill-color {
+        &:not(.bdl-is-selected) svg .fill-color {
             fill: $bdl-gray-80;
         }
     }

--- a/src/elements/content-sidebar/SidebarNavButton.scss
+++ b/src/elements/content-sidebar/SidebarNavButton.scss
@@ -15,7 +15,7 @@
         pointer-events: none;
     }
 
-    &.bcs-is-selected {
+    &.bcs-bdl-is-selected {
         &::before {
             background-color: $blue;
         }
@@ -28,7 +28,7 @@
     &:hover {
         background-color: $bdl-gray-05;
 
-        &:not(.bcs-is-selected) svg .fill-color {
+        &:not(.bcs-bdl-is-selected) svg .fill-color {
             fill: $bdl-gray-80;
         }
     }

--- a/src/elements/content-sidebar/SidebarNavButton.scss
+++ b/src/elements/content-sidebar/SidebarNavButton.scss
@@ -1,7 +1,7 @@
 @import '../common/variables';
 @import './mixins';
 
-.bcs .bcs-NavButton {
+.bcs .bdl-NavButton {
     @include bdl-SidebarNavButton;
 
     &::before {
@@ -15,7 +15,7 @@
         pointer-events: none;
     }
 
-    &.bdl-is-selected {
+    &.bcs-is-selected {
         &::before {
             background-color: $blue;
         }
@@ -28,7 +28,7 @@
     &:hover {
         background-color: $bdl-gray-05;
 
-        &:not(.bdl-is-selected) svg .fill-color {
+        &:not(.bcs-is-selected) svg .fill-color {
             fill: $bdl-gray-80;
         }
     }

--- a/src/elements/content-sidebar/SidebarSection.scss
+++ b/src/elements/content-sidebar/SidebarSection.scss
@@ -8,7 +8,7 @@
     margin: 0 8px 20px 25px;
 }
 
-.be .btn-plain.bcs-section-title {
+.be .bdl-Button--plain.bcs-section-title {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -33,6 +33,6 @@
     }
 }
 
-.be .bcs-section-open .btn-plain.bcs-section-title .icon-caret-down {
+.be .bcs-section-open .bdl-Button--plain.bcs-section-title .icon-caret-down {
     transform: rotateZ(180deg);
 }

--- a/src/elements/content-sidebar/SidebarSection.scss
+++ b/src/elements/content-sidebar/SidebarSection.scss
@@ -8,7 +8,7 @@
     margin: 0 8px 20px 25px;
 }
 
-.be .bdl-Button--plain.bcs-section-title {
+.be .bdl-PlainButton.bcs-section-title {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -33,6 +33,6 @@
     }
 }
 
-.be .bcs-section-open .bdl-Button--plain.bcs-section-title .icon-caret-down {
+.be .bcs-section-open .bdl-PlainButton.bcs-section-title .icon-caret-down {
     transform: rotateZ(180deg);
 }

--- a/src/elements/content-sidebar/__tests__/SidebarNavButton.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNavButton.test.js
@@ -19,7 +19,7 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const button = getButton(wrapper);
 
         expect(wrapper.find(Tooltip).prop('text')).toBe('foo');
-        expect(button.hasClass('bcs-bdl-is-selected')).toBe(false);
+        expect(button.hasClass('bdl-is-selected')).toBe(false);
     });
 
     test.each`
@@ -36,7 +36,7 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const wrapper = getWrapper(props, '/activity');
         const button = getButton(wrapper);
 
-        expect(button.hasClass('bcs-bdl-is-selected')).toBe(expected);
+        expect(button.hasClass('bdl-is-selected')).toBe(expected);
     });
 
     test.each`
@@ -50,6 +50,6 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const wrapper = getWrapper({ isOpen: true, sidebarView: 'activity' }, path);
         const button = getButton(wrapper);
 
-        expect(button.hasClass('bcs-bdl-is-selected')).toBe(expected);
+        expect(button.hasClass('bdl-is-selected')).toBe(expected);
     });
 });

--- a/src/elements/content-sidebar/__tests__/SidebarNavButton.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNavButton.test.js
@@ -19,7 +19,7 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const button = getButton(wrapper);
 
         expect(wrapper.find(Tooltip).prop('text')).toBe('foo');
-        expect(button.hasClass('bcs-is-selected')).toBe(false);
+        expect(button.hasClass('bcs-bdl-is-selected')).toBe(false);
     });
 
     test.each`
@@ -36,7 +36,7 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const wrapper = getWrapper(props, '/activity');
         const button = getButton(wrapper);
 
-        expect(button.hasClass('bcs-is-selected')).toBe(expected);
+        expect(button.hasClass('bcs-bdl-is-selected')).toBe(expected);
     });
 
     test.each`
@@ -50,6 +50,6 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const wrapper = getWrapper({ isOpen: true, sidebarView: 'activity' }, path);
         const button = getButton(wrapper);
 
-        expect(button.hasClass('bcs-is-selected')).toBe(expected);
+        expect(button.hasClass('bcs-bdl-is-selected')).toBe(expected);
     });
 });

--- a/src/elements/content-sidebar/__tests__/SidebarNavButton.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNavButton.test.js
@@ -19,7 +19,7 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const button = getButton(wrapper);
 
         expect(wrapper.find(Tooltip).prop('text')).toBe('foo');
-        expect(button.hasClass('bdl-is-selected')).toBe(false);
+        expect(button.hasClass('bcs-is-selected')).toBe(false);
     });
 
     test.each`
@@ -36,7 +36,7 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const wrapper = getWrapper(props, '/activity');
         const button = getButton(wrapper);
 
-        expect(button.hasClass('bdl-is-selected')).toBe(expected);
+        expect(button.hasClass('bcs-is-selected')).toBe(expected);
     });
 
     test.each`
@@ -50,6 +50,6 @@ describe('elements/content-sidebar/SidebarNavButton', () => {
         const wrapper = getWrapper({ isOpen: true, sidebarView: 'activity' }, path);
         const button = getButton(wrapper);
 
-        expect(button.hasClass('bdl-is-selected')).toBe(expected);
+        expect(button.hasClass('bcs-is-selected')).toBe(expected);
     });
 });

--- a/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties.test.js.snap
@@ -143,7 +143,7 @@ exports[`elements/content-sidebar/SidebarFileProperties render() should render r
                 onClick={[MockFunction]}
               >
                 <button
-                  className="btn-plain lnk"
+                  className="bdl-Button--plain lnk"
                   onClick={[MockFunction]}
                   type="submit"
                 >

--- a/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/SidebarFileProperties.test.js.snap
@@ -143,7 +143,7 @@ exports[`elements/content-sidebar/SidebarFileProperties render() should render r
                 onClick={[MockFunction]}
               >
                 <button
-                  className="bdl-Button--plain lnk"
+                  className="bdl-PlainButton lnk"
                   onClick={[MockFunction]}
                   type="submit"
                 >

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -95,7 +95,9 @@ const ActiveState = ({
                         return (
                             <li
                                 key={item.type + item.id}
-                                className={classNames('bcs-activity-feed-task-new', { 'bcs-is-focused': isFocused })}
+                                className={classNames('bcs-activity-feed-task-new', {
+                                    'bcs-is-focused': isFocused,
+                                })}
                                 data-testid="task"
                                 ref={refValue}
                             >

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
@@ -44,11 +44,11 @@
         margin-top: 20px;
         text-align: right;
 
-        .btn {
+        .bdl-Button {
             margin: 0;
         }
 
-        .btn:last-child {
+        .bdl-Button:last-child {
             margin-left: 10px;
         }
     }

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
@@ -50,7 +50,7 @@ $assignee-dropdown-height: 215px;
             margin-bottom: 15px;
         }
 
-        input.bdl-PillSelector-hiddenInput {
+        input.bdl-PillSelector-input--hidden {
             width: 1px;
         }
 

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
@@ -54,11 +54,11 @@ $assignee-dropdown-height: 215px;
             width: 1px;
         }
 
-        .bdl-PillSelector-wrapper {
+        .bdl-PillSelectorWrapper {
             width: 100%;
             margin-left: 0;
 
-            .bdl-PillSelector-inputWrapper {
+            .bdl-PillSelector {
                 width: auto;
             }
 

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
@@ -50,15 +50,15 @@ $assignee-dropdown-height: 215px;
             margin-bottom: 15px;
         }
 
-        input.pill-selector-hidden-input {
+        input.bdl-PillSelector-hiddenInput {
             width: 1px;
         }
 
-        .pill-selector-wrapper {
+        .bdl-PillSelector-wrapper {
             width: 100%;
             margin-left: 0;
 
-            .pill-selector-input-wrapper {
+            .bdl-PillSelector-inputWrapper {
                 width: auto;
             }
 

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss
@@ -9,13 +9,13 @@ $assignee-dropdown-height: 215px;
         display: block;
         text-align: right;
 
-        .btn {
+        .bdl-Button {
             margin-top: 0;
             margin-right: 0;
             margin-bottom: 10px;
         }
 
-        .btn:last-child {
+        .bdl-Button:last-child {
             margin-left: 10px;
         }
     }

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskForm.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskForm.test.js.snap
@@ -28,7 +28,7 @@ exports[`components/ContentSidebar/ActivityFeed/task-form/TaskForm addResinInfo(
     type="button"
   >
     <button
-      className="btn bcs-task-input-cancel-btn"
+      className="bdl-Button bcs-task-input-cancel-btn"
       data-resin-assigneesadded={
         Array [
           456,
@@ -84,7 +84,7 @@ exports[`components/ContentSidebar/ActivityFeed/task-form/TaskForm addResinInfo(
     isLoading={false}
   >
     <Button
-      className="btn-primary bcs-task-input-submit-btn"
+      className="bdl-PrimaryButton bcs-task-input-submit-btn"
       data-resin-assigneesadded={
         Array [
           456,
@@ -106,7 +106,7 @@ exports[`components/ContentSidebar/ActivityFeed/task-form/TaskForm addResinInfo(
       isLoading={false}
     >
       <button
-        className="btn btn-primary bcs-task-input-submit-btn"
+        className="bdl-Button bdl-PrimaryButton bcs-task-input-submit-btn"
         data-resin-assigneesadded={
           Array [
             456,

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskForm.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskForm.test.js.snap
@@ -84,7 +84,7 @@ exports[`components/ContentSidebar/ActivityFeed/task-form/TaskForm addResinInfo(
     isLoading={false}
   >
     <Button
-      className="bdl-PrimaryButton bcs-task-input-submit-btn"
+      className="bdl-Button--primary bcs-task-input-submit-btn"
       data-resin-assigneesadded={
         Array [
           456,
@@ -106,7 +106,7 @@ exports[`components/ContentSidebar/ActivityFeed/task-form/TaskForm addResinInfo(
       isLoading={false}
     >
       <button
-        className="bdl-Button bdl-PrimaryButton bcs-task-input-submit-btn"
+        className="bdl-Button bdl-Button--primary bcs-task-input-submit-btn"
         data-resin-assigneesadded={
           Array [
             456,

--- a/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskForm.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-form/__tests__/__snapshots__/TaskForm.test.js.snap
@@ -50,7 +50,7 @@ exports[`components/ContentSidebar/ActivityFeed/task-form/TaskForm addResinInfo(
       type="button"
     >
       <span
-        className="btn-content"
+        className="bdl-Button-content"
       >
         <FormattedMessage
           defaultMessage="Cancel"
@@ -128,7 +128,7 @@ exports[`components/ContentSidebar/ActivityFeed/task-form/TaskForm addResinInfo(
         type="submit"
       >
         <span
-          className="btn-content"
+          className="bdl-Button-content"
         >
           <FormattedMessage
             defaultMessage="Update"

--- a/src/elements/content-sidebar/activity-feed/task-form/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/messages.js
@@ -35,32 +35,32 @@ const messages = defineMessages({
     tasksAddTaskFormSelectAssigneesLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSelectAssigneesLabel',
         defaultMessage: 'Select Assignees',
-        description: 'label for task create form assignee input',
+        description: 'label bdl-Label for task create form assignee input',
     },
     tasksAddTaskFormMessageLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormMessageLabel',
         defaultMessage: 'Message',
-        description: 'label for task create form message input',
+        description: 'label bdl-Label for task create form message input',
     },
     tasksAddTaskFormDueDateLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormDueDateLabel',
         defaultMessage: 'Due Date',
-        description: 'label for task create form due date input',
+        description: 'label bdl-Label for task create form due date input',
     },
     tasksAddTaskFormSubmitLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSubmitLabel',
         defaultMessage: 'Create',
-        description: 'label for create button in create task modal in create mode',
+        description: 'label bdl-Label for create button in create task modal in create mode',
     },
     tasksEditTaskFormSubmitLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksEditTaskFormSubmitLabel',
         defaultMessage: 'Update',
-        description: 'label for edit button in create task modal in edit mode',
+        description: 'label bdl-Label for edit button in create task modal in edit mode',
     },
     tasksAddTaskFormCancelLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormCancelLabel',
         defaultMessage: 'Cancel',
-        description: 'label for cancel button in create task popup',
+        description: 'label bdl-Label for cancel button in create task popup',
     },
     taskAnyCheckboxLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.taskAnyCheckboxLabel',

--- a/src/elements/content-sidebar/activity-feed/task-form/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/messages.js
@@ -35,32 +35,32 @@ const messages = defineMessages({
     tasksAddTaskFormSelectAssigneesLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSelectAssigneesLabel',
         defaultMessage: 'Select Assignees',
-        description: 'label bdl-Label for task create form assignee input',
+        description: 'bdl-Label for task create form assignee input',
     },
     tasksAddTaskFormMessageLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormMessageLabel',
         defaultMessage: 'Message',
-        description: 'label bdl-Label for task create form message input',
+        description: 'bdl-Label for task create form message input',
     },
     tasksAddTaskFormDueDateLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormDueDateLabel',
         defaultMessage: 'Due Date',
-        description: 'label bdl-Label for task create form due date input',
+        description: 'bdl-Label for task create form due date input',
     },
     tasksAddTaskFormSubmitLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSubmitLabel',
         defaultMessage: 'Create',
-        description: 'label bdl-Label for create button in create task modal in create mode',
+        description: 'bdl-Label for create button in create task modal in create mode',
     },
     tasksEditTaskFormSubmitLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksEditTaskFormSubmitLabel',
         defaultMessage: 'Update',
-        description: 'label bdl-Label for edit button in create task modal in edit mode',
+        description: 'bdl-Label for edit button in create task modal in edit mode',
     },
     tasksAddTaskFormCancelLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormCancelLabel',
         defaultMessage: 'Cancel',
-        description: 'label bdl-Label for cancel button in create task popup',
+        description: 'bdl-Label for cancel button in create task popup',
     },
     taskAnyCheckboxLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.taskAnyCheckboxLabel',

--- a/src/elements/content-sidebar/activity-feed/task-form/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/messages.js
@@ -35,32 +35,32 @@ const messages = defineMessages({
     tasksAddTaskFormSelectAssigneesLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSelectAssigneesLabel',
         defaultMessage: 'Select Assignees',
-        description: 'bdl-Label for task create form assignee input',
+        description: 'label for task create form assignee input',
     },
     tasksAddTaskFormMessageLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormMessageLabel',
         defaultMessage: 'Message',
-        description: 'bdl-Label for task create form message input',
+        description: 'label for task create form message input',
     },
     tasksAddTaskFormDueDateLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormDueDateLabel',
         defaultMessage: 'Due Date',
-        description: 'bdl-Label for task create form due date input',
+        description: 'label for task create form due date input',
     },
     tasksAddTaskFormSubmitLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormSubmitLabel',
         defaultMessage: 'Create',
-        description: 'bdl-Label for create button in create task modal in create mode',
+        description: 'label for create button in create task modal in create mode',
     },
     tasksEditTaskFormSubmitLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksEditTaskFormSubmitLabel',
         defaultMessage: 'Update',
-        description: 'bdl-Label for edit button in create task modal in edit mode',
+        description: 'label for edit button in create task modal in edit mode',
     },
     tasksAddTaskFormCancelLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.tasksAddTaskFormCancelLabel',
         defaultMessage: 'Cancel',
-        description: 'bdl-Label for cancel button in create task popup',
+        description: 'label for cancel button in create task popup',
     },
     taskAnyCheckboxLabel: {
         id: 'be.contentSidebar.activityFeed.taskForm.taskAnyCheckboxLabel',

--- a/src/elements/content-sidebar/messages.js
+++ b/src/elements/content-sidebar/messages.js
@@ -10,12 +10,12 @@ const messages = defineMessages({
     tasksAddTask: {
         id: 'be.contentSidebar.addTask',
         defaultMessage: 'Add Task',
-        description: 'label for button that opens task popup',
+        description: 'label bdl-Label for button that opens task popup',
     },
     taskAddTaskGeneral: {
         id: 'be.contentSidebar.addTask.general',
         defaultMessage: 'General Task',
-        description: 'label for menu item that opens general task popup',
+        description: 'label bdl-Label for menu item that opens general task popup',
     },
     taskAddTaskGeneralDescription: {
         id: 'be.contentSidebar.addTask.general.description',
@@ -25,7 +25,7 @@ const messages = defineMessages({
     taskAddTaskApproval: {
         id: 'be.contentSidebar.addTask.approval',
         defaultMessage: 'Approval Task',
-        description: 'label for menu item that opens approval task popup',
+        description: 'label bdl-Label for menu item that opens approval task popup',
     },
     taskAddTaskApprovalDescription: {
         id: 'be.contentSidebar.addTask.approval.description',

--- a/src/elements/content-sidebar/messages.js
+++ b/src/elements/content-sidebar/messages.js
@@ -10,12 +10,12 @@ const messages = defineMessages({
     tasksAddTask: {
         id: 'be.contentSidebar.addTask',
         defaultMessage: 'Add Task',
-        description: 'label bdl-Label for button that opens task popup',
+        description: 'bdl-Label for button that opens task popup',
     },
     taskAddTaskGeneral: {
         id: 'be.contentSidebar.addTask.general',
         defaultMessage: 'General Task',
-        description: 'label bdl-Label for menu item that opens general task popup',
+        description: 'bdl-Label for menu item that opens general task popup',
     },
     taskAddTaskGeneralDescription: {
         id: 'be.contentSidebar.addTask.general.description',
@@ -25,7 +25,7 @@ const messages = defineMessages({
     taskAddTaskApproval: {
         id: 'be.contentSidebar.addTask.approval',
         defaultMessage: 'Approval Task',
-        description: 'label bdl-Label for menu item that opens approval task popup',
+        description: 'bdl-Label for menu item that opens approval task popup',
     },
     taskAddTaskApprovalDescription: {
         id: 'be.contentSidebar.addTask.approval.description',

--- a/src/elements/content-sidebar/messages.js
+++ b/src/elements/content-sidebar/messages.js
@@ -10,12 +10,12 @@ const messages = defineMessages({
     tasksAddTask: {
         id: 'be.contentSidebar.addTask',
         defaultMessage: 'Add Task',
-        description: 'bdl-Label for button that opens task popup',
+        description: 'label for button that opens task popup',
     },
     taskAddTaskGeneral: {
         id: 'be.contentSidebar.addTask.general',
         defaultMessage: 'General Task',
-        description: 'bdl-Label for menu item that opens general task popup',
+        description: 'label for menu item that opens general task popup',
     },
     taskAddTaskGeneralDescription: {
         id: 'be.contentSidebar.addTask.general.description',
@@ -25,7 +25,7 @@ const messages = defineMessages({
     taskAddTaskApproval: {
         id: 'be.contentSidebar.addTask.approval',
         defaultMessage: 'Approval Task',
-        description: 'bdl-Label for menu item that opens approval task popup',
+        description: 'label for menu item that opens approval task popup',
     },
     taskAddTaskApprovalDescription: {
         id: 'be.contentSidebar.addTask.approval.description',

--- a/src/elements/content-sidebar/skills/faces/Face.scss
+++ b/src/elements/content-sidebar/skills/faces/Face.scss
@@ -7,7 +7,7 @@
         margin: 0 10px 10px 0;
     }
 
-    .btn-plain.be-face {
+    .bdl-Button--plain.be-face {
         overflow: hidden;
         border-radius: 100%;
 
@@ -38,12 +38,12 @@
         }
     }
 
-    .be-face-unselected .btn-plain.be-face img {
+    .be-face-unselected .bdl-Button--plain.be-face img {
         opacity: .4;
         filter: none;
     }
 
-    .btn-plain.be-face-delete {
+    .bdl-Button--plain.be-face-delete {
         position: absolute;
         top: -3px;
         right: -5px;
@@ -56,7 +56,7 @@
     }
 
     &.be-faces-is-editing {
-        .btn-plain.be-face:hover img {
+        .bdl-Button--plain.be-face:hover img {
             transform: none;
             cursor: default;
         }

--- a/src/elements/content-sidebar/skills/faces/Face.scss
+++ b/src/elements/content-sidebar/skills/faces/Face.scss
@@ -7,7 +7,7 @@
         margin: 0 10px 10px 0;
     }
 
-    .bdl-Button--plain.be-face {
+    .bdl-PlainButton.be-face {
         overflow: hidden;
         border-radius: 100%;
 
@@ -38,12 +38,12 @@
         }
     }
 
-    .be-face-unselected .bdl-Button--plain.be-face img {
+    .be-face-unselected .bdl-PlainButton.be-face img {
         opacity: .4;
         filter: none;
     }
 
-    .bdl-Button--plain.be-face-delete {
+    .bdl-PlainButton.be-face-delete {
         position: absolute;
         top: -3px;
         right: -5px;
@@ -56,7 +56,7 @@
     }
 
     &.be-faces-is-editing {
-        .bdl-Button--plain.be-face:hover img {
+        .bdl-PlainButton.be-face:hover img {
             transform: none;
             cursor: default;
         }

--- a/src/elements/content-sidebar/skills/faces/Faces.scss
+++ b/src/elements/content-sidebar/skills/faces/Faces.scss
@@ -7,7 +7,7 @@
         margin: 0 0 20px;
     }
 
-    .bdl-Button--plain.be-face-edit {
+    .bdl-PlainButton.be-face-edit {
         position: absolute;
         top: -46px;
         right: 15px;

--- a/src/elements/content-sidebar/skills/faces/Faces.scss
+++ b/src/elements/content-sidebar/skills/faces/Faces.scss
@@ -7,7 +7,7 @@
         margin: 0 0 20px;
     }
 
-    .btn-plain.be-face-edit {
+    .bdl-Button--plain.be-face-edit {
         position: absolute;
         top: -46px;
         right: 15px;

--- a/src/elements/content-sidebar/skills/keywords/EditableKeywords.js
+++ b/src/elements/content-sidebar/skills/keywords/EditableKeywords.js
@@ -154,7 +154,7 @@ class EditableKeywords extends React.PureComponent<Props, State> {
         const { onSave, onCancel }: Props = this.props;
         const { pills, keyword }: State = this.state;
         return (
-            <span className="bdl-PillSelector-wrapper">
+            <span className="bdl-PillSelectorWrapper">
                 <PillSelector
                     onBlur={this.onBlur}
                     onCompositionEnd={this.onCompositionEnd}

--- a/src/elements/content-sidebar/skills/keywords/EditableKeywords.js
+++ b/src/elements/content-sidebar/skills/keywords/EditableKeywords.js
@@ -154,7 +154,7 @@ class EditableKeywords extends React.PureComponent<Props, State> {
         const { onSave, onCancel }: Props = this.props;
         const { pills, keyword }: State = this.state;
         return (
-            <span className="pill-selector-wrapper">
+            <span className="bdl-PillSelector-wrapper">
                 <PillSelector
                     onBlur={this.onBlur}
                     onCompositionEnd={this.onCompositionEnd}

--- a/src/elements/content-sidebar/skills/keywords/EditableKeywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/EditableKeywords.scss
@@ -10,14 +10,14 @@
         }
     }
 
-    .pill-selector-wrapper {
+    .bdl-PillSelector-wrapper {
         margin: 0;
 
-        .pill-selector-input-wrapper {
+        .bdl-PillSelector-inputWrapper {
             width: 100%;
             margin: 0;
 
-            input[type='text'].pill-selector-input {
+            input[type='text'].bdl-PillSelector-input {
                 min-width: 97%;
                 height: 24px;
                 margin: 2px 0 0 2px;

--- a/src/elements/content-sidebar/skills/keywords/EditableKeywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/EditableKeywords.scss
@@ -10,10 +10,10 @@
         }
     }
 
-    .bdl-PillSelector-wrapper {
+    .bdl-PillSelectorWrapper {
         margin: 0;
 
-        .bdl-PillSelector-inputWrapper {
+        .bdl-PillSelector {
             width: 100%;
             margin: 0;
 

--- a/src/elements/content-sidebar/skills/keywords/EditableKeywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/EditableKeywords.scss
@@ -5,7 +5,7 @@
         margin: 7px -5px 0 0;
         text-align: right;
 
-        .btn {
+        .bdl-Button {
             margin: 0 0 0 5px;
         }
     }

--- a/src/elements/content-sidebar/skills/keywords/Keywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/Keywords.scss
@@ -3,7 +3,7 @@
 .be-keywords {
     position: relative;
 
-    .bdl-Button--plain.be-keyword-edit {
+    .bdl-PlainButton.be-keyword-edit {
         position: absolute;
         top: -46px;
         right: 15px;

--- a/src/elements/content-sidebar/skills/keywords/Keywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/Keywords.scss
@@ -3,7 +3,7 @@
 .be-keywords {
     position: relative;
 
-    .btn-plain.be-keyword-edit {
+    .bdl-Button--plain.be-keyword-edit {
         position: absolute;
         top: -46px;
         right: 15px;

--- a/src/elements/content-sidebar/skills/keywords/ReadOnlyKeywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/ReadOnlyKeywords.scss
@@ -12,7 +12,7 @@
             border: 1px solid $bdl-gray-20;
 
             &:hover,
-            &.bdl-is-selected {
+            &.bcs-is-selected {
                 color: $white;
                 background-color: $blue;
                 border-color: $blue;

--- a/src/elements/content-sidebar/skills/keywords/ReadOnlyKeywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/ReadOnlyKeywords.scss
@@ -6,7 +6,7 @@
         overflow: hidden;
         border: 0 none;
 
-        .btn.pill.pill-cloud-button {
+        .bdl-Button.bdl-Pill.pill-cloud-button {
             margin: 0 5px 5px 0;
             color: inherit;
             border: 1px solid $bdl-gray-20;

--- a/src/elements/content-sidebar/skills/keywords/ReadOnlyKeywords.scss
+++ b/src/elements/content-sidebar/skills/keywords/ReadOnlyKeywords.scss
@@ -1,18 +1,18 @@
 @import '../../../common/variables';
 
 .be-keywords {
-    .pill-cloud-container {
+    .bdl-PillCloud {
         padding: 0;
         overflow: hidden;
         border: 0 none;
 
-        .bdl-Button.bdl-Pill.pill-cloud-button {
+        .bdl-Button.bdl-Pill.bdl-PillCloud-button {
             margin: 0 5px 5px 0;
             color: inherit;
             border: 1px solid $bdl-gray-20;
 
             &:hover,
-            &.is-selected {
+            &.bdl-is-selected {
                 color: $white;
                 background-color: $blue;
                 border-color: $blue;

--- a/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/EditableKeywords.test.js.snap
+++ b/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/EditableKeywords.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`elements/content-sidebar/Skills/Keywords/EditableKeywords should correctly render 1`] = `
 <span
-  className="bdl-PillSelector-wrapper"
+  className="bdl-PillSelectorWrapper"
 >
   <PillSelector
     allowInvalidPills={false}

--- a/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/EditableKeywords.test.js.snap
+++ b/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/EditableKeywords.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`elements/content-sidebar/Skills/Keywords/EditableKeywords should correctly render 1`] = `
 <span
-  className="pill-selector-wrapper"
+  className="bdl-PillSelector-wrapper"
 >
   <PillSelector
     allowInvalidPills={false}

--- a/src/elements/content-sidebar/skills/timeline/Timeline.scss
+++ b/src/elements/content-sidebar/skills/timeline/Timeline.scss
@@ -37,7 +37,7 @@
             margin-left: 10px;
         }
 
-        .btn-plain:hover svg path {
+        .bdl-Button--plain:hover svg path {
             fill: $bdl-gray;
         }
     }

--- a/src/elements/content-sidebar/skills/timeline/Timeline.scss
+++ b/src/elements/content-sidebar/skills/timeline/Timeline.scss
@@ -37,7 +37,7 @@
             margin-left: 10px;
         }
 
-        .bdl-Button--plain:hover svg path {
+        .bdl-PlainButton:hover svg path {
             fill: $bdl-gray;
         }
     }

--- a/src/elements/content-sidebar/skills/timeline/Timeslice.scss
+++ b/src/elements/content-sidebar/skills/timeline/Timeslice.scss
@@ -1,6 +1,6 @@
 @import '../../../common/variables';
 
-.be .btn-plain.be-timeline-time {
+.be .bdl-Button--plain.be-timeline-time {
     position: absolute;
     height: 6px;
     background-color: $blue;

--- a/src/elements/content-sidebar/skills/timeline/Timeslice.scss
+++ b/src/elements/content-sidebar/skills/timeline/Timeslice.scss
@@ -1,6 +1,6 @@
 @import '../../../common/variables';
 
-.be .bdl-Button--plain.be-timeline-time {
+.be .bdl-PlainButton.be-timeline-time {
     position: absolute;
     height: 6px;
     background-color: $blue;

--- a/src/elements/content-sidebar/skills/transcript/EditingTranscriptRow.scss
+++ b/src/elements/content-sidebar/skills/transcript/EditingTranscriptRow.scss
@@ -5,7 +5,7 @@
         margin-top: 5px;
         text-align: right;
 
-        .btn {
+        .bdl-Button {
             margin: 0 0 0 5px;
         }
     }

--- a/src/elements/content-sidebar/skills/transcript/Transcript.scss
+++ b/src/elements/content-sidebar/skills/transcript/Transcript.scss
@@ -9,9 +9,9 @@
         right: 15px;
     }
 
-    .btn-plain.be-transcript-edit,
-    .btn-plain.be-transcript-copy,
-    .btn-plain.be-transcript-expand {
+    .bdl-Button--plain.be-transcript-edit,
+    .bdl-Button--plain.be-transcript-copy,
+    .bdl-Button--plain.be-transcript-expand {
         width: 24px;
         height: 24px;
         margin-left: 7px;
@@ -31,7 +31,7 @@
         }
     }
 
-    .btn-plain.be-transcript-copy.be-transcript-copied {
+    .bdl-Button--plain.be-transcript-copy.be-transcript-copied {
         background-color: $bdl-gray-10;
         transition: background-color 1s;
 

--- a/src/elements/content-sidebar/skills/transcript/Transcript.scss
+++ b/src/elements/content-sidebar/skills/transcript/Transcript.scss
@@ -9,9 +9,9 @@
         right: 15px;
     }
 
-    .bdl-Button--plain.be-transcript-edit,
-    .bdl-Button--plain.be-transcript-copy,
-    .bdl-Button--plain.be-transcript-expand {
+    .bdl-PlainButton.be-transcript-edit,
+    .bdl-PlainButton.be-transcript-copy,
+    .bdl-PlainButton.be-transcript-expand {
         width: 24px;
         height: 24px;
         margin-left: 7px;
@@ -31,7 +31,7 @@
         }
     }
 
-    .bdl-Button--plain.be-transcript-copy.be-transcript-copied {
+    .bdl-PlainButton.be-transcript-copy.be-transcript-copied {
         background-color: $bdl-gray-10;
         transition: background-color 1s;
 

--- a/src/elements/content-sidebar/skills/transcript/TranscriptRow.scss
+++ b/src/elements/content-sidebar/skills/transcript/TranscriptRow.scss
@@ -2,7 +2,7 @@
 
 .be-transcript {
     .be-transcript-row,
-    .btn-plain.be-transcript-row {
+    .bdl-Button--plain.be-transcript-row {
         display: flex;
         width: 100%;
         margin-bottom: 10px;

--- a/src/elements/content-sidebar/skills/transcript/TranscriptRow.scss
+++ b/src/elements/content-sidebar/skills/transcript/TranscriptRow.scss
@@ -2,7 +2,7 @@
 
 .be-transcript {
     .be-transcript-row,
-    .bdl-Button--plain.be-transcript-row {
+    .bdl-PlainButton.be-transcript-row {
         display: flex;
         width: 100%;
         margin-bottom: 10px;

--- a/src/elements/content-sidebar/versions/VersionsItemButton.js
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.js
@@ -56,7 +56,7 @@ class VersionsItemButton extends React.Component<Props> {
         const { children, fileId, isCurrent, isDisabled, isSelected, onClick } = this.props;
         const buttonClassName = classNames('bcs-VersionsItemButton', {
             'bcs-is-disabled': isDisabled,
-            'bcs-bdl-is-selected': isSelected && !isDisabled,
+            'bdl-is-selected': isSelected && !isDisabled,
         });
 
         return (

--- a/src/elements/content-sidebar/versions/VersionsItemButton.js
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.js
@@ -56,7 +56,7 @@ class VersionsItemButton extends React.Component<Props> {
         const { children, fileId, isCurrent, isDisabled, isSelected, onClick } = this.props;
         const buttonClassName = classNames('bcs-VersionsItemButton', {
             'bcs-is-disabled': isDisabled,
-            'bcs-is-selected': isSelected && !isDisabled,
+            'bcs-bdl-is-selected': isSelected && !isDisabled,
         });
 
         return (

--- a/src/elements/content-sidebar/versions/VersionsItemButton.js
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.js
@@ -56,7 +56,7 @@ class VersionsItemButton extends React.Component<Props> {
         const { children, fileId, isCurrent, isDisabled, isSelected, onClick } = this.props;
         const buttonClassName = classNames('bcs-VersionsItemButton', {
             'bcs-is-disabled': isDisabled,
-            'bdl-is-selected': isSelected && !isDisabled,
+            'bcs-is-selected': isSelected && !isDisabled,
         });
 
         return (

--- a/src/elements/content-sidebar/versions/VersionsItemButton.scss
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.scss
@@ -39,7 +39,7 @@
         }
     }
 
-    &.bdl-is-selected {
+    &.bcs-is-selected {
         background-color: $hover-blue-background;
         border-color: $bdl-box-blue;
     }

--- a/src/elements/content-sidebar/versions/VersionsItemButton.scss
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.scss
@@ -39,7 +39,7 @@
         }
     }
 
-    &.bcs-is-selected {
+    &.bcs-bdl-is-selected {
         background-color: $hover-blue-background;
         border-color: $bdl-box-blue;
     }

--- a/src/elements/content-sidebar/versions/VersionsItemButton.scss
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.scss
@@ -39,7 +39,7 @@
         }
     }
 
-    &.bcs-bdl-is-selected {
+    &.bdl-is-selected {
         background-color: $hover-blue-background;
         border-color: $bdl-box-blue;
     }

--- a/src/elements/content-sidebar/versions/VersionsList.scss
+++ b/src/elements/content-sidebar/versions/VersionsList.scss
@@ -21,7 +21,7 @@
             z-index: 2;
         }
 
-        &.bcs-is-selected {
+        &.bcs-bdl-is-selected {
             z-index: 1;
         }
     }

--- a/src/elements/content-sidebar/versions/VersionsList.scss
+++ b/src/elements/content-sidebar/versions/VersionsList.scss
@@ -21,7 +21,7 @@
             z-index: 2;
         }
 
-        &.bdl-is-selected {
+        &.bcs-is-selected {
             z-index: 1;
         }
     }

--- a/src/elements/content-sidebar/versions/VersionsList.scss
+++ b/src/elements/content-sidebar/versions/VersionsList.scss
@@ -21,7 +21,7 @@
             z-index: 2;
         }
 
-        &.bcs-bdl-is-selected {
+        &.bdl-is-selected {
             z-index: 1;
         }
     }

--- a/src/elements/content-sidebar/versions/__tests__/VersionsItemButton.test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsItemButton.test.js
@@ -68,7 +68,7 @@ describe('elements/content-sidebar/versions/VersionsItemButton', () => {
                 isSelected: true,
             });
 
-            expect(wrapper.prop('className')).toContain('bdl-is-selected');
+            expect(wrapper.prop('className')).toContain('bcs-is-selected');
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/src/elements/content-sidebar/versions/__tests__/VersionsItemButton.test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsItemButton.test.js
@@ -68,7 +68,7 @@ describe('elements/content-sidebar/versions/VersionsItemButton', () => {
                 isSelected: true,
             });
 
-            expect(wrapper.prop('className')).toContain('bcs-is-selected');
+            expect(wrapper.prop('className')).toContain('bcs-bdl-is-selected');
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/src/elements/content-sidebar/versions/__tests__/VersionsItemButton.test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsItemButton.test.js
@@ -68,7 +68,7 @@ describe('elements/content-sidebar/versions/VersionsItemButton', () => {
                 isSelected: true,
             });
 
-            expect(wrapper.prop('className')).toContain('bcs-bdl-is-selected');
+            expect(wrapper.prop('className')).toContain('bdl-is-selected');
             expect(wrapper).toMatchSnapshot();
         });
     });

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton.test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton.test.js.snap
@@ -33,7 +33,7 @@ exports[`elements/content-sidebar/versions/VersionsItemButton render should rend
 exports[`elements/content-sidebar/versions/VersionsItemButton render should render in enabled state correctly 2`] = `
 <PlainButton
   aria-disabled={false}
-  className="bcs-VersionsItemButton bdl-is-selected"
+  className="bcs-VersionsItemButton bcs-is-selected"
   data-resin-iscurrent={false}
   data-resin-target="select"
   data-testid="versions-item-button"

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton.test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton.test.js.snap
@@ -33,7 +33,7 @@ exports[`elements/content-sidebar/versions/VersionsItemButton render should rend
 exports[`elements/content-sidebar/versions/VersionsItemButton render should render in enabled state correctly 2`] = `
 <PlainButton
   aria-disabled={false}
-  className="bcs-VersionsItemButton bcs-bdl-is-selected"
+  className="bcs-VersionsItemButton bdl-is-selected"
   data-resin-iscurrent={false}
   data-resin-target="select"
   data-testid="versions-item-button"

--- a/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton.test.js.snap
+++ b/src/elements/content-sidebar/versions/__tests__/__snapshots__/VersionsItemButton.test.js.snap
@@ -33,7 +33,7 @@ exports[`elements/content-sidebar/versions/VersionsItemButton render should rend
 exports[`elements/content-sidebar/versions/VersionsItemButton render should render in enabled state correctly 2`] = `
 <PlainButton
   aria-disabled={false}
-  className="bcs-VersionsItemButton bcs-is-selected"
+  className="bcs-VersionsItemButton bcs-bdl-is-selected"
   data-resin-iscurrent={false}
   data-resin-target="select"
   data-testid="versions-item-button"

--- a/src/elements/content-uploader/Footer.scss
+++ b/src/elements/content-uploader/Footer.scss
@@ -14,7 +14,7 @@
         text-align: center;
     }
 
-    .bcu-footer-right .btn {
+    .bcu-footer-right .bdl-Button {
         margin-left: 8px;
     }
 }

--- a/src/elements/content-uploader/UploadStateContent.js
+++ b/src/elements/content-uploader/UploadStateContent.js
@@ -18,7 +18,7 @@ type Props = {
 
 const UploadStateContent = ({ fileInputLabel, folderInputLabel, message, onChange, useButton = false }: Props) => {
     const messageContent = message ? <div className="bcu-upload-state-message">{message}</div> : null;
-    const inputLabelClass = useButton ? 'btn btn-primary be-input-btn' : 'be-input-link';
+    const inputLabelClass = useButton ? 'btn bdl-Button btn-primary be-input-btn' : 'be-input-link';
     const shouldShowFolderUploadInput = !useButton && !!folderInputLabel;
 
     const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {

--- a/src/elements/content-uploader/UploadStateContent.js
+++ b/src/elements/content-uploader/UploadStateContent.js
@@ -18,7 +18,7 @@ type Props = {
 
 const UploadStateContent = ({ fileInputLabel, folderInputLabel, message, onChange, useButton = false }: Props) => {
     const messageContent = message ? <div className="bcu-upload-state-message">{message}</div> : null;
-    const inputLabelClass = useButton ? 'btn bdl-Button bdl-Button--primary be-input-btn' : 'be-input-link';
+    const inputLabelClass = useButton ? 'bdl-Button bdl-Button--primary be-input-btn' : 'be-input-link';
     const shouldShowFolderUploadInput = !useButton && !!folderInputLabel;
 
     const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {

--- a/src/elements/content-uploader/UploadStateContent.js
+++ b/src/elements/content-uploader/UploadStateContent.js
@@ -18,7 +18,7 @@ type Props = {
 
 const UploadStateContent = ({ fileInputLabel, folderInputLabel, message, onChange, useButton = false }: Props) => {
     const messageContent = message ? <div className="bcu-upload-state-message">{message}</div> : null;
-    const inputLabelClass = useButton ? 'btn bdl-Button bdl-PrimaryButton be-input-btn' : 'be-input-link';
+    const inputLabelClass = useButton ? 'btn bdl-Button bdl-Button--primary be-input-btn' : 'be-input-link';
     const shouldShowFolderUploadInput = !useButton && !!folderInputLabel;
 
     const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {

--- a/src/elements/content-uploader/UploadStateContent.js
+++ b/src/elements/content-uploader/UploadStateContent.js
@@ -18,7 +18,7 @@ type Props = {
 
 const UploadStateContent = ({ fileInputLabel, folderInputLabel, message, onChange, useButton = false }: Props) => {
     const messageContent = message ? <div className="bcu-upload-state-message">{message}</div> : null;
-    const inputLabelClass = useButton ? 'btn bdl-Button btn-primary be-input-btn' : 'be-input-link';
+    const inputLabelClass = useButton ? 'btn bdl-Button bdl-PrimaryButton be-input-btn' : 'be-input-link';
     const shouldShowFolderUploadInput = !useButton && !!folderInputLabel;
 
     const handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {

--- a/src/elements/content-uploader/UploadsManager.scss
+++ b/src/elements/content-uploader/UploadsManager.scss
@@ -29,7 +29,7 @@
         display: none;
         height: 375px;
 
-        .buik-btn-plain:focus {
+        .buik-bdl-Button--plain:focus {
             border: 1px solid $bdl-gray-30;
         }
     }

--- a/src/elements/content-uploader/UploadsManager.scss
+++ b/src/elements/content-uploader/UploadsManager.scss
@@ -29,7 +29,7 @@
         display: none;
         height: 375px;
 
-        .buik-bdl-PlainButton:focus {
+        .buik-btn-plain:focus {
             border: 1px solid $bdl-gray-30;
         }
     }

--- a/src/elements/content-uploader/UploadsManager.scss
+++ b/src/elements/content-uploader/UploadsManager.scss
@@ -29,7 +29,7 @@
         display: none;
         height: 375px;
 
-        .buik-bdl-Button--plain:focus {
+        .buik-bdl-PlainButton:focus {
             border: 1px solid $bdl-gray-30;
         }
     }

--- a/src/elements/content-uploader/UploadsManagerAction.scss
+++ b/src/elements/content-uploader/UploadsManagerAction.scss
@@ -1,7 +1,7 @@
 .bcu-uploads-manager-action {
     margin: 5px -20px 5px 5px;
 
-    .bdl-Button--primary {
+    .bdl-PrimaryButton {
         display: flex;
     }
 }

--- a/src/elements/content-uploader/UploadsManagerAction.scss
+++ b/src/elements/content-uploader/UploadsManagerAction.scss
@@ -1,7 +1,7 @@
 .bcu-uploads-manager-action {
     margin: 5px -20px 5px 5px;
 
-    .btn-primary {
+    .bdl-Button--primary {
         display: flex;
     }
 }

--- a/src/elements/content-uploader/UploadsManagerAction.scss
+++ b/src/elements/content-uploader/UploadsManagerAction.scss
@@ -1,7 +1,7 @@
 .bcu-uploads-manager-action {
     margin: 5px -20px 5px 5px;
 
-    .bdl-PrimaryButton {
+    .bdl-Button--primary {
         display: flex;
     }
 }

--- a/src/features/access-stats/AccessStatsItem.scss
+++ b/src/features/access-stats/AccessStatsItem.scss
@@ -5,9 +5,9 @@
 
     .access-stats-item-content {
         &,
-        &.bdl-Button--plain,
-        &.bdl-Button--plain:focus,
-        &.bdl-Button--plain:hover {
+        &.bdl-PlainButton,
+        &.bdl-PlainButton:focus,
+        &.bdl-PlainButton:hover {
             display: flex;
             align-items: center;
             width: 100%;
@@ -20,8 +20,8 @@
             border-radius: 2px;
         }
 
-        &.bdl-Button--plain:focus,
-        &.bdl-Button--plain:hover {
+        &.bdl-PlainButton:focus,
+        &.bdl-PlainButton:hover {
             .access-stats-label {
                 text-decoration: underline;
             }

--- a/src/features/access-stats/AccessStatsItem.scss
+++ b/src/features/access-stats/AccessStatsItem.scss
@@ -5,9 +5,9 @@
 
     .access-stats-item-content {
         &,
-        &.btn-plain,
-        &.btn-plain:focus,
-        &.btn-plain:hover {
+        &.bdl-Button--plain,
+        &.bdl-Button--plain:focus,
+        &.bdl-Button--plain:hover {
             display: flex;
             align-items: center;
             width: 100%;
@@ -20,8 +20,8 @@
             border-radius: 2px;
         }
 
-        &.btn-plain:focus,
-        &.btn-plain:hover {
+        &.bdl-Button--plain:focus,
+        &.bdl-Button--plain:hover {
             .access-stats-label {
                 text-decoration: underline;
             }

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -8,7 +8,7 @@ import messages from './messages';
 import './Classification.scss';
 
 const STYLE_INLINE: 'inline' = 'inline';
-const STYLE_TOOLTIP: 'tooltip' = 'tooltip';
+const STYLE_TOOLTIP: 'tooltip bdl-Tooltip' = 'tooltip bdl-Tooltip';
 
 type Props = {
     className?: string,

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -8,7 +8,7 @@ import messages from './messages';
 import './Classification.scss';
 
 const STYLE_INLINE: 'inline' = 'inline';
-const STYLE_TOOLTIP: 'tooltip bdl-Tooltip' = 'tooltip bdl-Tooltip';
+const STYLE_TOOLTIP: 'bdl-Tooltip' = 'bdl-Tooltip';
 
 type Props = {
     className?: string,

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -8,7 +8,7 @@ import messages from './messages';
 import './Classification.scss';
 
 const STYLE_INLINE: 'inline' = 'inline';
-const STYLE_TOOLTIP: 'bdl-Tooltip' = 'bdl-Tooltip';
+const STYLE_TOOLTIP: 'tooltip' = 'tooltip';
 
 type Props = {
     className?: string,

--- a/src/features/classification/Classification.scss
+++ b/src/features/classification/Classification.scss
@@ -1,7 +1,7 @@
 @import '../../styles/variables';
 
 .bdl-Classification {
-    .label {
+    .bdl-Label {
         margin-top: 12px;
         font-weight: normal;
     }

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -30,6 +30,7 @@ exports[`features/classification/Classification should render a classified badge
 >
   <ClassifiedBadge
     name="Confidential"
+    tooltipText="fubar"
   />
 </article>
 `;

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -30,7 +30,6 @@ exports[`features/classification/Classification should render a classified badge
 >
   <ClassifiedBadge
     name="Confidential"
-    tooltipText="fubar"
   />
 </article>
 `;

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -130,7 +130,7 @@ const ItemList = ({
         let result = index === -1 ? 'table-header' : 'table-row';
 
         if (isItemSelected(item.id, selectedItems)) {
-            result = classNames('is-selected', result);
+            result = classNames('bdl-is-selected', result);
         }
         if (item && (item.isDisabled || item.isLoading)) {
             result = classNames('disabled', result);

--- a/src/features/content-explorer/item-list/ItemList.scss
+++ b/src/features/content-explorer/item-list/ItemList.scss
@@ -19,7 +19,7 @@
             opacity: .3;
         }
 
-        &:not(.is-selected):not(.disabled):hover {
+        &:not(.bdl-is-selected):not(.disabled):hover {
             background-color: $hover-blue-background;
         }
 

--- a/src/features/content-explorer/item-list/__tests__/ItemList.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemList.test.js
@@ -95,7 +95,7 @@ describe('features/content-explorer/item-list/ItemList', () => {
             const rows = wrapper.find('.table-row');
             rows.forEach((row, i) => {
                 const isSelected = i === 0;
-                expect(row.hasClass('is-selected')).toEqual(isSelected);
+                expect(row.hasClass('bdl-is-selected')).toEqual(isSelected);
                 expect(row.find('RadioButton').prop('isSelected')).toEqual(isSelected);
             });
         });

--- a/src/features/content-explorer/new-folder-modal/NewFolderModal.scss
+++ b/src/features/content-explorer/new-folder-modal/NewFolderModal.scss
@@ -1,6 +1,6 @@
 .new-folder-modal {
     .folder-name-input {
-        .label {
+        .bdl-Label {
             white-space: pre-wrap;
             word-wrap: break-word;
         }

--- a/src/features/invite-collaborators-modal/InviteCollaboratorsModal.js
+++ b/src/features/invite-collaborators-modal/InviteCollaboratorsModal.js
@@ -258,7 +258,7 @@ class InviteCollaboratorsModal extends Component {
         return (
             <div className="invite-permissions-container">
                 <Select
-                    className="bdl-Select-container--medium"
+                    className="bdl-Select-content--medium"
                     data-resin-target="selectpermission"
                     label={<FormattedMessage {...messages.inviteePermissionsFieldLabel} />}
                     name="invite-permission"

--- a/src/features/invite-collaborators-modal/InviteCollaboratorsModal.js
+++ b/src/features/invite-collaborators-modal/InviteCollaboratorsModal.js
@@ -258,7 +258,7 @@ class InviteCollaboratorsModal extends Component {
         return (
             <div className="invite-permissions-container">
                 <Select
-                    className="bdl-Select-container-medium"
+                    className="bdl-Select-container--medium"
                     data-resin-target="selectpermission"
                     label={<FormattedMessage {...messages.inviteePermissionsFieldLabel} />}
                     name="invite-permission"

--- a/src/features/invite-collaborators-modal/InviteCollaboratorsModal.js
+++ b/src/features/invite-collaborators-modal/InviteCollaboratorsModal.js
@@ -258,7 +258,7 @@ class InviteCollaboratorsModal extends Component {
         return (
             <div className="invite-permissions-container">
                 <Select
-                    className="select-container-medium"
+                    className="bdl-Select-container-medium"
                     data-resin-target="selectpermission"
                     label={<FormattedMessage {...messages.inviteePermissionsFieldLabel} />}
                     name="invite-permission"

--- a/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
+++ b/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
@@ -1,7 +1,7 @@
 @import '../../styles/variables';
 
 .invite-collaborators-modal {
-    .label {
+    .bdl-Label {
         color: $bdl-gray-62;
         font-weight: bold;
     }

--- a/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
+++ b/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
@@ -31,11 +31,11 @@
         margin-bottom: 20px;
     }
 
-    .select-container {
+    .bdl-Select-container {
         width: 100%;
     }
 
-    .select-input-container {
+    .bdl-Select-inputContainer {
         margin: 0;
     }
 
@@ -47,7 +47,7 @@
             overflow: auto;
         }
 
-        .pill-selector-input-wrapper {
+        .bdl-PillSelector-inputWrapper {
             width: 100%;
             height: 60px;
         }

--- a/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
+++ b/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
@@ -31,7 +31,7 @@
         margin-bottom: 20px;
     }
 
-    .bdl-Select-container {
+    .bdl-Select-content {
         width: 100%;
     }
 

--- a/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
+++ b/src/features/invite-collaborators-modal/InviteCollaboratorsModal.scss
@@ -35,7 +35,7 @@
         width: 100%;
     }
 
-    .bdl-Select-inputContainer {
+    .bdl-Select {
         margin: 0;
     }
 
@@ -47,7 +47,7 @@
             overflow: auto;
         }
 
-        .bdl-PillSelector-inputWrapper {
+        .bdl-PillSelector {
             width: 100%;
             height: 60px;
         }

--- a/src/features/item-details/ItemProperties.scss
+++ b/src/features/item-details/ItemProperties.scss
@@ -43,7 +43,7 @@
             margin: 0;
         }
 
-        &:not(.bdl-show-error) input {
+        &:not(.bdl-has-error) input {
             height: 16px;
             padding: 0;
             border: none;

--- a/src/features/item-details/ItemProperties.scss
+++ b/src/features/item-details/ItemProperties.scss
@@ -43,7 +43,7 @@
             margin: 0;
         }
 
-        &:not(.show-error) input {
+        &:not(.bdl-show-error) input {
             height: 16px;
             padding: 0;
             border: none;

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -246,8 +246,8 @@ class LeftSidebar extends React.Component<Props, State> {
             );
 
         const classes = classNames('left-sidebar-list', className, {
-            'is-loading-empty': showLoadingIndicator && menuItems && menuItems.length === 0,
-            'is-loading': showLoadingIndicator && menuItems && menuItems.length > 0,
+            'bdl-is-loading--empty': showLoadingIndicator && menuItems && menuItems.length === 0,
+            'bdl-is-loading': showLoadingIndicator && menuItems && menuItems.length > 0,
             'lsb-scrollable-shadow-top': this.state.isScrollableAbove,
             'lsb-scrollable-shadow-bottom': this.state.isScrollableBelow,
         });

--- a/src/features/left-sidebar/LeftSidebar.js
+++ b/src/features/left-sidebar/LeftSidebar.js
@@ -311,7 +311,7 @@ class LeftSidebar extends React.Component<Props, State> {
         } = props;
 
         const linkClassNames = classNames('left-sidebar-link', className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         });
 
         const linkProps = {

--- a/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar.test.js.snap
+++ b/src/features/left-sidebar/__tests__/__snapshots__/LeftSidebar.test.js.snap
@@ -155,7 +155,7 @@ exports[`feature/left-sidebar/LeftSidebar should pass in custom sidebar properti
     className="left-sidebar-container"
   >
     <LeftSidebarLink
-      className="left-sidebar-link is-selected"
+      className="left-sidebar-link bdl-is-selected"
       customTheme={
         Object {
           "contrastColor": "#123",

--- a/src/features/left-sidebar/icons/IconAdminConsole.js
+++ b/src/features/left-sidebar/icons/IconAdminConsole.js
@@ -18,7 +18,7 @@ const iconName = 'icon-admin-console';
 const IconAdminConsole = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 16"

--- a/src/features/left-sidebar/icons/IconAllFiles.js
+++ b/src/features/left-sidebar/icons/IconAllFiles.js
@@ -18,7 +18,7 @@ const iconName = 'icon-all-files';
 const IconAllFiles = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconAutomations.js
+++ b/src/features/left-sidebar/icons/IconAutomations.js
@@ -17,7 +17,7 @@ const iconName = 'icon-automations';
 const IconAutomations = ({ className = '', width = 14, color = '#c4c4c4', selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         viewBox="0 0 14 14"
         width={width}

--- a/src/features/left-sidebar/icons/IconBoxRelay.js
+++ b/src/features/left-sidebar/icons/IconBoxRelay.js
@@ -17,7 +17,7 @@ const iconName = 'icon-box-relay';
 const IconBoxRelay = ({ className = '', width = 14, color = '#c4c4c4', selected = false, title }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconDevConsole.js
+++ b/src/features/left-sidebar/icons/IconDevConsole.js
@@ -18,7 +18,7 @@ const iconName = 'icon-dev-console';
 const IconDevConsole = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconFavorites.js
+++ b/src/features/left-sidebar/icons/IconFavorites.js
@@ -18,7 +18,7 @@ const iconName = 'icon-favorites';
 const IconFavorites = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconFeed.js
+++ b/src/features/left-sidebar/icons/IconFeed.js
@@ -18,7 +18,7 @@ const iconName = 'icon-feed';
 const IconFeed = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconNotes.js
+++ b/src/features/left-sidebar/icons/IconNotes.js
@@ -18,7 +18,7 @@ const iconName = 'icon-notes';
 const IconNotes = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconNotifications.js
+++ b/src/features/left-sidebar/icons/IconNotifications.js
@@ -18,7 +18,7 @@ const iconName = 'icon-notifications';
 const IconNotifications = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 16.1"

--- a/src/features/left-sidebar/icons/IconOwnedByMe.js
+++ b/src/features/left-sidebar/icons/IconOwnedByMe.js
@@ -18,7 +18,7 @@ const iconName = 'icon-owned-by-me';
 const IconOwnedByMe = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconRecents.js
+++ b/src/features/left-sidebar/icons/IconRecents.js
@@ -18,7 +18,7 @@ const iconName = 'icon-recents';
 const IconRecents = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconRelay.js
+++ b/src/features/left-sidebar/icons/IconRelay.js
@@ -18,7 +18,7 @@ const iconName = 'icon-relay';
 const IconRelay = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconSharedWithMe.js
+++ b/src/features/left-sidebar/icons/IconSharedWithMe.js
@@ -18,7 +18,7 @@ const iconName = 'icon-shared-with-me';
 const IconSharedWithMe = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconSynced.js
+++ b/src/features/left-sidebar/icons/IconSynced.js
@@ -18,7 +18,7 @@ const iconName = 'icon-synced';
 const IconSynced = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/IconTrash.js
+++ b/src/features/left-sidebar/icons/IconTrash.js
@@ -18,7 +18,7 @@ const iconName = 'icon-trash';
 const IconTrash = ({ className = '', color = '#c4c4c4', title, width = 14, selected = false }: Props) => (
     <AccessibleSVG
         className={classNames(iconName, className, {
-            'is-selected': selected,
+            'bdl-is-selected': selected,
         })}
         title={title}
         viewBox="0 0 14 14"

--- a/src/features/left-sidebar/icons/__tests__/__snapshots__/left-sidebar-icons.test.js.snap
+++ b/src/features/left-sidebar/icons/__tests__/__snapshots__/left-sidebar-icons.test.js.snap
@@ -860,7 +860,7 @@ exports[`icons/left-sidebar should correctly render icon with title 15`] = `
 
 exports[`icons/left-sidebar should respect selected state 1`] = `
 <AccessibleSVG
-  className="icon-admin-console is-selected"
+  className="icon-admin-console bdl-is-selected"
   title="pity"
   viewBox="0 0 14 16"
   width={14}
@@ -876,7 +876,7 @@ exports[`icons/left-sidebar should respect selected state 1`] = `
 
 exports[`icons/left-sidebar should respect selected state 2`] = `
 <AccessibleSVG
-  className="icon-automations is-selected"
+  className="icon-automations bdl-is-selected"
   viewBox="0 0 14 14"
   width={14}
 >
@@ -891,7 +891,7 @@ exports[`icons/left-sidebar should respect selected state 2`] = `
 
 exports[`icons/left-sidebar should respect selected state 3`] = `
 <AccessibleSVG
-  className="icon-box-relay is-selected"
+  className="icon-box-relay bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -908,7 +908,7 @@ exports[`icons/left-sidebar should respect selected state 3`] = `
 
 exports[`icons/left-sidebar should respect selected state 4`] = `
 <AccessibleSVG
-  className="icon-all-files is-selected"
+  className="icon-all-files bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -924,7 +924,7 @@ exports[`icons/left-sidebar should respect selected state 4`] = `
 
 exports[`icons/left-sidebar should respect selected state 5`] = `
 <AccessibleSVG
-  className="icon-dev-console is-selected"
+  className="icon-dev-console bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -940,7 +940,7 @@ exports[`icons/left-sidebar should respect selected state 5`] = `
 
 exports[`icons/left-sidebar should respect selected state 6`] = `
 <AccessibleSVG
-  className="icon-favorites is-selected"
+  className="icon-favorites bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -956,7 +956,7 @@ exports[`icons/left-sidebar should respect selected state 6`] = `
 
 exports[`icons/left-sidebar should respect selected state 7`] = `
 <AccessibleSVG
-  className="icon-feed is-selected"
+  className="icon-feed bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -972,7 +972,7 @@ exports[`icons/left-sidebar should respect selected state 7`] = `
 
 exports[`icons/left-sidebar should respect selected state 8`] = `
 <AccessibleSVG
-  className="icon-notes is-selected"
+  className="icon-notes bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -988,7 +988,7 @@ exports[`icons/left-sidebar should respect selected state 8`] = `
 
 exports[`icons/left-sidebar should respect selected state 9`] = `
 <AccessibleSVG
-  className="icon-notifications is-selected"
+  className="icon-notifications bdl-is-selected"
   title="pity"
   viewBox="0 0 14 16.1"
   width={14}
@@ -1004,7 +1004,7 @@ exports[`icons/left-sidebar should respect selected state 9`] = `
 
 exports[`icons/left-sidebar should respect selected state 10`] = `
 <AccessibleSVG
-  className="icon-owned-by-me is-selected"
+  className="icon-owned-by-me bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -1020,7 +1020,7 @@ exports[`icons/left-sidebar should respect selected state 10`] = `
 
 exports[`icons/left-sidebar should respect selected state 11`] = `
 <AccessibleSVG
-  className="icon-recents is-selected"
+  className="icon-recents bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -1036,7 +1036,7 @@ exports[`icons/left-sidebar should respect selected state 11`] = `
 
 exports[`icons/left-sidebar should respect selected state 12`] = `
 <AccessibleSVG
-  className="icon-relay is-selected"
+  className="icon-relay bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -1052,7 +1052,7 @@ exports[`icons/left-sidebar should respect selected state 12`] = `
 
 exports[`icons/left-sidebar should respect selected state 13`] = `
 <AccessibleSVG
-  className="icon-shared-with-me is-selected"
+  className="icon-shared-with-me bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -1068,7 +1068,7 @@ exports[`icons/left-sidebar should respect selected state 13`] = `
 
 exports[`icons/left-sidebar should respect selected state 14`] = `
 <AccessibleSVG
-  className="icon-synced is-selected"
+  className="icon-synced bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}
@@ -1084,7 +1084,7 @@ exports[`icons/left-sidebar should respect selected state 14`] = `
 
 exports[`icons/left-sidebar should respect selected state 15`] = `
 <AccessibleSVG
-  className="icon-trash is-selected"
+  className="icon-trash bdl-is-selected"
   title="pity"
   viewBox="0 0 14 14"
   width={14}

--- a/src/features/left-sidebar/styles/LeftSidebar.scss
+++ b/src/features/left-sidebar/styles/LeftSidebar.scss
@@ -97,7 +97,7 @@
     }
 
     // Override nav-list default color for link
-    .left-sidebar-link:not(.is-selected) {
+    .left-sidebar-link:not(.bdl-is-selected) {
         color: $light-charcoal;
 
         &:hover {
@@ -278,7 +278,7 @@
         }
     }
 
-    &.is-selected,
+    &.bdl-is-selected,
     &.nav-link-callout-enabled {
         color: $charcoal;
         font-weight: bold;
@@ -287,12 +287,12 @@
             fill: $lsb-menu-selected-bg-highlight;
         }
 
-        .is-selected .fill-color {
+        .bdl-is-selected .fill-color {
             fill: currentColor;
         }
     }
 
-    &.is-selected:not(.nav-link-callout-enabled) {
+    &.bdl-is-selected:not(.nav-link-callout-enabled) {
         box-shadow: inset 2px 0 0 $lsb-menu-selected-bg-highlight;
 
         @include medium-size {

--- a/src/features/left-sidebar/styles/LeftSidebar.scss
+++ b/src/features/left-sidebar/styles/LeftSidebar.scss
@@ -88,11 +88,11 @@
         margin-bottom: 0;
     }
 
-    &.is-loading {
+    &.bdl-is-loading {
         margin-bottom: 0;
     }
 
-    &.is-loading-empty {
+    &.bdl-is-loading--empty {
         margin-bottom: 40px;
     }
 

--- a/src/features/left-sidebar/styles/LeftSidebarLink.scss
+++ b/src/features/left-sidebar/styles/LeftSidebarLink.scss
@@ -12,7 +12,7 @@
         text-decoration: none;
         background-color: $lsb-menu-hover-link-bg;
 
-        .left-sidebar-link:not(.is-selected) {
+        .left-sidebar-link:not(.bdl-is-selected) {
             color: $bdl-gray;
         }
 

--- a/src/features/metadata-based-view/MetadataBasedItemList.scss
+++ b/src/features/metadata-based-view/MetadataBasedItemList.scss
@@ -40,7 +40,7 @@
 .bdl-MetadataBasedItemList-cell--filename {
     color: $bdl-gray;
 
-    & .bdl-Button--plain {
+    & .bdl-PlainButton {
         outline: none;
     }
 }

--- a/src/features/metadata-based-view/MetadataBasedItemList.scss
+++ b/src/features/metadata-based-view/MetadataBasedItemList.scss
@@ -40,7 +40,7 @@
 .bdl-MetadataBasedItemList-cell--filename {
     color: $bdl-gray;
 
-    & .btn-plain {
+    & .bdl-Button--plain {
         outline: none;
     }
 }

--- a/src/features/metadata-instance-editor/CustomInstanceNewField.scss
+++ b/src/features/metadata-instance-editor/CustomInstanceNewField.scss
@@ -33,7 +33,7 @@
     margin: 20px 0 0;
     text-align: right;
 
-    .btn {
+    .bdl-Button {
         margin: 0 0 0 10px;
     }
 }

--- a/src/features/metadata-instance-editor/Footer.scss
+++ b/src/features/metadata-instance-editor/Footer.scss
@@ -6,11 +6,11 @@
     justify-content: space-between;
     margin-top: 10px;
 
-    .metadata-instance-editor-footer-delete .btn-plain {
+    .metadata-instance-editor-footer-delete .bdl-Button--plain {
         color: $bdl-watermelon-red;
     }
 
-    .metadata-instance-editor-footer-save-cancel .btn:last-child {
+    .metadata-instance-editor-footer-save-cancel .bdl-Button:last-child {
         margin-right: 0;
     }
 }

--- a/src/features/metadata-instance-editor/Footer.scss
+++ b/src/features/metadata-instance-editor/Footer.scss
@@ -6,7 +6,7 @@
     justify-content: space-between;
     margin-top: 10px;
 
-    .metadata-instance-editor-footer-delete .bdl-Button--plain {
+    .metadata-instance-editor-footer-delete .bdl-PlainButton {
         color: $bdl-watermelon-red;
     }
 

--- a/src/features/metadata-instance-editor/Instance.scss
+++ b/src/features/metadata-instance-editor/Instance.scss
@@ -20,7 +20,7 @@
     }
 }
 
-.bdl-Button--plain.metadata-instance-editor-instance-edit {
+.bdl-PlainButton.metadata-instance-editor-instance-edit {
     position: absolute;
     top: 8px;
     right: 25px;

--- a/src/features/metadata-instance-editor/Instance.scss
+++ b/src/features/metadata-instance-editor/Instance.scss
@@ -20,7 +20,7 @@
     }
 }
 
-.btn-plain.metadata-instance-editor-instance-edit {
+.bdl-Button--plain.metadata-instance-editor-instance-edit {
     position: absolute;
     top: 8px;
     right: 25px;

--- a/src/features/metadata-instance-editor/TemplateDropdown.js
+++ b/src/features/metadata-instance-editor/TemplateDropdown.js
@@ -125,7 +125,7 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
             const isTemplateSelected = activeTemplate && activeTemplate.id === template.id;
 
             const buttonClassName = classNames('metadata-template-dropdown-select-template', {
-                'metadata-template-dropdown-is-selected': isTemplateSelected,
+                'metadata-template-dropdown-bdl-is-selected': isTemplateSelected,
             });
 
             return (

--- a/src/features/metadata-instance-editor/TemplateDropdown.js
+++ b/src/features/metadata-instance-editor/TemplateDropdown.js
@@ -125,7 +125,7 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
             const isTemplateSelected = activeTemplate && activeTemplate.id === template.id;
 
             const buttonClassName = classNames('metadata-template-dropdown-select-template', {
-                'metadata-template-dropdown-bdl-is-selected': isTemplateSelected,
+                'metadata-template-dropdown-is-selected': isTemplateSelected,
             });
 
             return (

--- a/src/features/metadata-instance-editor/TemplateDropdown.scss
+++ b/src/features/metadata-instance-editor/TemplateDropdown.scss
@@ -125,7 +125,7 @@
         text-align: inherit;
         text-overflow: ellipsis;
 
-        &.metadata-template-dropdown-bdl-is-selected {
+        &.metadata-template-dropdown-is-selected {
             color: $bdl-box-blue;
         }
 

--- a/src/features/metadata-instance-editor/TemplateDropdown.scss
+++ b/src/features/metadata-instance-editor/TemplateDropdown.scss
@@ -112,7 +112,7 @@
         }
     }
 
-    .btn-plain.metadata-template-dropdown-select-template {
+    .bdl-Button--plain.metadata-template-dropdown-select-template {
         display: flex;
         align-items: center;
         width: 100%;

--- a/src/features/metadata-instance-editor/TemplateDropdown.scss
+++ b/src/features/metadata-instance-editor/TemplateDropdown.scss
@@ -112,7 +112,7 @@
         }
     }
 
-    .bdl-Button--plain.metadata-template-dropdown-select-template {
+    .bdl-PlainButton.metadata-template-dropdown-select-template {
         display: flex;
         align-items: center;
         width: 100%;
@@ -125,7 +125,7 @@
         text-align: inherit;
         text-overflow: ellipsis;
 
-        &.metadata-template-dropdown-is-selected {
+        &.metadata-template-dropdown-bdl-is-selected {
             color: $bdl-box-blue;
         }
 

--- a/src/features/metadata-instance-editor/fields/CustomField.scss
+++ b/src/features/metadata-instance-editor/fields/CustomField.scss
@@ -8,7 +8,7 @@
         flex: 1;
         overflow-x: hidden;
 
-        .label {
+        .bdl-Label {
             width: 100%;
             overflow: hidden;
             white-space: nowrap;
@@ -24,7 +24,7 @@
 .metadata-instance-editor-field-custom-actions {
     margin: 5px 0 0 10px;
 
-    .btn {
+    .bdl-Button {
         width: 32px;
         height: 32px;
         margin: 0 0 0 -1px;

--- a/src/features/metadata-instance-editor/fields/EnumField.scss
+++ b/src/features/metadata-instance-editor/fields/EnumField.scss
@@ -7,7 +7,7 @@
         word-wrap: break-word;
     }
 
-    label .select-container {
+    label .bdl-Select-container {
         display: block;
         margin-top: 5px;
 

--- a/src/features/metadata-instance-editor/fields/EnumField.scss
+++ b/src/features/metadata-instance-editor/fields/EnumField.scss
@@ -3,7 +3,7 @@
 .metadata-instance-editor-field-enum {
     margin: 0 0 20px;
 
-    .label {
+    .bdl-Label {
         word-wrap: break-word;
     }
 

--- a/src/features/metadata-instance-editor/fields/EnumField.scss
+++ b/src/features/metadata-instance-editor/fields/EnumField.scss
@@ -7,7 +7,7 @@
         word-wrap: break-word;
     }
 
-    label .bdl-Select-container {
+    label .bdl-Select-content {
         display: block;
         margin-top: 5px;
 

--- a/src/features/metadata-instance-editor/fields/MultiSelectField.scss
+++ b/src/features/metadata-instance-editor/fields/MultiSelectField.scss
@@ -7,7 +7,7 @@
         word-wrap: break-word;
     }
 
-    label .select-container {
+    label .bdl-Select-container {
         display: block;
         margin-top: 5px;
 

--- a/src/features/metadata-instance-editor/fields/MultiSelectField.scss
+++ b/src/features/metadata-instance-editor/fields/MultiSelectField.scss
@@ -3,7 +3,7 @@
 .metadata-instance-editor-field-multi-select {
     margin: 0 0 20px;
 
-    .label {
+    .bdl-Label {
         word-wrap: break-word;
     }
 
@@ -11,7 +11,7 @@
         display: block;
         margin-top: 5px;
 
-        .select-button {
+        .bdl-SelectButton {
             z-index: inherit;
         }
     }

--- a/src/features/metadata-instance-editor/fields/MultiSelectField.scss
+++ b/src/features/metadata-instance-editor/fields/MultiSelectField.scss
@@ -7,7 +7,7 @@
         word-wrap: break-word;
     }
 
-    label .bdl-Select-container {
+    label .bdl-Select-content {
         display: block;
         margin-top: 5px;
 

--- a/src/features/presence/Presence.js
+++ b/src/features/presence/Presence.js
@@ -241,7 +241,7 @@ class Presence extends Component {
         const overlayContent = showActivityPrompt ? (
             <>
                 <FormattedMessage {...messages.previewPresenceFlyoutCopy} />
-                <Button className="btn-primary" onClick={this._showRecentsFlyout}>
+                <Button className="bdl-PrimaryButton" onClick={this._showRecentsFlyout}>
                     <FormattedMessage {...messages.previewPresenceFlyoutActivityCTA} />
                 </Button>
             </>

--- a/src/features/presence/Presence.js
+++ b/src/features/presence/Presence.js
@@ -241,7 +241,7 @@ class Presence extends Component {
         const overlayContent = showActivityPrompt ? (
             <>
                 <FormattedMessage {...messages.previewPresenceFlyoutCopy} />
-                <Button className="bdl-PrimaryButton" onClick={this._showRecentsFlyout}>
+                <Button className="bdl-Button--primary" onClick={this._showRecentsFlyout}>
                     <FormattedMessage {...messages.previewPresenceFlyoutActivityCTA} />
                 </Button>
             </>

--- a/src/features/presence/Presence.scss
+++ b/src/features/presence/Presence.scss
@@ -203,12 +203,12 @@
     text-align: right;
 }
 
-.presence-autofly-first-load .bdl-PrimaryButton {
+.presence-autofly-first-load .bdl-Button--primary {
     margin-top: 16px;
     margin-left: 0;
 }
 
-.presence-autofly-first-load .bdl-PrimaryButton:not(.bdl-is-disabled):focus {
+.presence-autofly-first-load .bdl-Button--primary:not(.bdl-is-disabled):focus {
     box-shadow: none;
 }
 

--- a/src/features/presence/Presence.scss
+++ b/src/features/presence/Presence.scss
@@ -203,12 +203,12 @@
     text-align: right;
 }
 
-.presence-autofly-first-load .btn-primary {
+.presence-autofly-first-load .bdl-Button--primary {
     margin-top: 16px;
     margin-left: 0;
 }
 
-.presence-autofly-first-load .btn-primary:not(.is-disabled):focus {
+.presence-autofly-first-load .bdl-Button--primary:not(.bdl-is-disabled):focus {
     box-shadow: none;
 }
 

--- a/src/features/presence/Presence.scss
+++ b/src/features/presence/Presence.scss
@@ -203,12 +203,12 @@
     text-align: right;
 }
 
-.presence-autofly-first-load .bdl-Button--primary {
+.presence-autofly-first-load .bdl-PrimaryButton {
     margin-top: 16px;
     margin-left: 0;
 }
 
-.presence-autofly-first-load .bdl-Button--primary:not(.bdl-is-disabled):focus {
+.presence-autofly-first-load .bdl-PrimaryButton:not(.bdl-is-disabled):focus {
     box-shadow: none;
 }
 

--- a/src/features/presence/__tests__/__snapshots__/Presence.test.js.snap
+++ b/src/features/presence/__tests__/__snapshots__/Presence.test.js.snap
@@ -936,7 +936,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
       id="boxui.presence.previewPresenceFlyoutCopy"
     />
     <Button
-      className="bdl-PrimaryButton"
+      className="bdl-Button--primary"
       onClick={[Function]}
     >
       <FormattedMessage

--- a/src/features/presence/__tests__/__snapshots__/Presence.test.js.snap
+++ b/src/features/presence/__tests__/__snapshots__/Presence.test.js.snap
@@ -936,7 +936,7 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
       id="boxui.presence.previewPresenceFlyoutCopy"
     />
     <Button
-      className="btn-primary"
+      className="bdl-PrimaryButton"
       onClick={[Function]}
     >
       <FormattedMessage

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -273,7 +273,7 @@ const Condition = ({
         const error = getErrorMessage();
 
         const classnames = classNames('condition-value-dropdown-container', {
-            'show-error': error,
+            'bdl-show-error': error,
         });
 
         return (

--- a/src/features/query-bar/components/filter/Condition.js
+++ b/src/features/query-bar/components/filter/Condition.js
@@ -273,7 +273,7 @@ const Condition = ({
         const error = getErrorMessage();
 
         const classnames = classNames('condition-value-dropdown-container', {
-            'bdl-show-error': error,
+            'bdl-has-error': error,
         });
 
         return (

--- a/src/features/query-bar/styles/Condition.scss
+++ b/src/features/query-bar/styles/Condition.scss
@@ -83,7 +83,7 @@
             flex: 1;
         }
 
-        .select-container {
+        .bdl-Select-container {
             width: 110px;
             padding-right: 10px;
             padding-left: 10px;
@@ -135,7 +135,7 @@
             flex: 1;
         }
 
-        .select-container {
+        .bdl-Select-container {
             width: 100%;
 
             .bdl-SelectButton {
@@ -149,8 +149,8 @@
         }
     }
 
-    .condition-value-dropdown-container.show-error {
-        .select-container {
+    .condition-value-dropdown-container.bdl-show-error {
+        .bdl-Select-container {
             button.bdl-SelectButton {
                 @include error-border();
             }

--- a/src/features/query-bar/styles/Condition.scss
+++ b/src/features/query-bar/styles/Condition.scss
@@ -83,7 +83,7 @@
             flex: 1;
         }
 
-        .bdl-Select-container {
+        .bdl-Select-content {
             width: 110px;
             padding-right: 10px;
             padding-left: 10px;
@@ -135,7 +135,7 @@
             flex: 1;
         }
 
-        .bdl-Select-container {
+        .bdl-Select-content {
             width: 100%;
 
             .bdl-SelectButton {
@@ -149,8 +149,8 @@
         }
     }
 
-    .condition-value-dropdown-container.bdl-show-error {
-        .bdl-Select-container {
+    .condition-value-dropdown-container.bdl-has-error {
+        .bdl-Select-content {
             button.bdl-SelectButton {
                 @include error-border();
             }

--- a/src/features/query-bar/styles/Condition.scss
+++ b/src/features/query-bar/styles/Condition.scss
@@ -65,12 +65,12 @@
         }
 
         .select-field {
-            .select-button {
+            .bdl-SelectButton {
                 width: 160px;
                 border-radius: 5px;
             }
 
-            .select-button.placeholder {
+            .bdl-SelectButton.placeholder {
                 color: $bdl-gray-62;
             }
         }
@@ -88,7 +88,7 @@
             padding-right: 10px;
             padding-left: 10px;
 
-            .select-button {
+            .bdl-SelectButton {
                 border-radius: 5px;
             }
         }
@@ -138,12 +138,12 @@
         .select-container {
             width: 100%;
 
-            .select-button {
+            .bdl-SelectButton {
                 width: 160px;
                 border-radius: 5px;
             }
 
-            .select-button.placeholder {
+            .bdl-SelectButton.placeholder {
                 color: $bdl-gray-62;
             }
         }
@@ -151,7 +151,7 @@
 
     .condition-value-dropdown-container.show-error {
         .select-container {
-            button.select-button {
+            button.bdl-SelectButton {
                 @include error-border();
             }
         }
@@ -166,7 +166,7 @@
             @include error-border();
         }
 
-        .select-button.placeholder {
+        .bdl-SelectButton.placeholder {
             @include error-border();
         }
     }

--- a/src/features/shared-link-modal/AccessMenu.js
+++ b/src/features/shared-link-modal/AccessMenu.js
@@ -106,7 +106,7 @@ class AccessMenu extends Component<Props, State> {
                 <DropdownMenu {...accessDropdownMenuProps}>
                     <PlainButton
                         className={classNames('lnk', {
-                            'is-disabled': submitting,
+                            'bdl-is-disabled': submitting,
                         })}
                         disabled={submitting}
                         {...accessMenuButtonProps}

--- a/src/features/shared-link-modal/EmailSharedLink.scss
+++ b/src/features/shared-link-modal/EmailSharedLink.scss
@@ -1,5 +1,5 @@
 .email-shared-link {
-    .pill-selector-wrapper {
+    .bdl-PillSelector-wrapper {
         margin: 0;
     }
 
@@ -14,13 +14,13 @@
         transition: height .2s;
     }
 
-    .pill-selector-input-wrapper,
+    .bdl-PillSelector-inputWrapper,
     textarea {
         width: 100%;
     }
 
     &.is-expanded {
-        .pill-selector-wrapper {
+        .bdl-PillSelector-wrapper {
             margin-bottom: 20px;
         }
 
@@ -28,7 +28,7 @@
             height: 100px;
         }
 
-        .pill-selector-input-wrapper {
+        .bdl-PillSelector-inputWrapper {
             height: 58px;
         }
     }

--- a/src/features/shared-link-modal/EmailSharedLink.scss
+++ b/src/features/shared-link-modal/EmailSharedLink.scss
@@ -1,5 +1,5 @@
 .email-shared-link {
-    .bdl-PillSelector-wrapper {
+    .bdl-PillSelectorWrapper {
         margin: 0;
     }
 
@@ -14,13 +14,13 @@
         transition: height .2s;
     }
 
-    .bdl-PillSelector-inputWrapper,
+    .bdl-PillSelector,
     textarea {
         width: 100%;
     }
 
     &.is-expanded {
-        .bdl-PillSelector-wrapper {
+        .bdl-PillSelectorWrapper {
             margin-bottom: 20px;
         }
 
@@ -28,7 +28,7 @@
             height: 100px;
         }
 
-        .bdl-PillSelector-inputWrapper {
+        .bdl-PillSelector {
             height: 58px;
         }
     }

--- a/src/features/shared-link-modal/PermissionMenu.js
+++ b/src/features/shared-link-modal/PermissionMenu.js
@@ -35,7 +35,7 @@ const PermissionMenu = (props: Props) => {
         <DropdownMenu>
             <PlainButton
                 className={classNames('lnk', {
-                    'is-disabled': submitting,
+                    'bdl-is-disabled': submitting,
                 })}
                 disabled={submitting}
             >

--- a/src/features/shared-link-modal/RemoveLinkConfirmModal.js
+++ b/src/features/shared-link-modal/RemoveLinkConfirmModal.js
@@ -21,7 +21,7 @@ const RemoveLinkConfirmModal = (props: Props) => {
 
     return (
         <Modal
-            focusElementSelector=".bdl-PrimaryButton"
+            focusElementSelector=".bdl-Button--primary"
             isOpen={isOpen}
             onRequestClose={submitting ? undefined : onRequestClose}
             title={<FormattedMessage {...messages.removeLinkConfirmationTitle} />}

--- a/src/features/shared-link-modal/RemoveLinkConfirmModal.js
+++ b/src/features/shared-link-modal/RemoveLinkConfirmModal.js
@@ -21,7 +21,7 @@ const RemoveLinkConfirmModal = (props: Props) => {
 
     return (
         <Modal
-            focusElementSelector=".btn-primary"
+            focusElementSelector=".bdl-PrimaryButton"
             isOpen={isOpen}
             onRequestClose={submitting ? undefined : onRequestClose}
             title={<FormattedMessage {...messages.removeLinkConfirmationTitle} />}

--- a/src/features/shared-link-modal/SharedLink.scss
+++ b/src/features/shared-link-modal/SharedLink.scss
@@ -23,7 +23,7 @@
             color: $bdl-gray-50;
         }
 
-        .btn-plain {
+        .bdl-Button--plain {
             margin-right: 10px;
         }
     }

--- a/src/features/shared-link-modal/SharedLink.scss
+++ b/src/features/shared-link-modal/SharedLink.scss
@@ -23,7 +23,7 @@
             color: $bdl-gray-50;
         }
 
-        .bdl-Button--plain {
+        .bdl-PlainButton {
             margin-right: 10px;
         }
     }

--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
@@ -356,7 +356,7 @@ class SharedLinkSettingsModal extends Component {
                 <FormattedMessage {...messages.modalTitle} />
                 <Classification
                     definition={bannerPolicy ? bannerPolicy.body : undefined}
-                    messageStyle="bdl-Tooltip"
+                    messageStyle="tooltip"
                     name={classification}
                     className="bdl-SharedLinkSettingsModal-classification"
                 />

--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
@@ -356,7 +356,7 @@ class SharedLinkSettingsModal extends Component {
                 <FormattedMessage {...messages.modalTitle} />
                 <Classification
                     definition={bannerPolicy ? bannerPolicy.body : undefined}
-                    messageStyle="tooltip"
+                    messageStyle="tooltip bdl-Tooltip"
                     name={classification}
                     className="bdl-SharedLinkSettingsModal-classification"
                 />

--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
@@ -356,7 +356,7 @@ class SharedLinkSettingsModal extends Component {
                 <FormattedMessage {...messages.modalTitle} />
                 <Classification
                     definition={bannerPolicy ? bannerPolicy.body : undefined}
-                    messageStyle="tooltip bdl-Tooltip"
+                    messageStyle="bdl-Tooltip"
                     name={classification}
                     className="bdl-SharedLinkSettingsModal-classification"
                 />

--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.scss
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.scss
@@ -50,7 +50,7 @@
     }
 }
 
-/** title and classifiction label */
+/** title and classification label */
 .bdl-SharedLinkSettingsModal-title {
     display: flex;
     flex-flow: row wrap;

--- a/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal.test.js.snap
+++ b/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal.test.js.snap
@@ -11,7 +11,7 @@ exports[` 1`] = `
   <Classification
     className="bdl-SharedLinkSettingsModal-classification"
     definition="test"
-    messageStyle="bdl-Tooltip"
+    messageStyle="tooltip"
     name="internal"
   />
 </span>

--- a/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal.test.js.snap
+++ b/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal.test.js.snap
@@ -11,7 +11,7 @@ exports[` 1`] = `
   <Classification
     className="bdl-SharedLinkSettingsModal-classification"
     definition="test"
-    messageStyle="tooltip"
+    messageStyle="bdl-Tooltip"
     name="internal"
   />
 </span>

--- a/src/features/unified-share-modal/InviteePermissionsMenu.js
+++ b/src/features/unified-share-modal/InviteePermissionsMenu.js
@@ -89,7 +89,7 @@ class InviteePermissionsMenu extends Component<Props> {
         const plainButton = (
             <PlainButton
                 className={classNames('lnk', {
-                    'is-disabled': disabled,
+                    'bdl-is-disabled': disabled,
                 })}
                 disabled={disabled}
                 {...inviteePermissionsButtonProps}

--- a/src/features/unified-share-modal/RemoveLinkConfirmModal.js
+++ b/src/features/unified-share-modal/RemoveLinkConfirmModal.js
@@ -42,7 +42,7 @@ class RemoveLinkConfirmModal extends Component<Props> {
 
         return (
             <Modal
-                focusElementSelector=".bdl-PrimaryButton"
+                focusElementSelector=".bdl-Button--primary"
                 isOpen={isOpen}
                 onRequestClose={submitting ? undefined : onRequestClose}
                 title={<FormattedMessage {...messages.removeLinkConfirmationTitle} />}

--- a/src/features/unified-share-modal/RemoveLinkConfirmModal.js
+++ b/src/features/unified-share-modal/RemoveLinkConfirmModal.js
@@ -42,7 +42,7 @@ class RemoveLinkConfirmModal extends Component<Props> {
 
         return (
             <Modal
-                focusElementSelector=".btn-primary"
+                focusElementSelector=".bdl-PrimaryButton"
                 isOpen={isOpen}
                 onRequestClose={submitting ? undefined : onRequestClose}
                 title={<FormattedMessage {...messages.removeLinkConfirmationTitle} />}

--- a/src/features/unified-share-modal/SharedLinkAccessMenu.js
+++ b/src/features/unified-share-modal/SharedLinkAccessMenu.js
@@ -120,7 +120,7 @@ class SharedLinkAccessMenu extends React.Component<Props> {
                 <DropdownMenu onMenuOpen={onSharedLinkAccessMenuOpen} constrainToWindow>
                     <PlainButton
                         className={classNames('lnk', {
-                            'is-disabled': submitting,
+                            'bdl-is-disabled': submitting,
                         })}
                         disabled={submitting}
                         {...sharedLinkAccessMenuButtonProps}

--- a/src/features/unified-share-modal/SharedLinkPermissionMenu.js
+++ b/src/features/unified-share-modal/SharedLinkPermissionMenu.js
@@ -67,7 +67,7 @@ class SharedLinkPermissionMenu extends Component<Props> {
             <DropdownMenu constrainToWindow>
                 <PlainButton
                     className={classNames('lnk', {
-                        'is-disabled': submitting,
+                        'bdl-is-disabled': submitting,
                     })}
                     disabled={submitting}
                     {...sharedLinkPermissionsMenuButtonProps}

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -293,7 +293,7 @@ class SharedLinkSection extends React.Component<Props> {
                     isDisabled={!isToggleEnabled}
                     isOn={isSharedLinkEnabled}
                     label={linkText}
-                    name="bdl-Toggle"
+                    name="toggle"
                     onChange={onToggleSharedLink}
                 />
             </div>

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -293,7 +293,7 @@ class SharedLinkSection extends React.Component<Props> {
                     isDisabled={!isToggleEnabled}
                     isOn={isSharedLinkEnabled}
                     label={linkText}
-                    name="toggle"
+                    name="toggle bdl-Toggle"
                     onChange={onToggleSharedLink}
                 />
             </div>
@@ -348,7 +348,7 @@ class SharedLinkSection extends React.Component<Props> {
                 <hr />
                 {/* eslint-disable-next-line jsx-a11y/label-has-for */}
                 <label>
-                    <span className="label">
+                    <span className="label bdl-Label">
                         <FormattedMessage {...messages.sharedLinkSectionLabel} />
                     </span>
                 </label>

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -293,7 +293,7 @@ class SharedLinkSection extends React.Component<Props> {
                     isDisabled={!isToggleEnabled}
                     isOn={isSharedLinkEnabled}
                     label={linkText}
-                    name="toggle bdl-Toggle"
+                    name="bdl-Toggle"
                     onChange={onToggleSharedLink}
                 />
             </div>
@@ -348,7 +348,7 @@ class SharedLinkSection extends React.Component<Props> {
                 <hr />
                 {/* eslint-disable-next-line jsx-a11y/label-has-for */}
                 <label>
-                    <span className="label bdl-Label">
+                    <span className="bdl-Label">
                         <FormattedMessage {...messages.sharedLinkSectionLabel} />
                     </span>
                 </label>

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -693,7 +693,7 @@ class UnifiedShareModal extends React.Component<Props, State> {
         const extendedModalProps = {
             focusElementSelector: canInvite
                 ? '.bdl-PillSelector-input' // focus on invite collabs field
-                : '.toggle-simple', // focus on shared link toggle
+                : '.bdl-Toggle-label', // focus on shared link toggle
             ...modalProps,
         };
 

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -692,7 +692,7 @@ class UnifiedShareModal extends React.Component<Props, State> {
         // focus logic at modal level
         const extendedModalProps = {
             focusElementSelector: canInvite
-                ? '.pill-selector-input' // focus on invite collabs field
+                ? '.bdl-PillSelector-input' // focus on invite collabs field
                 : '.toggle-simple', // focus on shared link toggle
             ...modalProps,
         };

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -15,7 +15,7 @@
         font-weight: bold;
     }
 
-    .tooltip-close-button {
+    .bdl-Tooltip-closeButton {
         top: 8px;
         right: 4px;
     }

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -91,17 +91,17 @@
         margin-bottom: 20px;
     }
 
-    .bdl-PillSelector-wrapper .bdl-PillSelector-inputWrapper, // need both selectors for specificity
+    .bdl-PillSelectorWrapper .bdl-PillSelector, // need both selectors for specificity
     textarea {
         /* override for DOM element in `TextArea` which provides no id/class for targeting */
         width: 100%;
     }
 
-    .bdl-PillSelector-wrapper {
+    .bdl-PillSelectorWrapper {
         margin-bottom: 10px;
     }
 
-    .bdl-PillSelector-wrapper.scrollable {
+    .bdl-PillSelectorWrapper.scrollable {
         .overlay-wrapper {
             position: absolute;
             height: 280px;
@@ -124,12 +124,12 @@
             color: $bdl-gray-50;
         }
 
-        .bdl-PillSelector-inputWrapper {
+        .bdl-PillSelector {
             min-height: 68px;
         }
     }
 
-    .bdl-PillSelector-inputWrapper {
+    .bdl-PillSelector {
         margin-top: 10px;
         border: 1px solid $bdl-gray-20;
 

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -168,7 +168,7 @@
                 margin-bottom: 0;
             }
 
-            .toggle-simple-label {
+            .bdl-Toggle-labelContent {
                 color: $bdl-gray;
                 cursor: pointer;
             }

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -137,7 +137,7 @@
             color: $bdl-gray-50;
         }
 
-        &.is-disabled {
+        &.bdl-is-disabled {
             color: $bdl-gray-30;
             background-color: $bdl-gray-02;
             box-shadow: none;
@@ -214,7 +214,7 @@
     }
 
     .shared-link-access-row {
-        .btn-plain {
+        .bdl-Button--plain {
             margin-right: 10px;
 
             &.can-edit-btn {

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -44,13 +44,13 @@
     }
 }
 
-.usm-share-access-menu .menu-item.is-select-item.is-selected::before,
-.usm-share-permissions-menu .menu-item.is-select-item.is-selected::before {
+.usm-share-access-menu .menu-item.is-select-item.bdl-is-selected::before,
+.usm-share-permissions-menu .menu-item.is-select-item.bdl-is-selected::before {
     bottom: inherit;
 }
 
 .unified-share-modal {
-    /** title and classifiction label */
+    /** title and classification label */
     .bdl-UnifiedShareModalTitle {
         display: flex;
         flex-flow: row wrap;
@@ -91,17 +91,17 @@
         margin-bottom: 20px;
     }
 
-    .pill-selector-wrapper .pill-selector-input-wrapper, // need both selectors for specificity
+    .bdl-PillSelector-wrapper .bdl-PillSelector-inputWrapper, // need both selectors for specificity
     textarea {
         /* override for DOM element in `TextArea` which provides no id/class for targeting */
         width: 100%;
     }
 
-    .pill-selector-wrapper {
+    .bdl-PillSelector-wrapper {
         margin-bottom: 10px;
     }
 
-    .pill-selector-wrapper.scrollable {
+    .bdl-PillSelector-wrapper.scrollable {
         .overlay-wrapper {
             position: absolute;
             height: 280px;
@@ -124,16 +124,16 @@
             color: $bdl-gray-50;
         }
 
-        .pill-selector-input-wrapper {
+        .bdl-PillSelector-inputWrapper {
             min-height: 68px;
         }
     }
 
-    .pill-selector-input-wrapper {
+    .bdl-PillSelector-inputWrapper {
         margin-top: 10px;
         border: 1px solid $bdl-gray-20;
 
-        .pill-selector-input::placeholder {
+        .bdl-PillSelector-input::placeholder {
             color: $bdl-gray-50;
         }
 
@@ -142,7 +142,7 @@
             background-color: $bdl-gray-02;
             box-shadow: none;
 
-            .pill-selector-input::placeholder {
+            .bdl-PillSelector-input::placeholder {
                 color: $bdl-gray-50;
             }
 
@@ -214,7 +214,7 @@
     }
 
     .shared-link-access-row {
-        .bdl-Button--plain {
+        .bdl-PlainButton {
             margin-right: 10px;
 
             &.can-edit-btn {

--- a/src/features/unified-share-modal/UnifiedShareModalTitle.js
+++ b/src/features/unified-share-modal/UnifiedShareModalTitle.js
@@ -57,7 +57,7 @@ const UnifiedShareModalTitle = ({ isEmailLinkSectionExpanded, showCollaboratorLi
             {title}
             <Classification
                 definition={bannerPolicy ? bannerPolicy.body : undefined}
-                messageStyle="bdl-Tooltip"
+                messageStyle="tooltip"
                 name={classification}
                 className="bdl-UnifiedShareModalTitle-classification"
             />

--- a/src/features/unified-share-modal/UnifiedShareModalTitle.js
+++ b/src/features/unified-share-modal/UnifiedShareModalTitle.js
@@ -57,7 +57,7 @@ const UnifiedShareModalTitle = ({ isEmailLinkSectionExpanded, showCollaboratorLi
             {title}
             <Classification
                 definition={bannerPolicy ? bannerPolicy.body : undefined}
-                messageStyle="tooltip"
+                messageStyle="tooltip bdl-Tooltip"
                 name={classification}
                 className="bdl-UnifiedShareModalTitle-classification"
             />

--- a/src/features/unified-share-modal/UnifiedShareModalTitle.js
+++ b/src/features/unified-share-modal/UnifiedShareModalTitle.js
@@ -57,7 +57,7 @@ const UnifiedShareModalTitle = ({ isEmailLinkSectionExpanded, showCollaboratorLi
             {title}
             <Classification
                 definition={bannerPolicy ? bannerPolicy.body : undefined}
-                messageStyle="tooltip bdl-Tooltip"
+                messageStyle="bdl-Tooltip"
                 name={classification}
                 className="bdl-UnifiedShareModalTitle-classification"
             />

--- a/src/features/unified-share-modal/__tests__/UnifiedShareModalTitle.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareModalTitle.test.js
@@ -28,7 +28,7 @@ describe('features/unified-share-modal/HeaderTitle', () => {
         wrapper = getWrapper();
     });
 
-    test('should render classifiction label with title', () => {
+    test('should render classification label with title', () => {
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu.test.js.snap
@@ -26,7 +26,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
         className="tooltip-target"
       >
         <PlainButton
-          className="lnk is-disabled"
+          className="lnk bdl-is-disabled"
           disabled={true}
         >
           <MenuToggle>
@@ -258,7 +258,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
         className="tooltip-target"
       >
         <PlainButton
-          className="lnk is-disabled"
+          className="lnk bdl-is-disabled"
           disabled={true}
         >
           <MenuToggle>
@@ -490,7 +490,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
         className="tooltip-target"
       >
         <PlainButton
-          className="lnk is-disabled"
+          className="lnk bdl-is-disabled"
           disabled={true}
         >
           <MenuToggle>
@@ -722,7 +722,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
         className="tooltip-target"
       >
         <PlainButton
-          className="lnk is-disabled"
+          className="lnk bdl-is-disabled"
           disabled={true}
         >
           <MenuToggle>
@@ -954,7 +954,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
         className="tooltip-target"
       >
         <PlainButton
-          className="lnk is-disabled"
+          className="lnk bdl-is-disabled"
           disabled={true}
         >
           <MenuToggle>
@@ -1186,7 +1186,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
         className="tooltip-target"
       >
         <PlainButton
-          className="lnk is-disabled"
+          className="lnk bdl-is-disabled"
           disabled={true}
         >
           <MenuToggle>
@@ -1525,7 +1525,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
         className="tooltip-target"
       >
         <PlainButton
-          className="lnk is-disabled"
+          className="lnk bdl-is-disabled"
           disabled={true}
         >
           <MenuToggle>
@@ -1642,7 +1642,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() should ren
     className="tooltip-target"
   >
     <PlainButton
-      className="lnk is-disabled"
+      className="lnk bdl-is-disabled"
       disabled={true}
     >
       <MenuToggle>
@@ -1675,7 +1675,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() should ren
     className="tooltip-target"
   >
     <PlainButton
-      className="lnk is-disabled"
+      className="lnk bdl-is-disabled"
       disabled={true}
     >
       <MenuToggle>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu.test.js.snap
@@ -59,7 +59,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
     isRightAligned={false}
   >
     <PlainButton
-      className="lnk is-disabled"
+      className="lnk bdl-is-disabled"
       disabled={true}
     >
       <MenuToggle>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
@@ -7,7 +7,7 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
   isRightAligned={false}
 >
   <PlainButton
-    className="lnk is-disabled"
+    className="lnk bdl-is-disabled"
     disabled={true}
   >
     <MenuToggle>
@@ -37,12 +37,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>
@@ -61,12 +61,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>
@@ -111,12 +111,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>
@@ -135,12 +135,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>
@@ -155,7 +155,7 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
   isRightAligned={false}
 >
   <PlainButton
-    className="lnk is-disabled"
+    className="lnk bdl-is-disabled"
     disabled={true}
   >
     <MenuToggle>
@@ -185,12 +185,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>
@@ -209,12 +209,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>
@@ -259,12 +259,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>
@@ -283,12 +283,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-           
+
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-           
+
         </small>
       </div>
     </SelectMenuItem>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
@@ -37,12 +37,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>
@@ -61,12 +61,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>
@@ -111,12 +111,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>
@@ -135,12 +135,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>
@@ -185,12 +185,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>
@@ -209,12 +209,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>
@@ -259,12 +259,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>
@@ -283,12 +283,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
         <small
           className="usm-menu-description"
         >
-
+           
           <FormattedMessage
             defaultMessage="Users can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
           />
-
+           
         </small>
       </div>
     </SelectMenuItem>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -56,7 +56,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
             </Tooltip>
           </span>
         }
-        name="bdl-Toggle"
+        name="toggle"
       />
     </div>
   </div>
@@ -199,7 +199,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
               id="boxui.unifiedShare.linkShareOn"
             />
           }
-          name="bdl-Toggle"
+          name="toggle"
         />
       </div>
     </Tooltip>
@@ -339,7 +339,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
               id="boxui.unifiedShare.linkShareOff"
             />
           }
-          name="bdl-Toggle"
+          name="toggle"
         />
       </div>
     </Tooltip>
@@ -375,7 +375,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="bdl-Toggle"
+        name="toggle"
       />
     </div>
   </div>
@@ -505,7 +505,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
             id="boxui.unifiedShare.linkShareOff"
           />
         }
-        name="bdl-Toggle"
+        name="toggle"
       />
     </div>
   </div>
@@ -553,7 +553,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
               id="boxui.unifiedShare.linkShareOn"
             />
           }
-          name="bdl-Toggle"
+          name="toggle"
         />
       </div>
     </Tooltip>
@@ -690,7 +690,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="bdl-Toggle"
+        name="toggle"
       />
     </div>
   </div>
@@ -821,7 +821,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="bdl-Toggle"
+        name="toggle"
       />
     </div>
   </div>
@@ -977,7 +977,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="bdl-Toggle"
+        name="toggle"
       />
     </div>
   </div>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -5,7 +5,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -56,7 +56,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
             </Tooltip>
           </span>
         }
-        name="toggle"
+        name="bdl-Toggle"
       />
     </div>
   </div>
@@ -163,7 +163,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -199,7 +199,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
               id="boxui.unifiedShare.linkShareOn"
             />
           }
-          name="toggle"
+          name="bdl-Toggle"
         />
       </div>
     </Tooltip>
@@ -303,7 +303,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -339,7 +339,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
               id="boxui.unifiedShare.linkShareOff"
             />
           }
-          name="toggle"
+          name="bdl-Toggle"
         />
       </div>
     </Tooltip>
@@ -352,7 +352,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -375,7 +375,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="toggle"
+        name="bdl-Toggle"
       />
     </div>
   </div>
@@ -482,7 +482,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -505,7 +505,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
             id="boxui.unifiedShare.linkShareOff"
           />
         }
-        name="toggle"
+        name="bdl-Toggle"
       />
     </div>
   </div>
@@ -517,7 +517,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -553,7 +553,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
               id="boxui.unifiedShare.linkShareOn"
             />
           }
-          name="toggle"
+          name="bdl-Toggle"
         />
       </div>
     </Tooltip>
@@ -667,7 +667,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -690,7 +690,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="toggle"
+        name="bdl-Toggle"
       />
     </div>
   </div>
@@ -798,7 +798,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -821,7 +821,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="toggle"
+        name="bdl-Toggle"
       />
     </div>
   </div>
@@ -954,7 +954,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
   <hr />
   <label>
     <span
-      className="label"
+      className="bdl-Label"
     >
       <FormattedMessage
         defaultMessage="Share Link"
@@ -977,7 +977,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
             id="boxui.unifiedShare.linkShareOn"
           />
         }
-        name="toggle"
+        name="bdl-Toggle"
       />
     </div>
   </div>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
@@ -1680,7 +1680,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".pill-selector-input"
+    focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
         "backdrop": Object {},
@@ -1863,7 +1863,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".pill-selector-input"
+    focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
         "backdrop": Object {},
@@ -2639,7 +2639,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".pill-selector-input"
+    focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
         "backdrop": Object {},
@@ -2820,7 +2820,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".pill-selector-input"
+    focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
         "backdrop": Object {},
@@ -2976,7 +2976,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".pill-selector-input"
+    focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
         "backdrop": Object {},

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
@@ -4,7 +4,7 @@ exports[`features/unified-share-modal/UnifiedShareModal closeEmailSharedLinkForm
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -186,7 +186,7 @@ exports[`features/unified-share-modal/UnifiedShareModal openEmailSharedLinkForm(
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -247,7 +247,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -429,7 +429,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -611,7 +611,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -797,7 +797,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -979,7 +979,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -1161,7 +1161,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -1314,7 +1314,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -1497,7 +1497,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -2017,7 +2017,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -2084,7 +2084,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     isOpen={false}
     style={
       Object {
@@ -2271,7 +2271,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},
@@ -2457,7 +2457,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 <div>
   <Modal
     className="unified-share-modal"
-    focusElementSelector=".toggle-simple"
+    focusElementSelector=".bdl-Toggle-label"
     style={
       Object {
         "backdrop": Object {},

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModalTitle.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModalTitle.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/unified-share-modal/HeaderTitle should render classifiction label with title 1`] = `
+exports[`features/unified-share-modal/HeaderTitle should render classification label with title 1`] = `
 <span
   className="bdl-UnifiedShareModalTitle"
 >
@@ -16,7 +16,7 @@ exports[`features/unified-share-modal/HeaderTitle should render classifiction la
   <Classification
     className="bdl-UnifiedShareModalTitle-classification"
     definition="test"
-    messageStyle="tooltip"
+    messageStyle="bdl-Tooltip"
     name="internal"
   />
 </span>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModalTitle.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModalTitle.test.js.snap
@@ -16,7 +16,7 @@ exports[`features/unified-share-modal/HeaderTitle should render classification l
   <Classification
     className="bdl-UnifiedShareModalTitle-classification"
     definition="test"
-    messageStyle="bdl-Tooltip"
+    messageStyle="tooltip"
     name="internal"
   />
 </span>

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -109,7 +109,7 @@ button svg {
     pointer-events: none;
 }
 
-.bdl-PrimaryButton {
+.bdl-Button--primary {
     color: $white;
     background-color: $primary-color;
     border-color: $primary-color;

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -2,7 +2,7 @@
  * Buttons
  **************************************/
 
-.btn {
+.bdl-Button {
     position: relative;
     display: inline-block;
     box-sizing: border-box;
@@ -37,7 +37,7 @@
         outline: none;
     }
 
-    &:not(.is-disabled) {
+    &:not(.bdl-is-disabled) {
         &:hover {
             background-color: darken($white, 3%);
         }
@@ -53,7 +53,7 @@
         }
     }
 
-    &.is-disabled,
+    &.bdl-is-disabled,
     &.is-loading {
         top: 0; /* prevents disabled button from being depressed on click */
         cursor: default;
@@ -76,15 +76,15 @@
         }
     }
 
-    &.is-disabled {
+    &.bdl-is-disabled {
         box-shadow: none;
         opacity: .4;
     }
 }
 
-.btn-plain,
-.btn-plain:hover,
-.btn-plain:active {
+.bdl-Button--plain,
+.bdl-Button--plain:hover,
+.bdl-Button--plain:active {
     margin: 0;
     padding: 0;
     font-weight: normal;
@@ -92,16 +92,16 @@
     cursor: pointer;
 }
 
-.btn-plain,
-.btn-plain:hover,
-.btn-plain:active,
-.btn-plain:focus {
+.bdl-Button--plain,
+.bdl-Button--plain:hover,
+.bdl-Button--plain:active,
+.bdl-Button--plain:focus {
     background: transparent;
     box-shadow: none;
 }
 
 /* This setting is being used to override the dotted border on a firefox button */
-button.btn-plain::-moz-focus-inner {
+button.bdl-Button--plain::-moz-focus-inner {
     border: 0 none;
 }
 
@@ -109,13 +109,13 @@ button svg {
     pointer-events: none;
 }
 
-.btn-primary {
+.bdl-Button--primary {
     color: $white;
     background-color: $primary-color;
     border-color: $primary-color;
     -webkit-font-smoothing: antialiased;
 
-    &:not(.is-disabled) {
+    &:not(.bdl-is-disabled) {
         &:focus {
             border-color: $primary-color;
             box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -82,9 +82,9 @@
     }
 }
 
-.bdl-Button--plain,
-.bdl-Button--plain:hover,
-.bdl-Button--plain:active {
+.bdl-PlainButton,
+.bdl-PlainButton:hover,
+.bdl-PlainButton:active {
     margin: 0;
     padding: 0;
     font-weight: normal;
@@ -92,16 +92,16 @@
     cursor: pointer;
 }
 
-.bdl-Button--plain,
-.bdl-Button--plain:hover,
-.bdl-Button--plain:active,
-.bdl-Button--plain:focus {
+.bdl-PlainButton,
+.bdl-PlainButton:hover,
+.bdl-PlainButton:active,
+.bdl-PlainButton:focus {
     background: transparent;
     box-shadow: none;
 }
 
 /* This setting is being used to override the dotted border on a firefox button */
-button.bdl-Button--plain::-moz-focus-inner {
+button.bdl-PlainButton::-moz-focus-inner {
     border: 0 none;
 }
 
@@ -109,7 +109,7 @@ button svg {
     pointer-events: none;
 }
 
-.bdl-Button--primary {
+.bdl-PrimaryButton {
     color: $white;
     background-color: $primary-color;
     border-color: $primary-color;

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -54,17 +54,17 @@
     }
 
     &.bdl-is-disabled,
-    &.is-loading {
+    &.bdl-is-loading {
         top: 0; /* prevents disabled button from being depressed on click */
         cursor: default;
     }
 
-    &.is-loading {
-        .btn-content {
+    &.bdl-is-loading {
+        .bdl-Button-content {
             visibility: hidden;
         }
 
-        .btn-loading-indicator {
+        .bdl-Button-loadingIndicator {
             position: absolute;
             top: 0;
             left: 0;
@@ -133,8 +133,8 @@ button svg {
         }
     }
 
-    &.is-loading {
-        .btn-content {
+    &.bdl-is-loading {
+        .bdl-Button-content {
             background-color: $bdl-gray-30;
         }
     }

--- a/src/styles/common/_forms.scss
+++ b/src/styles/common/_forms.scss
@@ -181,7 +181,7 @@ textarea {
 }
 
 .bdl-Select-container .bdl-SelectButton,
-.bdl-Select-container .bdl-Select-container-inner {
+.bdl-Select-container .bdl-Select-innerContainer {
     display: inline-block;
     width: 100%;
     overflow: hidden;
@@ -284,23 +284,23 @@ textarea {
     background-color: $bdl-gray-10;
 }
 
-.bdl-Select-container-x-small {
+.bdl-Select-container--xSmall {
     width: 50px;
 }
 
-.bdl-Select-container-small {
+.bdl-Select-container--small {
     width: 100px;
 }
 
-.bdl-Select-container-medium {
+.bdl-Select-container--medium {
     width: 200px;
 }
 
-.bdl-Select-container-large {
+.bdl-Select-container--large {
     width: 262px;
 }
 
-.bdl-Select-container-x-large {
+.bdl-Select-container--xLarge {
     width: 345px;
 }
 

--- a/src/styles/common/_forms.scss
+++ b/src/styles/common/_forms.scss
@@ -50,27 +50,27 @@ input:-ms-input-placeholder {
     color: $bdl-gray-20;
 }
 
-input[type='text'].is-invalid,
-input[type='password'].is-invalid,
-input[type='search'].is-invalid,
-input[type='email'].is-invalid,
-input[type='url'].is-invalid,
-input[type='tel'].is-invalid,
-input[type='number'].is-invalid,
-div[contentEditable='true'].is-invalid,
-textarea.is-invalid {
+input[type='text'].bdl-is-invalid,
+input[type='password'].bdl-is-invalid,
+input[type='search'].bdl-is-invalid,
+input[type='email'].bdl-is-invalid,
+input[type='url'].bdl-is-invalid,
+input[type='tel'].bdl-is-invalid,
+input[type='number'].bdl-is-invalid,
+div[contentEditable='true'].bdl-is-invalid,
+textarea.bdl-is-invalid {
     border: 1px solid $bdl-watermelon-red;
 }
 
-input[type='text'].is-invalid:focus,
-input[type='password'].is-invalid:focus,
-input[type='search'].is-invalid:focus,
-input[type='email'].is-invalid:focus,
-input[type='url'].is-invalid:focus,
-input[type='tel'].is-invalid:focus,
-input[type='number'].is-invalid:focus,
-div[contentEditable='true'].is-invalid:focus,
-textarea.is-invalid:focus {
+input[type='text'].bdl-is-invalid:focus,
+input[type='password'].bdl-is-invalid:focus,
+input[type='search'].bdl-is-invalid:focus,
+input[type='email'].bdl-is-invalid:focus,
+input[type='url'].bdl-is-invalid:focus,
+input[type='tel'].bdl-is-invalid:focus,
+input[type='number'].bdl-is-invalid:focus,
+div[contentEditable='true'].bdl-is-invalid:focus,
+textarea.bdl-is-invalid:focus {
     border: 1px solid #f44;
 }
 
@@ -149,8 +149,8 @@ textarea {
 
 /* Select component with container */
 
-.select-container select,
-.select-container .bdl-SelectButton {
+.bdl-Select-container select,
+.bdl-Select-container .bdl-SelectButton {
     position: relative;
     z-index: 1; /* captures click */
     display: inline-block;
@@ -163,25 +163,25 @@ textarea {
     appearance: none;
 }
 
-.select-container select {
+.bdl-Select-container select {
     padding-right: 25px;
     color: $bdl-gray;
     background: none;
     border: none;
 }
 
-.select-container .bdl-SelectButton:disabled,
-.select-container select:disabled {
+.bdl-Select-container .bdl-SelectButton:disabled,
+.bdl-Select-container select:disabled {
     cursor: default;
 }
 
-.select-container {
+.bdl-Select-container {
     position: relative;
     display: inline-block;
 }
 
-.select-container .bdl-SelectButton,
-.select-container .select-container-inner {
+.bdl-Select-container .bdl-SelectButton,
+.bdl-Select-container .bdl-Select-container-inner {
     display: inline-block;
     width: 100%;
     overflow: hidden;
@@ -191,7 +191,7 @@ textarea {
     vertical-align: top;
 }
 
-.select-container .select-overlay {
+.bdl-Select-container .bdl-Select-overlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -202,8 +202,8 @@ textarea {
     padding: 0;
 }
 
-.select-container .select-overlay,
-.select-container .bdl-SelectButton {
+.bdl-Select-container .bdl-Select-overlay,
+.bdl-Select-container .bdl-SelectButton {
     background-color: $white;
     border: 1px solid $bdl-gray-20;
     border-radius: 2px;
@@ -212,8 +212,8 @@ textarea {
     transition: border-color linear .15s, box-shadow linear .1s;
 }
 
-.select-container .select-overlay::before,
-.select-container .bdl-SelectButton::before {
+.bdl-Select-container .bdl-Select-overlay::before,
+.bdl-Select-container .bdl-SelectButton::before {
     position: absolute;
     top: 15px;
     right: 11px;
@@ -226,85 +226,85 @@ textarea {
     content: '';
 }
 
-.select-container .bdl-SelectButton[aria-expanded='true']::before {
+.bdl-Select-container .bdl-SelectButton[aria-expanded='true']::before {
     transform: rotateZ(180deg);
 }
 
-.select-container .bdl-SelectButton {
+.bdl-Select-container .bdl-SelectButton {
     padding-right: 25px;
     color: $bdl-gray;
 }
 
-.select-container .bdl-SelectButton:focus,
-.select-container select:focus {
+.bdl-Select-container .bdl-SelectButton:focus,
+.bdl-Select-container select:focus {
     outline: none;
 }
 
-.select-container .bdl-SelectButton:focus,
-.select-container select:focus ~ .select-overlay {
+.bdl-Select-container .bdl-SelectButton:focus,
+.bdl-Select-container select:focus ~ .bdl-Select-overlay {
     border: 1px solid $primary-color;
 }
 
-.select-container .bdl-SelectButton:hover,
-.select-container select:hover ~ .select-overlay {
+.bdl-Select-container .bdl-SelectButton:hover,
+.bdl-Select-container select:hover ~ .bdl-Select-overlay {
     border: 1px solid #4c4c4c;
     box-shadow: 0 1px 1px 1px rgba(0, 0, 0, .1);
 }
 
-.select-container .bdl-SelectButton:disabled,
-.select-container select:disabled {
+.bdl-Select-container .bdl-SelectButton:disabled,
+.bdl-Select-container select:disabled {
     color: $bdl-gray-30;
 }
 
-.select-container .bdl-SelectButton:disabled,
-.select-container select:disabled ~ .select-overlay {
+.bdl-Select-container .bdl-SelectButton:disabled,
+.bdl-Select-container select:disabled ~ .bdl-Select-overlay {
     background-color: $bdl-gray-02;
     border-color: $bdl-gray-10;
     box-shadow: none;
 }
 
-.select-container .bdl-SelectButton:disabled:hover,
-.select-container select:disabled:hover ~ .select-overlay {
+.bdl-Select-container .bdl-SelectButton:disabled:hover,
+.bdl-Select-container select:disabled:hover ~ .bdl-Select-overlay {
     box-shadow: none;
 }
 
-.select-container .bdl-SelectButton:disabled::before,
-.select-container select:disabled ~ .select-overlay::before {
+.bdl-Select-container .bdl-SelectButton:disabled::before,
+.bdl-Select-container select:disabled ~ .bdl-Select-overlay::before {
     border-top: 3px solid #d5d5d5;
 }
 
-.select-container.is-invalid select + .select-overlay,
-.select-container.is-invalid .bdl-SelectButton:focus ~ .select-overlay,
-.select-container.is-invalid select:focus ~ .select-overlay,
-.select-container.is-invalid select:hover + .select-overlay {
+.bdl-Select-container.bdl-is-invalid select + .bdl-Select-overlay,
+.bdl-Select-container.bdl-is-invalid .bdl-SelectButton:focus ~ .bdl-Select-overlay,
+.bdl-Select-container.bdl-is-invalid select:focus ~ .bdl-Select-overlay,
+.bdl-Select-container.bdl-is-invalid select:hover + .bdl-Select-overlay {
     border: 1px solid $bdl-watermelon-red;
 }
 
-.select-container .bdl-SelectButton:active {
+.bdl-Select-container .bdl-SelectButton:active {
     background-color: $bdl-gray-10;
 }
 
-.select-container-x-small {
+.bdl-Select-container-x-small {
     width: 50px;
 }
 
-.select-container-small {
+.bdl-Select-container-small {
     width: 100px;
 }
 
-.select-container-medium {
+.bdl-Select-container-medium {
     width: 200px;
 }
 
-.select-container-large {
+.bdl-Select-container-large {
     width: 262px;
 }
 
-.select-container-x-large {
+.bdl-Select-container-x-large {
     width: 345px;
 }
 
-.select-container.huge {
+.bdl-Select-container.huge {
     width: 500px;
 }
 

--- a/src/styles/common/_forms.scss
+++ b/src/styles/common/_forms.scss
@@ -149,8 +149,8 @@ textarea {
 
 /* Select component with container */
 
-.bdl-Select-container select,
-.bdl-Select-container .bdl-SelectButton {
+.bdl-Select-content select,
+.bdl-Select-content .bdl-SelectButton {
     position: relative;
     z-index: 1; /* captures click */
     display: inline-block;
@@ -163,25 +163,25 @@ textarea {
     appearance: none;
 }
 
-.bdl-Select-container select {
+.bdl-Select-content select {
     padding-right: 25px;
     color: $bdl-gray;
     background: none;
     border: none;
 }
 
-.bdl-Select-container .bdl-SelectButton:disabled,
-.bdl-Select-container select:disabled {
+.bdl-Select-content .bdl-SelectButton:disabled,
+.bdl-Select-content select:disabled {
     cursor: default;
 }
 
-.bdl-Select-container {
+.bdl-Select-content {
     position: relative;
     display: inline-block;
 }
 
-.bdl-Select-container .bdl-SelectButton,
-.bdl-Select-container .bdl-Select-innerContainer {
+.bdl-Select-content .bdl-SelectButton,
+.bdl-Select-content .bdl-Select-contentBody {
     display: inline-block;
     width: 100%;
     overflow: hidden;
@@ -191,7 +191,7 @@ textarea {
     vertical-align: top;
 }
 
-.bdl-Select-container .bdl-Select-overlay {
+.bdl-Select-content .bdl-Select-overlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -202,8 +202,8 @@ textarea {
     padding: 0;
 }
 
-.bdl-Select-container .bdl-Select-overlay,
-.bdl-Select-container .bdl-SelectButton {
+.bdl-Select-content .bdl-Select-overlay,
+.bdl-Select-content .bdl-SelectButton {
     background-color: $white;
     border: 1px solid $bdl-gray-20;
     border-radius: 2px;
@@ -212,8 +212,8 @@ textarea {
     transition: border-color linear .15s, box-shadow linear .1s;
 }
 
-.bdl-Select-container .bdl-Select-overlay::before,
-.bdl-Select-container .bdl-SelectButton::before {
+.bdl-Select-content .bdl-Select-overlay::before,
+.bdl-Select-content .bdl-SelectButton::before {
     position: absolute;
     top: 15px;
     right: 11px;
@@ -226,85 +226,85 @@ textarea {
     content: '';
 }
 
-.bdl-Select-container .bdl-SelectButton[aria-expanded='true']::before {
+.bdl-Select-content .bdl-SelectButton[aria-expanded='true']::before {
     transform: rotateZ(180deg);
 }
 
-.bdl-Select-container .bdl-SelectButton {
+.bdl-Select-content .bdl-SelectButton {
     padding-right: 25px;
     color: $bdl-gray;
 }
 
-.bdl-Select-container .bdl-SelectButton:focus,
-.bdl-Select-container select:focus {
+.bdl-Select-content .bdl-SelectButton:focus,
+.bdl-Select-content select:focus {
     outline: none;
 }
 
-.bdl-Select-container .bdl-SelectButton:focus,
-.bdl-Select-container select:focus ~ .bdl-Select-overlay {
+.bdl-Select-content .bdl-SelectButton:focus,
+.bdl-Select-content select:focus ~ .bdl-Select-overlay {
     border: 1px solid $primary-color;
 }
 
-.bdl-Select-container .bdl-SelectButton:hover,
-.bdl-Select-container select:hover ~ .bdl-Select-overlay {
+.bdl-Select-content .bdl-SelectButton:hover,
+.bdl-Select-content select:hover ~ .bdl-Select-overlay {
     border: 1px solid #4c4c4c;
     box-shadow: 0 1px 1px 1px rgba(0, 0, 0, .1);
 }
 
-.bdl-Select-container .bdl-SelectButton:disabled,
-.bdl-Select-container select:disabled {
+.bdl-Select-content .bdl-SelectButton:disabled,
+.bdl-Select-content select:disabled {
     color: $bdl-gray-30;
 }
 
-.bdl-Select-container .bdl-SelectButton:disabled,
-.bdl-Select-container select:disabled ~ .bdl-Select-overlay {
+.bdl-Select-content .bdl-SelectButton:disabled,
+.bdl-Select-content select:disabled ~ .bdl-Select-overlay {
     background-color: $bdl-gray-02;
     border-color: $bdl-gray-10;
     box-shadow: none;
 }
 
-.bdl-Select-container .bdl-SelectButton:disabled:hover,
-.bdl-Select-container select:disabled:hover ~ .bdl-Select-overlay {
+.bdl-Select-content .bdl-SelectButton:disabled:hover,
+.bdl-Select-content select:disabled:hover ~ .bdl-Select-overlay {
     box-shadow: none;
 }
 
-.bdl-Select-container .bdl-SelectButton:disabled::before,
-.bdl-Select-container select:disabled ~ .bdl-Select-overlay::before {
+.bdl-Select-content .bdl-SelectButton:disabled::before,
+.bdl-Select-content select:disabled ~ .bdl-Select-overlay::before {
     border-top: 3px solid #d5d5d5;
 }
 
-.bdl-Select-container.bdl-is-invalid select + .bdl-Select-overlay,
-.bdl-Select-container.bdl-is-invalid .bdl-SelectButton:focus ~ .bdl-Select-overlay,
-.bdl-Select-container.bdl-is-invalid select:focus ~ .bdl-Select-overlay,
-.bdl-Select-container.bdl-is-invalid select:hover + .bdl-Select-overlay {
+.bdl-Select-content.bdl-is-invalid select + .bdl-Select-overlay,
+.bdl-Select-content.bdl-is-invalid .bdl-SelectButton:focus ~ .bdl-Select-overlay,
+.bdl-Select-content.bdl-is-invalid select:focus ~ .bdl-Select-overlay,
+.bdl-Select-content.bdl-is-invalid select:hover + .bdl-Select-overlay {
     border: 1px solid $bdl-watermelon-red;
 }
 
-.bdl-Select-container .bdl-SelectButton:active {
+.bdl-Select-content .bdl-SelectButton:active {
     background-color: $bdl-gray-10;
 }
 
-.bdl-Select-container--xSmall {
+.bdl-Select-content--xSmall {
     width: 50px;
 }
 
-.bdl-Select-container--small {
+.bdl-Select-content--small {
     width: 100px;
 }
 
-.bdl-Select-container--medium {
+.bdl-Select-content--medium {
     width: 200px;
 }
 
-.bdl-Select-container--large {
+.bdl-Select-content--large {
     width: 262px;
 }
 
-.bdl-Select-container--xLarge {
+.bdl-Select-content--xLarge {
     width: 345px;
 }
 
-.bdl-Select-container.huge {
+.bdl-Select-content.huge {
     width: 500px;
 }
 

--- a/src/styles/common/_forms.scss
+++ b/src/styles/common/_forms.scss
@@ -150,7 +150,7 @@ textarea {
 /* Select component with container */
 
 .select-container select,
-.select-container .select-button {
+.select-container .bdl-SelectButton {
     position: relative;
     z-index: 1; /* captures click */
     display: inline-block;
@@ -170,7 +170,7 @@ textarea {
     border: none;
 }
 
-.select-container .select-button:disabled,
+.select-container .bdl-SelectButton:disabled,
 .select-container select:disabled {
     cursor: default;
 }
@@ -180,7 +180,7 @@ textarea {
     display: inline-block;
 }
 
-.select-container .select-button,
+.select-container .bdl-SelectButton,
 .select-container .select-container-inner {
     display: inline-block;
     width: 100%;
@@ -203,7 +203,7 @@ textarea {
 }
 
 .select-container .select-overlay,
-.select-container .select-button {
+.select-container .bdl-SelectButton {
     background-color: $white;
     border: 1px solid $bdl-gray-20;
     border-radius: 2px;
@@ -213,7 +213,7 @@ textarea {
 }
 
 .select-container .select-overlay::before,
-.select-container .select-button::before {
+.select-container .bdl-SelectButton::before {
     position: absolute;
     top: 15px;
     right: 11px;
@@ -226,61 +226,61 @@ textarea {
     content: '';
 }
 
-.select-container .select-button[aria-expanded='true']::before {
+.select-container .bdl-SelectButton[aria-expanded='true']::before {
     transform: rotateZ(180deg);
 }
 
-.select-container .select-button {
+.select-container .bdl-SelectButton {
     padding-right: 25px;
     color: $bdl-gray;
 }
 
-.select-container .select-button:focus,
+.select-container .bdl-SelectButton:focus,
 .select-container select:focus {
     outline: none;
 }
 
-.select-container .select-button:focus,
+.select-container .bdl-SelectButton:focus,
 .select-container select:focus ~ .select-overlay {
     border: 1px solid $primary-color;
 }
 
-.select-container .select-button:hover,
+.select-container .bdl-SelectButton:hover,
 .select-container select:hover ~ .select-overlay {
     border: 1px solid #4c4c4c;
     box-shadow: 0 1px 1px 1px rgba(0, 0, 0, .1);
 }
 
-.select-container .select-button:disabled,
+.select-container .bdl-SelectButton:disabled,
 .select-container select:disabled {
     color: $bdl-gray-30;
 }
 
-.select-container .select-button:disabled,
+.select-container .bdl-SelectButton:disabled,
 .select-container select:disabled ~ .select-overlay {
     background-color: $bdl-gray-02;
     border-color: $bdl-gray-10;
     box-shadow: none;
 }
 
-.select-container .select-button:disabled:hover,
+.select-container .bdl-SelectButton:disabled:hover,
 .select-container select:disabled:hover ~ .select-overlay {
     box-shadow: none;
 }
 
-.select-container .select-button:disabled::before,
+.select-container .bdl-SelectButton:disabled::before,
 .select-container select:disabled ~ .select-overlay::before {
     border-top: 3px solid #d5d5d5;
 }
 
 .select-container.is-invalid select + .select-overlay,
-.select-container.is-invalid .select-button:focus ~ .select-overlay,
+.select-container.is-invalid .bdl-SelectButton:focus ~ .select-overlay,
 .select-container.is-invalid select:focus ~ .select-overlay,
 .select-container.is-invalid select:hover + .select-overlay {
     border: 1px solid $bdl-watermelon-red;
 }
 
-.select-container .select-button:active {
+.select-container .bdl-SelectButton:active {
     background-color: $bdl-gray-10;
 }
 

--- a/src/styles/common/_links.scss
+++ b/src/styles/common/_links.scss
@@ -38,17 +38,17 @@ a,
 
 a:focus,
 .lnk:focus,
-a.is-disabled:focus,
-.lnk.is-disabled:focus {
+a.bdl-is-disabled:focus,
+.lnk.bdl-is-disabled:focus {
     text-decoration: underline;
 }
 
-a.is-disabled,
-a.is-disabled:hover,
-a.is-disabled:active,
-.lnk.is-disabled,
-.lnk.is-disabled:hover,
-.lnk.is-disabled:active {
+a.bdl-is-disabled,
+a.bdl-is-disabled:hover,
+a.bdl-is-disabled:active,
+.lnk.bdl-is-disabled,
+.lnk.bdl-is-disabled:hover,
+.lnk.bdl-is-disabled:active {
     color: $bdl-gray-50;
     text-decoration: none;
     cursor: default;
@@ -63,9 +63,9 @@ a.is-disabled:active,
     text-decoration: none;
 }
 
-.lnk-plain.is-disabled,
-.lnk-plain.is-disabled:hover,
-.lnk-plain.is-disabled:active {
+.lnk-plain.bdl-is-disabled,
+.lnk-plain.bdl-is-disabled:hover,
+.lnk-plain.bdl-is-disabled:active {
     color: $bdl-gray-50;
 }
 

--- a/src/styles/common/_overlay.scss
+++ b/src/styles/common/_overlay.scss
@@ -48,7 +48,7 @@ $transform-duration: .125s;
 }
 
 .toggle-overlay-container {
-    > .btn {
+    > .bdl-Button {
         margin-bottom: 0;
         margin-left: 0;
     }

--- a/src/styles/common/_pills.scss
+++ b/src/styles/common/_pills.scss
@@ -4,8 +4,8 @@
 
 $pillTextColorDark: lighten($black, 31%);
 
-.pill,
-.btn.pill {
+.bdl-Pill,
+.bdl-Button.bdl-Pill {
     display: flex;
     flex: none;
     align-items: center;
@@ -39,7 +39,7 @@ $pillTextColorDark: lighten($black, 31%);
         cursor: pointer;
     }
 
-    &.is-disabled {
+    &.bdl-is-disabled {
         opacity: .5;
 
         .close-btn {
@@ -66,7 +66,7 @@ $pillTextColorDark: lighten($black, 31%);
     }
 }
 
-.pill-error {
+.bdl-Pill--error {
     color: $bdl-watermelon-red;
     background-color: $bdl-watermelon-red-10;
     border: 1px solid $bdl-watermelon-red-50;
@@ -76,7 +76,7 @@ $pillTextColorDark: lighten($black, 31%);
     }
 }
 
-.pill.pill-cloud-button {
+.bdl-Pill.pill-cloud-button {
     display: inline-block;
     margin: 3px;
     color: $primary-color;
@@ -87,7 +87,7 @@ $pillTextColorDark: lighten($black, 31%);
         box-shadow: none;
     }
 
-    &:not(.is-disabled) {
+    &:not(.bdl-is-disabled) {
         &:focus {
             border-color: darken($primary-color, 8%);
             box-shadow: 0 1px 2px fade-out($black, .9);

--- a/src/styles/common/_pills.scss
+++ b/src/styles/common/_pills.scss
@@ -20,14 +20,14 @@ $pillTextColorDark: lighten($black, 31%);
     background-color: $primary-color;
     border-radius: 3px;
 
-    .pill-text {
+    .bdl-Pill-text {
         display: block;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
     }
 
-    .close-btn {
+    .bdl-CloseButton {
         flex: none;
         margin: 0 0 0 4px;
         padding: 4px 0 4px 4px;
@@ -42,16 +42,16 @@ $pillTextColorDark: lighten($black, 31%);
     &.bdl-is-disabled {
         opacity: .5;
 
-        .close-btn {
+        .bdl-CloseButton {
             cursor: default;
         }
     }
 
-    &.is-invalid {
+    &.bdl-is-invalid {
         background-color: $bdl-watermelon-red;
     }
 
-    &.is-selected {
+    &.bdl-is-selected {
         box-shadow: inset 0 0 0 1px $white;
     }
 }
@@ -76,14 +76,14 @@ $pillTextColorDark: lighten($black, 31%);
     }
 }
 
-.bdl-Pill.pill-cloud-button {
+.bdl-Pill.bdl-PillCloud-button {
     display: inline-block;
     margin: 3px;
     color: $primary-color;
     background-color: $white;
     border: 1px solid $primary-color;
 
-    &.is-selected {
+    &.bdl-is-selected {
         box-shadow: none;
     }
 
@@ -95,7 +95,7 @@ $pillTextColorDark: lighten($black, 31%);
     }
 }
 
-.pill-cloud-container {
+.bdl-PillCloud {
     padding: 8px;
     overflow-y: scroll;
     border: 1px solid $bdl-gray-10;

--- a/src/styles/common/_tables.scss
+++ b/src/styles/common/_tables.scss
@@ -142,7 +142,7 @@
     }
 
     &:focus,
-    &.is-focused {
+    &.bdl-is-focused {
         outline: none;
 
         &::before {

--- a/src/styles/common/_tables.scss
+++ b/src/styles/common/_tables.scss
@@ -99,13 +99,13 @@
 .table-body .table-row {
     border-top: 1px solid $bdl-gray-10;
 
-    .table.has-hover-styles &:not(.is-selected):hover,
-    .table.has-hover-styles &:not(.is-selected).hover-styles {
+    .table.has-hover-styles &:not(.bdl-is-selected):hover,
+    .table.has-hover-styles &:not(.bdl-is-selected).hover-styles {
         color: darken($primary-color, 25%);
         background-color: $hover-blue-background;
         border-top: 1px solid $hover-blue-border;
 
-        & + .table-row:not(.is-selected) {
+        & + .table-row:not(.bdl-is-selected) {
             border-top: 1px solid $hover-blue-border;
         }
 
@@ -118,7 +118,7 @@
         }
     }
 
-    .table &.is-selected {
+    .table &.bdl-is-selected {
         color: darken($primary-color, 25%);
         background-color: $selected-blue-background;
         border-top: 1px solid $selected-blue-border;
@@ -233,7 +233,7 @@
                 background-color: $bdl-gray-05;
             }
 
-            &.is-selected {
+            &.bdl-is-selected {
                 background-color: fade-out($primary-color, .9);
             }
         }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -51,9 +51,7 @@ export function isFocusableElement(element: HTMLElement | EventTarget | null): b
 
     const isButton =
         element.classList.contains('bdl-Button-content') ||
-        (element.parentElement instanceof HTMLElement
-            ? element.parentElement.classList.contains('btn bdl-Button')
-            : false);
+        (element.parentElement instanceof HTMLElement ? element.parentElement.classList.contains('bdl-Button') : false);
 
     return isInputElement(element) || tag === 'button' || tag === 'a' || tag === 'option' || isCheckbox || isButton;
 }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -50,8 +50,10 @@ export function isFocusableElement(element: HTMLElement | EventTarget | null): b
             : false);
 
     const isButton =
-        element.classList.contains('btn-content') ||
-        (element.parentElement instanceof HTMLElement ? element.parentElement.classList.contains('btn') : false);
+        element.classList.contains('bdl-Button-content') ||
+        (element.parentElement instanceof HTMLElement
+            ? element.parentElement.classList.contains('btn bdl-Button')
+            : false);
 
     return isInputElement(element) || tag === 'button' || tag === 'a' || tag === 'option' || isCheckbox || isButton;
 }

--- a/test/integration/content-sidebar/TaskForm.e2e.test.js
+++ b/test/integration/content-sidebar/TaskForm.e2e.test.js
@@ -62,7 +62,7 @@ describe('Create Task', () => {
 
         it('shows error state after receiving server error', () => {
             cy.route('POST', '**/undoc/tasks').as('createTaskLink');
-            getSubmitButton().should('not.have.class', 'is-loading');
+            getSubmitButton().should('not.have.class', 'bdl-is-loading');
             cy.getByTestId('create-task-modal').within(() => {
                 getAssigneeField()
                     .type(username)
@@ -74,7 +74,7 @@ describe('Create Task', () => {
             });
 
             // submit button should be in loading state
-            getSubmitButton().should('have.class', 'is-loading');
+            getSubmitButton().should('have.class', 'bdl-is-loading');
 
             // wait for task creation request to finish
             cy.wait('@createTaskLink');


### PR DESCRIPTION
### Overview
This PR replaces several generic CSS class names with prefixed, SUIT-compliant class names.

Changes include:
- .btn -> .bdl-Button
- .btn-plain -> .bdl-PlainButton
- .btn-primary -> .bdl-PrimaryButton
- .btn-group -> .bdl-ButtonGroup
- .btn-loading-indicator -> .bdl-Button-loadingIndicator
- .close-button -> .bdl-CloseButton
- .select-button -> .bdl-SelectButton
- .select-input-container -> .bdl-Select
- .select-overlay -> .bdl-Select-overlay
- .select-container -> .bdl-Select-container
- .select-container-inner -> .bdl-Select-innerContainer
- .select-container-x-small -> .bdl-Select-container--xSmall
- .select-container-small -> .bdl-Select-container--small
- .select-container-medium -> .bdl-Select-container--medium
- .select-container-large -> .bdl-Select-container--large
- .select-container-x-large -> .bdl-Select-container--xLarge
- .label -> .bdl-Label
- .label-optional -> .bdl-Label-optionalText
- .toggle -> bdl-Toggle
- .tooltip -> .bdl-Tooltip
- .tooltip-icon -> .bdl-Tooltip-icon
- .pill -> .bdl-Pill
- .pill-error -> .bdl-Pill--error
- .pill-cloud-container-> .bdl-PillCloud
- .pill-cloud-button -> bdl-PillCloud-button
- .pill-selector-wrapper -> .bdl-PillSelectorWrapper
- .pill-selector-hidden-input -> .bdl-PillSelector-hiddenInput
- .pill-selector-input -> .bdl-PillSelector-input
- .pill-selector-input-wrapper -> .bdl-PillSelector
- .pill-selector-suggestions-enabled -> .bdl-PillSelector--suggestionsEnabled
- .pill-text -> .bdl-Pill-text
- .pills-list -> .bdl-PillsList
- .is-loading -> .bdl-is-loading
- .is-disabled -> .bdl-is-disabled
- .is-selected -> .bdl-is-selected
- .show-error -> .bdl-show-error

These new class names are **not** backwards-compatible, as this branch is intended for consumption by Platform customers only. We will warn our customers that this branch contains experimental changes that have not been thoroughly tested (although I have personally verified that all the Elements look correct).

This PR will be merged into the new **next** branch, which is currently set up to track **master**, but which will follow the release schedule of the **release** branch. We will create a new dist tag based on this branch so that Platform customers can immediately begin using the new class names. 

### Renaming decisions
#### .bdl-PlainButton and .bdl-PrimaryButton
I renamed `.btn-plain` and `.btn-primary` to `.bdl-PlainButton` and `.bdl-PrimaryButton` instead of `.bdl-Button--plain` and `.bdl-Button--primary`.

`PlainButton` and `PrimaryButton` are standalone components and not merely states of `Button`, just like `SelectButton`. According to the SUIT documentation, modifier class names should be used *in addition* to the base class name. Neither `PlainButton` nor `PrimaryButton` uses `Button`'s class name (`PlainButton` uses `.btn-plain` only, not `.btn .btn-plain`; likewise, `PrimaryButton` uses `.btn-primary` and not `.btn .btn-primary`).

(EDIT: I was wrong about `PrimaryButton`. It is indeed a state of `Button` and will be merged into `Button` in a future PR. The comments above apply to `PlainButton` only.)

#### Wrapper class names
- I renamed two top-level class names to match their components: `.select-input-container` -> `.bdl-Select` and `.pill-selector-input-wrapper` -> `.bdl-PillSelector`.
- `.bdl-Select-container` and `.bdl-Select-innerContainer` still have "container" in their names, because they are descendants of `.bdl-Select`.
- `.bdl-PillSelectorWrapper` is now separate from the `.bdl-PillSelector` class name family, because it is used in `PillSelectorDropdown` and `EditableKeywords` as a wrapper around `PillSelector`.