### PR TITLE
fix(select-field): Reintroduce separators

### DIFF
--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -1,5 +1,6 @@
 @import '../../styles/variables';
 
+.bdl-SelectField,
 .select-field {
     .overlay {
         min-width: 100%;


### PR DESCRIPTION
This PR reintroduces separators into `BaseSelectField` components.

A `SingleSelectField` without the intended separators:
<img width="130" alt="buie-missing-separators" src="https://user-images.githubusercontent.com/2956895/70945929-0cd16500-200b-11ea-8980-dec0f1a1f664.png">

The same `SingleSelectField`, fixed:
<img width="131" alt="buie-bugfix-separators" src="https://user-images.githubusercontent.com/2956895/70945932-0e9b2880-200b-11ea-9b9d-f1194a1a7987.png">
