### PR TITLE
fix(content-explorer): fix prop usage warning in content explorer

### DIFF
--- a/src/features/content-explorer/item-list/ItemListButton.js
+++ b/src/features/content-explorer/item-list/ItemListButton.js
@@ -18,6 +18,7 @@ const ItemListButton = ({ contentExplorerMode, id = '', isDisabled = false, isSe
                 isDisabled={isDisabled}
                 label={<FormattedMessage {...messages.selectItem} values={{ name }} />}
                 name="item"
+                readOnly
                 value={id}
             />
         );


### PR DESCRIPTION
make the field `readOnly` as the checkbox is cosmetic

![fix-content-explorer-checked-prop](https://user-images.githubusercontent.com/3056447/75074588-d4d61a80-54b0-11ea-8681-010f899355bb.gif)
