### PR TITLE
fix(form): make description more customizable for components

### DIFF
--- a/src/components/date-picker/DatePicker.js
+++ b/src/components/date-picker/DatePicker.js
@@ -4,6 +4,7 @@ import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import Pikaday from 'pikaday';
 import range from 'lodash/range';
+import uniqueId from 'lodash/uniqueId';
 
 import { RESIN_TAG_TARGET } from '../../common/variables';
 import IconAlert from '../../icons/general/IconAlert';
@@ -162,6 +163,10 @@ class DatePicker extends React.Component<Props> {
         isTextInputAllowed: false,
         yearRange: 10,
     };
+
+    errorMessageID = uniqueId('errorMessage');
+
+    descriptionID = uniqueId('description');
 
     componentDidMount() {
         const { dateFormat, intl, maxDate, minDate, value, yearRange, isTextInputAllowed } = this.props;
@@ -386,6 +391,15 @@ class DatePicker extends React.Component<Props> {
             'show-error': !!error,
         });
 
+        const hasError = !!error;
+
+        const ariaAttrs = {
+            'aria-invalid': hasError,
+            'aria-required': isRequired,
+            'aria-errormessage': this.errorMessageID,
+            'aria-describedby': description ? this.descriptionID : undefined,
+        };
+
         const resinTargetAttr = resinTarget ? { [RESIN_TAG_TARGET]: resinTarget } : {};
 
         const valueAttr = isTextInputAllowed
@@ -402,7 +416,11 @@ class DatePicker extends React.Component<Props> {
             <div className={classes}>
                 <span className="date-picker-icon-holder">
                     <Label hideLabel={hideLabel} showOptionalText={!hideOptionalLabel && !isRequired} text={label}>
-                        {!!description && <i className="date-picker-description">{description}</i>}
+                        {!!description && (
+                            <div id={this.descriptionID} className="date-picker-description">
+                                {description}
+                            </div>
+                        )}
                         <Tooltip
                             className="date-picker-error-tooltip"
                             isShown={!!error}
@@ -424,10 +442,14 @@ class DatePicker extends React.Component<Props> {
                                 onFocus={onFocus}
                                 onKeyDown={this.handleInputKeyDown}
                                 {...resinTargetAttr}
+                                {...ariaAttrs}
                                 {...inputProps}
                                 {...valueAttr}
                             />
                         </Tooltip>
+                        <span id={this.errorMessageID} className="accessibility-hidden" role="alert">
+                            {error}
+                        </span>
                     </Label>
                     {isClearable && !!value && !isDisabled ? (
                         <PlainButton

--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -19,7 +19,6 @@
     }
 
     .date-picker-description {
-        display: block;
         color: $bdl-gray-62;
     }
 

--- a/src/components/text-area/TextArea.js
+++ b/src/components/text-area/TextArea.js
@@ -56,9 +56,9 @@ const TextArea = ({
         <div className={classes}>
             <Label hideLabel={hideLabel} showOptionalText={!hideOptionalLabel && !isRequired} text={label}>
                 {!!description && (
-                    <i id={descriptionID} className="text-area-description">
+                    <div id={descriptionID} className="text-area-description">
                         {description}
-                    </i>
+                    </div>
                 )}
                 <Tooltip isShown={hasError} position="bottom-left" text={error || ''} theme="error">
                     <textarea

--- a/src/components/text-area/TextArea.scss
+++ b/src/components/text-area/TextArea.scss
@@ -13,7 +13,6 @@
     }
 
     .text-area-description {
-        display: block;
         color: $bdl-gray-62;
         word-wrap: break-word;
     }

--- a/src/components/text-area/__tests__/__snapshots__/TextArea.test.js.snap
+++ b/src/components/text-area/__tests__/__snapshots__/TextArea.test.js.snap
@@ -44,12 +44,12 @@ exports[`components/text-area/TextArea should render text area with description 
     showOptionalText={true}
     text="label"
   >
-    <i
+    <div
       className="text-area-description"
       id="description24"
     >
       some description
-    </i>
+    </div>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}

--- a/src/components/text-input/TextInput.js
+++ b/src/components/text-input/TextInput.js
@@ -74,9 +74,9 @@ const TextInput = ({
                 tooltip={labelTooltip}
             >
                 {!!description && (
-                    <i id={descriptionID} className="text-input-description">
+                    <div id={descriptionID} className="text-input-description">
                         {description}
-                    </i>
+                    </div>
                 )}
                 <Tooltip isShown={hasError} position={errorPosition || 'middle-right'} text={error || ''} theme="error">
                     <input ref={inputRef} required={isRequired} {...ariaAttrs} {...rest} />

--- a/src/components/text-input/TextInput.scss
+++ b/src/components/text-input/TextInput.scss
@@ -24,7 +24,6 @@
     }
 
     .text-input-description {
-        display: block;
         color: $bdl-gray-62;
         word-wrap: break-word;
     }

--- a/src/components/text-input/__tests__/__snapshots__/TextInput.test.js.snap
+++ b/src/components/text-input/__tests__/__snapshots__/TextInput.test.js.snap
@@ -7,12 +7,12 @@ exports[`components/text-input/TextInput should render text input with descripti
   <Label
     showOptionalText={true}
   >
-    <i
+    <div
       className="text-input-description"
       id="description36"
     >
       some description
-    </i>
+    </div>
     <Tooltip
       constrainToScrollParent={false}
       constrainToWindow={true}


### PR DESCRIPTION
DatePicker
- make description a \<div\> instead of a \<i\> and have it respect accessibility
- add error accessibility

TextArea
- make description a \<div\> instead of a \<i\>

TextInput
- make description a \<div\> instead of a \<i\>