### PR TITLE
feat(targeting): add types used for targeting

### DIFF
--- a/src/features/targeting/README.md
+++ b/src/features/targeting/README.md
@@ -1,0 +1,23 @@
+### Description
+Model to providing Targeting Feature
+
+The TargetingContextProvider consumes MessageAPI and provides TargetingAPI for each message.
+
+### Examples
+Targeting Api is provided for each message. It can be consumed by the below pseudo code:
+```
+function SharedLinkPreviewModal() {
+  const { getTargetingApi } = useContext(TargetingContext);
+
+  const { shouldShow, onClose, onSeen } = getTargetingApi('adhoc_shared_link_preview');
+
+  if (shouldShow()) {
+    onSeen();
+    return <Modal><button onClick={onClose}></button><Model/>
+  }
+}
+```
+### Note
+* onSeen can only be called once when shouldShow() return true, or it will be ignored.
+* onClose can only be called once when shouldShow() return true and onSeen is already called, or it
+will be ignored.

--- a/src/features/targeting/constants.js
+++ b/src/features/targeting/constants.js
@@ -1,0 +1,9 @@
+// @flow
+const ADHOC: 'adhoc' = 'adhoc';
+const BANNER: 'banner' = 'banner';
+const MODAL: 'modal' = 'modal';
+const POPOUT: 'popout' = 'popout';
+
+const MESSAGE_TYPES = { ADHOC, BANNER, MODAL, POPOUT };
+
+export { ADHOC, BANNER, MODAL, POPOUT, MESSAGE_TYPES };

--- a/src/features/targeting/contexts.js
+++ b/src/features/targeting/contexts.js
@@ -5,6 +5,15 @@ import { type FtuxContextValue, type TargetingContextValue } from './types';
 
 const FtuxContext = createContext<FtuxContextValue>({});
 
-const TargetingContext = createContext<TargetingContextValue>({});
+const defaultTargetingContextValue = {
+    getTargetingApi: () => ({
+        shouldShow: () => false,
+        onSeen: () => {},
+        onClosed: () => {},
+    }),
+    setEligibleMessageHeaders: () => {},
+};
+
+const TargetingContext = createContext<TargetingContextValue>(defaultTargetingContextValue);
 
 export { FtuxContext, TargetingContext };

--- a/src/features/targeting/index.js
+++ b/src/features/targeting/index.js
@@ -1,4 +1,6 @@
 // @flow
-export * from './contexts';
-
+export * from './constants';
 export * from './types';
+export * from './message-api';
+export * from './targeting-api';
+export * from './contexts';

--- a/src/features/targeting/message-api.js
+++ b/src/features/targeting/message-api.js
@@ -1,0 +1,13 @@
+// @flow
+import type { MessageName } from './types';
+
+/**
+ * Message API is provided to TargetingContext as a set of persistence API that inlcudes
+ * 1) getEligibleMessageHeaders -> to be added when in app message is migrated to use Targeting
+ * 2) markMessageAsClosed
+ * 3) markMessageAsSeen
+ */
+export type MessageApi = {|
+    markMessageAsClosed: MessageName => void,
+    markMessageAsSeen: MessageName => void,
+|};

--- a/src/features/targeting/targeting-api.js
+++ b/src/features/targeting/targeting-api.js
@@ -1,0 +1,23 @@
+// @flow
+import type { MessageHeader } from './types';
+
+/**
+ * TargetingApi is provided by TargetingContext. It is provided on a per message basis.
+ * const { getTargetingApi } = useContext(TargetingContext);
+ * const targetingApi = getTargetingApi(messageName)
+ * will return the TargetingApi for the given message. See README.
+ */
+export type TargetingApi = {|
+    onClosed: () => void,
+    // call to onSeen will cause the message seen count to increment
+    onSeen: () => void,
+    // call to onClosed will cause shouldShow to be false for the rest of the session, and
+    // message close count to increment.
+    shouldShow: () => boolean,
+|};
+
+/**
+ * SetEligibleMessageHeaders call back is provided to Context component in in-app-messenger to get a
+ * copy of eligible messages.
+ */
+export type SetEligibleMessageHeaders = (Array<MessageHeader>) => void;

--- a/src/features/targeting/types.js
+++ b/src/features/targeting/types.js
@@ -1,4 +1,35 @@
 // @flow
+import type { SetEligibleMessageHeaders, TargetingApi } from './targeting-api';
+import { MESSAGE_TYPES } from './constants';
+
+export type MessageType = $Values<typeof MESSAGE_TYPES>;
+
+export type MessageID = number;
+
+export type MessageName = string;
+
+export type MessageHeader = {|
+    // an integer used to load message in getMessageRepresentation
+    canBeShownMultipleTimes: boolean,
+    // used to form messageIdentifier where namespace is 'contextual'
+    createdDate: number,
+    // whether it can be shown again
+    id: MessageID,
+    isCustomMessage: boolean,
+    // if it is custom message, custom message maker must exist to show
+    isExemptFromSuppression: boolean,
+    // is this message exempt from suppression
+    isMessageTypeSuppressed: boolean,
+    // is this message type suppressed for the user
+    name: MessageName,
+    priority: number,
+    shouldAutoShow: boolean,
+    type: MessageType,
+|};
+
 export type FtuxContextValue = {};
 
-export type TargetingContextValue = {};
+export type TargetingContextValue = {|
+    getTargetingApi: MessageName => TargetingApi,
+    setEligibleMessageHeaders: SetEligibleMessageHeaders,
+|};


### PR DESCRIPTION
most of the types were copied from EUA's in-app-messenger directory. Another PR will remove EUA's same type and import those here.