### PR TITLE
fix(classification): Fixing typo on security controls message

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1041,7 +1041,7 @@ boxui.securityControls.sharingCollabAndCompanyOnly = Shared links allowed for co
 # Bullet point that summarizes shared link restriction applied to classification
 boxui.securityControls.sharingCollabOnly = Shared links cannot be made publicly accessible.
 # Short summary displayed for classification when sharing, download and app download restrictions are applied to it
-boxui.securityControls.shortAllRestrictions = Sharing, download and app and restrictions apply
+boxui.securityControls.shortAllRestrictions = Sharing, download and app restrictions apply
 # Short summary displayed for classification when an application download restriction is applied to it
 boxui.securityControls.shortApp = Application restrictions apply
 # Short summary displayed for classification when a download restriction is applied to it

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
@@ -58,7 +58,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     key="0"
     message={
       Object {
-        "defaultMessage": "Sharing, download and app and restrictions apply",
+        "defaultMessage": "Sharing, download and app restrictions apply",
         "id": "boxui.securityControls.shortAllRestrictions",
       }
     }
@@ -97,7 +97,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     key="0"
     message={
       Object {
-        "defaultMessage": "Sharing, download and app and restrictions apply",
+        "defaultMessage": "Sharing, download and app restrictions apply",
         "id": "boxui.securityControls.shortAllRestrictions",
       }
     }

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -37,7 +37,7 @@ const messages = defineMessages({
         id: 'boxui.securityControls.shortDownloadApp',
     },
     shortAllRestrictions: {
-        defaultMessage: 'Sharing, download and app and restrictions apply',
+        defaultMessage: 'Sharing, download and app restrictions apply',
         description:
             'Short summary displayed for classification when sharing, download and app download restrictions are applied to it',
         id: 'boxui.securityControls.shortAllRestrictions',


### PR DESCRIPTION
Just removing an extra "and" from one of the messages