### PR TITLE
fix(flyout): add non-DOM prop to default values in `FakeOverlay`

### DIFF
--- a/src/components/flyout/__tests__/Flyout.test.js
+++ b/src/components/flyout/__tests__/Flyout.test.js
@@ -27,6 +27,7 @@ describe('components/flyout/Flyout', () => {
     const FakeOverlay = ({
         onClick = () => {},
         onClose = () => {},
+        shouldDefaultFocus = false,
         ...rest
     }) => (
         <div {...rest} className="overlay-wrapper is-visible">


### PR DESCRIPTION
This fixes a warning that appears when running tests. Only affects a faked component, so won't affect component behavior.