### PR TITLE
fix(i18n): formatted comp message

### DIFF
--- a/src/components/i18n/Composition.js
+++ b/src/components/i18n/Composition.js
@@ -27,7 +27,7 @@ class Composition {
                 if (Array.isArray(element)) {
                     element.forEach(subelement => this.recompose(subelement));
                 } else if (element) {
-                    if (element.type === 'Param') {
+                    if (element.type === 'Param' || element.type.name === 'Param') {
                         this.ma.addParam(element);
                     } else {
                         this.ma.push(element);
@@ -87,11 +87,12 @@ class Composition {
 
         const el = node.extra;
         if (children.length === 0 && el && el.props) {
-            children = el.props.children;
+            const { temp } = el.props;
+            children = temp;
         }
 
         if (children && children.length === 1 && typeof children[0] === 'string') {
-            children = children[0];
+            [children] = children;
         }
 
         if (el) {

--- a/src/components/i18n/__tests__/FormattedCompMessage.test.js
+++ b/src/components/i18n/__tests__/FormattedCompMessage.test.js
@@ -10,7 +10,7 @@ jest.unmock('react-intl');
 
 const { IntlProvider, intlShape } = jest.requireActual('react-intl');
 
-//Create the IntlProvider to retrieve context for wrapping around.
+// Create the IntlProvider to retrieve context for wrapping around.
 function createIntl(locale, messages) {
     const intlProvider = new IntlProvider(locale, messages);
     const { intl } = intlProvider.getChildContext();
@@ -18,19 +18,19 @@ function createIntl(locale, messages) {
     return intl;
 }
 
-const intl = createIntl("en-US", {});
+const intl = createIntl('en-US', {});
 
 /**
  * When using React-Intl `injectIntl` on components, props.intl is required.
  */
-function nodeWithIntlProp(intl, node) {
-  return React.cloneElement(node, { intl });
+function nodeWithIntlProp(intlObj, node) {
+    return React.cloneElement(node, { intl: intlObj });
 }
 
-function mountWithIntl(intl, node) {
-    return mount(nodeWithIntlProp(intl, node), {
-        context: { intl },
-        childContextTypes: { intl: intlShape }
+function mountWithIntl(intlObj, node) {
+    return mount(nodeWithIntlProp(intlObj, node), {
+        context: { intl: intlObj },
+        childContextTypes: { intl: intlShape },
     });
 }
 
@@ -50,7 +50,10 @@ LinkButton.propTypes = {
 describe('components/i18n', () => {
     describe('components/i18n/FormattedCompMessage', () => {
         test('should correctly render simple FormattedCompMessage', () => {
-            const wrapper = mountWithIntl(intl, <FormattedCompMessage id="test" description="asdf" defaultMessage="some text" />);
+            const wrapper = mountWithIntl(
+                intl,
+                <FormattedCompMessage id="test" description="asdf" defaultMessage="some text" />,
+            );
 
             const span = wrapper.find('span');
             expect(span.prop('x-resource-id')).toEqual('test');
@@ -58,7 +61,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with children', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some text
                 </FormattedCompMessage>,
@@ -70,7 +74,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with children snapshot', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some text
                 </FormattedCompMessage>,
@@ -80,7 +85,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with HTML', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <b>bold</b> text
                 </FormattedCompMessage>,
@@ -92,7 +98,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with HTML snapshot', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <b>bold</b> text
                 </FormattedCompMessage>,
@@ -102,7 +109,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage which starts with HTML, snapshot', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     <b>bold</b> text. More text.
                 </FormattedCompMessage>,
@@ -112,7 +120,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with subcomponents', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <LinkButton to="foo">link</LinkButton> text
                 </FormattedCompMessage>,
@@ -129,7 +138,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with subcomponents snapshot', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <LinkButton to="foo">link</LinkButton> text
                 </FormattedCompMessage>,
@@ -139,7 +149,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in English (singular)', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf" count={1}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -152,7 +163,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in English (plural)', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf" count={21}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -168,10 +180,12 @@ describe('components/i18n', () => {
             const ruIntl = createIntl({
                 locale: 'ru-RU',
                 messages: {
-                    "test": "{count, plural, one {This is the singular in Russian.} other {These are the other plurals in Russian.}}"
-                }
+                    test:
+                        '{count, plural, one {This is the singular in Russian.} other {These are the other plurals in Russian.}}',
+                },
             });
-            const wrapper = mountWithIntl(ruIntl,
+            const wrapper = mountWithIntl(
+                ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={1}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -187,10 +201,12 @@ describe('components/i18n', () => {
             const ruIntl = createIntl({
                 locale: 'ru-RU',
                 messages: {
-                    "test": "{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}"
-                }
+                    test:
+                        '{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}',
+                },
             });
-            const wrapper = mountWithIntl(ruIntl,
+            const wrapper = mountWithIntl(
+                ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={21}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -208,10 +224,12 @@ describe('components/i18n', () => {
             const ruIntl = createIntl({
                 locale: 'ru-RU',
                 messages: {
-                    "test": "{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}"
-                }
+                    test:
+                        '{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}',
+                },
             });
-            const wrapper = mountWithIntl(ruIntl,
+            const wrapper = mountWithIntl(
+                ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={24}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -229,10 +247,12 @@ describe('components/i18n', () => {
             const ruIntl = createIntl({
                 locale: 'ru-RU',
                 messages: {
-                    "test": "{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}"
-                }
+                    test:
+                        '{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}',
+                },
             });
-            const wrapper = mountWithIntl(ruIntl,
+            const wrapper = mountWithIntl(
+                ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={27}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -247,7 +267,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with a Param subcomponent', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value="asdf" description="asdf" />.
                 </FormattedCompMessage>,
@@ -260,7 +281,8 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with multiple Param subcomponents', () => {
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value="asdf" description="foo" /> and the number is{' '}
                     <Param value={3} description="bar" />.
@@ -275,7 +297,8 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with a Param subcomponent that has its own value', () => {
             const str = 'a string';
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -289,7 +312,8 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with undefined Param value', () => {
             const str = undefined;
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -304,7 +328,8 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with null Param value', () => {
             const str = null;
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -319,7 +344,8 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with boolean Param value', () => {
             const str = true;
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -334,7 +360,8 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with numeric Param value', () => {
             const str = 123.456;
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -351,7 +378,8 @@ describe('components/i18n', () => {
             const str = function str() {
                 return 'Hello!';
             };
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -366,7 +394,8 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with replacement parameters within subcomponents', () => {
             const name = 'substituted';
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some{' '}
                     <LinkButton url="https://foo.com/a/b">
@@ -385,45 +414,52 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with replacement parameters inside subcomponents', () => {
             const folderName = 'substituted';
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test.x.y" description="asdf">
                     Settings{' '}
                     <span className="deemphasized">
-                    for <Param description="Folder name" value={folderName} />
-                  </span>
+                        for <Param description="Folder name" value={folderName} />
+                    </span>
                 </FormattedCompMessage>,
             );
 
             const span = wrapper.find('span').first();
-            expect(span.html()).toContain('<span x-resource-id=\"test.x.y\">Settings <span class=\"deemphasized\">for substituted</span></span>');
+            expect(span.html()).toContain(
+                '<span x-resource-id="test.x.y">Settings <span class="deemphasized">for substituted</span></span>',
+            );
         });
 
         test('should correctly render FormattedCompMessage with replacement parameters inside subcomponents and translations', () => {
             const folderName = 'substituted';
             const translations = {
-                'test.x.y': 'Einstellungen <c0> für <p0/> </c0>'
+                'test.x.y': 'Einstellungen <c0> für <p0/></c0>',
             };
             const deintl = createIntl({
                 locale: 'de',
-                messages: translations
+                messages: translations,
             });
 
-            const wrapper = mountWithIntl(deintl,
+            const wrapper = mountWithIntl(
+                deintl,
                 <FormattedCompMessage id="test.x.y" description="asdf">
                     Settings{' '}
                     <span className="deemphasized">
-                    for <Param description="Folder name" value={folderName} />
-                  </span>
-                </FormattedCompMessage>
+                        for <Param description="Folder name" value={folderName} />
+                    </span>
+                </FormattedCompMessage>,
             );
 
             const span = wrapper.find('span').first();
-            expect(span.html()).toContain('<span x-resource-id=\"test.x.y\">Einstellungen <span class=\"deemphasized\"> für substituted</span></span>');
+            expect(span.html()).toContain(
+                '<span x-resource-id="test.x.y">Einstellungen <span class="deemphasized"> für substituted</span></span>',
+            );
         });
 
         test('should correctly render FormattedCompMessage with HTML jsx replacement parameter values', () => {
             const name = <b>bold!</b>;
-            const wrapper = mountWithIntl(intl,
+            const wrapper = mountWithIntl(
+                intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some{' '}
                     <i>
@@ -441,7 +477,8 @@ describe('components/i18n', () => {
 
         test('should throw when specifying a count but no nested plurals', () => {
             function testCount() {
-                mountWithIntl(intl,
+                mountWithIntl(
+                    intl,
                     <FormattedCompMessage id="asdf" description="asdf" count="23">
                         some <b>bold</b> text
                     </FormattedCompMessage>,
@@ -453,7 +490,8 @@ describe('components/i18n', () => {
 
         test('should throw when specifying a count but no "one" plural', () => {
             function testPlural() {
-                mountWithIntl(intl,
+                mountWithIntl(
+                    intl,
                     <FormattedCompMessage id="asdf" description="asdf" count="23">
                         <Plural category="other">
                             some <b>bold</b> text
@@ -467,7 +505,8 @@ describe('components/i18n', () => {
 
         test('should throw when specifying a count but no "other" plural', () => {
             function testPlural() {
-                mountWithIntl(intl,
+                mountWithIntl(
+                    intl,
                     <FormattedCompMessage id="asdf" description="asdf" count="23">
                         <Plural category="one">
                             some <b>bold</b> text

--- a/src/components/i18n/__tests__/FormattedCompMessage.test.js
+++ b/src/components/i18n/__tests__/FormattedCompMessage.test.js
@@ -6,6 +6,34 @@ import FormattedCompMessage from '../FormattedCompMessage';
 import Param from '../Param';
 import Plural from '../Plural';
 
+jest.unmock('react-intl');
+
+const { IntlProvider, intlShape } = jest.requireActual('react-intl');
+
+//Create the IntlProvider to retrieve context for wrapping around.
+function createIntl(locale, messages) {
+    const intlProvider = new IntlProvider(locale, messages);
+    const { intl } = intlProvider.getChildContext();
+
+    return intl;
+}
+
+const intl = createIntl("en-US", {});
+
+/**
+ * When using React-Intl `injectIntl` on components, props.intl is required.
+ */
+function nodeWithIntlProp(intl, node) {
+  return React.cloneElement(node, { intl });
+}
+
+function mountWithIntl(intl, node) {
+    return mount(nodeWithIntlProp(intl, node), {
+        context: { intl },
+        childContextTypes: { intl: intlShape }
+    });
+}
+
 function LinkButton(props) {
     return (
         <a className="btn" href={props.to}>
@@ -22,7 +50,7 @@ LinkButton.propTypes = {
 describe('components/i18n', () => {
     describe('components/i18n/FormattedCompMessage', () => {
         test('should correctly render simple FormattedCompMessage', () => {
-            const wrapper = mount(<FormattedCompMessage id="test" description="asdf" defaultMessage="some text" />);
+            const wrapper = mountWithIntl(intl, <FormattedCompMessage id="test" description="asdf" defaultMessage="some text" />);
 
             const span = wrapper.find('span');
             expect(span.prop('x-resource-id')).toEqual('test');
@@ -30,7 +58,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with children', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some text
                 </FormattedCompMessage>,
@@ -42,7 +70,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with children snapshot', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some text
                 </FormattedCompMessage>,
@@ -52,7 +80,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with HTML', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <b>bold</b> text
                 </FormattedCompMessage>,
@@ -64,7 +92,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with HTML snapshot', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <b>bold</b> text
                 </FormattedCompMessage>,
@@ -74,7 +102,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage which starts with HTML, snapshot', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     <b>bold</b> text. More text.
                 </FormattedCompMessage>,
@@ -84,7 +112,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with subcomponents', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <LinkButton to="foo">link</LinkButton> text
                 </FormattedCompMessage>,
@@ -101,7 +129,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with subcomponents snapshot', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some <LinkButton to="foo">link</LinkButton> text
                 </FormattedCompMessage>,
@@ -111,7 +139,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in English (singular)', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf" count={1}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -124,7 +152,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in English (plural)', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf" count={21}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -137,7 +165,13 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in Russian (singular)', () => {
-            const wrapper = mount(
+            const ruIntl = createIntl({
+                locale: 'ru-RU',
+                messages: {
+                    "test": "{count, plural, one {This is the singular in Russian.} other {These are the other plurals in Russian.}}"
+                }
+            });
+            const wrapper = mountWithIntl(ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={1}>
                     <Plural category="one">This is the singular.</Plural>
                     <Plural category="other">These are the plurals.</Plural>
@@ -146,16 +180,20 @@ describe('components/i18n', () => {
 
             const span = wrapper.find('span');
             expect(span.prop('x-resource-id')).toEqual('test');
-            expect(span.prop('children')).toEqual('This is the singular.');
+            expect(span.prop('children')).toEqual('This is the singular in Russian.');
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in Russian (one)', () => {
-            const wrapper = mount(
+            const ruIntl = createIntl({
+                locale: 'ru-RU',
+                messages: {
+                    "test": "{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}"
+                }
+            });
+            const wrapper = mountWithIntl(ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={21}>
                     <Plural category="one">This is the singular.</Plural>
-                    <Plural category="few">These are the few plurals.</Plural>
-                    <Plural category="many">These are the many plurals.</Plural>
-                    <Plural category="other">These are the other plurals.</Plural>
+                    <Plural category="other">These are the plurals.</Plural>
                 </FormattedCompMessage>,
             );
 
@@ -163,16 +201,20 @@ describe('components/i18n', () => {
             expect(span.prop('x-resource-id')).toEqual('test');
 
             // 21 is singular in Russian!
-            expect(span.prop('children')).toEqual('This is the singular.');
+            expect(span.prop('children')).toEqual('This is the singular in Russian.');
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in Russian (few)', () => {
-            const wrapper = mount(
+            const ruIntl = createIntl({
+                locale: 'ru-RU',
+                messages: {
+                    "test": "{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}"
+                }
+            });
+            const wrapper = mountWithIntl(ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={24}>
                     <Plural category="one">This is the singular.</Plural>
-                    <Plural category="few">These are the few plurals.</Plural>
-                    <Plural category="many">These are the many plurals.</Plural>
-                    <Plural category="other">These are the other plurals.</Plural>
+                    <Plural category="other">These are the plurals.</Plural>
                 </FormattedCompMessage>,
             );
 
@@ -180,16 +222,20 @@ describe('components/i18n', () => {
             expect(span.prop('x-resource-id')).toEqual('test');
 
             // 24 is few in Russian!
-            expect(span.prop('children')).toEqual('These are the few plurals.');
+            expect(span.prop('children')).toEqual('These are the few plurals in Russian.');
         });
 
         test('should correctly render FormattedCompMessage with simple plurals in Russian (many)', () => {
-            const wrapper = mount(
+            const ruIntl = createIntl({
+                locale: 'ru-RU',
+                messages: {
+                    "test": "{count, plural, one {This is the singular in Russian.} few {These are the few plurals in Russian.} many {These are the many plurals in Russian.} other {These are the other plurals in Russian.}}"
+                }
+            });
+            const wrapper = mountWithIntl(ruIntl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf" count={27}>
                     <Plural category="one">This is the singular.</Plural>
-                    <Plural category="few">These are the few plurals.</Plural>
-                    <Plural category="many">These are the many plurals.</Plural>
-                    <Plural category="other">These are the other plurals.</Plural>
+                    <Plural category="other">These are the plurals.</Plural>
                 </FormattedCompMessage>,
             );
 
@@ -197,11 +243,11 @@ describe('components/i18n', () => {
             expect(span.prop('x-resource-id')).toEqual('test');
 
             // 27 is many in Russian!
-            expect(span.prop('children')).toEqual('These are the many plurals.');
+            expect(span.prop('children')).toEqual('These are the many plurals in Russian.');
         });
 
         test('should correctly render FormattedCompMessage with a Param subcomponent', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value="asdf" description="asdf" />.
                 </FormattedCompMessage>,
@@ -214,7 +260,7 @@ describe('components/i18n', () => {
         });
 
         test('should correctly render FormattedCompMessage with multiple Param subcomponents', () => {
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value="asdf" description="foo" /> and the number is{' '}
                     <Param value={3} description="bar" />.
@@ -229,7 +275,7 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with a Param subcomponent that has its own value', () => {
             const str = 'a string';
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -243,7 +289,7 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with undefined Param value', () => {
             const str = undefined;
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -258,7 +304,7 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with null Param value', () => {
             const str = null;
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -273,7 +319,7 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with boolean Param value', () => {
             const str = true;
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -288,7 +334,7 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with numeric Param value', () => {
             const str = 123.456;
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage locale="ru-RU" id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -305,7 +351,7 @@ describe('components/i18n', () => {
             const str = function str() {
                 return 'Hello!';
             };
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     The string is <Param value={str} description="foo" />.
                 </FormattedCompMessage>,
@@ -320,7 +366,7 @@ describe('components/i18n', () => {
 
         test('should correctly render FormattedCompMessage with replacement parameters within subcomponents', () => {
             const name = 'substituted';
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some{' '}
                     <LinkButton url="https://foo.com/a/b">
@@ -337,9 +383,47 @@ describe('components/i18n', () => {
             expect(a.text()).toContain('substituted');
         });
 
+        test('should correctly render FormattedCompMessage with replacement parameters inside subcomponents', () => {
+            const folderName = 'substituted';
+            const wrapper = mountWithIntl(intl,
+                <FormattedCompMessage id="test.x.y" description="asdf">
+                    Settings{' '}
+                    <span className="deemphasized">
+                    for <Param description="Folder name" value={folderName} />
+                  </span>
+                </FormattedCompMessage>,
+            );
+
+            const span = wrapper.find('span').first();
+            expect(span.html()).toContain('<span x-resource-id=\"test.x.y\">Settings <span class=\"deemphasized\">for substituted</span></span>');
+        });
+
+        test('should correctly render FormattedCompMessage with replacement parameters inside subcomponents and translations', () => {
+            const folderName = 'substituted';
+            const translations = {
+                'test.x.y': 'Einstellungen <c0> für <p0/> </c0>'
+            };
+            const deintl = createIntl({
+                locale: 'de',
+                messages: translations
+            });
+
+            const wrapper = mountWithIntl(deintl,
+                <FormattedCompMessage id="test.x.y" description="asdf">
+                    Settings{' '}
+                    <span className="deemphasized">
+                    for <Param description="Folder name" value={folderName} />
+                  </span>
+                </FormattedCompMessage>
+            );
+
+            const span = wrapper.find('span').first();
+            expect(span.html()).toContain('<span x-resource-id=\"test.x.y\">Einstellungen <span class=\"deemphasized\"> für substituted</span></span>');
+        });
+
         test('should correctly render FormattedCompMessage with HTML jsx replacement parameter values', () => {
             const name = <b>bold!</b>;
-            const wrapper = mount(
+            const wrapper = mountWithIntl(intl,
                 <FormattedCompMessage id="test" description="asdf">
                     some{' '}
                     <i>
@@ -357,7 +441,7 @@ describe('components/i18n', () => {
 
         test('should throw when specifying a count but no nested plurals', () => {
             function testCount() {
-                mount(
+                mountWithIntl(intl,
                     <FormattedCompMessage id="asdf" description="asdf" count="23">
                         some <b>bold</b> text
                     </FormattedCompMessage>,
@@ -369,7 +453,7 @@ describe('components/i18n', () => {
 
         test('should throw when specifying a count but no "one" plural', () => {
             function testPlural() {
-                mount(
+                mountWithIntl(intl,
                     <FormattedCompMessage id="asdf" description="asdf" count="23">
                         <Plural category="other">
                             some <b>bold</b> text
@@ -383,7 +467,7 @@ describe('components/i18n', () => {
 
         test('should throw when specifying a count but no "other" plural', () => {
             function testPlural() {
-                mount(
+                mountWithIntl(intl,
                     <FormattedCompMessage id="asdf" description="asdf" count="23">
                         <Plural category="one">
                             some <b>bold</b> text

--- a/src/components/i18n/__tests__/__snapshots__/FormattedCompMessage.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/FormattedCompMessage.test.js.snap
@@ -1,17 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/i18n components/i18n/FormattedCompMessage should correctly render FormattedCompMessage which starts with HTML, snapshot 1`] = `
-<FormattedCompMessage
+<InjectIntl(FormattedCompMessage)
   description="asdf"
   id="test"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
 >
   <FormattedCompMessage
     description="asdf"
     id="test"
     intl={
       Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
         "formatDate": [Function],
+        "formatHTMLMessage": [Function],
         "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": "span",
+        "timeZone": null,
       }
     }
     tagName="span"
@@ -28,21 +76,69 @@ exports[`components/i18n components/i18n/FormattedCompMessage should correctly r
        text. More text.
     </span>
   </FormattedCompMessage>
-</FormattedCompMessage>
+</InjectIntl(FormattedCompMessage)>
 `;
 
 exports[`components/i18n components/i18n/FormattedCompMessage should correctly render FormattedCompMessage with HTML snapshot 1`] = `
-<FormattedCompMessage
+<InjectIntl(FormattedCompMessage)
   description="asdf"
   id="test"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
 >
   <FormattedCompMessage
     description="asdf"
     id="test"
     intl={
       Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
         "formatDate": [Function],
+        "formatHTMLMessage": [Function],
         "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": "span",
+        "timeZone": null,
       }
     }
     tagName="span"
@@ -60,21 +156,69 @@ exports[`components/i18n components/i18n/FormattedCompMessage should correctly r
        text
     </span>
   </FormattedCompMessage>
-</FormattedCompMessage>
+</InjectIntl(FormattedCompMessage)>
 `;
 
 exports[`components/i18n components/i18n/FormattedCompMessage should correctly render FormattedCompMessage with children snapshot 1`] = `
-<FormattedCompMessage
+<InjectIntl(FormattedCompMessage)
   description="asdf"
   id="test"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
 >
   <FormattedCompMessage
     description="asdf"
     id="test"
     intl={
       Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
         "formatDate": [Function],
+        "formatHTMLMessage": [Function],
         "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": "span",
+        "timeZone": null,
       }
     }
     tagName="span"
@@ -86,21 +230,69 @@ exports[`components/i18n components/i18n/FormattedCompMessage should correctly r
       some text
     </span>
   </FormattedCompMessage>
-</FormattedCompMessage>
+</InjectIntl(FormattedCompMessage)>
 `;
 
 exports[`components/i18n components/i18n/FormattedCompMessage should correctly render FormattedCompMessage with subcomponents snapshot 1`] = `
-<FormattedCompMessage
+<InjectIntl(FormattedCompMessage)
   description="asdf"
   id="test"
+  intl={
+    Object {
+      "defaultFormats": Object {},
+      "defaultLocale": "en",
+      "formatDate": [Function],
+      "formatHTMLMessage": [Function],
+      "formatMessage": [Function],
+      "formatNumber": [Function],
+      "formatPlural": [Function],
+      "formatRelative": [Function],
+      "formatTime": [Function],
+      "formats": Object {},
+      "formatters": Object {
+        "getDateTimeFormat": [Function],
+        "getMessageFormat": [Function],
+        "getNumberFormat": [Function],
+        "getPluralFormat": [Function],
+        "getRelativeFormat": [Function],
+      },
+      "locale": "en",
+      "messages": Object {},
+      "now": [Function],
+      "onError": [Function],
+      "textComponent": "span",
+      "timeZone": null,
+    }
+  }
 >
   <FormattedCompMessage
     description="asdf"
     id="test"
     intl={
       Object {
+        "defaultFormats": Object {},
+        "defaultLocale": "en",
         "formatDate": [Function],
+        "formatHTMLMessage": [Function],
         "formatMessage": [Function],
+        "formatNumber": [Function],
+        "formatPlural": [Function],
+        "formatRelative": [Function],
+        "formatTime": [Function],
+        "formats": Object {},
+        "formatters": Object {
+          "getDateTimeFormat": [Function],
+          "getMessageFormat": [Function],
+          "getNumberFormat": [Function],
+          "getPluralFormat": [Function],
+          "getRelativeFormat": [Function],
+        },
+        "locale": "en",
+        "messages": Object {},
+        "now": [Function],
+        "onError": [Function],
+        "textComponent": "span",
+        "timeZone": null,
       }
     }
     tagName="span"
@@ -124,5 +316,5 @@ exports[`components/i18n components/i18n/FormattedCompMessage should correctly r
        text
     </span>
   </FormattedCompMessage>
-</FormattedCompMessage>
+</InjectIntl(FormattedCompMessage)>
 `;


### PR DESCRIPTION
Fixed a bug where a Param component inside of another component or HTML inside of the children of a FormattedCompMessage would not have its value substituted into the string for translated versions of that string.

Had to unmock the IntlProvider class from react-intl in the FormattedCompMessage tests so that we could use the real react-intl code to do translations. This bug didn't show up if we only used the English string, and the mocked version of the react-intl stuff doesn't support real translations. This also meant we had to do real tests for the Russian plurals tests using react-intl, which is better anyways because it works correctly and we're testing the real thing.

It also meant we had to do a little fancy footwork to get enzyme to work correctly because when you test with real react-intl, it wraps other classes and injects the "intl" prop into them by searching for a IntlProvider context somewhere up the element tree and finding the locale that way. That context doesn't exist when you are testing a little snippet of code (as opposed to a whole app), so when you try to "mount" your code that with enzyme, it ends up not not finding the context and therefore not having the correct locale. To get around that, we inject the intl prop manually instead so that we don't need that context to be available in the tree. We do that with the call "mountWithIntl".