### PR TITLE
chore(typescript): Update bdlClassnameManager to handle TypeScript files

### DIFF
--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -218,7 +218,7 @@ async function main() {
                 .join('|'),
             'g',
         );
-    } else if (jsExtensions.has(fileType) || fileType === '') {
+    } else if (jsExtensions.has(fileType)) {
         // The majority of .js classnames are surrounded by quotation marks
         // Restrict to those prefixes to avoid overrwriting variable names
         const converter = entry => jsPrefixes.map(prefix => `${prefix}${entry}`).join('|');

--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -5,21 +5,23 @@ const colors = require('colors/safe');
 const { promisify } = require('util');
 const invert = require('lodash/invert');
 const trimStart = require('lodash/trimStart');
+
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
 /*
     The BDL classname manager is a tool to help identify and correct the usage of classnames
-    names across box-ui-elements, and other projects.
+    names across box-ui-elements and other projects.
 
     USAGE
 
-    How to use this tool in "box-ui-elements"
+    How to use this tool in "box-ui-elements":
     (1) find . -name "*.scss" -exec ../scripts/utils/bdlClassnameManager swap {} \;
     (2) find . -name "*.scss" -exec ../scripts/utils/bdlClassnameManager extend {} \;
     (3) find . -not -name "*test.js" -and -name "*.js" -exec ../scripts/utils/bdlClassnameManager append {} \;
+    (4) find . -not -name "*test.tsx" -and -name "*.tsx" -exec ../scripts/utils/bdlClassnameManager append {} \;
 
-    How to use this tool in other projects that have "box-ui-elements" as a dependency
+    How to use this tool in other projects that have "box-ui-elements" as a dependency:
     (1) find . -name "*.scss" -exec ../scripts/utils/bdlClassnameManager swap {} \;
     (2) find . -not -name "*test.js" -and -name "*.js" -exec ../scripts/utils/bdlClassnameManager swap {} \;
 
@@ -27,13 +29,12 @@ const writeFile = promisify(fs.writeFile);
 */
 
 const conversionMap = {
-    // 'btn': 'bdl-Button',
     // 'btn-group': 'bdl-ButtonGroup',
     // 'btn-plain': 'bdl-Button--plain',
     // 'btn-primary': 'bdl-Button--primary',
     // 'is-disabled': 'bdl-is-disabled',
     // 'label': 'bdl-Label',
-    'pill': 'bdl-Pill',
+    pill: 'bdl-Pill',
     'pill-cloud-button': 'bdl-PillCloud-button',
     'pill-cloud-container': 'bdl-PillCloud',
     'pill-error': 'bdl-Pill--error',
@@ -51,6 +52,7 @@ const conversionMap = {
 };
 const scssPrefix = '.';
 const jsPrefixes = ["'", '"', '`'];
+const jsExtensions = new Set(['js', 'tsx']);
 
 function lengthSorter(a, b) {
     return a.length > b.length ? -1 : 1;
@@ -69,8 +71,8 @@ function printHelp() {
     console.log(`Usage: ${process.argv[1].split('/').pop()} operation fileName [--verbose]`);
     console.log('\nSupported operations:');
     console.log('\tcheck\t\tcheck to see if a file contains deprecated values (returns error if it does)');
-    console.log('\tswap\t\treplace known-deprecated classes in a JS or SCSS file');
-    console.log('\tappend\t\tappend new namespaced clases to known-deprecated classes in a JS or SCSS file');
+    console.log('\tswap\t\treplace known-deprecated classes in a JS, TSX, or SCSS file');
+    console.log('\tappend\t\tappend new namespaced clases to known-deprecated classes in a JS, TSX, or SCSS file');
     console.log('\textend\t\tadd @extend to SCSS files with new namespaced classes');
 }
 
@@ -116,7 +118,7 @@ async function swap({ currentConversionMap, fileType, ...operationParams }) {
                 match,
                 `${scssPrefix}${currentConversionMap[trimStart(match, scssPrefix)]}`,
             );
-        } else if (fileType === 'js') {
+        } else if (jsExtensions.has(fileType)) {
             const quotationMark = match[0];
             if (jsPrefixes.includes(quotationMark)) {
                 fileContents = findAndReplaceJS(
@@ -125,7 +127,9 @@ async function swap({ currentConversionMap, fileType, ...operationParams }) {
                     `${quotationMark}${currentConversionMap[trimStart(match, quotationMark)]}`,
                 );
             } else if (operationParams.isVerbose) {
-                console.warn(colors.yellow('Incorrect match for js files. skipping', operationParams.fileName, '...'));
+                console.warn(
+                    colors.yellow('Incorrect match for JS/TSX files. Skipping', operationParams.fileName, '...'),
+                );
             }
         }
         return fileContents;
@@ -140,7 +144,7 @@ async function append({ currentConversionMap, fileType, ...operationParams }) {
                 match,
                 `${match}, ${scssPrefix}${currentConversionMap[trimStart(match, scssPrefix)]}`,
             );
-        } else if (fileType === 'js') {
+        } else if (jsExtensions.has(fileType)) {
             const quotationMark = match[0];
             if (jsPrefixes.includes(quotationMark)) {
                 fileContents = findAndReplaceJS(
@@ -149,7 +153,9 @@ async function append({ currentConversionMap, fileType, ...operationParams }) {
                     `${match} ${currentConversionMap[trimStart(match, quotationMark)]}`,
                 );
             } else if (operationParams.isVerbose) {
-                console.warn(colors.yellow('Incorrect match for js files. skipping', operationParams.fileName, '...'));
+                console.warn(
+                    colors.yellow('Incorrect match for JS/TSX files. Skipping', operationParams.fileName, '...'),
+                );
             }
         }
         return fileContents;
@@ -170,7 +176,7 @@ async function extend({ currentConversionMap, fileType, ...operationParams }) {
             );
         } else {
             console.error(
-                colors.yellow('Unrecognized file type for extend operation. skipping', operationParams.fileName, '...'),
+                colors.yellow('Unrecognized file type for extend operation. Skipping', operationParams.fileName, '...'),
             );
             process.exit(0);
         }
@@ -211,7 +217,7 @@ async function main() {
                 .join('|'),
             'g',
         );
-    } else if (fileType === 'js') {
+    } else if (jsExtensions.has(fileType) || fileType === '') {
         // The majority of .js classnames are surrounded by quotation marks
         // Restrict to those prefixes to avoid overrwriting variable names
         const converter = entry => jsPrefixes.map(prefix => `${prefix}${entry}`).join('|');
@@ -222,7 +228,7 @@ async function main() {
             'g',
         );
     } else {
-        console.error(colors.yellow('Unrecognized file type for this tool. skipping', fileName, '...'));
+        console.error(colors.yellow('Unrecognized file type for this tool. Skipping', fileName, '...'));
         process.exit(0);
     }
 

--- a/scripts/utils/bdlClassnameManager
+++ b/scripts/utils/bdlClassnameManager
@@ -29,6 +29,7 @@ const writeFile = promisify(fs.writeFile);
 */
 
 const conversionMap = {
+    // 'btn': 'bdl-Button',
     // 'btn-group': 'bdl-ButtonGroup',
     // 'btn-plain': 'bdl-Button--plain',
     // 'btn-primary': 'bdl-Button--primary',


### PR DESCRIPTION
This PR enables bdlClassnameManager to modify class names within TypeScript files (specifically, TSX files).