### PR TITLE
style(media): Correctly size Media body flex container for MS Edge

### DIFF
--- a/src/components/media/Media.scss
+++ b/src/components/media/Media.scss
@@ -18,6 +18,7 @@
 // the main content, e.g. title and message
 .bdl-Media-body {
     flex: 1 1 100%;
+    min-width: 0; // Prevents overflow with long text strings in MS Edge
     word-wrap: break-word; // old IE
     word-break: break-word; // CJK scripts
     // handle wrapping long words in text content without breaking


### PR DESCRIPTION
Before:
![Screen Shot 2019-11-06 at 10 06 57 AM](https://user-images.githubusercontent.com/17791289/68324916-3cd93000-007d-11ea-9789-d11d9c2c9e23.png)

After:
![Screen Shot 2019-11-06 at 10 07 11 AM](https://user-images.githubusercontent.com/17791289/68324925-42cf1100-007d-11ea-8269-a5f500c182bb.png)


