### PR TITLE
feat(uploads): save the mb uploaded on resume

### DIFF
--- a/src/common/types/upload.js
+++ b/src/common/types/upload.js
@@ -56,6 +56,7 @@ type FolderUploadItem = {
 type UploadItem = {
     api: PlainUploadAPI | MultiputUploadAPI,
     boxFile?: BoxItem,
+    bytesUploadedOnLastResume?: number,
     error?: Object,
     extension: string,
     file: UploadFile,

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -999,6 +999,7 @@ class ContentUploader extends Component<Props, State> {
                 break;
             case STATUS_ERROR:
                 if (isResumable) {
+                    item.bytesUploadedOnLastResume = item.api.totalUploadedBytes;
                     this.resumeFile(item);
                 } else {
                     this.resetFile(item);


### PR DESCRIPTION
Adds a new optional field on upload item that saves the mb uploaded so far for an item when user resumes an upload