### PR TITLE
fix(metadata): Fix misaligned multiselect dropdown

### DIFF
--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -40,6 +40,8 @@ type Props = {
     error?: React.Node,
     /** The select button is disabled if true */
     isDisabled?: boolean,
+    /** Whether to allow the dropdown to overflow its boundaries and remain attached to its reference */
+    isEscapedWithReference?: Boolean,
     /** Whether to align the dropdown to the right */
     isRightAligned: boolean,
     /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
@@ -391,7 +393,14 @@ class BaseSelectField extends React.Component<Props, State> {
     };
 
     render() {
-        const { className, multiple, isRightAligned, isScrollable, selectedValues } = this.props;
+        const {
+            className,
+            multiple,
+            isEscapedWithReference,
+            isRightAligned,
+            isScrollable,
+            selectedValues,
+        } = this.props;
         const { isOpen } = this.state;
 
         // @TODO: Need invariants on specific conditions.
@@ -402,6 +411,8 @@ class BaseSelectField extends React.Component<Props, State> {
         // 5) defaultValue, if defined, cannot be selected in addition to other options (must be exclusive)
 
         const dropdownPlacement = isRightAligned ? PLACEMENT_BOTTOM_END : PLACEMENT_BOTTOM_START;
+        // popper.js modifier to allow dropdown to overflow its bounderies and remain attached to its reference
+        const dropdownModifiers = isEscapedWithReference ? { preventOverflow: { escapeWithReference: true } } : {};
 
         return (
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -410,7 +421,7 @@ class BaseSelectField extends React.Component<Props, State> {
                 onBlur={this.handleBlur}
                 onKeyDown={this.handleKeyDown}
             >
-                <PopperComponent placement={dropdownPlacement} isOpen={isOpen}>
+                <PopperComponent placement={dropdownPlacement} isOpen={isOpen} modifiers={dropdownModifiers}>
                     {this.renderSelectButton()}
                     <SelectFieldDropdown
                         isScrollable={isScrollable}

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -41,7 +41,7 @@ type Props = {
     /** The select button is disabled if true */
     isDisabled?: boolean,
     /** Whether to allow the dropdown to overflow its boundaries and remain attached to its reference */
-    isEscapedWithReference?: Boolean,
+    isEscapedWithReference?: boolean,
     /** Whether to align the dropdown to the right */
     isRightAligned: boolean,
     /** The select field overlay (dropdown) will have a scrollbar and max-height if true * */
@@ -411,7 +411,7 @@ class BaseSelectField extends React.Component<Props, State> {
         // 5) defaultValue, if defined, cannot be selected in addition to other options (must be exclusive)
 
         const dropdownPlacement = isRightAligned ? PLACEMENT_BOTTOM_END : PLACEMENT_BOTTOM_START;
-        // popper.js modifier to allow dropdown to overflow its bounderies and remain attached to its reference
+        // popper.js modifier to allow dropdown to overflow its boundaries and remain attached to its reference
         const dropdownModifiers = isEscapedWithReference ? { preventOverflow: { escapeWithReference: true } } : {};
 
         return (

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -242,6 +242,20 @@ describe('components/select-field/BaseSelectField', () => {
                 expect(overlay.hasClass(OVERLAY_SCROLLABLE_CLASS)).toBe(result);
             },
         );
+
+        test('should apply preventOverflow modifier when isEscapedWithReference is true', () => {
+            const wrapper = shallowRenderSelectField({ isEscapedWithReference: true });
+
+            const props = wrapper.find('PopperComponent').props();
+            expect(props.modifiers.preventOverflow).toBeDefined();
+        });
+
+        test('should not apply preventOverflow modifier when isEscapedWithReference is not set', () => {
+            const wrapper = shallowRenderSelectField();
+
+            const props = wrapper.find('PopperComponent').props();
+            expect(props.modifiers.preventOverflow).toBeUndefined();
+        });
     });
 
     describe('onBlur', () => {

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -247,7 +247,7 @@ describe('components/select-field/BaseSelectField', () => {
             const wrapper = shallowRenderSelectField({ isEscapedWithReference: true });
 
             const props = wrapper.find('PopperComponent').props();
-            expect(props.modifiers.preventOverflow).toBeDefined();
+            expect(props.modifiers.preventOverflow).toEqual({ escapeWithReference: true });
         });
 
         test('should not apply preventOverflow modifier when isEscapedWithReference is not set', () => {

--- a/src/features/metadata-instance-editor/fields/MultiSelectField.js
+++ b/src/features/metadata-instance-editor/fields/MultiSelectField.js
@@ -38,6 +38,7 @@ const MultiSelectField = ({
             <Label text={displayName}>
                 {!!description && <i className="metadata-instance-editor-field-multi-select-desc">{description}</i>}
                 <MultiSelect
+                    isEscapedWithReference
                     isScrollable
                     onChange={(selectedOptions: Array<SelectOptionProp>) => {
                         if (selectedOptions.length) {

--- a/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/MultiSelectField.test.js.snap
+++ b/src/features/metadata-instance-editor/fields/__tests__/__snapshots__/MultiSelectField.test.js.snap
@@ -6,6 +6,7 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
 >
   <Label>
     <MultiSelectField
+      isEscapedWithReference={true}
       isScrollable={true}
       onChange={[Function]}
       options={Array []}
@@ -36,6 +37,7 @@ exports[`features/metadata-instance-editor/fields/MultiSelectField should correc
       description
     </i>
     <MultiSelectField
+      isEscapedWithReference={true}
       isScrollable={true}
       onChange={[Function]}
       options={Array []}


### PR DESCRIPTION
Issue: misaligned dropdown in Chrome (Mac), IE11 & Edge

**Mac Chrome - before**
<img width="561" alt="mac_chrome_before" src="https://user-images.githubusercontent.com/14035562/70562375-21ac8500-1b41-11ea-90a8-fb8afa59b902.png">

**Mac Chrome - after**
<img width="559" alt="mac_chrome_after" src="https://user-images.githubusercontent.com/14035562/70562391-2a9d5680-1b41-11ea-9a39-6eb8f0c28bb0.png">

<img width="555" alt="after_mac_chrome_1" src="https://user-images.githubusercontent.com/14035562/70562598-8cf65700-1b41-11ea-8938-deada64a25a1.png">

**Edge - before**
<img width="425" alt="before_win_edge_1" src="https://user-images.githubusercontent.com/14035562/70562436-3ee15380-1b41-11ea-9716-8eb62ad1d122.png">

**Edge - after**
<img width="425" alt="after_win_edge_2" src="https://user-images.githubusercontent.com/14035562/70562458-456fcb00-1b41-11ea-8ba0-cf34ce35899d.png">

**IE11 - before**
<img width="578" alt="before_ie11" src="https://user-images.githubusercontent.com/14035562/70562509-66382080-1b41-11ea-956b-85b1d6d789fa.png">

**IE11 - after**
<img width="563" alt="after_ie11" src="https://user-images.githubusercontent.com/14035562/70562556-7d770e00-1b41-11ea-8339-83fb4f4a1f39.png">

**Safari - after**
<img width="569" alt="after_safari_1" src="https://user-images.githubusercontent.com/14035562/70562685-be6f2280-1b41-11ea-8a82-c4774d8df392.png">

**Firefox - after**
<img width="563" alt="after_mac_firefox_2" src="https://user-images.githubusercontent.com/14035562/70562712-ccbd3e80-1b41-11ea-975f-07da97906311.png">