### PR TITLE
fix(css): Add legacy class names to pill components

### DIFF
--- a/src/components/pill-cloud/PillCloud.js
+++ b/src/components/pill-cloud/PillCloud.js
@@ -14,12 +14,12 @@ type Props = {
 };
 
 const PillCloud = ({ options, onSelect, selectedOptions = [], buttonProps = {} }: Props) => (
-    <div className="bdl-PillCloud">
+    <div className="bdl-PillCloud pill-cloud-container">
         {options &&
             options.map(option => (
                 <Button
                     key={option.value}
-                    className={classNames('bdl-Pill', 'bdl-PillCloud-button', {
+                    className={classNames('bdl-Pill', 'bdl-PillCloud-button', 'pill', 'pill-cloud-button', {
                         'is-selected': selectedOptions.find(op => isEqual(op, option)),
                     })}
                     onClick={onSelect ? () => onSelect(option) : undefined}

--- a/src/components/pill-cloud/__tests__/__snapshots__/PillCloud.test.js.snap
+++ b/src/components/pill-cloud/__tests__/__snapshots__/PillCloud.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`components/pill-cloud/PillCloud should render pills 1`] = `
 <div
-  className="bdl-PillCloud"
+  className="bdl-PillCloud pill-cloud-container"
 >
   <Button
-    className="bdl-Pill bdl-PillCloud-button"
+    className="bdl-Pill bdl-PillCloud-button pill pill-cloud-button"
     isLoading={false}
     key="1"
     showRadar={false}
@@ -14,7 +14,7 @@ exports[`components/pill-cloud/PillCloud should render pills 1`] = `
     Hello
   </Button>
   <Button
-    className="bdl-Pill bdl-PillCloud-button"
+    className="bdl-Pill bdl-PillCloud-button pill pill-cloud-button"
     isLoading={false}
     key="2"
     showRadar={false}
@@ -23,7 +23,7 @@ exports[`components/pill-cloud/PillCloud should render pills 1`] = `
     There
   </Button>
   <Button
-    className="bdl-Pill bdl-PillCloud-button"
+    className="bdl-Pill bdl-PillCloud-button pill pill-cloud-button"
     isLoading={false}
     key="3"
     showRadar={false}

--- a/src/components/pill-selector-dropdown/Pill.js
+++ b/src/components/pill-selector-dropdown/Pill.js
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const Pill = ({ isDisabled = false, isSelected = false, isValid = true, onRemove, text }: Props) => {
-    const styles = classNames('bdl-Pill', {
+    const styles = classNames('bdl-Pill', 'pill', {
         'is-selected': isSelected && !isDisabled,
         'is-invalid': !isValid,
         'is-disabled': isDisabled,
@@ -21,7 +21,7 @@ const Pill = ({ isDisabled = false, isSelected = false, isValid = true, onRemove
 
     return (
         <span className={styles}>
-            <span className="bdl-Pill-text">{text}</span>
+            <span className="bdl-Pill-text pill-text">{text}</span>
             <span aria-hidden="true" className="close-btn" onClick={onClick}>
                 ✕
             </span>

--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -176,10 +176,11 @@ class PillSelector extends React.Component<Props, State> {
         } = this.props;
         const suggestedPillsEnabled = suggestedPillsData && suggestedPillsData.length > 0;
         const hasError = !!error;
-        const classes = classNames('bdl-PillSelector', {
+        const classes = classNames('bdl-PillSelector', 'pill-selector-input-wrapper', {
             'is-disabled': disabled,
             'is-focused': isFocused,
             'show-error': hasError,
+            'pill-selector-suggestions-enabled': suggestedPillsEnabled,
             'bdl-PillSelector--suggestionsEnabled': suggestedPillsEnabled,
         });
         const ariaAttrs = {
@@ -222,7 +223,7 @@ class PillSelector extends React.Component<Props, State> {
                         {...rest}
                         {...inputProps}
                         autoComplete="off"
-                        className={classNames('bdl-PillSelector-input', className)}
+                        className={classNames('bdl-PillSelector-input', 'pill-selector-input', className)}
                         disabled={disabled}
                         onInput={onInput}
                         placeholder={this.getNumSelected() === 0 ? placeholder : ''}

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.js
@@ -245,7 +245,7 @@ class PillSelectorDropdown extends React.Component<Props, State> {
         return (
             <Label text={label}>
                 <SelectorDropdown
-                    className={classNames('bdl-PillSelectorDropdown', className)}
+                    className={classNames('bdl-PillSelectorDropdown', 'pill-selector-wrapper', className)}
                     dividerIndex={dividerIndex}
                     onEnter={this.handleEnter}
                     onSelect={this.handleSelect}

--- a/src/components/pill-selector-dropdown/SuggestedPill.js
+++ b/src/components/pill-selector-dropdown/SuggestedPill.js
@@ -44,7 +44,7 @@ const SuggestedPill = ({ email, id, name, onAdd }: Props) => {
                 onKeyDown={handleKeyPress}
                 type="button"
             >
-                <span className="bdl-Pill-text suggested-pill">{name}</span>
+                <span className="bdl-Pill-text pill-text suggested-pill">{name}</span>
             </PlainButton>
         </Tooltip>
     );

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/Pill.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/Pill.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`components/pill-selector-dropdown/Pill should generate pill with invalid class when pill is not valid 1`] = `
 <span
-  className="bdl-Pill is-selected is-invalid"
+  className="bdl-Pill pill is-selected is-invalid"
 >
   <span
-    className="bdl-Pill-text"
+    className="bdl-Pill-text pill-text"
   >
     box
   </span>

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
@@ -11,7 +11,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
   theme="error"
 >
   <span
-    className="bdl-PillSelector is-disabled"
+    className="bdl-PillSelector pill-selector-input-wrapper is-disabled"
     onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
@@ -28,7 +28,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
       aria-errormessage="errorMessage2"
       aria-invalid={false}
       autoComplete="off"
-      className="bdl-PillSelector-input"
+      className="bdl-PillSelector-input pill-selector-input"
       disabled={true}
       onInput={[Function]}
       placeholder=""

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelectorDropdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`components/pill-selector-dropdown/PillSelectorDropdown render() should 
   text=""
 >
   <SelectorDropdown
-    className="bdl-PillSelectorDropdown"
+    className="bdl-PillSelectorDropdown pill-selector-wrapper"
     onEnter={[Function]}
     onSelect={[Function]}
     selector={

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/SuggestedPill.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/SuggestedPill.test.js.snap
@@ -16,7 +16,7 @@ exports[`components/pill-selector-dropdown/SuggestedPill render() should render 
     type="button"
   >
     <span
-      className="bdl-Pill-text suggested-pill"
+      className="bdl-Pill-text pill-text suggested-pill"
     >
       Foo
     </span>


### PR DESCRIPTION
This PR brings back legacy class names for pill components, to maintain backwards compatibility in apps that consume BUIE. Related to #1734 and #1745.