### PR TITLE
fix(classification): Added missing application restriction messages

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1002,12 +1002,16 @@ boxui.searchForm.searchLabel = Search query
 boxui.securityCloudGame.instructions = For security purposes, please drag the white cloud into the dark cloud.
 # Success message shown when a user successfully drags the cloud into position.
 boxui.securityCloudGame.success = Success!
+# Bullet point that summarizes application download restriction applied to classification
+boxui.securityControls.appDownloadBlacklist = Some applications will be restricted; {appNames}
+# Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
+boxui.securityControls.appDownloadBlacklistOverflow = Some applications will be restricted; {appNames} +{remainingAppCount} more
 # Bullet point that summarizes application download blocked restriction applied to classification
 boxui.securityControls.appDownloadBlock = Some application restrictions apply.
 # Bullet point that summarizes application download restriction applied to classification
-boxui.securityControls.appDownloadList = Some applications will be restricted; {appNames}
+boxui.securityControls.appDownloadWhitelist = Only select applications are allowed; {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
-boxui.securityControls.appDownloadListOverflow = Only select applications are allowed; {appNames} +{remainingAppCount} more
+boxui.securityControls.appDownloadWhitelistOverflow = Only select applications are allowed; {appNames} +{remainingAppCount} more
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners. Box Drive is a product name and not translated
 boxui.securityControls.desktopDownloadExternalOwners = Download restricted on Box Drive for external users, except Owners/Co-Owners.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors. Box Drive is a product name and not translated

--- a/src/features/classification/security-controls/__tests__/SecurityControls.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControls.test.js
@@ -84,7 +84,7 @@ describe('features/classification/security-controls/SecurityControls', () => {
         expect(
             wrapper
                 .find(SecurityControlsItem)
-                .findWhere(item => item.props().message.id === 'boxui.securityControls.appDownloadListOverflow')
+                .findWhere(item => item.props().message.id === 'boxui.securityControls.appDownloadWhitelistOverflow')
                 .props().message.values,
         ).toEqual({
             appNames: 'App 1, App 2',

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
@@ -38,8 +38,8 @@ exports[`features/classification/security-controls/SecurityControls should rende
     key="3"
     message={
       Object {
-        "defaultMessage": "Some applications will be restricted; {appNames}",
-        "id": "boxui.securityControls.appDownloadList",
+        "defaultMessage": "Only select applications are allowed; {appNames}",
+        "id": "boxui.securityControls.appDownloadWhitelist",
         "values": Object {
           "appNames": "",
         },
@@ -77,8 +77,8 @@ exports[`features/classification/security-controls/SecurityControls should rende
           "id": "boxui.securityControls.desktopDownloadOwners",
         },
         Object {
-          "defaultMessage": "Some applications will be restricted; {appNames}",
-          "id": "boxui.securityControls.appDownloadList",
+          "defaultMessage": "Only select applications are allowed; {appNames}",
+          "id": "boxui.securityControls.appDownloadWhitelist",
           "values": Object {
             "appNames": "",
           },

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -1,4 +1,5 @@
 import messages from '../messages';
+import appRestrictionsMessageMap from '../appRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from '../downloadRestrictionsMessageMap';
 import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from '../utils';
 import {
@@ -137,22 +138,7 @@ describe('features/classification/security-controls/utils', () => {
                     },
                 };
                 expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
-                    { ...messages.appDownloadList, values: { appNames: 'a, b, c' } },
-                ]);
-            },
-        );
-
-        test.each([WHITELIST, BLACKLIST])(
-            'should include correct message when app download is restricted by %s and apps are less than maxAppCount',
-            listType => {
-                accessPolicy = {
-                    app: {
-                        accessLevel: listType,
-                        apps: [{ displayText: 'a' }, { displayText: 'b' }, { displayText: 'c' }],
-                    },
-                };
-                expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
-                    { ...messages.appDownloadList, values: { appNames: 'a, b, c' } },
+                    { ...appRestrictionsMessageMap[listType].default, values: { appNames: 'a, b, c' } },
                 ]);
             },
         );
@@ -174,7 +160,7 @@ describe('features/classification/security-controls/utils', () => {
                 };
                 expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
                     {
-                        ...messages.appDownloadListOverflow,
+                        ...appRestrictionsMessageMap[listType].overflow,
                         values: { appNames: 'a, b, c', remainingAppCount: 2 },
                     },
                 ]);

--- a/src/features/classification/security-controls/appRestrictionsMessageMap.js
+++ b/src/features/classification/security-controls/appRestrictionsMessageMap.js
@@ -1,0 +1,18 @@
+// @flow
+import messages from './messages';
+import { LIST_ACCESS_LEVEL } from '../constants';
+
+const { BLACKLIST, WHITELIST } = LIST_ACCESS_LEVEL;
+
+const appRestrictionsMessageMap = {
+    [BLACKLIST]: {
+        default: messages.appDownloadBlacklist,
+        overflow: messages.appDownloadBlacklistOverflow,
+    },
+    [WHITELIST]: {
+        default: messages.appDownloadWhitelist,
+        overflow: messages.appDownloadWhitelistOverflow,
+    },
+};
+
+export default appRestrictionsMessageMap;

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -68,16 +68,27 @@ const messages = defineMessages({
         description: 'Bullet point that summarizes application download blocked restriction applied to classification',
         id: 'boxui.securityControls.appDownloadBlock',
     },
-    appDownloadList: {
+    appDownloadBlacklist: {
         defaultMessage: 'Some applications will be restricted; {appNames}',
         description: 'Bullet point that summarizes application download restriction applied to classification',
-        id: 'boxui.securityControls.appDownloadList',
+        id: 'boxui.securityControls.appDownloadBlacklist',
     },
-    appDownloadListOverflow: {
+    appDownloadBlacklistOverflow: {
+        defaultMessage: 'Some applications will be restricted; {appNames} +{remainingAppCount} more',
+        description:
+            'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
+        id: 'boxui.securityControls.appDownloadBlacklistOverflow',
+    },
+    appDownloadWhitelist: {
+        defaultMessage: 'Only select applications are allowed; {appNames}',
+        description: 'Bullet point that summarizes application download restriction applied to classification',
+        id: 'boxui.securityControls.appDownloadWhitelist',
+    },
+    appDownloadWhitelistOverflow: {
         defaultMessage: 'Only select applications are allowed; {appNames} +{remainingAppCount} more',
         description:
             'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
-        id: 'boxui.securityControls.appDownloadListOverflow',
+        id: 'boxui.securityControls.appDownloadWhitelistOverflow',
     },
     // Web Download Restrictions
     webDownloadOwners: {

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -5,6 +5,7 @@ import isNil from 'lodash/isNil';
 import type { MessageDescriptor } from 'react-intl';
 import type { Controls } from '../flowTypes';
 
+import appRestrictionsMessageMap from './appRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from './downloadRestrictionsMessageMap';
 import messages from './messages';
 import { ACCESS_POLICY_RESTRICTION, DOWNLOAD_CONTROL, LIST_ACCESS_LEVEL, SHARED_LINK_ACCESS_LEVEL } from '../constants';
@@ -106,11 +107,11 @@ const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array
 
             if (remainingAppCount) {
                 items.push({
-                    ...messages.appDownloadListOverflow,
+                    ...appRestrictionsMessageMap[accessLevel].overflow,
                     values: { appNames, remainingAppCount },
                 });
             } else {
-                items.push({ ...messages.appDownloadList, values: { appNames } });
+                items.push({ ...appRestrictionsMessageMap[accessLevel].default, values: { appNames } });
             }
             break;
         }


### PR DESCRIPTION
`SecurityControls` component was using the same message for application restrictions regardless of whether the list of apps was allowed or disallowed. We will now use a separate message for each case.