### PR TITLE
feat(radio-group): Add support for custom radio button components

### DIFF
--- a/src/components/radio/RadioGroup.js.flow
+++ b/src/components/radio/RadioGroup.js.flow
@@ -1,8 +1,6 @@
 // @flow
 import * as React from 'react';
 
-import RadioButton from './RadioButton';
-
 type Props = {
     children: React.Node,
     className: string,
@@ -52,9 +50,12 @@ class RadioGroup extends React.Component<Props, State> {
         return (
             <div className={`radio-group ${className}`} onChange={this.onChangeHandler}>
                 {React.Children.map(children, radio => {
-                    const { value, ...rest } = radio.props;
+                    const { value } = radio.props;
 
-                    return <RadioButton isSelected={value === stateValue} name={name} value={value} {...rest} />;
+                    return React.cloneElement(radio, {
+                        name,
+                        isSelected: value === stateValue,
+                    });
                 })}
             </div>
         );

--- a/src/components/radio/RadioGroup.tsx
+++ b/src/components/radio/RadioGroup.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import RadioButton from './RadioButton';
-
 export interface RadioGroupProps {
     children: Array<React.ReactElement> | React.ReactElement;
     className: string;
@@ -50,9 +48,12 @@ class RadioGroup extends React.Component<RadioGroupProps, RadioGroupState> {
         return (
             <div className={`radio-group ${className}`} onChange={this.onChangeHandler}>
                 {React.Children.map(children, (radio: React.ReactElement) => {
-                    const { value, ...rest } = radio.props;
+                    const { value } = radio.props;
 
-                    return <RadioButton isSelected={value === stateValue} name={name} value={value} {...rest} />;
+                    return React.cloneElement(radio, {
+                        name,
+                        isSelected: value === stateValue,
+                    });
                 })}
             </div>
         );

--- a/src/components/radio/__tests__/RadioGroup.test.tsx
+++ b/src/components/radio/__tests__/RadioGroup.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 
@@ -11,20 +11,26 @@ describe('components/radio/RadioGroup', () => {
         sandbox.verifyAndRestore();
     });
 
-    const renderRadioButtons = (onChange?: Function) =>
-        mount(
+    const renderRadioButtons = (onChange?: Function, children?: Array<React.ReactElement> | React.ReactElement) => {
+        children = children || [
+            <RadioButton
+                key="1"
+                data-resin-target="resin1"
+                description="radio1desc"
+                label="Radio Button 1"
+                value="radio1"
+            />,
+            <RadioButton key="2" label="Radio Button 2" value="radio2" />,
+            <RadioButton key="3" description="radio3desc" label="Radio Button 3" value="radio3" />,
+            <RadioButton key="4" label="Radio Button 4" value="radio4" />,
+        ];
+
+        return mount(
             <RadioGroup name="radiogroup" onChange={onChange} value="radio3">
-                <RadioButton
-                    data-resin-target="resin1"
-                    description="radio1desc"
-                    label="Radio Button 1"
-                    value="radio1"
-                />
-                <RadioButton label="Radio Button 2" value="radio2" />
-                <RadioButton description="radio3desc" label="Radio Button 3" value="radio3" />
-                <RadioButton label="Radio Button 4" value="radio4" />
+                {children}
             </RadioGroup>,
         );
+    };
 
     test('should correctly render component with radio buttons', () => {
         const component = renderRadioButtons();
@@ -120,5 +126,29 @@ describe('components/radio/RadioGroup', () => {
                 .at(3)
                 .prop('checked'),
         ).toEqual(true);
+    });
+
+    test('should preserve radio button component type and props', () => {
+        const radioButtonProps = {
+            'data-resin-target': 'resinTarget',
+            description: 'description',
+            label: 'label',
+            randomProp: true,
+            value: 'radio3',
+        };
+
+        const CustomRadioButton = () => <span />;
+        const component = renderRadioButtons(jest.fn(), <CustomRadioButton {...radioButtonProps} />);
+
+        expect(
+            component
+                .find(CustomRadioButton)
+                .at(0)
+                .props(),
+        ).toEqual({
+            ...radioButtonProps,
+            isSelected: true,
+            name: 'radiogroup',
+        });
     });
 });

--- a/src/components/radio/stories/RadioGroup.stories.tsx
+++ b/src/components/radio/stories/RadioGroup.stories.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { boolean } from '@storybook/addon-knobs';
 
-import RadioButton from '../RadioButton';
+import { bdlGray20, bdlPurpleRain } from '../../../styles/variables';
+import RadioButton, { RadioButtonProps } from '../RadioButton';
 
 import RadioGroup from '../RadioGroup';
 import notes from './RadioGroup.stories.md';
 
-export const example = () => (
+export const basic = () => (
     <RadioGroup name="radiogroup" value="radio3">
         <RadioButton label="Radio Button 1" value="radio1" description="I have a description" />
         <RadioButton label="Radio Button 2" value="radio2" description="I also have a description" />
@@ -15,6 +16,42 @@ export const example = () => (
         <RadioButton label="Disabled Radio Button" value="radio5" isDisabled={boolean('isDisabled', true)} />
     </RadioGroup>
 );
+
+export const withCustomRadioButtonComponent = () => {
+    const CustomRadioButton = ({ isSelected, name, value }: RadioButtonProps) => (
+        <span style={{ marginRight: '8px', position: 'relative' }}>
+            <input
+                checked={isSelected}
+                name={name}
+                type="radio"
+                value={value}
+                style={{ height: '20px', opacity: 0, width: '20px' }}
+            />
+            <span
+                style={{
+                    backgroundColor: isSelected ? bdlPurpleRain : bdlGray20,
+                    borderRadius: '50%',
+                    display: 'inline-block',
+                    height: '20px',
+                    left: '0px',
+                    position: 'absolute',
+                    width: '20px',
+                    zIndex: -1,
+                }}
+            />
+        </span>
+    );
+
+    return (
+        <RadioGroup name="customradiogroup" value="customRadio3">
+            <CustomRadioButton label="Radio Button 1" value="customRadio1" />
+            <CustomRadioButton label="Radio Button 2" value="customRadio2" />
+            <CustomRadioButton label="Radio Button 3" value="customRadio3" />
+            <CustomRadioButton label="Radio Button 4" value="customRadio4" />
+            <CustomRadioButton label="Radio Button 5" value="customRadio5" />
+        </RadioGroup>
+    );
+};
 
 export default {
     title: 'Components|Radio/RadioGroup',

--- a/src/components/radio/stories/RadioGroup.stories.tsx
+++ b/src/components/radio/stories/RadioGroup.stories.tsx
@@ -25,7 +25,7 @@ export const withCustomRadioButtonComponent = () => {
                     borderRadius: '50%',
                     display: 'inline-block',
                     height: '20px',
-                    left: '0px',
+                    left: '0',
                     position: 'absolute',
                     width: '20px',
                 }}

--- a/src/components/radio/stories/RadioGroup.stories.tsx
+++ b/src/components/radio/stories/RadioGroup.stories.tsx
@@ -3,7 +3,6 @@ import { boolean } from '@storybook/addon-knobs';
 
 import { bdlGray20, bdlPurpleRain } from '../../../styles/variables';
 import RadioButton, { RadioButtonProps } from '../RadioButton';
-
 import RadioGroup from '../RadioGroup';
 import notes from './RadioGroup.stories.md';
 
@@ -18,15 +17,8 @@ export const basic = () => (
 );
 
 export const withCustomRadioButtonComponent = () => {
-    const CustomRadioButton = ({ isSelected, name, value }: RadioButtonProps) => (
-        <span style={{ marginRight: '8px', position: 'relative' }}>
-            <input
-                checked={isSelected}
-                name={name}
-                type="radio"
-                value={value}
-                style={{ height: '20px', opacity: 0, width: '20px' }}
-            />
+    const CustomRadioButton = ({ isSelected, label, name, value }: RadioButtonProps) => (
+        <span style={{ marginRight: '15px', position: 'relative' }} title={String(label)}>
             <span
                 style={{
                     backgroundColor: isSelected ? bdlPurpleRain : bdlGray20,
@@ -36,8 +28,14 @@ export const withCustomRadioButtonComponent = () => {
                     left: '0px',
                     position: 'absolute',
                     width: '20px',
-                    zIndex: -1,
                 }}
+            />
+            <input
+                checked={isSelected}
+                name={name}
+                type="radio"
+                value={value}
+                style={{ cursor: 'pointer', height: '20px', opacity: 0, width: '20px' }}
             />
         </span>
     );


### PR DESCRIPTION
This update will add support for using `RadioGroup` with custom radio button components, so long as they accept and implement the same props as `RadioButton`. This will allow us to support use cases in which a single value needs to be selected, but the appearance and behavior of the UI itself is slightly different from `RadioButton` (e.g. color picker radio buttons).

This change is backward compatible because our existing usages of `RadioGroup` all declare `RadioButton` children, so the only difference is that these will now be cloned instead of replaced with a new `RadioButton` declaration. 