### PR TITLE
feat(i18n): deprecate FormattedCompMessage and Plural

### DIFF
--- a/src/components/i18n/FormattedCompMessage.js
+++ b/src/components/i18n/FormattedCompMessage.js
@@ -1,4 +1,5 @@
 // @flow
+// @deprecated, use FormattedMessage from react-intl v3 instead
 import * as React from 'react';
 import { injectIntl } from 'react-intl';
 import isNaN from 'lodash/isNaN';

--- a/src/components/i18n/FormattedCompMessage.js
+++ b/src/components/i18n/FormattedCompMessage.js
@@ -77,9 +77,11 @@ class FormattedCompMessage extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
 
+        /* eslint-disable no-console */
         console.warn(
             "box-ui-elements: the FormattedCompMessage component is deprecated! Use react-intl's FormattedMessage instead.",
         );
+        /* eslint-enable no-console */
 
         // these parameters echo the ones in react-intl's FormattedMessage
         // component, plus a few extra

--- a/src/components/i18n/FormattedCompMessage.js
+++ b/src/components/i18n/FormattedCompMessage.js
@@ -1,5 +1,4 @@
 // @flow
-// @deprecated, use FormattedMessage from react-intl v3 instead
 import * as React from 'react';
 import { injectIntl } from 'react-intl';
 import isNaN from 'lodash/isNaN';
@@ -77,6 +76,10 @@ class FormattedCompMessage extends React.Component<Props, State> {
 
     constructor(props: Props) {
         super(props);
+
+        console.warn(
+            "box-ui-elements: the FormattedCompMessage component is deprecated! Use react-intl's FormattedMessage instead.",
+        );
 
         // these parameters echo the ones in react-intl's FormattedMessage
         // component, plus a few extra

--- a/src/components/i18n/Plural.js
+++ b/src/components/i18n/Plural.js
@@ -48,7 +48,9 @@ type Props = {
  * rules](http://cldr.unicode.org/index/cldr-spec/plural-rules) for more details.
  */
 const Plural = ({ children }: Props) => {
+    /* eslint-disable no-console */
     console.warn("box-ui-elements: the Plural component is deprecated! Use react-intl's FormattedPlural instead.");
+    /* eslint-enable no-console */
 
     return children;
 };

--- a/src/components/i18n/Plural.js
+++ b/src/components/i18n/Plural.js
@@ -47,6 +47,10 @@ type Props = {
  * See the [Unicode CLDR description of plural category
  * rules](http://cldr.unicode.org/index/cldr-spec/plural-rules) for more details.
  */
-const Plural = ({ children }: Props) => children;
+const Plural = ({ children }: Props) => {
+    console.warn("box-ui-elements: the Plural component is deprecated! Use react-intl's FormattedPlural instead.");
+
+    return children;
+};
 
 export default Plural;

--- a/src/components/i18n/Plural.js
+++ b/src/components/i18n/Plural.js
@@ -1,4 +1,5 @@
 // @flow
+// @deprecated, use FormattedPlural from react-intl v3 instead
 import * as React from 'react';
 
 type Props = {

--- a/src/components/i18n/index.js
+++ b/src/components/i18n/index.js
@@ -1,4 +1,5 @@
 // @flow
+// @deprecated, use FormattedPlural or FormattedMessage from react-intl v3 instead
 export { default as Param } from './Param';
 export { default as Plural } from './Plural';
 export { default } from './FormattedCompMessage';


### PR DESCRIPTION
- use the react-intl v3 components instead, as they are standard
and will be supported going forward
- FormattedCompMessage -> FormattedMessage
- Plural -> FormattedPlural