### PR TITLE
fix(classification): Updated Security Controls messages

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1003,15 +1003,15 @@ boxui.securityCloudGame.instructions = For security purposes, please drag the wh
 # Success message shown when a user successfully drags the cloud into position.
 boxui.securityCloudGame.success = Success!
 # Bullet point that summarizes application download restriction applied to classification
-boxui.securityControls.appDownloadBlacklist = Some applications will be restricted; {appNames}
+boxui.securityControls.appDownloadBlacklist = Some applications will be restricted: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
-boxui.securityControls.appDownloadBlacklistOverflow = Some applications will be restricted; {appNames} +{remainingAppCount} more
+boxui.securityControls.appDownloadBlacklistOverflow = Some applications will be restricted: {appNames} +{remainingAppCount} more
 # Bullet point that summarizes application download blocked restriction applied to classification
 boxui.securityControls.appDownloadBlock = Some application restrictions apply.
 # Bullet point that summarizes application download restriction applied to classification
-boxui.securityControls.appDownloadWhitelist = Only select applications are allowed; {appNames}
+boxui.securityControls.appDownloadWhitelist = Only select applications are allowed: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
-boxui.securityControls.appDownloadWhitelistOverflow = Only select applications are allowed; {appNames} +{remainingAppCount} more
+boxui.securityControls.appDownloadWhitelistOverflow = Only select applications are allowed: {appNames} +{remainingAppCount} more
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners. Box Drive is a product name and not translated
 boxui.securityControls.desktopDownloadExternalOwners = Download restricted on Box Drive for external users, except Owners/Co-Owners.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors. Box Drive is a product name and not translated

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
@@ -38,7 +38,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     key="3"
     message={
       Object {
-        "defaultMessage": "Only select applications are allowed; {appNames}",
+        "defaultMessage": "Only select applications are allowed: {appNames}",
         "id": "boxui.securityControls.appDownloadWhitelist",
         "values": Object {
           "appNames": "",
@@ -77,7 +77,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
           "id": "boxui.securityControls.desktopDownloadOwners",
         },
         Object {
-          "defaultMessage": "Only select applications are allowed; {appNames}",
+          "defaultMessage": "Only select applications are allowed: {appNames}",
           "id": "boxui.securityControls.appDownloadWhitelist",
           "values": Object {
             "appNames": "",

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -69,23 +69,23 @@ const messages = defineMessages({
         id: 'boxui.securityControls.appDownloadBlock',
     },
     appDownloadBlacklist: {
-        defaultMessage: 'Some applications will be restricted; {appNames}',
+        defaultMessage: 'Some applications will be restricted: {appNames}',
         description: 'Bullet point that summarizes application download restriction applied to classification',
         id: 'boxui.securityControls.appDownloadBlacklist',
     },
     appDownloadBlacklistOverflow: {
-        defaultMessage: 'Some applications will be restricted; {appNames} +{remainingAppCount} more',
+        defaultMessage: 'Some applications will be restricted: {appNames} +{remainingAppCount} more',
         description:
             'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
         id: 'boxui.securityControls.appDownloadBlacklistOverflow',
     },
     appDownloadWhitelist: {
-        defaultMessage: 'Only select applications are allowed; {appNames}',
+        defaultMessage: 'Only select applications are allowed: {appNames}',
         description: 'Bullet point that summarizes application download restriction applied to classification',
         id: 'boxui.securityControls.appDownloadWhitelist',
     },
     appDownloadWhitelistOverflow: {
-        defaultMessage: 'Only select applications are allowed; {appNames} +{remainingAppCount} more',
+        defaultMessage: 'Only select applications are allowed: {appNames} +{remainingAppCount} more',
         description:
             'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
         id: 'boxui.securityControls.appDownloadWhitelistOverflow',


### PR DESCRIPTION
Changing from `;` to `:` in app restriction messages.