### PR TITLE
feat(collapsible): display action button when collapsed and hovered

### DIFF
--- a/src/components/collapsible/Collapsible.js
+++ b/src/components/collapsible/Collapsible.js
@@ -82,6 +82,14 @@ class Collapsible extends React.PureComponent<Props, State> {
         this.setState({ isHovered: false });
     };
 
+    handleFocus = () => {
+        this.setState({ isHovered: true });
+    };
+
+    handleBlur = () => {
+        this.setState({ isHovered: false });
+    };
+
     render() {
         const { isHovered, isOpen }: State = this.state;
         const {
@@ -119,8 +127,12 @@ class Collapsible extends React.PureComponent<Props, State> {
             <div className={sectionClassName}>
                 <div
                     className={buttonClassName}
+                    onBlur={this.handleBlur}
+                    onFocus={this.handleFocus}
                     onMouseEnter={this.handleMouseEnter}
                     onMouseLeave={this.handleMouseLeave}
+                    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                    tabIndex="0"
                 >
                     <PlainButton
                         {...modifiedButtonProps}

--- a/src/components/collapsible/Collapsible.js
+++ b/src/components/collapsible/Collapsible.js
@@ -117,7 +117,7 @@ class Collapsible extends React.PureComponent<Props, State> {
                         {title}
                         <IconCaretDown className="collapsible-card-header-caret" color={bdlGray50} width={8} />
                     </PlainButton>
-                    {!!headerActionItems && <span className="bdl-collapsible-actionItems">{headerActionItems}</span>}
+                    {!!headerActionItems && <span className="bdl-Collapsible-actionItems">{headerActionItems}</span>}
                 </div>
                 <AnimateHeight duration={animationDuration} height={isOpen ? 'auto' : 0}>
                     <div className="collapsible-card-content">{children}</div>

--- a/src/components/collapsible/Collapsible.js
+++ b/src/components/collapsible/Collapsible.js
@@ -37,6 +37,7 @@ type Props = {
 };
 
 type State = {
+    isHovered: boolean,
     isOpen: boolean,
 };
 
@@ -51,6 +52,7 @@ class Collapsible extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
+            isHovered: false,
             isOpen: props.isOpen,
         };
     }
@@ -72,8 +74,16 @@ class Collapsible extends React.PureComponent<Props, State> {
         );
     };
 
+    handleMouseEnter = () => {
+        this.setState({ isHovered: true });
+    };
+
+    handleMouseLeave = () => {
+        this.setState({ isHovered: false });
+    };
+
     render() {
-        const { isOpen }: State = this.state;
+        const { isHovered, isOpen }: State = this.state;
         const {
             animationDuration,
             buttonProps = {},
@@ -107,7 +117,11 @@ class Collapsible extends React.PureComponent<Props, State> {
 
         return (
             <div className={sectionClassName}>
-                <div className={buttonClassName}>
+                <div
+                    className={buttonClassName}
+                    onMouseEnter={this.handleMouseEnter}
+                    onMouseLeave={this.handleMouseLeave}
+                >
                     <PlainButton
                         {...modifiedButtonProps}
                         className="collapsible-card-title"
@@ -117,7 +131,7 @@ class Collapsible extends React.PureComponent<Props, State> {
                         {title}
                         <IconCaretDown className="collapsible-card-header-caret" color={bdlGray50} width={8} />
                     </PlainButton>
-                    {isOpen && headerActionItems}
+                    {(isOpen && headerActionItems) || (!isOpen && isHovered && headerActionItems)}
                 </div>
                 <AnimateHeight duration={animationDuration} height={isOpen ? 'auto' : 0}>
                     <div className="collapsible-card-content">{children}</div>

--- a/src/components/collapsible/Collapsible.js
+++ b/src/components/collapsible/Collapsible.js
@@ -28,12 +28,8 @@ type Props = {
     isBordered?: boolean,
     /** Initial state of the collapsible card */
     isOpen: boolean,
-    /** callback called when collapsible is unfocused */
-    onBlur?: Function,
     /** callback called when collapsible is opened */
     onClose?: Function,
-    /** callback called when collapsible is focused */
-    onFocus?: Function,
     /** callback called when collapsible is collapsed */
     onOpen?: Function,
     /** Title string or component */
@@ -86,8 +82,6 @@ class Collapsible extends React.PureComponent<Props, State> {
             isBordered,
             hasStickyHeader,
             headerActionItems,
-            onBlur,
-            onFocus,
             title,
         }: Props = this.props;
 
@@ -113,7 +107,7 @@ class Collapsible extends React.PureComponent<Props, State> {
 
         return (
             <div className={sectionClassName}>
-                <div className={buttonClassName} onBlur={onBlur} onFocus={onFocus}>
+                <div className={buttonClassName}>
                     <PlainButton
                         {...modifiedButtonProps}
                         className="collapsible-card-title"

--- a/src/components/collapsible/Collapsible.js
+++ b/src/components/collapsible/Collapsible.js
@@ -28,8 +28,12 @@ type Props = {
     isBordered?: boolean,
     /** Initial state of the collapsible card */
     isOpen: boolean,
+    /** callback called when collapsible is unfocused */
+    onBlur?: Function,
     /** callback called when collapsible is opened */
     onClose?: Function,
+    /** callback called when collapsible is focused */
+    onFocus?: Function,
     /** callback called when collapsible is collapsed */
     onOpen?: Function,
     /** Title string or component */
@@ -37,7 +41,6 @@ type Props = {
 };
 
 type State = {
-    isHovered: boolean,
     isOpen: boolean,
 };
 
@@ -52,7 +55,6 @@ class Collapsible extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
-            isHovered: false,
             isOpen: props.isOpen,
         };
     }
@@ -74,24 +76,8 @@ class Collapsible extends React.PureComponent<Props, State> {
         );
     };
 
-    handleMouseEnter = () => {
-        this.setState({ isHovered: true });
-    };
-
-    handleMouseLeave = () => {
-        this.setState({ isHovered: false });
-    };
-
-    handleFocus = () => {
-        this.setState({ isHovered: true });
-    };
-
-    handleBlur = () => {
-        this.setState({ isHovered: false });
-    };
-
     render() {
-        const { isHovered, isOpen }: State = this.state;
+        const { isOpen }: State = this.state;
         const {
             animationDuration,
             buttonProps = {},
@@ -100,6 +86,8 @@ class Collapsible extends React.PureComponent<Props, State> {
             isBordered,
             hasStickyHeader,
             headerActionItems,
+            onBlur,
+            onFocus,
             title,
         }: Props = this.props;
 
@@ -127,10 +115,8 @@ class Collapsible extends React.PureComponent<Props, State> {
             <div className={sectionClassName}>
                 <div
                     className={buttonClassName}
-                    onBlur={this.handleBlur}
-                    onFocus={this.handleFocus}
-                    onMouseEnter={this.handleMouseEnter}
-                    onMouseLeave={this.handleMouseLeave}
+                    onBlur={onBlur}
+                    onFocus={onFocus}
                     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
                     tabIndex="0"
                 >
@@ -143,7 +129,9 @@ class Collapsible extends React.PureComponent<Props, State> {
                         {title}
                         <IconCaretDown className="collapsible-card-header-caret" color={bdlGray50} width={8} />
                     </PlainButton>
-                    {(isOpen && headerActionItems) || (!isOpen && isHovered && headerActionItems)}
+                    {!!headerActionItems && (
+                        <span className="collapsible-card-header-actionItems">{headerActionItems}</span>
+                    )}
                 </div>
                 <AnimateHeight duration={animationDuration} height={isOpen ? 'auto' : 0}>
                     <div className="collapsible-card-content">{children}</div>

--- a/src/components/collapsible/Collapsible.js
+++ b/src/components/collapsible/Collapsible.js
@@ -123,9 +123,7 @@ class Collapsible extends React.PureComponent<Props, State> {
                         {title}
                         <IconCaretDown className="collapsible-card-header-caret" color={bdlGray50} width={8} />
                     </PlainButton>
-                    {!!headerActionItems && (
-                        <span className="collapsible-card-header-actionItems">{headerActionItems}</span>
-                    )}
+                    {!!headerActionItems && <span className="bdl-collapsible-actionItems">{headerActionItems}</span>}
                 </div>
                 <AnimateHeight duration={animationDuration} height={isOpen ? 'auto' : 0}>
                     <div className="collapsible-card-content">{children}</div>

--- a/src/components/collapsible/Collapsible.js
+++ b/src/components/collapsible/Collapsible.js
@@ -113,13 +113,7 @@ class Collapsible extends React.PureComponent<Props, State> {
 
         return (
             <div className={sectionClassName}>
-                <div
-                    className={buttonClassName}
-                    onBlur={onBlur}
-                    onFocus={onFocus}
-                    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-                    tabIndex="0"
-                >
+                <div className={buttonClassName} onBlur={onBlur} onFocus={onFocus}>
                     <PlainButton
                         {...modifiedButtonProps}
                         className="collapsible-card-title"

--- a/src/components/collapsible/Collapsible.scss
+++ b/src/components/collapsible/Collapsible.scss
@@ -38,14 +38,31 @@
         width: 100%;
         padding: 10px 0;
         text-align: left;
+
+        + .collapsible-card-header-actionItems {
+            display: none;
+        }
+
+        &:focus,
+        &:hover {
+            + .collapsible-card-header-actionItems {
+                display: block;
+            }
+        }
     }
 
     .collapsible-card-content {
         padding: 10px 0;
     }
 
-    &.is-open .collapsible-card-header-caret {
-        transform: rotateZ(180deg);
+    &.is-open {
+        .collapsible-card-header-caret {
+            transform: rotateZ(180deg);
+        }
+
+        .collapsible-card-title + .collapsible-card-header-actionItems {
+            display: block;
+        }
     }
 
     &.is-bordered {

--- a/src/components/collapsible/Collapsible.scss
+++ b/src/components/collapsible/Collapsible.scss
@@ -39,7 +39,7 @@
         padding: 10px 0;
         text-align: left;
 
-        + .collapsible-card-header-actionItems {
+        + .bdl-collapsible-actionItems {
             display: none;
         }
 
@@ -47,7 +47,7 @@
         &:hover {
             text-decoration: underline;
 
-            + .collapsible-card-header-actionItems {
+            + .bdl-collapsible-actionItems {
                 display: block;
             }
         }
@@ -62,7 +62,7 @@
             transform: rotateZ(180deg);
         }
 
-        .collapsible-card-title + .collapsible-card-header-actionItems {
+        .collapsible-card-title + .bdl-collapsible-actionItems {
             display: block;
         }
     }

--- a/src/components/collapsible/Collapsible.scss
+++ b/src/components/collapsible/Collapsible.scss
@@ -45,6 +45,8 @@
 
         &:focus,
         &:hover {
+            text-decoration: underline;
+
             + .collapsible-card-header-actionItems {
                 display: block;
             }

--- a/src/components/collapsible/Collapsible.scss
+++ b/src/components/collapsible/Collapsible.scss
@@ -62,8 +62,15 @@
             transform: rotateZ(180deg);
         }
 
-        .collapsible-card-title + .bdl-collapsible-actionItems {
-            display: block;
+        .collapsible-card-title {
+            &:focus,
+            &:hover {
+                text-decoration: none;
+            }
+
+            + .bdl-collapsible-actionItems {
+                display: block;
+            }
         }
     }
 

--- a/src/components/collapsible/Collapsible.scss
+++ b/src/components/collapsible/Collapsible.scss
@@ -39,7 +39,7 @@
         padding: 10px 0;
         text-align: left;
 
-        + .bdl-collapsible-actionItems {
+        + .bdl-Collapsible-actionItems {
             display: none;
         }
 
@@ -47,7 +47,7 @@
         &:hover {
             text-decoration: underline;
 
-            + .bdl-collapsible-actionItems {
+            + .bdl-Collapsible-actionItems {
                 display: block;
             }
         }
@@ -62,13 +62,13 @@
             transform: rotateZ(180deg);
         }
 
-        .collapsible-card-title {
+        .btn-plain.collapsible-card-title {
             &:focus,
             &:hover {
                 text-decoration: none;
             }
 
-            + .bdl-collapsible-actionItems {
+            + .bdl-Collapsible-actionItems {
                 display: block;
             }
         }

--- a/src/components/collapsible/__tests__/Collapsible.test.js
+++ b/src/components/collapsible/__tests__/Collapsible.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import sinon from 'sinon';
 
+import Button from '../../button/Button';
 import PlainButton from '../../plain-button/PlainButton';
 import Collapsible from '..';
 
@@ -25,6 +26,36 @@ describe('components/collapsible/Collapsible', () => {
 
         wrapper.find('.collapsible-card-title').simulate('click');
         expect(wrapper.state('isOpen')).toBeTruthy();
+    });
+
+    test('should handle mouse enter event and show edit button', () => {
+        wrapper = shallow(
+            <Collapsible
+                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
+                isOpen={false}
+                title="foo"
+            >
+                <span className="test-content">foobar</span>
+            </Collapsible>,
+        );
+        wrapper.find('.collapsible-card-header').simulate('mouseEnter');
+        expect(wrapper.state('isHovered')).toBeTruthy();
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should handle mouse leave event and hide edit button', () => {
+        wrapper = shallow(
+            <Collapsible
+                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
+                isOpen={false}
+                title="foo"
+            >
+                <span className="test-content">foobar</span>
+            </Collapsible>,
+        );
+        wrapper.find('.collapsible-card-header').simulate('mouseLeave');
+        expect(wrapper.state('isHovered')).toBeFalsy();
+        expect(wrapper).toMatchSnapshot();
     });
 
     test('should apply correct border class', () => {

--- a/src/components/collapsible/__tests__/Collapsible.test.js
+++ b/src/components/collapsible/__tests__/Collapsible.test.js
@@ -28,13 +28,9 @@ describe('components/collapsible/Collapsible', () => {
         expect(wrapper.state('isOpen')).toBeTruthy();
     });
 
-    test('should render with handleActionItems', () => {
+    test('should render with headerActionItems', () => {
         wrapper = shallow(
-            <Collapsible
-                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
-                isOpen={false}
-                title="foo"
-            >
+            <Collapsible headerActionItems={<Button>Click Here</Button>} isOpen={false} title="foo">
                 <span className="test-content">foobar</span>
             </Collapsible>,
         );

--- a/src/components/collapsible/__tests__/Collapsible.test.js
+++ b/src/components/collapsible/__tests__/Collapsible.test.js
@@ -28,28 +28,6 @@ describe('components/collapsible/Collapsible', () => {
         expect(wrapper.state('isOpen')).toBeTruthy();
     });
 
-    test('should call onFocusStub when focused', () => {
-        const onFocusStub = sinon.spy();
-        wrapper = shallow(
-            <Collapsible isOpen onFocus={onFocusStub} title="foo">
-                <span className="test-content">foobar</span>
-            </Collapsible>,
-        );
-        wrapper.find('.collapsible-card-header').simulate('focus');
-        expect(onFocusStub.calledOnce).toBe(true);
-    });
-
-    test('should call onBlurStub when unfocused', () => {
-        const onBlurStub = sinon.spy();
-        wrapper = shallow(
-            <Collapsible isOpen onBlur={onBlurStub} title="foo">
-                <span className="test-content">foobar</span>
-            </Collapsible>,
-        );
-        wrapper.find('.collapsible-card-header').simulate('blur');
-        expect(onBlurStub.calledOnce).toBe(true);
-    });
-
     test('should render with handleActionItems', () => {
         wrapper = shallow(
             <Collapsible

--- a/src/components/collapsible/__tests__/Collapsible.test.js
+++ b/src/components/collapsible/__tests__/Collapsible.test.js
@@ -58,6 +58,36 @@ describe('components/collapsible/Collapsible', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should handle focus event and show edit button', () => {
+        wrapper = shallow(
+            <Collapsible
+                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
+                isOpen={false}
+                title="foo"
+            >
+                <span className="test-content">foobar</span>
+            </Collapsible>,
+        );
+        wrapper.find('.collapsible-card-header').simulate('focus');
+        expect(wrapper.state('isHovered')).toBeTruthy();
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should handle blur event and hide edit button', () => {
+        wrapper = shallow(
+            <Collapsible
+                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
+                isOpen={false}
+                title="foo"
+            >
+                <span className="test-content">foobar</span>
+            </Collapsible>,
+        );
+        wrapper.find('.collapsible-card-header').simulate('blur');
+        expect(wrapper.state('isHovered')).toBeFalsy();
+        expect(wrapper).toMatchSnapshot();
+    });
+
     test('should apply correct border class', () => {
         wrapper = shallow(
             <Collapsible isBordered isOpen title="foo">

--- a/src/components/collapsible/__tests__/Collapsible.test.js
+++ b/src/components/collapsible/__tests__/Collapsible.test.js
@@ -28,52 +28,29 @@ describe('components/collapsible/Collapsible', () => {
         expect(wrapper.state('isOpen')).toBeTruthy();
     });
 
-    test('should handle mouse enter event and show edit button', () => {
+    test('should call onFocusStub when focused', () => {
+        const onFocusStub = sinon.spy();
         wrapper = shallow(
-            <Collapsible
-                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
-                isOpen={false}
-                title="foo"
-            >
-                <span className="test-content">foobar</span>
-            </Collapsible>,
-        );
-        wrapper.find('.collapsible-card-header').simulate('mouseEnter');
-        expect(wrapper.state('isHovered')).toBeTruthy();
-        expect(wrapper).toMatchSnapshot();
-    });
-
-    test('should handle mouse leave event and hide edit button', () => {
-        wrapper = shallow(
-            <Collapsible
-                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
-                isOpen={false}
-                title="foo"
-            >
-                <span className="test-content">foobar</span>
-            </Collapsible>,
-        );
-        wrapper.find('.collapsible-card-header').simulate('mouseLeave');
-        expect(wrapper.state('isHovered')).toBeFalsy();
-        expect(wrapper).toMatchSnapshot();
-    });
-
-    test('should handle focus event and show edit button', () => {
-        wrapper = shallow(
-            <Collapsible
-                headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
-                isOpen={false}
-                title="foo"
-            >
+            <Collapsible isOpen onFocus={onFocusStub} title="foo">
                 <span className="test-content">foobar</span>
             </Collapsible>,
         );
         wrapper.find('.collapsible-card-header').simulate('focus');
-        expect(wrapper.state('isHovered')).toBeTruthy();
-        expect(wrapper).toMatchSnapshot();
+        expect(onFocusStub.calledOnce).toBe(true);
     });
 
-    test('should handle blur event and hide edit button', () => {
+    test('should call onBlurStub when unfocused', () => {
+        const onBlurStub = sinon.spy();
+        wrapper = shallow(
+            <Collapsible isOpen onBlur={onBlurStub} title="foo">
+                <span className="test-content">foobar</span>
+            </Collapsible>,
+        );
+        wrapper.find('.collapsible-card-header').simulate('blur');
+        expect(onBlurStub.calledOnce).toBe(true);
+    });
+
+    test('should render with handleActionItems', () => {
         wrapper = shallow(
             <Collapsible
                 headerActionItems={<Button className="collapsible-card-action-items">Click Here</Button>}
@@ -83,8 +60,6 @@ describe('components/collapsible/Collapsible', () => {
                 <span className="test-content">foobar</span>
             </Collapsible>,
         );
-        wrapper.find('.collapsible-card-header').simulate('blur');
-        expect(wrapper.state('isHovered')).toBeFalsy();
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -348,7 +348,7 @@ exports[`components/collapsible/Collapsible should render with headerActionItems
       />
     </PlainButton>
     <span
-      className="bdl-collapsible-actionItems"
+      className="bdl-Collapsible-actionItems"
     >
       <Button
         className=""

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -6,10 +6,6 @@ exports[`components/collapsible/Collapsible should apply buttonProps correctly 1
 >
   <div
     className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
     tabIndex="0"
   >
     <PlainButton
@@ -67,10 +63,6 @@ exports[`components/collapsible/Collapsible should apply correct border class 1`
 >
   <div
     className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
     tabIndex="0"
   >
     <PlainButton
@@ -126,10 +118,6 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
 >
   <div
     className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
     tabIndex="0"
   >
     <PlainButton
@@ -179,276 +167,12 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
 </div>
 `;
 
-exports[`components/collapsible/Collapsible should handle blur event and hide edit button 1`] = `
-<div
-  className="collapsible-card"
->
-  <div
-    className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    tabIndex="0"
-  >
-    <PlainButton
-      className="collapsible-card-title"
-      onClick={[Function]}
-      type="button"
-    >
-      foo
-      <IconCaretDown
-        className="collapsible-card-header-caret"
-        color="#909090"
-        width={8}
-      />
-    </PlainButton>
-  </div>
-  <AnimateHeight
-    animateOpacity={false}
-    animationStateClasses={
-      Object {
-        "animating": "rah-animating",
-        "animatingDown": "rah-animating--down",
-        "animatingToHeightAuto": "rah-animating--to-height-auto",
-        "animatingToHeightSpecific": "rah-animating--to-height-specific",
-        "animatingToHeightZero": "rah-animating--to-height-zero",
-        "animatingUp": "rah-animating--up",
-        "static": "rah-static",
-        "staticHeightAuto": "rah-static--height-auto",
-        "staticHeightSpecific": "rah-static--height-specific",
-        "staticHeightZero": "rah-static--height-zero",
-      }
-    }
-    applyInlineTransitions={true}
-    delay={0}
-    duration={100}
-    easing="ease"
-    height={0}
-    style={Object {}}
-  >
-    <div
-      className="collapsible-card-content"
-    >
-      <span
-        className="test-content"
-      >
-        foobar
-      </span>
-    </div>
-  </AnimateHeight>
-</div>
-`;
-
-exports[`components/collapsible/Collapsible should handle focus event and show edit button 1`] = `
-<div
-  className="collapsible-card"
->
-  <div
-    className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    tabIndex="0"
-  >
-    <PlainButton
-      className="collapsible-card-title"
-      onClick={[Function]}
-      type="button"
-    >
-      foo
-      <IconCaretDown
-        className="collapsible-card-header-caret"
-        color="#909090"
-        width={8}
-      />
-    </PlainButton>
-    <Button
-      className="collapsible-card-action-items"
-      isLoading={false}
-      showRadar={false}
-      type="submit"
-    >
-      Click Here
-    </Button>
-  </div>
-  <AnimateHeight
-    animateOpacity={false}
-    animationStateClasses={
-      Object {
-        "animating": "rah-animating",
-        "animatingDown": "rah-animating--down",
-        "animatingToHeightAuto": "rah-animating--to-height-auto",
-        "animatingToHeightSpecific": "rah-animating--to-height-specific",
-        "animatingToHeightZero": "rah-animating--to-height-zero",
-        "animatingUp": "rah-animating--up",
-        "static": "rah-static",
-        "staticHeightAuto": "rah-static--height-auto",
-        "staticHeightSpecific": "rah-static--height-specific",
-        "staticHeightZero": "rah-static--height-zero",
-      }
-    }
-    applyInlineTransitions={true}
-    delay={0}
-    duration={100}
-    easing="ease"
-    height={0}
-    style={Object {}}
-  >
-    <div
-      className="collapsible-card-content"
-    >
-      <span
-        className="test-content"
-      >
-        foobar
-      </span>
-    </div>
-  </AnimateHeight>
-</div>
-`;
-
-exports[`components/collapsible/Collapsible should handle mouse enter event and show edit button 1`] = `
-<div
-  className="collapsible-card"
->
-  <div
-    className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    tabIndex="0"
-  >
-    <PlainButton
-      className="collapsible-card-title"
-      onClick={[Function]}
-      type="button"
-    >
-      foo
-      <IconCaretDown
-        className="collapsible-card-header-caret"
-        color="#909090"
-        width={8}
-      />
-    </PlainButton>
-    <Button
-      className="collapsible-card-action-items"
-      isLoading={false}
-      showRadar={false}
-      type="submit"
-    >
-      Click Here
-    </Button>
-  </div>
-  <AnimateHeight
-    animateOpacity={false}
-    animationStateClasses={
-      Object {
-        "animating": "rah-animating",
-        "animatingDown": "rah-animating--down",
-        "animatingToHeightAuto": "rah-animating--to-height-auto",
-        "animatingToHeightSpecific": "rah-animating--to-height-specific",
-        "animatingToHeightZero": "rah-animating--to-height-zero",
-        "animatingUp": "rah-animating--up",
-        "static": "rah-static",
-        "staticHeightAuto": "rah-static--height-auto",
-        "staticHeightSpecific": "rah-static--height-specific",
-        "staticHeightZero": "rah-static--height-zero",
-      }
-    }
-    applyInlineTransitions={true}
-    delay={0}
-    duration={100}
-    easing="ease"
-    height={0}
-    style={Object {}}
-  >
-    <div
-      className="collapsible-card-content"
-    >
-      <span
-        className="test-content"
-      >
-        foobar
-      </span>
-    </div>
-  </AnimateHeight>
-</div>
-`;
-
-exports[`components/collapsible/Collapsible should handle mouse leave event and hide edit button 1`] = `
-<div
-  className="collapsible-card"
->
-  <div
-    className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    tabIndex="0"
-  >
-    <PlainButton
-      className="collapsible-card-title"
-      onClick={[Function]}
-      type="button"
-    >
-      foo
-      <IconCaretDown
-        className="collapsible-card-header-caret"
-        color="#909090"
-        width={8}
-      />
-    </PlainButton>
-  </div>
-  <AnimateHeight
-    animateOpacity={false}
-    animationStateClasses={
-      Object {
-        "animating": "rah-animating",
-        "animatingDown": "rah-animating--down",
-        "animatingToHeightAuto": "rah-animating--to-height-auto",
-        "animatingToHeightSpecific": "rah-animating--to-height-specific",
-        "animatingToHeightZero": "rah-animating--to-height-zero",
-        "animatingUp": "rah-animating--up",
-        "static": "rah-static",
-        "staticHeightAuto": "rah-static--height-auto",
-        "staticHeightSpecific": "rah-static--height-specific",
-        "staticHeightZero": "rah-static--height-zero",
-      }
-    }
-    applyInlineTransitions={true}
-    delay={0}
-    duration={100}
-    easing="ease"
-    height={0}
-    style={Object {}}
-  >
-    <div
-      className="collapsible-card-content"
-    >
-      <span
-        className="test-content"
-      >
-        foobar
-      </span>
-    </div>
-  </AnimateHeight>
-</div>
-`;
-
 exports[`components/collapsible/Collapsible should not render a PlainButton if a button is not passed in 1`] = `
 <div
   className="collapsible-card is-open"
 >
   <div
     className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
     tabIndex="0"
   >
     <PlainButton
@@ -504,10 +228,6 @@ exports[`components/collapsible/Collapsible should render a PlainButton if a but
 >
   <div
     className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
     tabIndex="0"
   >
     <PlainButton
@@ -563,10 +283,6 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
 >
   <div
     className="collapsible-card-header"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
     tabIndex="0"
   >
     <PlainButton
@@ -603,6 +319,75 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
     duration={100}
     easing="ease"
     height="auto"
+    style={Object {}}
+  >
+    <div
+      className="collapsible-card-content"
+    >
+      <span
+        className="test-content"
+      >
+        foobar
+      </span>
+    </div>
+  </AnimateHeight>
+</div>
+`;
+
+exports[`components/collapsible/Collapsible should render with handleActionItems 1`] = `
+<div
+  className="collapsible-card"
+>
+  <div
+    className="collapsible-card-header"
+    tabIndex="0"
+  >
+    <PlainButton
+      className="collapsible-card-title"
+      onClick={[Function]}
+      type="button"
+    >
+      foo
+      <IconCaretDown
+        className="collapsible-card-header-caret"
+        color="#909090"
+        width={8}
+      />
+    </PlainButton>
+    <span
+      className="collapsible-card-header-actionItems"
+    >
+      <Button
+        className="collapsible-card-action-items"
+        isLoading={false}
+        showRadar={false}
+        type="submit"
+      >
+        Click Here
+      </Button>
+    </span>
+  </div>
+  <AnimateHeight
+    animateOpacity={false}
+    animationStateClasses={
+      Object {
+        "animating": "rah-animating",
+        "animatingDown": "rah-animating--down",
+        "animatingToHeightAuto": "rah-animating--to-height-auto",
+        "animatingToHeightSpecific": "rah-animating--to-height-specific",
+        "animatingToHeightZero": "rah-animating--to-height-zero",
+        "animatingUp": "rah-animating--up",
+        "static": "rah-static",
+        "staticHeightAuto": "rah-static--height-auto",
+        "staticHeightSpecific": "rah-static--height-specific",
+        "staticHeightZero": "rah-static--height-zero",
+      }
+    }
+    applyInlineTransitions={true}
+    delay={0}
+    duration={100}
+    easing="ease"
+    height={0}
     style={Object {}}
   >
     <div

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -6,8 +6,11 @@ exports[`components/collapsible/Collapsible should apply buttonProps correctly 1
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       a={1}
@@ -64,8 +67,11 @@ exports[`components/collapsible/Collapsible should apply correct border class 1`
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -120,8 +126,11 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -170,14 +179,147 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
 </div>
 `;
 
+exports[`components/collapsible/Collapsible should handle blur event and hide edit button 1`] = `
+<div
+  className="collapsible-card"
+>
+  <div
+    className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    tabIndex="0"
+  >
+    <PlainButton
+      className="collapsible-card-title"
+      onClick={[Function]}
+      type="button"
+    >
+      foo
+      <IconCaretDown
+        className="collapsible-card-header-caret"
+        color="#909090"
+        width={8}
+      />
+    </PlainButton>
+  </div>
+  <AnimateHeight
+    animateOpacity={false}
+    animationStateClasses={
+      Object {
+        "animating": "rah-animating",
+        "animatingDown": "rah-animating--down",
+        "animatingToHeightAuto": "rah-animating--to-height-auto",
+        "animatingToHeightSpecific": "rah-animating--to-height-specific",
+        "animatingToHeightZero": "rah-animating--to-height-zero",
+        "animatingUp": "rah-animating--up",
+        "static": "rah-static",
+        "staticHeightAuto": "rah-static--height-auto",
+        "staticHeightSpecific": "rah-static--height-specific",
+        "staticHeightZero": "rah-static--height-zero",
+      }
+    }
+    applyInlineTransitions={true}
+    delay={0}
+    duration={100}
+    easing="ease"
+    height={0}
+    style={Object {}}
+  >
+    <div
+      className="collapsible-card-content"
+    >
+      <span
+        className="test-content"
+      >
+        foobar
+      </span>
+    </div>
+  </AnimateHeight>
+</div>
+`;
+
+exports[`components/collapsible/Collapsible should handle focus event and show edit button 1`] = `
+<div
+  className="collapsible-card"
+>
+  <div
+    className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    tabIndex="0"
+  >
+    <PlainButton
+      className="collapsible-card-title"
+      onClick={[Function]}
+      type="button"
+    >
+      foo
+      <IconCaretDown
+        className="collapsible-card-header-caret"
+        color="#909090"
+        width={8}
+      />
+    </PlainButton>
+    <Button
+      className="collapsible-card-action-items"
+      isLoading={false}
+      showRadar={false}
+      type="submit"
+    >
+      Click Here
+    </Button>
+  </div>
+  <AnimateHeight
+    animateOpacity={false}
+    animationStateClasses={
+      Object {
+        "animating": "rah-animating",
+        "animatingDown": "rah-animating--down",
+        "animatingToHeightAuto": "rah-animating--to-height-auto",
+        "animatingToHeightSpecific": "rah-animating--to-height-specific",
+        "animatingToHeightZero": "rah-animating--to-height-zero",
+        "animatingUp": "rah-animating--up",
+        "static": "rah-static",
+        "staticHeightAuto": "rah-static--height-auto",
+        "staticHeightSpecific": "rah-static--height-specific",
+        "staticHeightZero": "rah-static--height-zero",
+      }
+    }
+    applyInlineTransitions={true}
+    delay={0}
+    duration={100}
+    easing="ease"
+    height={0}
+    style={Object {}}
+  >
+    <div
+      className="collapsible-card-content"
+    >
+      <span
+        className="test-content"
+      >
+        foobar
+      </span>
+    </div>
+  </AnimateHeight>
+</div>
+`;
+
 exports[`components/collapsible/Collapsible should handle mouse enter event and show edit button 1`] = `
 <div
   className="collapsible-card"
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -242,8 +384,11 @@ exports[`components/collapsible/Collapsible should handle mouse leave event and 
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -300,8 +445,11 @@ exports[`components/collapsible/Collapsible should not render a PlainButton if a
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -356,8 +504,11 @@ exports[`components/collapsible/Collapsible should render a PlainButton if a but
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -412,8 +563,11 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
 >
   <div
     className="collapsible-card-header"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -348,7 +348,7 @@ exports[`components/collapsible/Collapsible should render with handleActionItems
       />
     </PlainButton>
     <span
-      className="collapsible-card-header-actionItems"
+      className="bdl-collapsible-actionItems"
     >
       <Button
         className="collapsible-card-action-items"

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -6,6 +6,8 @@ exports[`components/collapsible/Collapsible should apply buttonProps correctly 1
 >
   <div
     className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <PlainButton
       a={1}
@@ -62,6 +64,8 @@ exports[`components/collapsible/Collapsible should apply correct border class 1`
 >
   <div
     className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <PlainButton
       className="collapsible-card-title"
@@ -116,6 +120,8 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
 >
   <div
     className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <PlainButton
       className="collapsible-card-title"
@@ -164,12 +170,138 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
 </div>
 `;
 
+exports[`components/collapsible/Collapsible should handle mouse enter event and show edit button 1`] = `
+<div
+  className="collapsible-card"
+>
+  <div
+    className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <PlainButton
+      className="collapsible-card-title"
+      onClick={[Function]}
+      type="button"
+    >
+      foo
+      <IconCaretDown
+        className="collapsible-card-header-caret"
+        color="#909090"
+        width={8}
+      />
+    </PlainButton>
+    <Button
+      className="collapsible-card-action-items"
+      isLoading={false}
+      showRadar={false}
+      type="submit"
+    >
+      Click Here
+    </Button>
+  </div>
+  <AnimateHeight
+    animateOpacity={false}
+    animationStateClasses={
+      Object {
+        "animating": "rah-animating",
+        "animatingDown": "rah-animating--down",
+        "animatingToHeightAuto": "rah-animating--to-height-auto",
+        "animatingToHeightSpecific": "rah-animating--to-height-specific",
+        "animatingToHeightZero": "rah-animating--to-height-zero",
+        "animatingUp": "rah-animating--up",
+        "static": "rah-static",
+        "staticHeightAuto": "rah-static--height-auto",
+        "staticHeightSpecific": "rah-static--height-specific",
+        "staticHeightZero": "rah-static--height-zero",
+      }
+    }
+    applyInlineTransitions={true}
+    delay={0}
+    duration={100}
+    easing="ease"
+    height={0}
+    style={Object {}}
+  >
+    <div
+      className="collapsible-card-content"
+    >
+      <span
+        className="test-content"
+      >
+        foobar
+      </span>
+    </div>
+  </AnimateHeight>
+</div>
+`;
+
+exports[`components/collapsible/Collapsible should handle mouse leave event and hide edit button 1`] = `
+<div
+  className="collapsible-card"
+>
+  <div
+    className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <PlainButton
+      className="collapsible-card-title"
+      onClick={[Function]}
+      type="button"
+    >
+      foo
+      <IconCaretDown
+        className="collapsible-card-header-caret"
+        color="#909090"
+        width={8}
+      />
+    </PlainButton>
+  </div>
+  <AnimateHeight
+    animateOpacity={false}
+    animationStateClasses={
+      Object {
+        "animating": "rah-animating",
+        "animatingDown": "rah-animating--down",
+        "animatingToHeightAuto": "rah-animating--to-height-auto",
+        "animatingToHeightSpecific": "rah-animating--to-height-specific",
+        "animatingToHeightZero": "rah-animating--to-height-zero",
+        "animatingUp": "rah-animating--up",
+        "static": "rah-static",
+        "staticHeightAuto": "rah-static--height-auto",
+        "staticHeightSpecific": "rah-static--height-specific",
+        "staticHeightZero": "rah-static--height-zero",
+      }
+    }
+    applyInlineTransitions={true}
+    delay={0}
+    duration={100}
+    easing="ease"
+    height={0}
+    style={Object {}}
+  >
+    <div
+      className="collapsible-card-content"
+    >
+      <span
+        className="test-content"
+      >
+        foobar
+      </span>
+    </div>
+  </AnimateHeight>
+</div>
+`;
+
 exports[`components/collapsible/Collapsible should not render a PlainButton if a button is not passed in 1`] = `
 <div
   className="collapsible-card is-open"
 >
   <div
     className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <PlainButton
       className="collapsible-card-title"
@@ -224,6 +356,8 @@ exports[`components/collapsible/Collapsible should render a PlainButton if a but
 >
   <div
     className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <PlainButton
       className="collapsible-card-title"
@@ -278,6 +412,8 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
 >
   <div
     className="collapsible-card-header"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <PlainButton
       className="collapsible-card-title"

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -6,7 +6,6 @@ exports[`components/collapsible/Collapsible should apply buttonProps correctly 1
 >
   <div
     className="collapsible-card-header"
-    tabIndex="0"
   >
     <PlainButton
       a={1}
@@ -63,7 +62,6 @@ exports[`components/collapsible/Collapsible should apply correct border class 1`
 >
   <div
     className="collapsible-card-header"
-    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -118,7 +116,6 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
 >
   <div
     className="collapsible-card-header"
-    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -173,7 +170,6 @@ exports[`components/collapsible/Collapsible should not render a PlainButton if a
 >
   <div
     className="collapsible-card-header"
-    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -228,7 +224,6 @@ exports[`components/collapsible/Collapsible should render a PlainButton if a but
 >
   <div
     className="collapsible-card-header"
-    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -283,7 +278,6 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
 >
   <div
     className="collapsible-card-header"
-    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"
@@ -340,7 +334,6 @@ exports[`components/collapsible/Collapsible should render with handleActionItems
 >
   <div
     className="collapsible-card-header"
-    tabIndex="0"
   >
     <PlainButton
       className="collapsible-card-title"

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -328,7 +328,7 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
 </div>
 `;
 
-exports[`components/collapsible/Collapsible should render with handleActionItems 1`] = `
+exports[`components/collapsible/Collapsible should render with headerActionItems 1`] = `
 <div
   className="collapsible-card"
 >
@@ -351,7 +351,7 @@ exports[`components/collapsible/Collapsible should render with handleActionItems
       className="bdl-collapsible-actionItems"
     >
       <Button
-        className="collapsible-card-action-items"
+        className=""
         isLoading={false}
         showRadar={false}
         type="submit"


### PR DESCRIPTION
UX change was requested to add hover effect to the Collapsible component, and they are ok with having this as the default behavior of the component.
Expected behavior: In collapsed state, hovering over the card header should display the Edit button and underline the card title. 
<img width="1401" alt="Screen Shot 2020-01-15 at 10 02 46 PM" src="https://user-images.githubusercontent.com/10932475/72497953-cbd39880-37e2-11ea-85a5-634a06a76e52.png">
