### PR TITLE
fix(classification): Fixing messages for sharing restrictions

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1055,7 +1055,7 @@ boxui.securityControls.shortSharingApp = Sharing and app restrictions apply
 # Short summary displayed for classification when both sharing and download restrictions are applied to it
 boxui.securityControls.shortSharingDownload = Sharing and download restrictions apply
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users
-boxui.securityControls.webDownloadExternal = Download restricted on Box Desktop for external users.
+boxui.securityControls.webDownloadExternal = Download restricted on web for external users.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners
 boxui.securityControls.webDownloadExternalOwners = Download restricted on web, except Owners/Co-Owners. Also restricted for external users.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1013,9 +1013,9 @@ boxui.securityControls.appDownloadWhitelist = Only select applications are allow
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
 boxui.securityControls.appDownloadWhitelistOverflow = Only select applications are allowed: {appNames} +{remainingAppCount} more
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners. Box Drive is a product name and not translated
-boxui.securityControls.desktopDownloadExternalOwners = Download restricted on Box Drive for external users, except Owners/Co-Owners.
+boxui.securityControls.desktopDownloadExternalOwners = Download restricted on Box Drive, except Owners/Co-Owners. Also restricted for external users.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors. Box Drive is a product name and not translated
-boxui.securityControls.desktopDownloadExternalOwnersEditors = Download restricted on Box Drive for external users, except Owners/Co-Owners/Editors.
+boxui.securityControls.desktopDownloadExternalOwnersEditors = Download restricted on Box Drive, except Owners/Co-Owners/Editors. Also restricted for external users.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to managed users except Owners/Co-Owners. Box Drive is a product name and not translated
 boxui.securityControls.desktopDownloadOwners = Download restricted on Box Drive, except Owners/Co-Owners.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to managed users except Owners/Co-Owners/Editors. Box Drive is a product name and not translated
@@ -1029,17 +1029,17 @@ boxui.securityControls.externalCollabDomainList = External collaboration limited
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users
 boxui.securityControls.mobileDownloadExternal = Download restricted on mobile for external users.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners
-boxui.securityControls.mobileDownloadExternalOwners = Download restricted on mobile for external users, except Owners/Co-Owners.
+boxui.securityControls.mobileDownloadExternalOwners = Download restricted on mobile, except Owners/Co-Owners. Also restricted for external users.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors
-boxui.securityControls.mobileDownloadExternalOwnersEditors = Download restricted on mobile for external users, except Owners/Co-Owners/Editors.
+boxui.securityControls.mobileDownloadExternalOwnersEditors = Download restricted on mobile, except Owners/Co-Owners/Editors. Also restricted for external users.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to managed users except Owners/Co-Owners
 boxui.securityControls.mobileDownloadOwners = Download restricted on mobile, except Owners/Co-Owners.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to managed users except Owners/Co-Owners/Editors
 boxui.securityControls.mobileDownloadOwnersEditors = Download restricted on mobile, except Owners/Co-Owners/Editors.
 # Bullet point that summarizes collaborators shared link restriction applied to classification
-boxui.securityControls.sharingCollabAndCompanyOnly = Shared links allowed for collaborators only.
+boxui.securityControls.sharingCollabAndCompanyOnly = Shared links cannot be made publicly accessible.
 # Bullet point that summarizes shared link restriction applied to classification
-boxui.securityControls.sharingCollabOnly = Shared links cannot be made publicly accessible.
+boxui.securityControls.sharingCollabOnly = Shared links allowed for collaborators only.
 # Short summary displayed for classification when sharing, download and app download restrictions are applied to it
 boxui.securityControls.shortAllRestrictions = Sharing, download and app restrictions apply
 # Short summary displayed for classification when an application download restriction is applied to it
@@ -1057,9 +1057,9 @@ boxui.securityControls.shortSharingDownload = Sharing and download restrictions 
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users
 boxui.securityControls.webDownloadExternal = Download restricted on Box Desktop for external users.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners
-boxui.securityControls.webDownloadExternalOwners = Download restricted on web for external users, except Owners/Co-Owners.
+boxui.securityControls.webDownloadExternalOwners = Download restricted on web, except Owners/Co-Owners. Also restricted for external users.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors
-boxui.securityControls.webDownloadExternalOwnersEditors = Download restricted on web for external users, except Owners/Co-Owners/Editors.
+boxui.securityControls.webDownloadExternalOwnersEditors = Download restricted on web, except Owners/Co-Owners/Editors. Also restricted for external users.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to managed users except Owners/Co-Owners
 boxui.securityControls.webDownloadOwners = Download restricted on web, except Owners/Co-Owners.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to managed users except Owners/Co-Owners/Editors

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
@@ -8,7 +8,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     key="0"
     message={
       Object {
-        "defaultMessage": "Shared links cannot be made publicly accessible.",
+        "defaultMessage": "Shared links allowed for collaborators only.",
         "id": "boxui.securityControls.sharingCollabOnly",
       }
     }
@@ -65,7 +65,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     tooltipItems={
       Array [
         Object {
-          "defaultMessage": "Shared links cannot be made publicly accessible.",
+          "defaultMessage": "Shared links allowed for collaborators only.",
           "id": "boxui.securityControls.sharingCollabOnly",
         },
         Object {

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -12,7 +12,7 @@ import {
 const { DESKTOP, MOBILE, WEB } = DOWNLOAD_CONTROL;
 const { BLOCK, WHITELIST, BLACKLIST } = LIST_ACCESS_LEVEL;
 const { OWNERS_AND_COOWNERS, OWNERS_COOWNERS_AND_EDITORS } = MANAGED_USERS_ACCESS_LEVEL;
-const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY } = SHARED_LINK_ACCESS_LEVEL;
+const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVEL;
 
 describe('features/classification/security-controls/utils', () => {
     let accessPolicy;
@@ -24,6 +24,11 @@ describe('features/classification/security-controls/utils', () => {
     describe('getShortSecurityControlsMessage()', () => {
         test('should return null when there are no restrictions', () => {
             expect(getShortSecurityControlsMessage({})).toBeNull();
+        });
+
+        test('should not return messages when shared link restriction has a "public" access level', () => {
+            accessPolicy = { sharedLink: { accessLevel: PUBLIC } };
+            expect(getShortSecurityControlsMessage(accessPolicy)).toBeNull();
         });
 
         test('should return all restrictions message when all restrictions are present', () => {

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -43,12 +43,12 @@ const messages = defineMessages({
         id: 'boxui.securityControls.shortAllRestrictions',
     },
     sharingCollabOnly: {
-        defaultMessage: 'Shared links cannot be made publicly accessible.',
+        defaultMessage: 'Shared links allowed for collaborators only.',
         description: 'Bullet point that summarizes shared link restriction applied to classification',
         id: 'boxui.securityControls.sharingCollabOnly',
     },
     sharingCollabAndCompanyOnly: {
-        defaultMessage: 'Shared links allowed for collaborators only.',
+        defaultMessage: 'Shared links cannot be made publicly accessible.',
         description: 'Bullet point that summarizes collaborators shared link restriction applied to classification',
         id: 'boxui.securityControls.sharingCollabAndCompanyOnly',
     },
@@ -104,13 +104,14 @@ const messages = defineMessages({
         id: 'boxui.securityControls.webDownloadOwnersEditors',
     },
     webDownloadExternalOwners: {
-        defaultMessage: 'Download restricted on web for external users, except Owners/Co-Owners.',
+        defaultMessage: 'Download restricted on web, except Owners/Co-Owners. Also restricted for external users.',
         description:
             'Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners',
         id: 'boxui.securityControls.webDownloadExternalOwners',
     },
     webDownloadExternalOwnersEditors: {
-        defaultMessage: 'Download restricted on web for external users, except Owners/Co-Owners/Editors.',
+        defaultMessage:
+            'Download restricted on web, except Owners/Co-Owners/Editors. Also restricted for external users.',
         description:
             'Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors',
         id: 'boxui.securityControls.webDownloadExternalOwnersEditors',
@@ -135,13 +136,14 @@ const messages = defineMessages({
         id: 'boxui.securityControls.mobileDownloadOwnersEditors',
     },
     mobileDownloadExternalOwners: {
-        defaultMessage: 'Download restricted on mobile for external users, except Owners/Co-Owners.',
+        defaultMessage: 'Download restricted on mobile, except Owners/Co-Owners. Also restricted for external users.',
         description:
             'Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners',
         id: 'boxui.securityControls.mobileDownloadExternalOwners',
     },
     mobileDownloadExternalOwnersEditors: {
-        defaultMessage: 'Download restricted on mobile for external users, except Owners/Co-Owners/Editors.',
+        defaultMessage:
+            'Download restricted on mobile, except Owners/Co-Owners/Editors. Also restricted for external users.',
         description:
             'Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors',
         id: 'boxui.securityControls.mobileDownloadExternalOwnersEditors',
@@ -166,13 +168,15 @@ const messages = defineMessages({
         id: 'boxui.securityControls.desktopDownloadOwnersEditors',
     },
     desktopDownloadExternalOwners: {
-        defaultMessage: 'Download restricted on Box Drive for external users, except Owners/Co-Owners.',
+        defaultMessage:
+            'Download restricted on Box Drive, except Owners/Co-Owners. Also restricted for external users.',
         description:
             'Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners. Box Drive is a product name and not translated',
         id: 'boxui.securityControls.desktopDownloadExternalOwners',
     },
     desktopDownloadExternalOwnersEditors: {
-        defaultMessage: 'Download restricted on Box Drive for external users, except Owners/Co-Owners/Editors.',
+        defaultMessage:
+            'Download restricted on Box Drive, except Owners/Co-Owners/Editors. Also restricted for external users.',
         description:
             'Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors. Box Drive is a product name and not translated',
         id: 'boxui.securityControls.desktopDownloadExternalOwnersEditors',

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -117,7 +117,7 @@ const messages = defineMessages({
         id: 'boxui.securityControls.webDownloadExternalOwnersEditors',
     },
     webDownloadExternal: {
-        defaultMessage: 'Download restricted on Box Desktop for external users.',
+        defaultMessage: 'Download restricted on web for external users.',
         description:
             'Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users',
         id: 'boxui.securityControls.webDownloadExternal',

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -13,13 +13,14 @@ import { ACCESS_POLICY_RESTRICTION, DOWNLOAD_CONTROL, LIST_ACCESS_LEVEL, SHARED_
 const { SHARED_LINK, DOWNLOAD, EXTERNAL_COLLAB, APP } = ACCESS_POLICY_RESTRICTION;
 const { DESKTOP, MOBILE, WEB } = DOWNLOAD_CONTROL;
 const { BLOCK, WHITELIST, BLACKLIST } = LIST_ACCESS_LEVEL;
-const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY } = SHARED_LINK_ACCESS_LEVEL;
+const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVEL;
 
 const getShortSecurityControlsMessage = (controls: Controls): ?MessageDescriptor => {
     const { sharedLink, download, externalCollab, app } = controls;
-    const sharing = sharedLink || externalCollab;
     // Shared link and external collab restrictions are grouped
     // together as generic "sharing" restrictions
+    const sharing = (sharedLink && sharedLink.accessLevel !== PUBLIC) || externalCollab;
+
     if (sharing && download && app) {
         return messages.shortAllRestrictions;
     }
@@ -36,7 +37,7 @@ const getShortSecurityControlsMessage = (controls: Controls): ?MessageDescriptor
         return messages.shortDownloadApp;
     }
 
-    if (sharedLink || externalCollab) {
+    if (sharing) {
         return messages.shortSharing;
     }
 


### PR DESCRIPTION
This contains the following fixes/updates:

- Fixed an issue in which `Sharing restriction applies` message was being shown for `SecurityControls` in short format when a sharing restriction object with `accessLevel="public"` was provided. 
- Fixed an issue in which the message for sharing restriction for company and collaborators was being shown instead of the one for collaborators only, and vice versa.
- Updated the messages for download restrictions that apply to external users in order to remove ambiguity.
- Fixed typo in web download restriction for external users message