### PR TITLE
test(xhr): use `.catch` to handle promise reject in test

### DIFF
--- a/src/utils/__tests__/Xhr.test.js
+++ b/src/utils/__tests__/Xhr.test.js
@@ -411,11 +411,11 @@ describe('util/Xhr', () => {
                 return Promise.resolve();
             });
             xhrInstance.shouldRetryRequest.mockReturnValue(false);
-            xhrInstance.errorInterceptor(error);
-
-            expect(xhrInstance.getExponentialRetryTimeoutInMs).not.toHaveBeenCalled();
-            expect(xhrInstance.axios).not.toHaveBeenCalled();
-            expect(xhrInstance.responseInterceptor).toHaveBeenCalledWith(response.data);
+            xhrInstance.errorInterceptor(error).catch(() => {
+                expect(xhrInstance.getExponentialRetryTimeoutInMs).not.toHaveBeenCalled();
+                expect(xhrInstance.axios).not.toHaveBeenCalled();
+                expect(xhrInstance.responseInterceptor).toHaveBeenCalledWith(response.data);
+            });
         });
     });
 

--- a/src/utils/__tests__/Xhr.test.js
+++ b/src/utils/__tests__/Xhr.test.js
@@ -397,6 +397,7 @@ describe('util/Xhr', () => {
         });
 
         test('should not retry the request before calling the error interceptor', () => {
+            expect.assertions(3);
             const response = {
                 data: {
                     foo: 'bar',


### PR DESCRIPTION
The test was able to pass before because of how mocks were created. Change it so that the expectations are checked after handling the error that this function always generates in this condition.