### PR TITLE
fix(typescript): remove prop exports

### DIFF
--- a/src/components/accessible-svg/index.ts
+++ b/src/components/accessible-svg/index.ts
@@ -1,1 +1,1 @@
-export { default, SVGProps, AccessibleSVGProps } from './AccessibleSVG';
+export { default } from './AccessibleSVG';

--- a/src/components/avatar/UnknownUserAvatar.tsx
+++ b/src/components/avatar/UnknownUserAvatar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import AccessibleSVG, { SVGProps } from '../accessible-svg';
+import AccessibleSVG, { SVGProps } from '../accessible-svg/AccessibleSVG';
 
 const UnknownUserAvatar = ({ className = '', height = 28, title, width = 28 }: SVGProps) => (
     <AccessibleSVG

--- a/src/components/avatar/index.ts
+++ b/src/components/avatar/index.ts
@@ -1,4 +1,4 @@
-export { default as AvatarImage, AvatarImageProps } from './AvatarImage';
-export { default as AvatarInitials, AvatarInitialsProps } from './AvatarInitials';
+export { default as AvatarImage } from './AvatarImage';
+export { default as AvatarInitials } from './AvatarInitials';
 export { default as UnknownUserAvatar } from './UnknownUserAvatar';
-export { default, AvatarProps } from './Avatar';
+export { default } from './Avatar';

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,1 +1,1 @@
-export { default, ButtonType, ButtonProps } from './Button';
+export { default, ButtonType } from './Button';

--- a/src/components/loading-indicator/index.ts
+++ b/src/components/loading-indicator/index.ts
@@ -1,7 +1,3 @@
-export { default as makeLoadable, MakeLoadableProps } from './makeLoadable';
-export {
-    default as LoadingIndicatorWrapper,
-    LoadingIndicatorWrapperPosition,
-    LoadingIndicatorWrapperProps,
-} from './LoadingIndicatorWrapper';
-export { default, LoadingIndicatorSize, LoadingIndicatorProps } from './LoadingIndicator';
+export { default as makeLoadable } from './makeLoadable';
+export { default as LoadingIndicatorWrapper, LoadingIndicatorWrapperPosition } from './LoadingIndicatorWrapper';
+export { default, LoadingIndicatorSize } from './LoadingIndicator';

--- a/src/components/primary-button/PrimaryButton.tsx
+++ b/src/components/primary-button/PrimaryButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Button, { ButtonProps } from '../button';
+import Button, { ButtonProps } from '../button/Button';
 
 const PrimaryButton = ({ children, className = '', ...rest }: Partial<ButtonProps>) => (
     <Button className={`btn-primary ${className}`} {...rest}>

--- a/src/components/radar/index.ts
+++ b/src/components/radar/index.ts
@@ -1,1 +1,1 @@
-export { default, RadarAnimationPosition, RadarAnimationProps } from './RadarAnimation';
+export { default, RadarAnimationPosition } from './RadarAnimation';


### PR DESCRIPTION
Since they get compiled out and don't exist in the final output. It was causing unnecessary warnings when compiling in consuming repos.