### PR TITLE
fix(typescript): migrate to explicit exports

### DIFF
--- a/src/components/accessible-svg/index.ts
+++ b/src/components/accessible-svg/index.ts
@@ -1,2 +1,1 @@
-export { default } from './AccessibleSVG';
-export * from './AccessibleSVG';
+export { default, SVGProps, AccessibleSVGProps } from './AccessibleSVG';

--- a/src/components/avatar/index.ts
+++ b/src/components/avatar/index.ts
@@ -1,11 +1,4 @@
-export { default as AvatarImage } from './AvatarImage';
-export * from './AvatarImage';
-
-export { default as AvatarInitials } from './AvatarInitials';
-export * from './AvatarInitials';
-
+export { default as AvatarImage, AvatarImageProps } from './AvatarImage';
+export { default as AvatarInitials, AvatarInitialsProps } from './AvatarInitials';
 export { default as UnknownUserAvatar } from './UnknownUserAvatar';
-export * from './UnknownUserAvatar';
-
-export { default } from './Avatar';
-export * from './Avatar';
+export { default, AvatarProps } from './Avatar';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,2 +1,1 @@
-export { default } from './Button';
-export * from './Button';
+export { default, ButtonType, ButtonProps } from './Button';

--- a/src/components/loading-indicator/index.ts
+++ b/src/components/loading-indicator/index.ts
@@ -1,8 +1,7 @@
-export { default as makeLoadable } from './makeLoadable';
-export * from './makeLoadable';
-
-export { default as LoadingIndicatorWrapper } from './LoadingIndicatorWrapper';
-export * from './LoadingIndicatorWrapper';
-
-export { default } from './LoadingIndicator';
-export * from './LoadingIndicator';
+export { default as makeLoadable, MakeLoadableProps } from './makeLoadable';
+export {
+    default as LoadingIndicatorWrapper,
+    LoadingIndicatorWrapperPosition,
+    LoadingIndicatorWrapperProps,
+} from './LoadingIndicatorWrapper';
+export { default, LoadingIndicatorSize, LoadingIndicatorProps } from './LoadingIndicator';

--- a/src/components/primary-button/index.ts
+++ b/src/components/primary-button/index.ts
@@ -1,2 +1,1 @@
 export { default } from './PrimaryButton';
-export * from './PrimaryButton';

--- a/src/components/radar/index.ts
+++ b/src/components/radar/index.ts
@@ -1,2 +1,1 @@
-export { default } from './RadarAnimation';
-export * from './RadarAnimation';
+export { default, RadarAnimationPosition, RadarAnimationProps } from './RadarAnimation';


### PR DESCRIPTION
`export * from foo` currently seems to cause a problem with jest/rewire and breaks tests in projects using rewire.