### PR TITLE
feat(content-uploader): Add tracking on upload resume buttons

### DIFF
--- a/src/elements/content-uploader/ItemAction.js
+++ b/src/elements/content-uploader/ItemAction.js
@@ -13,6 +13,7 @@ import LoadingIndicator from '../../components/loading-indicator';
 import PlainButton from '../../components/plain-button/PlainButton';
 import Tooltip from '../../components/tooltip';
 import messages from '../common/messages';
+import { RESIN_TAG_TARGET } from '../../common/variables';
 import { STATUS_PENDING, STATUS_IN_PROGRESS, STATUS_STAGED, STATUS_COMPLETE, STATUS_ERROR } from '../../constants';
 import type { UploadStatus } from '../../common/types/upload';
 
@@ -47,7 +48,7 @@ const ItemAction = ({ status, onClick, intl, isResumableUploadsEnabled, isFolder
         case STATUS_ERROR:
             icon = <IconRetry height={24} width={24} />;
             tooltip = isResumableUploadsEnabled ? messages.resume : messages.retry;
-            target = 'uploadretry';
+            target = isResumableUploadsEnabled ? 'uploadresume' : 'uploadretry';
             break;
         case STATUS_IN_PROGRESS:
         case STATUS_STAGED:
@@ -70,7 +71,7 @@ const ItemAction = ({ status, onClick, intl, isResumableUploadsEnabled, isFolder
     }
 
     if (target) {
-        resin = { 'data-resin-target': target };
+        resin = { [RESIN_TAG_TARGET]: target };
     }
 
     return (

--- a/src/elements/content-uploader/UploadsManagerAction.js
+++ b/src/elements/content-uploader/UploadsManagerAction.js
@@ -8,6 +8,7 @@ import { FormattedMessage } from 'react-intl';
 import messages from '../common/messages';
 import PrimaryButton from '../../components/primary-button';
 import { STATUS_ERROR } from '../../constants';
+import { RESIN_TAG_TARGET } from '../../common/variables';
 import './UploadsManagerAction.scss';
 
 type Props = {
@@ -23,9 +24,11 @@ const UploadsManagerAction = ({ onClick, hasMultipleFailedUploads }: Props) => {
 
     const resumeMessage = hasMultipleFailedUploads ? messages.resumeAll : messages.resume;
 
+    const resin = { [RESIN_TAG_TARGET]: 'uploadresumeheader' };
+
     return (
         <div className="bcu-uploads-manager-action">
-            <PrimaryButton onClick={handleResumeClick} type="button">
+            <PrimaryButton onClick={handleResumeClick} type="button" {...resin}>
                 <FormattedMessage {...resumeMessage} />
             </PrimaryButton>
         </div>

--- a/src/elements/content-uploader/__tests__/__snapshots__/ItemAction.test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/ItemAction.test.js.snap
@@ -92,7 +92,7 @@ exports[`elements/content-uploader/ItemAction should render correctly with error
     theme="default"
   >
     <PlainButton
-      data-resin-target="uploadretry"
+      data-resin-target="uploadresume"
       isDisabled={false}
       onClick={[Function]}
       type="button"

--- a/src/elements/content-uploader/__tests__/__snapshots__/UploadsManagerAction.test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/UploadsManagerAction.test.js.snap
@@ -5,6 +5,7 @@ exports[`elements/content-uploader/UploadsManagerAction should render correctly 
   className="bcu-uploads-manager-action"
 >
   <PrimaryButton
+    data-resin-target="uploadresumeheader"
     onClick={[Function]}
     type="button"
   >
@@ -21,6 +22,7 @@ exports[`elements/content-uploader/UploadsManagerAction should render correctly 
   className="bcu-uploads-manager-action"
 >
   <PrimaryButton
+    data-resin-target="uploadresumeheader"
     onClick={[Function]}
     type="button"
   >


### PR DESCRIPTION
Adding tracking attributes on the `Resume`/`Resume All` buttons.