### PR TITLE
fix(explorer): Fix search dropdown too long

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorer.scss
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.scss
@@ -6,6 +6,10 @@
         align-items: center;
         height: 38px;
         margin-top: 20px;
+
+        .quick-search .overlay {
+            max-height: 345px;
+        }
     }
 
     .content-explorer-search-container {


### PR DESCRIPTION
Before:
<img width="695" alt="dropdown-before" src="https://user-images.githubusercontent.com/17711683/74281183-d34b6c00-4cd2-11ea-955a-da4edca0c9db.png">

After:
<img width="693" alt="dropdown-after" src="https://user-images.githubusercontent.com/17711683/74281187-d6465c80-4cd2-11ea-99e1-d48490c37559.png">
