### PR TITLE
fix(metadata-sidebar): bind onApiError properly

### DIFF
--- a/src/elements/content-sidebar/MetadataSidebar.js
+++ b/src/elements/content-sidebar/MetadataSidebar.js
@@ -91,7 +91,7 @@ class MetadataSidebar extends React.PureComponent<Props, State> {
      * @param {Object} [newState] - optional state to set
      * @return {void}
      */
-    onApiError(error: ElementsXhrError, code: string, newState: Object = {}) {
+    onApiError = (error: ElementsXhrError, code: string, newState: Object = {}) => {
         const { onError }: Props = this.props;
         const { status } = error;
         const isValidError = isUserCorrectableError(status);
@@ -104,7 +104,7 @@ class MetadataSidebar extends React.PureComponent<Props, State> {
             error,
             [IS_ERROR_DISPLAYED]: isValidError,
         });
-    }
+    };
 
     /**
      * Checks upload permission


### PR DESCRIPTION
onApiError wasn't bound properly to the class so calls to extract onError would fail.