### PR TITLE
fix(uploads): fix auto retry after timeout

### DIFF
--- a/src/api/uploads/MultiputUpload.js
+++ b/src/api/uploads/MultiputUpload.js
@@ -488,7 +488,6 @@ class MultiputUpload extends BaseMultiput {
             logEvent: session_endpoints.log_event,
         };
 
-        console.log('getSessionSuccessHandler');
         this.processNextParts();
     }
 
@@ -648,10 +647,7 @@ class MultiputUpload extends BaseMultiput {
             while (this.numPartsUploading > 0) {
                 const part = this.parts[nextUploadIndex];
                 if (part && part.state === PART_STATE_UPLOADING) {
-                    part.state = PART_STATE_DIGEST_READY;
-                    part.numUploadRetriesPerformed = 0;
-                    part.timing = {};
-                    part.uploadedBytes = 0;
+                    part.reset();
                     part.pause();
 
                     this.numPartsUploading -= 1;
@@ -659,14 +655,6 @@ class MultiputUpload extends BaseMultiput {
                 }
                 nextUploadIndex += 1;
             }
-
-            console.log(
-                `partUploadErrorHandler numPartsUploading ${this.numPartsUploading} numPartsDigestReady ${
-                    this.numPartsDigestReady
-                }`,
-            );
-
-            // then when resuming, call part.retryupload (see uploadNextPart)
         }
     };
 
@@ -701,12 +689,6 @@ class MultiputUpload extends BaseMultiput {
         if (this.failSessionIfFileChangeDetected()) {
             return;
         }
-
-        console.log(
-            `processNextParts numPartsUploading ${this.numPartsUploading} numPartsDigestReady ${
-                this.numPartsDigestReady
-            } numPartsUploaded ${this.numPartsUploaded}`,
-        );
 
         if (this.numPartsUploaded === this.parts.length && this.fileSha1) {
             this.commitSession();

--- a/src/utils/Xhr.js
+++ b/src/utils/Xhr.js
@@ -458,6 +458,7 @@ class Xhr {
                 if (withIdleTimeout) {
                     // Func that aborts upload and executes timeout callback
                     const idleTimeoutFunc = () => {
+                        console.log('idleTimeoutFunc called');
                         this.abort();
 
                         if (idleTimeoutHandler) {
@@ -508,6 +509,7 @@ class Xhr {
                         successHandler(response);
                     })
                     .catch(error => {
+                        console.log('catch axios error: ' + error.message);
                         clearTimeout(idleTimeout);
                         errorHandler(error);
                     });
@@ -521,6 +523,8 @@ class Xhr {
      * @return {void}
      */
     abort(): void {
+        console.log('abort() called');
+
         if (this.retryTimeout) {
             clearTimeout(this.retryTimeout);
         }

--- a/src/utils/Xhr.js
+++ b/src/utils/Xhr.js
@@ -458,7 +458,6 @@ class Xhr {
                 if (withIdleTimeout) {
                     // Func that aborts upload and executes timeout callback
                     const idleTimeoutFunc = () => {
-                        console.log('idleTimeoutFunc called');
                         this.abort();
 
                         if (idleTimeoutHandler) {
@@ -509,7 +508,6 @@ class Xhr {
                         successHandler(response);
                     })
                     .catch(error => {
-                        console.log('catch axios error: ' + error.message);
                         clearTimeout(idleTimeout);
                         errorHandler(error);
                     });
@@ -523,8 +521,6 @@ class Xhr {
      * @return {void}
      */
     abort(): void {
-        console.log('abort() called');
-
         if (this.retryTimeout) {
             clearTimeout(this.retryTimeout);
         }


### PR DESCRIPTION
Adds pause state and resets uploading process for all parts on error. Updates state and retries upload on unpausing the parts. This change stops all auto-resuming after we display an error message to the user.