### PR TITLE
fix(avatar): check for mount status before calling promise

### DIFF
--- a/src/elements/content-sidebar/activity-feed/Avatar.js
+++ b/src/elements/content-sidebar/activity-feed/Avatar.js
@@ -23,15 +23,19 @@ class Avatar extends React.PureComponent<Props, State> {
         avatarUrl: null,
     };
 
+    isMounted: boolean = false;
+
     /**
      * Success handler for getting avatar url
      *
      * @param {string} avatarUrl the user avatar url
      */
     getAvatarUrlHandler = (avatarUrl: ?string) => {
-        this.setState({
-            avatarUrl,
-        });
+        if (this.isMounted) {
+            this.setState({
+                avatarUrl,
+            });
+        }
     };
 
     /**
@@ -48,7 +52,12 @@ class Avatar extends React.PureComponent<Props, State> {
     }
 
     componentDidMount() {
+        this.isMounted = true;
         this.getAvatarUrl();
+    }
+
+    componentWillUnmount() {
+        this.isMounted = false;
     }
 
     render() {

--- a/src/elements/content-sidebar/activity-feed/__tests__/Avatar.test.js
+++ b/src/elements/content-sidebar/activity-feed/__tests__/Avatar.test.js
@@ -37,6 +37,7 @@ describe('elements/content-sidebar/ActivityFeed/Avatar', () => {
         wrapper.instance().getAvatarUrlHandler('foo');
         wrapper.update();
         expect(wrapper).toMatchSnapshot();
+        expect(wrapper.instance().isMounted).toBe(true);
     });
 
     test('should set the avatarUrl state by calling getAvatarUrl function prop', () => {
@@ -50,23 +51,19 @@ describe('elements/content-sidebar/ActivityFeed/Avatar', () => {
             });
     });
 
-    test('should set the avatarUrl state from user prop', () => {
+    test('should set the avatarUrl state from user prop', async () => {
         const completeUser = { ...user, avatar_url: 'bar' };
         const wrapper = getWrapper({ user: completeUser });
         expect(wrapper.state('avatarUrl')).toBe(null);
-        wrapper
-            .instance()
-            .getAvatarUrl()
-            .then(() => {
-                expect(wrapper.state('avatarUrl')).toBe('bar');
-            });
+        await wrapper.instance().getAvatarUrl();
+        expect(wrapper.state('avatarUrl')).toBe('bar');
         expect(getAvatarUrl).not.toBeCalledWith(user.id);
     });
 
-    test('should set the avatarUrl state from user prop', () => {
+    test('should set the avatarUrl state from user prop', async () => {
         const wrapper = getWrapper({ user });
         expect(wrapper.state('avatarUrl')).toBe(null);
-        wrapper.instance().getAvatarUrl();
+        await wrapper.instance().getAvatarUrl();
         wrapper.update();
         expect(getAvatarUrl).not.toBeCalledWith(user.id);
         expect(wrapper.dive()).toMatchSnapshot();


### PR DESCRIPTION
this prevents calls to update state when a component has unmounted prior to the promise resolving