### PR TITLE
fix(classification): classification tooltip not showing in IE11

### DIFF
--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -15,15 +15,14 @@ type Props = {
     definition?: string,
     messageStyle?: typeof STYLE_INLINE | typeof STYLE_TOOLTIP,
     name?: string,
+    onClick?: () => void,
 };
 
-const Classification = ({ definition, className = '', messageStyle, name }: Props) => {
+const Classification = ({ definition, className = '', messageStyle, name, onClick }: Props) => {
     const isClassified = !!name;
-    const hasMessage = !!definition;
-
-    const isTooltipMessageEnabled = isClassified && hasMessage && messageStyle === STYLE_TOOLTIP;
-    const isInlineMessageEnabled = isClassified && hasMessage && messageStyle === STYLE_INLINE;
-
+    const hasDefinition = !!definition;
+    const isTooltipMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_TOOLTIP;
+    const isInlineMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_INLINE;
     const isNotClassifiedMessageVisible = !isClassified && messageStyle === STYLE_INLINE;
 
     return (
@@ -31,6 +30,7 @@ const Classification = ({ definition, className = '', messageStyle, name }: Prop
             {isClassified && (
                 <ClassifiedBadge
                     name={((name: any): string)}
+                    onClick={onClick}
                     tooltipText={isTooltipMessageEnabled ? definition : undefined}
                 />
             )}

--- a/src/features/classification/ClassifiedBadge.js
+++ b/src/features/classification/ClassifiedBadge.js
@@ -1,26 +1,47 @@
 // @flow
 import * as React from 'react';
 
+import PlainButton from '../../components/plain-button';
 import Tooltip from '../../components/tooltip';
 import IconSecurityClassification from '../../icons/general/IconSecurityClassification';
 import SecurityBadge from '../security';
 import { bdlYellorange } from '../../styles/variables';
 import type { Position } from '../../components/tooltip';
+import './ClassifiedBadge.scss';
 
 type Props = {
     name: string,
+    onClick?: () => void,
     tooltipPosition?: Position,
     tooltipText?: string,
 };
 
-const ClassifiedBadge = ({ name, tooltipPosition = 'bottom-center', tooltipText }: Props) => (
-    <Tooltip isDisabled={!tooltipText} position={tooltipPosition} text={tooltipText} isTabbable={false}>
+const ClassifiedBadge = ({ name, onClick, tooltipPosition = 'bottom-center', tooltipText }: Props) => {
+    const isClickable = typeof onClick === 'function';
+    const isTooltipDisabled = !tooltipText;
+    const badge = (
         <SecurityBadge
             className="bdl-ClassifiedBadge"
-            message={name}
             icon={<IconSecurityClassification color={bdlYellorange} height={10} width={10} strokeWidth={3} />}
+            message={name}
         />
-    </Tooltip>
-);
+    );
+    return (
+        <Tooltip isDisabled={isTooltipDisabled} isTabbable={false} position={tooltipPosition} text={tooltipText}>
+            {isClickable ? (
+                <PlainButton
+                    className="bdl-ClassifiedBadge-editButton"
+                    data-resin-target="editclassification"
+                    onClick={onClick}
+                    type="button"
+                >
+                    {badge}
+                </PlainButton>
+            ) : (
+                badge
+            )}
+        </Tooltip>
+    );
+};
 
 export default ClassifiedBadge;

--- a/src/features/classification/ClassifiedBadge.scss
+++ b/src/features/classification/ClassifiedBadge.scss
@@ -1,0 +1,6 @@
+.bdl-ClassifiedBadge-editButton {
+    &,
+    &:hover {
+        cursor: pointer;
+    }
+}

--- a/src/features/classification/__tests__/Classification.test.js
+++ b/src/features/classification/__tests__/Classification.test.js
@@ -44,4 +44,14 @@ describe('features/classification/Classification', () => {
         });
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should render a classified badge with click functionality', () => {
+        const wrapper = getWrapper({
+            name: 'Confidential',
+            definition: 'fubar',
+            messageStyle: 'tooltip',
+            onClick: () => {},
+        });
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/src/features/classification/__tests__/ClassifiedBadge.test.js
+++ b/src/features/classification/__tests__/ClassifiedBadge.test.js
@@ -19,4 +19,13 @@ describe('features/classification/ClassifiedBadge', () => {
         });
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should render a classified badge within a button when onClick is provided', () => {
+        const wrapper = getWrapper({
+            name: 'Confidential',
+            tooltipText: 'fubar',
+            onClick: () => {},
+        });
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -24,6 +24,18 @@ exports[`features/classification/Classification should render a classified badge
 </article>
 `;
 
+exports[`features/classification/Classification should render a classified badge with click functionality 1`] = `
+<article
+  className="bdl-Classification "
+>
+  <ClassifiedBadge
+    name="Confidential"
+    onClick={[Function]}
+    tooltipText="fubar"
+  />
+</article>
+`;
+
 exports[`features/classification/Classification should render a classified badge with definition in tooltip 1`] = `
 <article
   className="bdl-Classification "

--- a/src/features/classification/__tests__/__snapshots__/ClassifiedBadge.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/ClassifiedBadge.test.js.snap
@@ -48,3 +48,35 @@ exports[`features/classification/ClassifiedBadge should render a classified badg
   />
 </Tooltip>
 `;
+
+exports[`features/classification/ClassifiedBadge should render a classified badge within a button when onClick is provided 1`] = `
+<Tooltip
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isDisabled={false}
+  isTabbable={false}
+  position="bottom-center"
+  text="fubar"
+  theme="default"
+>
+  <PlainButton
+    className="bdl-ClassifiedBadge-editButton"
+    data-resin-target="editclassification"
+    onClick={[Function]}
+    type="button"
+  >
+    <SecurityBadge
+      className="bdl-ClassifiedBadge"
+      icon={
+        <IconSecurityClassification
+          color="#f5b31b"
+          height={10}
+          strokeWidth={3}
+          width={10}
+        />
+      }
+      message="Confidential"
+    />
+  </PlainButton>
+</Tooltip>
+`;


### PR DESCRIPTION
An issue with certain versions of IE11, where rendering a tooltip inside the button breaks. So making the tooltip be the wrapper for button.