### PR TITLE
fix(modal): Fix shared link setting modal input overflow

### DIFF
--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.scss
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.scss
@@ -15,7 +15,12 @@
     }
 
     .checkbox-subsection {
+        max-width: 400px;
         margin-left: 0;
+
+        .custom-url-preview {
+            overflow: hidden;
+        }
     }
 
     .vanity-name-section {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/17711683/74201742-6d51dc80-4c1f-11ea-9930-ce36515705cf.png)

After:
![image](https://user-images.githubusercontent.com/17711683/74201749-6fb43680-4c1f-11ea-8e3d-e658eaa32cc8.png)
