### PR TITLE
fix(shared-link-settings): match classification type to value

### DIFF
--- a/src/features/shared-link-settings-modal/AllowDownloadSection.js
+++ b/src/features/shared-link-settings-modal/AllowDownloadSection.js
@@ -88,7 +88,7 @@ const AllowDownloadSection = ({
 
 AllowDownloadSection.propTypes = {
     canChangeDownload: PropTypes.bool.isRequired,
-    classification: PropTypes.object,
+    classification: PropTypes.string,
     directLink: PropTypes.string.isRequired,
     directLinkInputProps: PropTypes.object,
     downloadCheckboxProps: PropTypes.object,


### PR DESCRIPTION
tests and the Item object treat `classification` as a string value, but here it was set as object.
update to clear the warning when performing `yarn test` on these components