### PR TITLE
refactor(types): port some types to explicit imports

### DIFF
--- a/flow-typed/box-ui-elements.js
+++ b/flow-typed/box-ui-elements.js
@@ -9,7 +9,6 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import type { MessageDescriptor, InjectIntlProvidedProps } from 'react-intl';
-import type { $AxiosXHR, $AxiosError, Axios, CancelTokenSource } from 'axios';
 import type FolderAPI from '../src/api/Folder';
 import type FileAPI from '../src/api/File';
 import type WebLinkAPI from '../src/api/WebLink';

--- a/src/api/AppActivity.js
+++ b/src/api/AppActivity.js
@@ -3,6 +3,8 @@
  * @file Helper for the box App Activity API
  * @author Box
  */
+import type { $AxiosError } from 'axios';
+
 import MarkerBasedAPI from './MarkerBasedAPI';
 import { ERROR_CODE_DELETE_APP_ACTIVITY, HTTP_STATUS_CODE_NOT_FOUND } from '../constants';
 import { APP_ACTIVITY_FIELDS_TO_FETCH } from '../utils/fields';
@@ -79,7 +81,7 @@ class AppActivity extends MarkerBasedAPI {
     /**
      * Generic error handler
      *
-     * @param {AxiosError} error - the error response
+     * @param {$AxiosError} error - the error response
      */
     errorHandler = (error: $AxiosError<any>): void => {
         if (this.isDestroyed() && typeof this.errorCallback !== 'function') {

--- a/src/api/Base.js
+++ b/src/api/Base.js
@@ -5,6 +5,8 @@
  */
 
 import noop from 'lodash/noop';
+import type { $AxiosError } from 'axios';
+
 import Xhr from '../utils/Xhr';
 import Cache from '../utils/Cache';
 import { getTypedFileId } from '../utils/file';

--- a/src/api/Item.js
+++ b/src/api/Item.js
@@ -6,6 +6,8 @@
 
 import noop from 'lodash/noop';
 import setProp from 'lodash/set';
+import type { $AxiosError } from 'axios';
+
 import { getBadItemError, getBadPermissionsError } from '../utils/error';
 import Base from './Base';
 import {

--- a/src/common/types/api.js
+++ b/src/common/types/api.js
@@ -1,4 +1,5 @@
 // @flow
+import type { $AxiosError } from 'axios';
 import type { ElementOrigin } from '../../elements/common/flowTypes';
 
 type FetchOptions = {

--- a/src/utils/Xhr.js
+++ b/src/utils/Xhr.js
@@ -5,7 +5,7 @@
  */
 
 import axios from 'axios';
-import type { $AxiosError, $AxiosXHR } from 'axios';
+import type { $AxiosError, $AxiosXHR, Axios, CancelTokenSource } from 'axios';
 import getProp from 'lodash/get';
 import includes from 'lodash/includes';
 import lowerCase from 'lodash/lowerCase';


### PR DESCRIPTION
Some cleanup from a few imports I missed related to the API types earlier. Adding these explicit imports causes a lot of flow errors that I'm not quite sure how to resolve though. May need some help on this.