### PR TITLE
chore: Pin @hapi/address to 2.1.1 to prevent IE11 breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
         "@box/languages": "^1.0.0",
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.3.4",
-        "@hapi/address": "^2.0.0",
+        "@hapi/address": "2.1.1",
         "@sambego/storybook-state": "^2.0.1",
         "@storybook/addon-actions": "^5.3.9",
         "@storybook/addon-docs": "^5.3.9",
@@ -303,7 +303,7 @@
         "yargs": "^15.1.0"
     },
     "peerDependencies": {
-        "@hapi/address": "^2.0.0",
+        "@hapi/address": ">=2.0.0 <2.1.2",
         "axios": "^0.18.1",
         "classnames": "^2.2.5",
         "color": "^3.1.2",
@@ -338,5 +338,11 @@
         "scroll-into-view-if-needed": "^2.2.20",
         "tabbable": "^1.1.2",
         "uuid": "^3.3.2"
+    },
+    "comments": {
+        "dependencies": {
+            "@hapi/address": "Version 2.1.2+ requires a polyfill for TextEncoder. Pinning to version 2.1.1 prevents IE11 from breaking.",
+            "react-tether": "Version 2.x has too many breaking changes and requires forwardRef on all components"
+        }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3426,15 +3426,15 @@
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.0.4.tgz#936961b7eade01f6d331d31cc9fb512d1fb3981a"
   integrity sha512-zd92HkqxeEprsyM3JLGr+jhhMkmY0NCYQ+Jyw/DC6qZHiFejdO19doYcH5/iMUUPEYLI2h/k7TETqAEez8Btog==
 
+"@hapi/address@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.1.tgz#61395b5ed94c4cb19c2dc4c85969cff3d40d583f"
+  integrity sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==
+
 "@hapi/address@2.x.x", "@hapi/address@^2.1.2":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
   integrity sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==
-
-"@hapi/address@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
-  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
 
 "@hapi/bourne@1.x.x":
   version "1.3.2"


### PR DESCRIPTION
Note: v2.1.2+ requires a TextEncoder polyfill