### PR TITLE
feat(classification): Adding loading indicator for SecurityControls

### DIFF
--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -43,6 +43,7 @@ const Classification = ({
     const isTooltipMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_TOOLTIP;
     const isInlineMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_INLINE;
     const isNotClassifiedMessageVisible = !isClassified && messageStyle === STYLE_INLINE;
+    const isControlsIndicatorEnabled = isClassified && isLoadingControls && messageStyle === STYLE_INLINE;
     const isSecurityControlsEnabled =
         isClassified && !isLoadingControls && hasSecurityControls && messageStyle === STYLE_INLINE;
 
@@ -65,10 +66,10 @@ const Classification = ({
                     <FormattedMessage {...messages.missing} />
                 </span>
             )}
-            {controls && isSecurityControlsEnabled && (
-                <SecurityControls controls={controls} controlsFormat={controlsFormat} maxAppCount={maxAppCount} />
+            {isSecurityControlsEnabled && (
+                <SecurityControls controls={controls || {}} controlsFormat={controlsFormat} maxAppCount={maxAppCount} />
             )}
-            {isLoadingControls && <LoadingIndicator />}
+            {isControlsIndicatorEnabled && <LoadingIndicator />}
         </article>
     );
 };

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -67,7 +67,7 @@ const Classification = ({
                 </span>
             )}
             {isSecurityControlsEnabled && (
-                <SecurityControls controls={controls || {}} controlsFormat={controlsFormat} maxAppCount={maxAppCount} />
+                <SecurityControls controls={controls} controlsFormat={controlsFormat} maxAppCount={maxAppCount} />
             )}
             {isControlsIndicatorEnabled && <LoadingIndicator />}
         </article>

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Label from '../../components/label/Label';
+import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
 import ClassifiedBadge from './ClassifiedBadge';
 import SecurityControls from './security-controls';
 import messages from './messages';
@@ -18,6 +19,7 @@ type Props = {
     controls?: Controls,
     controlsFormat?: ControlsFormat,
     definition?: string,
+    isLoadingControls?: boolean,
     maxAppCount?: number,
     messageStyle?: typeof STYLE_INLINE | typeof STYLE_TOOLTIP,
     name?: string,
@@ -29,6 +31,7 @@ const Classification = ({
     className = '',
     controls,
     controlsFormat,
+    isLoadingControls,
     maxAppCount,
     messageStyle,
     name,
@@ -39,8 +42,9 @@ const Classification = ({
     const hasSecurityControls = !!controls;
     const isTooltipMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_TOOLTIP;
     const isInlineMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_INLINE;
-    const isSecurityControlsEnabled = isClassified && hasSecurityControls && messageStyle === STYLE_INLINE;
     const isNotClassifiedMessageVisible = !isClassified && messageStyle === STYLE_INLINE;
+    const isSecurityControlsEnabled =
+        isClassified && !isLoadingControls && hasSecurityControls && messageStyle === STYLE_INLINE;
 
     return (
         <article className={`bdl-Classification ${className}`}>
@@ -64,6 +68,7 @@ const Classification = ({
             {controls && isSecurityControlsEnabled && (
                 <SecurityControls controls={controls} controlsFormat={controlsFormat} maxAppCount={maxAppCount} />
             )}
+            {isLoadingControls && <LoadingIndicator />}
         </article>
     );
 };

--- a/src/features/classification/__tests__/Classification.test.js
+++ b/src/features/classification/__tests__/Classification.test.js
@@ -114,4 +114,20 @@ describe('features/classification/Classification', () => {
         expect(wrapper.find(LoadingIndicator)).toHaveLength(1);
         expect(wrapper.find(SecurityControls)).toHaveLength(0);
     });
+
+    test('should not render loading indicator when item is not classified', () => {
+        const wrapper = getWrapper({
+            messageStyle: 'inline',
+            isLoadingControls: true,
+        });
+        expect(wrapper.find(LoadingIndicator)).toHaveLength(0);
+    });
+
+    test('should not render loading indicator when message style is not inline', () => {
+        const wrapper = getWrapper({
+            messageStyle: 'tooltip',
+            isLoadingControls: true,
+        });
+        expect(wrapper.find(LoadingIndicator)).toHaveLength(0);
+    });
 });

--- a/src/features/classification/__tests__/Classification.test.js
+++ b/src/features/classification/__tests__/Classification.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import Classification from '../Classification';
 import ClassifiedBadge from '../ClassifiedBadge';
 import SecurityControls from '../security-controls';
+import LoadingIndicator from '../../../components/loading-indicator/LoadingIndicator';
 
 describe('features/classification/Classification', () => {
     const getWrapper = (props = {}) => shallow(<Classification {...props} />);
@@ -84,6 +85,33 @@ describe('features/classification/Classification', () => {
 
         expect(wrapper.find(SecurityControls)).toHaveLength(1);
         wrapper.setProps({ messageStyle: 'tooltip' });
+        expect(wrapper.find(SecurityControls)).toHaveLength(0);
+    });
+
+    test('should render loading indicator when isLoadingControls is true and controls are not provided', () => {
+        const wrapper = getWrapper({
+            name: 'Confidential',
+            definition: 'fubar',
+            messageStyle: 'inline',
+            isLoadingControls: true,
+        });
+        expect(wrapper.find(LoadingIndicator)).toHaveLength(1);
+        expect(wrapper.find(SecurityControls)).toHaveLength(0);
+    });
+
+    test('should render loading indicator when isLoadingControls is true and controls are provided', () => {
+        const wrapper = getWrapper({
+            name: 'Confidential',
+            definition: 'fubar',
+            messageStyle: 'inline',
+            isLoadingControls: true,
+            controls: {
+                sharedLink: {
+                    accessLevel: 'collabOnly',
+                },
+            },
+        });
+        expect(wrapper.find(LoadingIndicator)).toHaveLength(1);
         expect(wrapper.find(SecurityControls)).toHaveLength(0);
     });
 });

--- a/src/features/classification/__tests__/Classification.test.js
+++ b/src/features/classification/__tests__/Classification.test.js
@@ -121,6 +121,7 @@ describe('features/classification/Classification', () => {
             isLoadingControls: true,
         });
         expect(wrapper.find(LoadingIndicator)).toHaveLength(0);
+        expect(wrapper.find(SecurityControls)).toHaveLength(0);
     });
 
     test('should not render loading indicator when message style is not inline', () => {
@@ -129,5 +130,6 @@ describe('features/classification/Classification', () => {
             isLoadingControls: true,
         });
         expect(wrapper.find(LoadingIndicator)).toHaveLength(0);
+        expect(wrapper.find(SecurityControls)).toHaveLength(0);
     });
 });

--- a/src/features/classification/security-controls/SecurityControls.js
+++ b/src/features/classification/security-controls/SecurityControls.js
@@ -51,6 +51,7 @@ const SecurityControls = ({ controls, controlsFormat, maxAppCount }: Props) => {
 };
 
 SecurityControls.defaultProps = {
+    controls: {},
     controlsFormat: SHORT,
     maxAppCount: DEFAULT_MAX_APP_COUNT,
 };

--- a/src/features/classification/security-controls/SecurityControlsItem.js
+++ b/src/features/classification/security-controls/SecurityControlsItem.js
@@ -10,7 +10,7 @@ import { bdlBoxBlue } from '../../../styles/variables';
 
 import './SecurityControlsItem.scss';
 
-const ICON_SIZE = 14;
+const ICON_SIZE = 16;
 
 type Props = {
     message: MessageDescriptor,
@@ -32,7 +32,7 @@ const SecurityControlsItem = ({ message, tooltipItems }: Props) => {
         <li className="bdl-SecurityControlsItem">
             <FormattedMessage {...message} />
             {isTooltipEnabled && (
-                <Tooltip text={tooltipContent} position="middle-left">
+                <Tooltip className="bdl-SecurityControlsItem-tooltip" text={tooltipContent} position="middle-left">
                     <span className="bdl-SecurityControlsItem-tooltipIcon">
                         <IconInfo color={bdlBoxBlue} width={ICON_SIZE} height={ICON_SIZE} />
                     </span>

--- a/src/features/classification/security-controls/SecurityControlsItem.scss
+++ b/src/features/classification/security-controls/SecurityControlsItem.scss
@@ -23,6 +23,10 @@
     }
 }
 
+.bdl-SecurityControlsItem-tooltip {
+    max-width: 270px;
+}
+
 .bdl-SecurityControlsItem-tooltipIcon {
     display: inline-block;
     width: 15px;

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsItem.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsItem.test.js.snap
@@ -9,6 +9,7 @@ exports[`features/classification/security-controls/SecurityControlsItem should r
     id="msg1"
   />
   <Tooltip
+    className="bdl-SecurityControlsItem-tooltip"
     constrainToScrollParent={false}
     constrainToWindow={true}
     isDisabled={false}
@@ -36,8 +37,8 @@ exports[`features/classification/security-controls/SecurityControlsItem should r
     >
       <IconInfo
         color="#0061d5"
-        height={14}
-        width={14}
+        height={16}
+        width={16}
       />
     </span>
   </Tooltip>


### PR DESCRIPTION
The information for the `SecurityControls` will normally be fetched separately from the item's own classification data and will be subsequently cached. We're adding a loading indicator in order to allow displaying classification while this additional data is being retrieved.

This PR also includes some style tweaks for the `SecurityControlsItem` tooltip styles.

<img width="250" alt="Loading Indicator" src="https://user-images.githubusercontent.com/1322503/69501845-b8c8da00-0ebd-11ea-9b2c-594286dc2607.png">
