### PR TITLE
feat(tasks): updating task layout in preview

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -137,7 +137,7 @@ be.contentSidebar.activityFeed.taskNew.taskAssignmentCompleted = Completed
 # Error message when we failed to load the collaborators when user tries to edit a task
 be.contentSidebar.activityFeed.taskNew.taskCollaboratorLoadErrorMessage = An error has occurred while loading collaborators for this task. Please try again.
 # Label and date for task due date
-be.contentSidebar.activityFeed.taskNew.taskDueDateLabel = Due: {date}
+be.contentSidebar.activityFeed.taskNew.taskDueDateLabel = DUE: {date}
 # Text for due date description formatted with relative date and relative time. (Upper-case in supported languages)
 be.contentSidebar.activityFeed.taskNew.taskFeedStatusDue = DUE {dateTime}
 # Button name to hide task assignee list
@@ -158,6 +158,8 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedAssigneeListTitle = Assignees
 be.contentSidebar.activityFeed.taskNew.tasksFeedCompleteAction = Mark as Complete
 # Label for a completed task
 be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedLabel = Completed
+# Label for an completed task (in upper-case in supported language)
+be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel = COMPLETED
 # Comment headline for an approval task
 be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineApproval = {user} assigned an Approval Task
 # Comment headline for an approval task assigned to the current user
@@ -166,6 +168,8 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineApprovalCurrentUser = {u
 be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineGeneral = {user} assigned a Task
 # Comment headline for a general task assigned to the current user
 be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineGeneralCurrentUser = {user} assigned you a Task
+# Headline for a task assigned to a current user
+be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlinePreviewCurrentUser = {user}
 # Label for a task in progress
 be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressLabel = In Progress
 # Label for a task in progress (in upper-case in supported language)
@@ -183,7 +187,7 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedStatusApproved = Approved {dateT
 # Completed task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusCompleted = Completed {dateTime}
 # Label for the task status
-be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel = Status: {taskStatus}
+be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel = {taskStatus}
 # Rejected task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusRejected = Rejected {dateTime}
 # label for button that opens task popup

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -137,7 +137,7 @@ be.contentSidebar.activityFeed.taskNew.taskAssignmentCompleted = Completed
 # Error message when we failed to load the collaborators when user tries to edit a task
 be.contentSidebar.activityFeed.taskNew.taskCollaboratorLoadErrorMessage = An error has occurred while loading collaborators for this task. Please try again.
 # Label and date for task due date
-be.contentSidebar.activityFeed.taskNew.taskDueDateLabel = DUE: {date}
+be.contentSidebar.activityFeed.taskNew.taskDueDateLabel = Due: {date}
 # Text for due date description formatted with relative date and relative time. (Upper-case in supported languages)
 be.contentSidebar.activityFeed.taskNew.taskFeedStatusDue = DUE {dateTime}
 # Button name to hide task assignee list
@@ -168,8 +168,6 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineApprovalCurrentUser = {u
 be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineGeneral = {user} assigned a Task
 # Comment headline for a general task assigned to the current user
 be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineGeneralCurrentUser = {user} assigned you a Task
-# Headline for a task assigned to a current user
-be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlinePreviewCurrentUser = {user}
 # Label for a task in progress
 be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressLabel = In Progress
 # Label for a task in progress (in upper-case in supported language)
@@ -186,8 +184,6 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel = REJECTE
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusApproved = Approved {dateTime}
 # Completed task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusCompleted = Completed {dateTime}
-# Label for the task status
-be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel = {taskStatus}
 # Rejected task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusRejected = Rejected {dateTime}
 # label for button that opens task popup

--- a/src/components/time/messages.js
+++ b/src/components/time/messages.js
@@ -8,12 +8,12 @@ const messages = defineMessages({
         id: 'boxui.readableTime.eventTime',
     },
     eventTimeToday: {
-        defaultMessage: 'TODAY at {time, time, short}',
+        defaultMessage: 'Today at {time, time, short}',
         description: 'The time that an event occurred today',
         id: 'boxui.readableTime.eventTimeToday',
     },
     eventTimeYesterday: {
-        defaultMessage: 'YESTERDAY at {time, time, short}',
+        defaultMessage: 'Yesterday at {time, time, short}',
         description: 'The time that an event occurred yesterday',
         id: 'boxui.readableTime.eventTimeYesterday',
     },

--- a/src/components/time/messages.js
+++ b/src/components/time/messages.js
@@ -8,12 +8,12 @@ const messages = defineMessages({
         id: 'boxui.readableTime.eventTime',
     },
     eventTimeToday: {
-        defaultMessage: 'Today at {time, time, short}',
+        defaultMessage: 'TODAY at {time, time, short}',
         description: 'The time that an event occurred today',
         id: 'boxui.readableTime.eventTimeToday',
     },
     eventTimeYesterday: {
-        defaultMessage: 'Yesterday at {time, time, short}',
+        defaultMessage: 'YESTERDAY at {time, time, short}',
         description: 'The time that an event occurred yesterday',
         id: 'boxui.readableTime.eventTimeYesterday',
     },

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.js
@@ -32,7 +32,7 @@ import {
     PLACEHOLDER_USER,
     TASK_EDIT_MODE_EDIT,
 } from '../../../../constants';
-import type { TaskAssigneeCollection, TaskNew, TaskType } from '../../../../common/types/tasks';
+import type { TaskAssigneeCollection, TaskNew } from '../../../../common/types/tasks';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 import { bdlGray80 } from '../../../../styles/variables';
 import TaskActions from './TaskActions';
@@ -81,20 +81,6 @@ type State = {
     isLoading: boolean,
     loadCollabError: ?ActionItemError,
     modalError: ?ElementsXhrError,
-};
-
-const getMessageForTask = (isCurrentUser: boolean, taskType: TaskType) => {
-    if (isCurrentUser) {
-        if (taskType === TASK_TYPE_APPROVAL) {
-            return messages.tasksFeedHeadlineApprovalCurrentUser;
-        }
-        return messages.tasksFeedHeadlineGeneralCurrentUser;
-    }
-
-    if (taskType === TASK_TYPE_APPROVAL) {
-        return messages.tasksFeedHeadlineApproval;
-    }
-    return messages.tasksFeedHeadlineGeneral;
 };
 
 class Task extends React.Component<Props, State> {
@@ -323,7 +309,7 @@ class Task extends React.Component<Props, State> {
                         )}
                         <div className="bcs-Task-headline">
                             <FormattedMessage
-                                {...getMessageForTask(!!currentUserAssignment, task_type)}
+                                {...messages.taskFeedHeadlinePreviewCurrentUser}
                                 values={{
                                     user: (
                                         <UserLink
@@ -340,6 +326,7 @@ class Task extends React.Component<Props, State> {
                         </div>
                         <div className="bcs-Task-statusContainer">
                             <TaskStatus status={status} />
+
                             <TaskCompletionRuleIcon completionRule={completion_rule} />
                         </div>
                         <div className="bcs-Task-dueDateContainer">

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.js
@@ -341,6 +341,8 @@ class Task extends React.Component<Props, State> {
                         <div className="bcs-Task-statusContainer">
                             <TaskStatus status={status} />
                             <TaskCompletionRuleIcon completionRule={completion_rule} />
+                        </div>
+                        <div className="bcs-Task-dueDateContainer">
                             {!!due_at && <TaskDueDate dueDate={due_at} status={status} />}
                         </div>
                         <div>

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.js
@@ -308,28 +308,21 @@ class Task extends React.Component<Props, State> {
                             </TetherComponent>
                         )}
                         <div className="bcs-Task-headline">
-                            <FormattedMessage
-                                {...messages.taskFeedHeadlinePreviewCurrentUser}
-                                values={{
-                                    user: (
-                                        <UserLink
-                                            {...createdByUser}
-                                            data-resin-target={ACTIVITY_TARGETS.PROFILE}
-                                            getUserProfileUrl={getUserProfileUrl}
-                                        />
-                                    ),
-                                }}
+                            <UserLink
+                                {...createdByUser}
+                                data-resin-target={ACTIVITY_TARGETS.PROFILE}
+                                getUserProfileUrl={getUserProfileUrl}
                             />
                         </div>
                         <div>
                             <ActivityTimestamp date={createdAtTimestamp} />
                         </div>
-                        <div className="bcs-Task-statusContainer">
+                        <div className="bcs-Task-status">
                             <TaskStatus status={status} />
 
                             <TaskCompletionRuleIcon completionRule={completion_rule} />
                         </div>
-                        <div className="bcs-Task-dueDateContainer">
+                        <div className="bcs-Task-dueDate">
                             {!!due_at && <TaskDueDate dueDate={due_at} status={status} />}
                         </div>
                         <div>

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.js
@@ -338,6 +338,11 @@ class Task extends React.Component<Props, State> {
                         <div>
                             <ActivityTimestamp date={createdAtTimestamp} />
                         </div>
+                        <div className="bcs-Task-statusContainer">
+                            <TaskStatus status={status} />
+                            <TaskCompletionRuleIcon completionRule={completion_rule} />
+                            {!!due_at && <TaskDueDate dueDate={due_at} status={status} />}
+                        </div>
                         <div>
                             <ActivityMessage
                                 id={id}
@@ -347,11 +352,6 @@ class Task extends React.Component<Props, State> {
                                 translationFailed={error ? true : null}
                                 getUserProfileUrl={getUserProfileUrl}
                             />
-                        </div>
-                        <div className="bcs-Task-statusContainer">
-                            {!!due_at && <TaskDueDate dueDate={due_at} status={status} />}
-                            <TaskStatus status={status} />
-                            <TaskCompletionRuleIcon completionRule={completion_rule} />
                         </div>
                         <div className="bcs-Task-assigneeListContainer">
                             <AssigneeList

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -39,6 +39,11 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
 
 .bcs-Task-statusContainer {
     margin-top: 2 * $bcs-task-grid;
+    margin-bottom: 10px;
+}
+
+.bcs-Task-dueDateContainer {
+    margin-bottom: 13px;
 }
 
 .bcs-Task-assigneeListContainer {

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -37,13 +37,13 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
     }
 }
 
-.bcs-Task-statusContainer {
-    margin-top: 2 * $bcs-task-grid;
-    margin-bottom: 10px;
+.bcs-Task-status {
+    margin-top: 3 * $bcs-task-grid;
+    margin-bottom: 2 * $bcs-task-grid;
 }
 
-.bcs-Task-dueDateContainer {
-    margin-bottom: 13px;
+.bcs-Task-dueDate {
+    margin-bottom: 12px;
     text-transform: uppercase;
 }
 

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -44,7 +44,6 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
 
 .bcs-Task-dueDate {
     margin-bottom: 12px;
-    text-transform: uppercase;
 }
 
 .bcs-Task-assigneeListContainer {

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -44,6 +44,7 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
 
 .bcs-Task-dueDateContainer {
     margin-bottom: 13px;
+    text-transform: uppercase;
 }
 
 .bcs-Task-assigneeListContainer {

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -43,7 +43,7 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
 }
 
 .bcs-Task-dueDate {
-    margin-bottom: 12px;
+    margin-bottom: 3 * $bcs-task-grid;
 }
 
 .bcs-Task-assigneeListContainer {

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskActions.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskActions.js
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 import messages from './messages';
 import Button from '../../../../components/button';
+import PrimaryButton from '../../../../components/primary-button';
 import { TASK_TYPE_APPROVAL, TASK_TYPE_GENERAL } from '../../../../constants';
 import type { TaskType } from '../../../../common/types/tasks';
 
@@ -24,32 +25,32 @@ const TaskActions = ({ onTaskApproval, onTaskReject, onTaskComplete, taskType }:
             <>
                 <Button
                     className="bcs-TaskActions-button"
-                    data-testid="approve-task"
-                    onClick={onTaskApproval}
-                    data-resin-target={ACTIVITY_TARGETS.TASK_APPROVE}
-                >
-                    <FormattedMessage {...messages.tasksFeedApproveAction} />
-                </Button>
-                <Button
-                    className="bcs-TaskActions-button"
                     data-testid="reject-task"
                     onClick={onTaskReject}
                     data-resin-target={ACTIVITY_TARGETS.TASK_REJECT}
                 >
                     <FormattedMessage {...messages.tasksFeedRejectAction} />
                 </Button>
+                <PrimaryButton
+                    className="bcs-TaskActions-button"
+                    data-testid="approve-task"
+                    onClick={onTaskApproval}
+                    data-resin-target={ACTIVITY_TARGETS.TASK_APPROVE}
+                >
+                    <FormattedMessage {...messages.tasksFeedApproveAction} />
+                </PrimaryButton>
             </>
         );
     } else if (taskType === TASK_TYPE_GENERAL) {
         action = (
-            <Button
+            <PrimaryButton
                 className="bcs-TaskActions-button"
                 data-testid="complete-task"
                 onClick={onTaskComplete}
                 data-resin-target={ACTIVITY_TARGETS.TASK_COMPLETE}
             >
                 <FormattedMessage {...messages.tasksFeedCompleteAction} />
-            </Button>
+            </PrimaryButton>
         );
     }
     return <div className="bcs-TaskActions">{action}</div>;

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl';
 import { TASK_COMPLETION_RULE_ANY } from '../../../../constants';
 import messages from './messages';
 import Tooltip from '../../../../components/tooltip';
+// $FlowFixMe
+import LabelPill from '../../../../components/label-pill';
 import IconAnyTask from '../../../../icons/general/IconAnyTask';
 import type { TaskCompletionRule } from '../../../../common/types/tasks';
 
@@ -16,9 +18,11 @@ type Props = {|
 const TaskCompletionRuleIcon = ({ completionRule }: Props): React.Node =>
     completionRule === TASK_COMPLETION_RULE_ANY && (
         <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
-            <span>
-                <IconAnyTask height={11} width={11} className="bcs-TaskCompletionRuleIcon" />
-            </span>
+            <LabelPill.Pill>
+                <span>
+                    <IconAnyTask height={11} width={11} className="bcs-TaskCompletionRuleIcon" />
+                </span>
+            </LabelPill.Pill>
         </Tooltip>
     );
 

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { TASK_COMPLETION_RULE_ANY } from '../../../../constants';
 import messages from './messages';
-import Tooltip from '../../../../components/tooltip';
+// $FlowFixMe LabelPill is in typescript
 import LabelPill from '../../../../components/label-pill';
-
+import Tooltip from '../../../../components/tooltip';
 import Avatar16 from '../../../../icon/line/Avatar16';
 import type { TaskCompletionRule } from '../../../../common/types/tasks';
 
@@ -21,7 +21,7 @@ const TaskCompletionRuleIcon = ({ completionRule }: Props): React.Node =>
             <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
                 <LabelPill.Pill>
                     <LabelPill.Icon Component={Avatar16} />
-                    <span>1</span>
+                    <span className="bcs-TaskCompletionRuleIcon-oneSize">1</span>
                 </LabelPill.Pill>
             </Tooltip>
         </span>

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
@@ -18,13 +18,13 @@ type Props = {|
 
 const TaskCompletionRuleIcon = ({ completionRule }: Props): React.Node =>
     completionRule === TASK_COMPLETION_RULE_ANY && (
-        <LabelPill.Pill>
-            <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
-                <span>
-                    <IconAnyTask height={11} width={11} className="bcs-TaskCompletionRuleIcon" />{' '}
-                </span>
-            </Tooltip>
-        </LabelPill.Pill>
+        <span className="bcs-TaskCompletionRuleIcon">
+            <LabelPill.Pill>
+                <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
+                    <LabelPill.Icon Component={IconAnyTask} />
+                </Tooltip>
+            </LabelPill.Pill>
+        </span>
     );
 
 export default TaskCompletionRuleIcon;

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 import { TASK_COMPLETION_RULE_ANY } from '../../../../constants';
 import messages from './messages';
 import Tooltip from '../../../../components/tooltip';
-// $FlowFixMe LabelPill is in typescript
 import LabelPill from '../../../../components/label-pill';
 
 import Avatar16 from '../../../../icon/line/Avatar16';

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
@@ -6,6 +6,7 @@ import messages from './messages';
 import Tooltip from '../../../../components/tooltip';
 // $FlowFixMe
 import LabelPill from '../../../../components/label-pill';
+
 import IconAnyTask from '../../../../icons/general/IconAnyTask';
 import type { TaskCompletionRule } from '../../../../common/types/tasks';
 
@@ -17,13 +18,13 @@ type Props = {|
 
 const TaskCompletionRuleIcon = ({ completionRule }: Props): React.Node =>
     completionRule === TASK_COMPLETION_RULE_ANY && (
-        <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
-            <LabelPill.Pill>
+        <LabelPill.Pill>
+            <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
                 <span>
-                    <IconAnyTask height={11} width={11} className="bcs-TaskCompletionRuleIcon" />
+                    <IconAnyTask height={11} width={11} className="bcs-TaskCompletionRuleIcon" />{' '}
                 </span>
-            </LabelPill.Pill>
-        </Tooltip>
+            </Tooltip>
+        </LabelPill.Pill>
     );
 
 export default TaskCompletionRuleIcon;

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
@@ -21,7 +21,7 @@ const TaskCompletionRuleIcon = ({ completionRule }: Props): React.Node =>
             <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
                 <LabelPill.Pill>
                     <LabelPill.Icon Component={Avatar16} />
-                    <span className="bcs-TaskCompletionRuleIcon-oneSize">1</span>
+                    <LabelPill.Text className="bcs-TaskCompletionRuleIcon-oneSize">1</LabelPill.Text>
                 </LabelPill.Pill>
             </Tooltip>
         </span>

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.js
@@ -4,10 +4,10 @@ import { FormattedMessage } from 'react-intl';
 import { TASK_COMPLETION_RULE_ANY } from '../../../../constants';
 import messages from './messages';
 import Tooltip from '../../../../components/tooltip';
-// $FlowFixMe
+// $FlowFixMe LabelPill is in typescript
 import LabelPill from '../../../../components/label-pill';
 
-import IconAnyTask from '../../../../icons/general/IconAnyTask';
+import Avatar16 from '../../../../icon/line/Avatar16';
 import type { TaskCompletionRule } from '../../../../common/types/tasks';
 
 import './TaskCompletionRuleIcon.scss';
@@ -19,11 +19,12 @@ type Props = {|
 const TaskCompletionRuleIcon = ({ completionRule }: Props): React.Node =>
     completionRule === TASK_COMPLETION_RULE_ANY && (
         <span className="bcs-TaskCompletionRuleIcon">
-            <LabelPill.Pill>
-                <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
-                    <LabelPill.Icon Component={IconAnyTask} />
-                </Tooltip>
-            </LabelPill.Pill>
+            <Tooltip position="top-center" text={<FormattedMessage {...messages.taskAnyAffordanceTooltip} />}>
+                <LabelPill.Pill>
+                    <LabelPill.Icon Component={Avatar16} />
+                    <span>1</span>
+                </LabelPill.Pill>
+            </Tooltip>
         </span>
     );
 

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
@@ -3,5 +3,6 @@
 }
 
 .bcs-TaskCompletionRuleIcon-oneSize {
-    font-size: 9px;
+    margin-left: 0;
+    font-weight: normal;
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
@@ -1,3 +1,3 @@
 .bcs-TaskCompletionRuleIcon {
-    margin-left: 5px;
+    margin-left: 4px;
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
@@ -1,3 +1,3 @@
 .bcs-TaskCompletionRuleIcon {
-    margin-left: 4px;
+    margin-left: 5px;
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
@@ -1,3 +1,7 @@
 .bcs-TaskCompletionRuleIcon {
     margin-left: 4px;
 }
+
+.bcs-TaskCompletionRuleIcon-oneSize {
+    font-size: 9px;
+}

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
-import { ReadableTime } from '../../../../components/time';
+// $FlowFixMe LabelPill is in typescript
 import LabelPill from '../../../../components/label-pill';
-
+import { ReadableTime } from '../../../../components/time';
 import { TASK_NEW_NOT_STARTED } from '../../../../constants';
 
 import type { TaskStatus } from '../../../../common/types/tasks';

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -24,7 +24,7 @@ const TaskDueDate = ({ dueDate, status }: Props): React.Node => {
     const fullDueDate = new Date(dueDate);
 
     return (
-        <div data-testid="task-due-date">
+        <div data-testid="task-due-date" className="bcs-TaskDueDate">
             <LabelPill.Pill type={isOverdue ? 'error' : 'default'}>
                 <FormattedMessage
                     {...messages.taskDueDateLabel}

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -11,8 +11,6 @@ import { TASK_NEW_NOT_STARTED } from '../../../../constants';
 import type { TaskStatus } from '../../../../common/types/tasks';
 import type { ISODate } from '../../../../common/types/core';
 
-import './TaskDueDate.scss';
-
 type Props = {
     dueDate: ISODate,
     status: TaskStatus,
@@ -23,7 +21,7 @@ const TaskDueDate = ({ dueDate, status }: Props): React.Node => {
     const fullDueDate = new Date(dueDate);
     const pillProps = isOverdue ? { 'data-testid': 'task-overdue-date', type: 'error' } : { type: 'default' };
     return (
-        <div data-testid="task-due-date" className="bcs-TaskDueDate">
+        <div data-testid="task-due-date">
             <LabelPill.Pill {...pillProps}>
                 <LabelPill.Text>
                     <FormattedMessage

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -27,7 +27,7 @@ const TaskDueDate = ({ dueDate, status }: Props): React.Node => {
                     <FormattedMessage
                         {...messages.taskFeedStatusDue}
                         values={{
-                            dateTime: <ReadableTime alwaysShowTime timestamp={fullDueDate.getTime()} />,
+                            dateTime: <ReadableTime alwaysShowTime uppercase timestamp={fullDueDate.getTime()} />,
                         }}
                     />
                 </LabelPill.Text>

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
@@ -25,12 +24,7 @@ const TaskDueDate = ({ dueDate, status }: Props): React.Node => {
     const fullDueDate = new Date(dueDate);
 
     return (
-        <div
-            className={classNames('bcs-TaskDueDate', {
-                'bcs-is-taskOverdue': isOverdue,
-            })}
-            data-testid="task-due-date"
-        >
+        <div data-testid="task-due-date">
             <LabelPill.Pill type={isOverdue ? 'error' : 'default'}>
                 <FormattedMessage
                     {...messages.taskDueDateLabel}

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import { ReadableTime } from '../../../../components/time';
-// $FlowFixMe
 import LabelPill from '../../../../components/label-pill';
 
 import { TASK_NEW_NOT_STARTED } from '../../../../constants';

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -5,6 +5,8 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import { ReadableTime } from '../../../../components/time';
+// $FlowFixMe
+import LabelPill from '../../../../components/label-pill';
 
 import { TASK_NEW_NOT_STARTED } from '../../../../constants';
 
@@ -29,12 +31,14 @@ const TaskDueDate = ({ dueDate, status }: Props): React.Node => {
             })}
             data-testid="task-due-date"
         >
-            <FormattedMessage
-                {...messages.taskDueDateLabel}
-                values={{
-                    date: <ReadableTime alwaysShowTime timestamp={fullDueDate.getTime()} />,
-                }}
-            />
+            <LabelPill.Pill type={isOverdue ? 'error' : 'default'}>
+                <FormattedMessage
+                    {...messages.taskDueDateLabel}
+                    values={{
+                        date: <ReadableTime alwaysShowTime timestamp={fullDueDate.getTime()} />,
+                    }}
+                />
+            </LabelPill.Pill>
         </div>
     );
 };

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.js
@@ -22,16 +22,18 @@ type Props = {
 const TaskDueDate = ({ dueDate, status }: Props): React.Node => {
     const isOverdue = dueDate ? status === TASK_NEW_NOT_STARTED && new Date(dueDate) < Date.now() : false;
     const fullDueDate = new Date(dueDate);
-
+    const pillProps = isOverdue ? { 'data-testid': 'task-overdue-date', type: 'error' } : { type: 'default' };
     return (
         <div data-testid="task-due-date" className="bcs-TaskDueDate">
-            <LabelPill.Pill type={isOverdue ? 'error' : 'default'}>
-                <FormattedMessage
-                    {...messages.taskDueDateLabel}
-                    values={{
-                        date: <ReadableTime alwaysShowTime timestamp={fullDueDate.getTime()} />,
-                    }}
-                />
+            <LabelPill.Pill {...pillProps}>
+                <LabelPill.Text>
+                    <FormattedMessage
+                        {...messages.taskFeedStatusDue}
+                        values={{
+                            dateTime: <ReadableTime alwaysShowTime timestamp={fullDueDate.getTime()} />,
+                        }}
+                    />
+                </LabelPill.Text>
             </LabelPill.Pill>
         </div>
     );

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.scss
@@ -1,5 +1,0 @@
-@import '../../../common/variables';
-
-.bcs-TaskDueDate {
-    font-weight: bold;
-}

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskDueDate.scss
@@ -1,10 +1,5 @@
 @import '../../../common/variables';
 
 .bcs-TaskDueDate {
-    color: $bdl-gray-62;
     font-weight: bold;
-
-    &.bcs-is-taskOverdue {
-        color: $bdl-watermelon-red;
-    }
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
@@ -13,17 +13,27 @@ import messages from './messages';
 import type { TaskStatus } from '../../../../common/types/tasks';
 
 import './TaskStatus.scss';
+// $FlowFixMe
+import LabelPill from '../../../../components/label-pill';
 
 type Props = {|
     status: TaskStatus,
 |};
 
 const statusMessageKeyMap = {
-    [TASK_NEW_APPROVED]: messages.tasksFeedApprovedLabel,
-    [TASK_NEW_COMPLETED]: messages.tasksFeedCompletedLabel,
-    [TASK_NEW_REJECTED]: messages.tasksFeedRejectedLabel,
-    [TASK_NEW_NOT_STARTED]: messages.tasksFeedInProgressLabel,
-    [TASK_NEW_IN_PROGRESS]: messages.tasksFeedInProgressLabel,
+    [TASK_NEW_APPROVED]: messages.taskFeedApprovedUppercaseLabel,
+    [TASK_NEW_COMPLETED]: messages.taskFeedCompletedUppercaseLabel,
+    [TASK_NEW_REJECTED]: messages.taskFeedRejectedUppercaseLabel,
+    [TASK_NEW_NOT_STARTED]: messages.taskFeedInProgressUppercaseLabel,
+    [TASK_NEW_IN_PROGRESS]: messages.taskFeedInProgressUppercaseLabel,
+};
+
+const typeKeyMap = {
+    [TASK_NEW_APPROVED]: 'success',
+    [TASK_NEW_COMPLETED]: 'success',
+    [TASK_NEW_REJECTED]: 'error',
+    [TASK_NEW_NOT_STARTED]: 'default',
+    [TASK_NEW_IN_PROGRESS]: 'default',
 };
 
 const Status = React.memo<Props>(({ status }: Props) => (
@@ -31,9 +41,11 @@ const Status = React.memo<Props>(({ status }: Props) => (
         {...messages.tasksFeedStatusLabel}
         values={{
             taskStatus: (
-                <span className={`bcs-TaskStatus-message ${camelCase(status)}`}>
-                    <FormattedMessage {...statusMessageKeyMap[status]} />
-                </span>
+                <LabelPill.Pill type={typeKeyMap[status]}>
+                    <span className={`bcs-TaskStatus-message ${camelCase(status)}`}>
+                        <FormattedMessage {...statusMessageKeyMap[status]} />
+                    </span>
+                </LabelPill.Pill>
             ),
         }}
     >

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
@@ -12,7 +12,7 @@ import messages from './messages';
 import type { TaskStatus } from '../../../../common/types/tasks';
 
 import './TaskStatus.scss';
-// $FlowFixMe
+// $FlowFixMe LabelPill is in typescript
 import LabelPill from '../../../../components/label-pill';
 
 type Props = {|
@@ -36,20 +36,13 @@ const typeKeyMap = {
 };
 
 const Status = React.memo<Props>(({ status }: Props) => (
-    <FormattedMessage
-        {...messages.tasksFeedStatusLabel}
-        values={{
-            taskStatus: (
-                <LabelPill.Pill type={typeKeyMap[status]}>
-                    <span>
-                        <FormattedMessage {...statusMessageKeyMap[status]} />
-                    </span>
-                </LabelPill.Pill>
-            ),
-        }}
-    >
-        {(...msg: Array<React.Node>): React.Node => <div className="bcs-TaskStatus">{msg}</div>}
-    </FormattedMessage>
+    <LabelPill.Pill type={typeKeyMap[status]}>
+        <LabelPill.Text>
+            <FormattedMessage {...statusMessageKeyMap[status]}>
+                {(...msg: Array<React.Node>): React.Node => <div className="bcs-TaskStatus">{msg}</div>}
+            </FormattedMessage>
+        </LabelPill.Text>
+    </LabelPill.Pill>
 ));
 
 export default Status;

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
-import camelCase from 'lodash/camelCase';
 import {
     TASK_NEW_APPROVED,
     TASK_NEW_REJECTED,
@@ -42,7 +41,7 @@ const Status = React.memo<Props>(({ status }: Props) => (
         values={{
             taskStatus: (
                 <LabelPill.Pill type={typeKeyMap[status]}>
-                    <span className={`bcs-TaskStatus-message ${camelCase(status)}`}>
+                    <span>
                         <FormattedMessage {...statusMessageKeyMap[status]} />
                     </span>
                 </LabelPill.Pill>

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
@@ -12,7 +12,6 @@ import messages from './messages';
 import type { TaskStatus } from '../../../../common/types/tasks';
 
 import './TaskStatus.scss';
-// $FlowFixMe LabelPill is in typescript
 import LabelPill from '../../../../components/label-pill';
 
 type Props = {|
@@ -39,7 +38,7 @@ const Status = React.memo<Props>(({ status }: Props) => (
     <LabelPill.Pill type={typeKeyMap[status]}>
         <LabelPill.Text>
             <FormattedMessage {...statusMessageKeyMap[status]}>
-                {(...msg: Array<React.Node>): React.Node => <div className="bcs-TaskStatus">{msg}</div>}
+                {(...msg: Array<React.Node>): React.Node => <span className="bcs-TaskStatus">{msg}</span>}
             </FormattedMessage>
         </LabelPill.Text>
     </LabelPill.Pill>

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
@@ -9,10 +9,11 @@ import {
     TASK_NEW_IN_PROGRESS,
 } from '../../../../constants';
 import messages from './messages';
+// $FlowFixMe LabelPill is in typescript
+import LabelPill from '../../../../components/label-pill';
 import type { TaskStatus } from '../../../../common/types/tasks';
 
 import './TaskStatus.scss';
-import LabelPill from '../../../../components/label-pill';
 
 type Props = {|
     status: TaskStatus,
@@ -37,9 +38,9 @@ const typeKeyMap = {
 const Status = React.memo<Props>(({ status }: Props) => (
     <LabelPill.Pill type={typeKeyMap[status]}>
         <LabelPill.Text>
-            <FormattedMessage {...statusMessageKeyMap[status]}>
-                {(...msg: Array<React.Node>): React.Node => <span className="bcs-TaskStatus">{msg}</span>}
-            </FormattedMessage>
+            <span className="bcs-TaskStatus">
+                <FormattedMessage {...statusMessageKeyMap[status]} />
+            </span>
         </LabelPill.Text>
     </LabelPill.Pill>
 ));

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.js
@@ -13,8 +13,6 @@ import messages from './messages';
 import LabelPill from '../../../../components/label-pill';
 import type { TaskStatus } from '../../../../common/types/tasks';
 
-import './TaskStatus.scss';
-
 type Props = {|
     status: TaskStatus,
 |};
@@ -38,9 +36,7 @@ const typeKeyMap = {
 const Status = React.memo<Props>(({ status }: Props) => (
     <LabelPill.Pill type={typeKeyMap[status]}>
         <LabelPill.Text>
-            <span className="bcs-TaskStatus">
-                <FormattedMessage {...statusMessageKeyMap[status]} />
-            </span>
+            <FormattedMessage {...statusMessageKeyMap[status]} />
         </LabelPill.Text>
     </LabelPill.Pill>
 ));

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.scss
@@ -2,17 +2,5 @@
 
 .bcs-TaskStatus {
     display: inline-block;
-    color: $bdl-gray-62;
     font-weight: bold;
-}
-
-.bcs-TaskStatus-message {
-    &.completed,
-    &.approved {
-        color: $bdl-green-light;
-    }
-
-    &.rejected {
-        color: $bdl-watermelon-red;
-    }
 }

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskStatus.scss
@@ -1,6 +1,0 @@
-@import '../../../common/variables';
-
-.bcs-TaskStatus {
-    display: inline-block;
-    font-weight: bold;
-}

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
@@ -109,7 +109,7 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
                 status="NOT_STARTED"
             />,
         );
-        expect(incompleteWrapper.find('.bcs-is-taskOverdue')).toHaveLength(1);
+        expect(incompleteWrapper.find('.bcs-TaskDueDate')).toHaveLength(1);
     });
 
     test('due date should not have overdue class if task is complete and due date is in past', () => {

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
@@ -109,7 +109,7 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
                 status="NOT_STARTED"
             />,
         );
-        expect(incompleteWrapper.find('.bcs-TaskDueDate')).toHaveLength(1);
+        expect(incompleteWrapper.render().find('[data-testid="task-overdue-date"]')).toHaveLength(1);
     });
 
     test('due date should not have overdue class if task is complete and due date is in past', () => {
@@ -123,7 +123,7 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
                 status="COMPLETED"
             />,
         );
-        expect(completeWrapper.find('.bcs-is-taskOverdue')).toHaveLength(0);
+        expect(completeWrapper.find('[data-testid="task-overdue-date"]')).toHaveLength(0);
     });
 
     test('should add pending class for isPending prop', () => {

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/TaskCompletionRuleIcon.test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/TaskCompletionRuleIcon.test.js
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { TASK_COMPLETION_RULE_ALL, TASK_COMPLETION_RULE_ANY, TASK_NEW_IN_PROGRESS } from '../../../../../constants';
-import IconAnyTask from '../../../../../icons/general/IconAnyTask';
+
+import Avatar16 from '../../../../../icon/line/Avatar16';
+
 import TaskCompletionRuleIcon from '../TaskCompletionRuleIcon';
 
 const getWrapper = props => mount(<TaskCompletionRuleIcon {...props} />);
@@ -18,6 +20,6 @@ describe('elements/content-sidebar/ActivityFeed/task-new/TaskCompletionRuleIcon'
             completionRule,
         });
 
-        expect(wrapper.find(IconAnyTask).length).toBe(iconLength);
+        expect(wrapper.find(Avatar16).length).toBe(iconLength);
     });
 });

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/TaskDueDate.test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/TaskDueDate.test.js
@@ -13,6 +13,6 @@ describe('elements/content-sidebar/ActivityFeed/task-new/TaskDueDate', () => {
     test('should add proper class when past due date', () => {
         const dueDate = shallow(<TaskDueDate dueDate={new Date() - 1000} status="NOT_STARTED" />);
 
-        expect(dueDate.find('.bcs-TaskDueDate')).toHaveLength(1);
+        expect(dueDate.find('[data-testid="task-overdue-date"]')).toHaveLength(1);
     });
 });

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/TaskDueDate.test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/TaskDueDate.test.js
@@ -13,6 +13,6 @@ describe('elements/content-sidebar/ActivityFeed/task-new/TaskDueDate', () => {
     test('should add proper class when past due date', () => {
         const dueDate = shallow(<TaskDueDate dueDate={new Date() - 1000} status="NOT_STARTED" />);
 
-        expect(dueDate.find('.bcs-is-taskOverdue')).toHaveLength(1);
+        expect(dueDate.find('.bcs-TaskDueDate')).toHaveLength(1);
     });
 });

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
@@ -85,19 +85,11 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
       <div
         className="bcs-Task-headline"
       >
-        <FormattedMessage
-          defaultMessage="{user}"
-          id="be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlinePreviewCurrentUser"
-          values={
-            Object {
-              "user": <UserLink
-                data-resin-target="activityfeed-profilelink"
-                id="1"
-                name="Jake Thomas"
-                type="user"
-              />,
-            }
-          }
+        <UserLink
+          data-resin-target="activityfeed-profilelink"
+          id="1"
+          name="Jake Thomas"
+          type="user"
         />
       </div>
       <div>
@@ -106,7 +98,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
         />
       </div>
       <div
-        className="bcs-Task-statusContainer"
+        className="bcs-Task-status"
       >
         <Memo()
           status="NOT_STARTED"
@@ -116,7 +108,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
         />
       </div>
       <div
-        className="bcs-Task-dueDateContainer"
+        className="bcs-Task-dueDate"
       />
       <div>
         <ActivityMessage

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
@@ -86,8 +86,8 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
         className="bcs-Task-headline"
       >
         <FormattedMessage
-          defaultMessage="{user} assigned you a Task"
-          id="be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineGeneralCurrentUser"
+          defaultMessage="{user}"
+          id="be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlinePreviewCurrentUser"
           values={
             Object {
               "user": <UserLink
@@ -105,14 +105,6 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
           date={1262304000000}
         />
       </div>
-      <div>
-        <ActivityMessage
-          id="123125"
-          tagged_message="This is where we tell each other what we need to do"
-          translationEnabled={false}
-          translationFailed={null}
-        />
-      </div>
       <div
         className="bcs-Task-statusContainer"
       >
@@ -121,6 +113,17 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
         />
         <TaskCompletionRuleIcon
           completionRule="ALL_ASSIGNEES"
+        />
+      </div>
+      <div
+        className="bcs-Task-dueDateContainer"
+      />
+      <div>
+        <ActivityMessage
+          id="123125"
+          tagged_message="This is where we tell each other what we need to do"
+          translationEnabled={false}
+          translationFailed={null}
         />
       </div>
       <div

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
@@ -6,23 +6,35 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskDueDate should rende
   status="NOT_STARTED"
 >
   <div
-    className="bcs-TaskDueDate bcs-is-taskOverdue"
+    className="bcs-TaskDueDate"
     data-testid="task-due-date"
   >
-    <FormattedMessage
-      defaultMessage="Due: {date}"
-      id="be.contentSidebar.activityFeed.taskNew.taskDueDateLabel"
-      values={
-        Object {
-          "date": <ReadableTime
-            alwaysShowTime={true}
-            timestamp={987654321000}
-          />,
-        }
-      }
+    <LabelPill
+      type="error"
     >
-      <div />
-    </FormattedMessage>
+      <span
+        className="bdl-LabelPill bdl-LabelPill--error"
+      >
+        <span
+          className="bdl-LabelPill-content"
+        >
+          <FormattedMessage
+            defaultMessage="DUE: {date}"
+            id="be.contentSidebar.activityFeed.taskNew.taskDueDateLabel"
+            values={
+              Object {
+                "date": <ReadableTime
+                  alwaysShowTime={true}
+                  timestamp={987654321000}
+                />,
+              }
+            }
+          >
+            <div />
+          </FormattedMessage>
+        </span>
+      </span>
+    </LabelPill>
   </div>
 </TaskDueDate>
 `;

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
@@ -10,29 +10,33 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskDueDate should rende
     data-testid="task-due-date"
   >
     <LabelPill
+      data-testid="task-overdue-date"
       type="error"
     >
       <span
-        className="bdl-LabelPill bdl-LabelPill--error"
+        className="bdl-LabelPill bdl-LabelPill--error bdl-LabelPill--sizeRegular"
+        data-testid="task-overdue-date"
       >
-        <span
-          className="bdl-LabelPill-content"
-        >
-          <FormattedMessage
-            defaultMessage="DUE: {date}"
-            id="be.contentSidebar.activityFeed.taskNew.taskDueDateLabel"
-            values={
-              Object {
-                "date": <ReadableTime
-                  alwaysShowTime={true}
-                  timestamp={987654321000}
-                />,
-              }
-            }
+        <LabelPillText>
+          <span
+            className="bdl-LabelPill-textContent"
           >
-            <div />
-          </FormattedMessage>
-        </span>
+            <FormattedMessage
+              defaultMessage="DUE {dateTime}"
+              id="be.contentSidebar.activityFeed.taskNew.taskFeedStatusDue"
+              values={
+                Object {
+                  "dateTime": <ReadableTime
+                    alwaysShowTime={true}
+                    timestamp={987654321000}
+                  />,
+                }
+              }
+            >
+              <div />
+            </FormattedMessage>
+          </span>
+        </LabelPillText>
       </span>
     </LabelPill>
   </div>

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
@@ -6,7 +6,6 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskDueDate should rende
   status="NOT_STARTED"
 >
   <div
-    className="bcs-TaskDueDate"
     data-testid="task-due-date"
   >
     <LabelPill

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
@@ -28,6 +28,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskDueDate should rende
                   "dateTime": <ReadableTime
                     alwaysShowTime={true}
                     timestamp={987654321000}
+                    uppercase={true}
                   />,
                 }
               }

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
@@ -14,16 +14,12 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <span
-            className="bcs-TaskStatus"
+          <FormattedMessage
+            defaultMessage="APPROVED"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedUppercaseLabel"
           >
-            <FormattedMessage
-              defaultMessage="APPROVED"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedUppercaseLabel"
-            >
-              <div />
-            </FormattedMessage>
-          </span>
+            <div />
+          </FormattedMessage>
         </span>
       </LabelPillText>
     </span>
@@ -45,16 +41,12 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <span
-            className="bcs-TaskStatus"
+          <FormattedMessage
+            defaultMessage="COMPLETED"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel"
           >
-            <FormattedMessage
-              defaultMessage="COMPLETED"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel"
-            >
-              <div />
-            </FormattedMessage>
-          </span>
+            <div />
+          </FormattedMessage>
         </span>
       </LabelPillText>
     </span>
@@ -76,16 +68,12 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <span
-            className="bcs-TaskStatus"
+          <FormattedMessage
+            defaultMessage="IN PROGRESS"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
           >
-            <FormattedMessage
-              defaultMessage="IN PROGRESS"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
-            >
-              <div />
-            </FormattedMessage>
-          </span>
+            <div />
+          </FormattedMessage>
         </span>
       </LabelPillText>
     </span>
@@ -107,16 +95,12 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <span
-            className="bcs-TaskStatus"
+          <FormattedMessage
+            defaultMessage="IN PROGRESS"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
           >
-            <FormattedMessage
-              defaultMessage="IN PROGRESS"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
-            >
-              <div />
-            </FormattedMessage>
-          </span>
+            <div />
+          </FormattedMessage>
         </span>
       </LabelPillText>
     </span>
@@ -138,16 +122,12 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <span
-            className="bcs-TaskStatus"
+          <FormattedMessage
+            defaultMessage="REJECTED"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel"
           >
-            <FormattedMessage
-              defaultMessage="REJECTED"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel"
-            >
-              <div />
-            </FormattedMessage>
-          </span>
+            <div />
+          </FormattedMessage>
         </span>
       </LabelPillText>
     </span>

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
@@ -5,18 +5,20 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
   status="APPROVED"
 >
   <FormattedMessage
-    defaultMessage="Status: {taskStatus}"
+    defaultMessage="{taskStatus}"
     id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
     values={
       Object {
-        "taskStatus": <span
-          className="bcs-TaskStatus-message approved"
+        "taskStatus": <LabelPill
+          type="success"
         >
-          <FormattedMessage
-            defaultMessage="Approved"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedLabel"
-          />
-        </span>,
+          <span>
+            <FormattedMessage
+              defaultMessage="APPROVED"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedUppercaseLabel"
+            />
+          </span>
+        </LabelPill>,
       }
     }
   >
@@ -30,18 +32,20 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
   status="COMPLETED"
 >
   <FormattedMessage
-    defaultMessage="Status: {taskStatus}"
+    defaultMessage="{taskStatus}"
     id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
     values={
       Object {
-        "taskStatus": <span
-          className="bcs-TaskStatus-message completed"
+        "taskStatus": <LabelPill
+          type="success"
         >
-          <FormattedMessage
-            defaultMessage="Completed"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedLabel"
-          />
-        </span>,
+          <span>
+            <FormattedMessage
+              defaultMessage="COMPLETED"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel"
+            />
+          </span>
+        </LabelPill>,
       }
     }
   >
@@ -55,18 +59,20 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
   status="IN_PROGRESS"
 >
   <FormattedMessage
-    defaultMessage="Status: {taskStatus}"
+    defaultMessage="{taskStatus}"
     id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
     values={
       Object {
-        "taskStatus": <span
-          className="bcs-TaskStatus-message inProgress"
+        "taskStatus": <LabelPill
+          type="default"
         >
-          <FormattedMessage
-            defaultMessage="In Progress"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressLabel"
-          />
-        </span>,
+          <span>
+            <FormattedMessage
+              defaultMessage="IN PROGRESS"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+            />
+          </span>
+        </LabelPill>,
       }
     }
   >
@@ -80,18 +86,20 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
   status="NOT_STARTED"
 >
   <FormattedMessage
-    defaultMessage="Status: {taskStatus}"
+    defaultMessage="{taskStatus}"
     id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
     values={
       Object {
-        "taskStatus": <span
-          className="bcs-TaskStatus-message notStarted"
+        "taskStatus": <LabelPill
+          type="default"
         >
-          <FormattedMessage
-            defaultMessage="In Progress"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressLabel"
-          />
-        </span>,
+          <span>
+            <FormattedMessage
+              defaultMessage="IN PROGRESS"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+            />
+          </span>
+        </LabelPill>,
       }
     }
   >
@@ -105,18 +113,20 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
   status="REJECTED"
 >
   <FormattedMessage
-    defaultMessage="Status: {taskStatus}"
+    defaultMessage="{taskStatus}"
     id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
     values={
       Object {
-        "taskStatus": <span
-          className="bcs-TaskStatus-message rejected"
+        "taskStatus": <LabelPill
+          type="error"
         >
-          <FormattedMessage
-            defaultMessage="Rejected"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedLabel"
-          />
-        </span>,
+          <span>
+            <FormattedMessage
+              defaultMessage="REJECTED"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel"
+            />
+          </span>
+        </LabelPill>,
       }
     }
   >

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
@@ -4,26 +4,26 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
 <Memo()
   status="APPROVED"
 >
-  <FormattedMessage
-    defaultMessage="{taskStatus}"
-    id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
-    values={
-      Object {
-        "taskStatus": <LabelPill
-          type="success"
-        >
-          <span>
-            <FormattedMessage
-              defaultMessage="APPROVED"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedUppercaseLabel"
-            />
-          </span>
-        </LabelPill>,
-      }
-    }
+  <LabelPill
+    type="success"
   >
-    <div />
-  </FormattedMessage>
+    <span
+      className="bdl-LabelPill bdl-LabelPill--success bdl-LabelPill--sizeRegular"
+    >
+      <LabelPillText>
+        <span
+          className="bdl-LabelPill-textContent"
+        >
+          <FormattedMessage
+            defaultMessage="APPROVED"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedUppercaseLabel"
+          >
+            <div />
+          </FormattedMessage>
+        </span>
+      </LabelPillText>
+    </span>
+  </LabelPill>
 </Memo()>
 `;
 
@@ -31,26 +31,26 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
 <Memo()
   status="COMPLETED"
 >
-  <FormattedMessage
-    defaultMessage="{taskStatus}"
-    id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
-    values={
-      Object {
-        "taskStatus": <LabelPill
-          type="success"
-        >
-          <span>
-            <FormattedMessage
-              defaultMessage="COMPLETED"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel"
-            />
-          </span>
-        </LabelPill>,
-      }
-    }
+  <LabelPill
+    type="success"
   >
-    <div />
-  </FormattedMessage>
+    <span
+      className="bdl-LabelPill bdl-LabelPill--success bdl-LabelPill--sizeRegular"
+    >
+      <LabelPillText>
+        <span
+          className="bdl-LabelPill-textContent"
+        >
+          <FormattedMessage
+            defaultMessage="COMPLETED"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel"
+          >
+            <div />
+          </FormattedMessage>
+        </span>
+      </LabelPillText>
+    </span>
+  </LabelPill>
 </Memo()>
 `;
 
@@ -58,26 +58,26 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
 <Memo()
   status="IN_PROGRESS"
 >
-  <FormattedMessage
-    defaultMessage="{taskStatus}"
-    id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
-    values={
-      Object {
-        "taskStatus": <LabelPill
-          type="default"
-        >
-          <span>
-            <FormattedMessage
-              defaultMessage="IN PROGRESS"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
-            />
-          </span>
-        </LabelPill>,
-      }
-    }
+  <LabelPill
+    type="default"
   >
-    <div />
-  </FormattedMessage>
+    <span
+      className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeRegular"
+    >
+      <LabelPillText>
+        <span
+          className="bdl-LabelPill-textContent"
+        >
+          <FormattedMessage
+            defaultMessage="IN PROGRESS"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+          >
+            <div />
+          </FormattedMessage>
+        </span>
+      </LabelPillText>
+    </span>
+  </LabelPill>
 </Memo()>
 `;
 
@@ -85,26 +85,26 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
 <Memo()
   status="NOT_STARTED"
 >
-  <FormattedMessage
-    defaultMessage="{taskStatus}"
-    id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
-    values={
-      Object {
-        "taskStatus": <LabelPill
-          type="default"
-        >
-          <span>
-            <FormattedMessage
-              defaultMessage="IN PROGRESS"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
-            />
-          </span>
-        </LabelPill>,
-      }
-    }
+  <LabelPill
+    type="default"
   >
-    <div />
-  </FormattedMessage>
+    <span
+      className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeRegular"
+    >
+      <LabelPillText>
+        <span
+          className="bdl-LabelPill-textContent"
+        >
+          <FormattedMessage
+            defaultMessage="IN PROGRESS"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+          >
+            <div />
+          </FormattedMessage>
+        </span>
+      </LabelPillText>
+    </span>
+  </LabelPill>
 </Memo()>
 `;
 
@@ -112,25 +112,25 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
 <Memo()
   status="REJECTED"
 >
-  <FormattedMessage
-    defaultMessage="{taskStatus}"
-    id="be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel"
-    values={
-      Object {
-        "taskStatus": <LabelPill
-          type="error"
-        >
-          <span>
-            <FormattedMessage
-              defaultMessage="REJECTED"
-              id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel"
-            />
-          </span>
-        </LabelPill>,
-      }
-    }
+  <LabelPill
+    type="error"
   >
-    <div />
-  </FormattedMessage>
+    <span
+      className="bdl-LabelPill bdl-LabelPill--error bdl-LabelPill--sizeRegular"
+    >
+      <LabelPillText>
+        <span
+          className="bdl-LabelPill-textContent"
+        >
+          <FormattedMessage
+            defaultMessage="REJECTED"
+            id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel"
+          >
+            <div />
+          </FormattedMessage>
+        </span>
+      </LabelPillText>
+    </span>
+  </LabelPill>
 </Memo()>
 `;

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
@@ -14,12 +14,16 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <FormattedMessage
-            defaultMessage="APPROVED"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedUppercaseLabel"
+          <span
+            className="bcs-TaskStatus"
           >
-            <div />
-          </FormattedMessage>
+            <FormattedMessage
+              defaultMessage="APPROVED"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedUppercaseLabel"
+            >
+              <div />
+            </FormattedMessage>
+          </span>
         </span>
       </LabelPillText>
     </span>
@@ -41,12 +45,16 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <FormattedMessage
-            defaultMessage="COMPLETED"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel"
+          <span
+            className="bcs-TaskStatus"
           >
-            <div />
-          </FormattedMessage>
+            <FormattedMessage
+              defaultMessage="COMPLETED"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel"
+            >
+              <div />
+            </FormattedMessage>
+          </span>
         </span>
       </LabelPillText>
     </span>
@@ -68,12 +76,16 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <FormattedMessage
-            defaultMessage="IN PROGRESS"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+          <span
+            className="bcs-TaskStatus"
           >
-            <div />
-          </FormattedMessage>
+            <FormattedMessage
+              defaultMessage="IN PROGRESS"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+            >
+              <div />
+            </FormattedMessage>
+          </span>
         </span>
       </LabelPillText>
     </span>
@@ -95,12 +107,16 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <FormattedMessage
-            defaultMessage="IN PROGRESS"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+          <span
+            className="bcs-TaskStatus"
           >
-            <div />
-          </FormattedMessage>
+            <FormattedMessage
+              defaultMessage="IN PROGRESS"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel"
+            >
+              <div />
+            </FormattedMessage>
+          </span>
         </span>
       </LabelPillText>
     </span>
@@ -122,12 +138,16 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
         <span
           className="bdl-LabelPill-textContent"
         >
-          <FormattedMessage
-            defaultMessage="REJECTED"
-            id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel"
+          <span
+            className="bcs-TaskStatus"
           >
-            <div />
-          </FormattedMessage>
+            <FormattedMessage
+              defaultMessage="REJECTED"
+              id="be.contentSidebar.activityFeed.taskNew.tasksFeedRejectedUppercaseLabel"
+            >
+              <div />
+            </FormattedMessage>
+          </span>
         </span>
       </LabelPillText>
     </span>

--- a/src/elements/content-sidebar/activity-feed/task-new/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/messages.js
@@ -31,7 +31,7 @@ const messages = defineMessages({
     },
     taskDueDateLabel: {
         id: 'be.contentSidebar.activityFeed.taskNew.taskDueDateLabel',
-        defaultMessage: 'Due: {date}',
+        defaultMessage: 'DUE: {date}',
         description: 'Label and date for task due date',
     },
     tasksFeedApproveAction: {
@@ -51,13 +51,18 @@ const messages = defineMessages({
     },
     tasksFeedStatusLabel: {
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel',
-        defaultMessage: 'Status: {taskStatus}',
+        defaultMessage: '{taskStatus}',
         description: 'Label for the task status',
     },
     tasksFeedCompletedLabel: {
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedLabel',
         defaultMessage: 'Completed',
         description: 'Label for a completed task',
+    },
+    taskFeedCompletedUppercaseLabel: {
+        id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedUppercaseLabel',
+        defaultMessage: 'COMPLETED',
+        description: 'Label for an completed task (in upper-case in supported language)',
     },
     tasksFeedApprovedLabel: {
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedApprovedLabel',

--- a/src/elements/content-sidebar/activity-feed/task-new/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/messages.js
@@ -31,7 +31,7 @@ const messages = defineMessages({
     },
     taskDueDateLabel: {
         id: 'be.contentSidebar.activityFeed.taskNew.taskDueDateLabel',
-        defaultMessage: 'DUE: {date}',
+        defaultMessage: 'Due: {date}',
         description: 'Label and date for task due date',
     },
     tasksFeedApproveAction: {
@@ -48,11 +48,6 @@ const messages = defineMessages({
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedRejectAction',
         defaultMessage: 'Reject',
         description: 'Reject option for an approval task',
-    },
-    tasksFeedStatusLabel: {
-        id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedStatusLabel',
-        defaultMessage: '{taskStatus}',
-        description: 'Label for the task status',
     },
     tasksFeedCompletedLabel: {
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedLabel',
@@ -93,11 +88,6 @@ const messages = defineMessages({
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedInProgressUppercaseLabel',
         defaultMessage: 'IN PROGRESS',
         description: 'Label for a task in progress (in upper-case in supported language)',
-    },
-    taskFeedHeadlinePreviewCurrentUser: {
-        id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlinePreviewCurrentUser',
-        defaultMessage: '{user}',
-        description: 'Headline for a task assigned to a current user',
     },
     tasksFeedHeadlineApprovalCurrentUser: {
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineApprovalCurrentUser',

--- a/src/elements/content-sidebar/activity-feed/task-new/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/messages.js
@@ -94,6 +94,11 @@ const messages = defineMessages({
         defaultMessage: 'IN PROGRESS',
         description: 'Label for a task in progress (in upper-case in supported language)',
     },
+    taskFeedHeadlinePreviewCurrentUser: {
+        id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlinePreviewCurrentUser',
+        defaultMessage: '{user}',
+        description: 'Headline for a task assigned to a current user',
+    },
     tasksFeedHeadlineApprovalCurrentUser: {
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedHeadlineApprovalCurrentUser',
         defaultMessage: '{user} assigned you an Approval Task',


### PR DESCRIPTION
This PR reflects only layout changes made to tasks in preview. 
Will be making changes to the LabelPill component (to adjust the any/all icon and bold text) as well as ReadableTime in a follow up PR to reflect desired design.

Will not be merging this PR until follow up PR's have been made.


Examples of updates:
<img width="338" alt="Screen Shot 2020-02-21 at 5 09 50 PM" src="https://user-images.githubusercontent.com/21349325/75083335-09f06600-54cd-11ea-97bf-a94d6854d70a.png">
<img width="335" alt="Screen Shot 2020-02-21 at 5 09 39 PM" src="https://user-images.githubusercontent.com/21349325/75083338-0e1c8380-54cd-11ea-81bd-d34c988486e5.png">
<img width="340" alt="Screen Shot 2020-02-21 at 5 10 57 PM" src="https://user-images.githubusercontent.com/21349325/75083354-255b7100-54cd-11ea-9f36-3c542e5276a4.png">



