### PR TITLE
docs(storybook): add annotations to ContentPreview stories

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,6 +1,11 @@
 <style>
+    html,
+    body,
     #root {
-        height: 100vh;
+        height: 100%;
+    }
+
+    #root {
         padding: 16px;
     }
 

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,10 +1,4 @@
 <style>
-    html,
-    body,
-    #root {
-        height: 100%;
-    }
-
     #root {
         padding: 16px;
     }
@@ -14,10 +8,10 @@
     }
 
     .be.bcpr {
-        height: 100%;
+        height: 600px;
     }
 
     .be.bcs {
-        height: 100%;
+        height: 900px;
     }
 </style>

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,5 +1,6 @@
 <style>
     #root {
+        height: 100vh;
         padding: 16px;
     }
 
@@ -8,10 +9,10 @@
     }
 
     .be.bcpr {
-        height: 600px;
+        height: 100%;
     }
 
     .be.bcs {
-        height: 900px;
+        height: 100%;
     }
 </style>

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -62,6 +62,7 @@ type Props = {
     apiHost: string,
     appHost: string,
     autoFocus: boolean,
+    boxAnnotations?: Object,
     cache?: APICache,
     canDownload?: boolean,
     className: string,
@@ -840,7 +841,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
         id: ?string,
         successCallback?: Function,
         errorCallback?: Function,
-        fetchOptions?: FetchOptions = {},
+        fetchOptions: FetchOptions = {},
     ): void {
         if (!id) {
             return;
@@ -1080,7 +1081,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
      * @param {string} [version] - The version that is now previewed
      * @param {object} [additionalVersionInfo] - extra info about the version
      */
-    onVersionChange = (version?: BoxItemVersion, additionalVersionInfo?: AdditionalVersionInfo = {}): void => {
+    onVersionChange = (version?: BoxItemVersion, additionalVersionInfo: AdditionalVersionInfo = {}): void => {
         const { onVersionChange }: Props = this.props;
         this.updateVersionToCurrent = additionalVersionInfo.updateVersionToCurrent;
 
@@ -1121,6 +1122,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
     render() {
         const {
             apiHost,
+            collection,
             token,
             language,
             messages,
@@ -1149,7 +1151,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
             isThumbnailSidebarOpen,
             selectedVersion,
         }: State = this.state;
-        const { collection }: Props = this.props;
+
         const styleClassName = classNames(
             'be bcpr',
             {

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -217,14 +217,16 @@ describe('elements/content-preview/ContentPreview', () => {
             };
 
             file = { id: '123' };
-        });
-
-        test('should bind onPreviewError prop to preview "preview_error" event', async () => {
             props = {
-                onError: jest.fn(),
+                onMetric: jest.fn(),
                 token: 'token',
                 fileId: file.id,
             };
+        });
+
+        test('should bind onPreviewError prop to preview "preview_error" event', async () => {
+            props.onError = jest.fn();
+
             const wrapper = getWrapper(props);
             wrapper.setState({ file });
             const instance = wrapper.instance();
@@ -234,11 +236,6 @@ describe('elements/content-preview/ContentPreview', () => {
         });
 
         test('should bind onPreviewMetric prop to preview "preview_metric" event', async () => {
-            props = {
-                onMetric: jest.fn(),
-                token: 'token',
-                fileId: file.id,
-            };
             const wrapper = getWrapper(props);
             wrapper.setState({ file });
             const instance = wrapper.instance();
@@ -248,11 +245,6 @@ describe('elements/content-preview/ContentPreview', () => {
         });
 
         test('should bind onPreviewLoad method to preview "load" event', async () => {
-            props = {
-                onMetric: jest.fn(),
-                token: 'token',
-                fileId: file.id,
-            };
             const wrapper = getWrapper(props);
             wrapper.setState({ file });
             const instance = wrapper.instance();
@@ -261,11 +253,6 @@ describe('elements/content-preview/ContentPreview', () => {
         });
 
         test('should call preview show with correct params', async () => {
-            props = {
-                onMetric: jest.fn(),
-                token: 'token',
-                fileId: file.id,
-            };
             const wrapper = getWrapper(props);
             wrapper.setState({ file });
             const instance = wrapper.instance();
@@ -284,11 +271,6 @@ describe('elements/content-preview/ContentPreview', () => {
         });
 
         test('should call preview show with file version params if provided', async () => {
-            props = {
-                onMetric: jest.fn(),
-                token: 'token',
-                fileId: file.id,
-            };
             const wrapper = getWrapper(props);
             wrapper.setState({
                 file,
@@ -312,6 +294,25 @@ describe('elements/content-preview/ContentPreview', () => {
                             fileVersionId: '12345',
                         },
                     },
+                }),
+            );
+        });
+
+        test('should use boxAnnotations instance if provided', async () => {
+            const boxAnnotations = jest.fn();
+            const wrapper = getWrapper({ ...props, boxAnnotations });
+
+            wrapper.setState({ file });
+
+            const instance = wrapper.instance();
+
+            await instance.loadPreview();
+
+            expect(instance.preview.show).toHaveBeenCalledWith(
+                file.id,
+                expect.any(Function),
+                expect.objectContaining({
+                    boxAnnotations,
                 }),
             );
         });

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -225,9 +225,7 @@ describe('elements/content-preview/ContentPreview', () => {
         });
 
         test('should bind onPreviewError prop to preview "preview_error" event', async () => {
-            props.onError = jest.fn();
-
-            const wrapper = getWrapper(props);
+            const wrapper = getWrapper({ ...props, onError: jest.fn() });
             wrapper.setState({ file });
             const instance = wrapper.instance();
             instance.onPreviewError = jest.fn();

--- a/src/elements/content-preview/stories/ContentPreview.stories.js
+++ b/src/elements/content-preview/stories/ContentPreview.stories.js
@@ -11,7 +11,8 @@ export const Preview = () => (
         <ContentPreview
             features={global.FEATURES}
             fileId={text('File ID', global.FILE_ID)}
-            token={text('Token', global.TOKEN)}
+            hasHeader
+            token={text('Access Token', global.TOKEN)}
         />
     </IntlProvider>
 );
@@ -51,7 +52,7 @@ export const PreviewWithSidebar = () => (
             features={global.FEATURES}
             fileId={text('File ID', global.FILE_ID)}
             hasHeader
-            token={text('Token', global.TOKEN)}
+            token={text('Access Token', global.TOKEN)}
         />
     </IntlProvider>
 );

--- a/src/elements/content-preview/stories/ContentPreview.stories.js
+++ b/src/elements/content-preview/stories/ContentPreview.stories.js
@@ -1,15 +1,34 @@
 // @flow
 import * as React from 'react';
 import { IntlProvider } from 'react-intl';
+import { text } from '@storybook/addon-knobs';
 
 import ContentPreview from '../ContentPreview';
 import notes from './ContentPreview.notes.md';
 
 export const Preview = () => (
     <IntlProvider locale="en">
-        <ContentPreview hasHeader features={global.FEATURES} fileId={global.FILE_ID} token={global.TOKEN} />
+        <ContentPreview
+            features={global.FEATURES}
+            fileId={text('File ID', global.FILE_ID)}
+            token={text('Token', global.TOKEN)}
+        />
     </IntlProvider>
 );
+
+export const PreviewWithAnnotations = () => {
+    return (
+        <IntlProvider locale="en">
+            <ContentPreview
+                features={global.FEATURES}
+                fileId={text('File ID', global.FILE_ID)}
+                hasHeader
+                showAnnotations
+                token={text('Access Token', global.TOKEN)}
+            />
+        </IntlProvider>
+    );
+};
 
 export const PreviewWithSidebar = () => (
     <IntlProvider locale="en">
@@ -29,10 +48,10 @@ export const PreviewWithSidebar = () => (
                 hasSkills: true,
                 hasVersions: true,
             }}
-            hasHeader
             features={global.FEATURES}
-            fileId={global.FILE_ID}
-            token={global.TOKEN}
+            fileId={text('File ID', global.FILE_ID)}
+            hasHeader
+            token={text('Token', global.TOKEN)}
         />
     </IntlProvider>
 );

--- a/src/elements/content-preview/stories/ContentPreview.stories.js
+++ b/src/elements/content-preview/stories/ContentPreview.stories.js
@@ -1,19 +1,12 @@
 // @flow
 import * as React from 'react';
 import { IntlProvider } from 'react-intl';
-import { text } from '@storybook/addon-knobs';
-
 import ContentPreview from '../ContentPreview';
 import notes from './ContentPreview.notes.md';
 
 export const Preview = () => (
     <IntlProvider locale="en">
-        <ContentPreview
-            features={global.FEATURES}
-            fileId={text('File ID', global.FILE_ID)}
-            hasHeader
-            token={text('Access Token', global.TOKEN)}
-        />
+        <ContentPreview features={global.FEATURES} fileId={global.FILE_ID} hasHeader token={global.TOKEN} />
     </IntlProvider>
 );
 
@@ -22,10 +15,10 @@ export const PreviewWithAnnotations = () => {
         <IntlProvider locale="en">
             <ContentPreview
                 features={global.FEATURES}
-                fileId={text('File ID', global.FILE_ID)}
+                fileId={global.FILE_ID}
                 hasHeader
                 showAnnotations
-                token={text('Access Token', global.TOKEN)}
+                token={global.TOKEN}
             />
         </IntlProvider>
     );
@@ -50,9 +43,9 @@ export const PreviewWithSidebar = () => (
                 hasVersions: true,
             }}
             features={global.FEATURES}
-            fileId={text('File ID', global.FILE_ID)}
+            fileId={global.FILE_ID}
             hasHeader
-            token={text('Access Token', global.TOKEN)}
+            token={global.TOKEN}
         />
     </IntlProvider>
 );


### PR DESCRIPTION
* Add annotations to ContentPreview stories and enable knobs for file id and access_token
* Add a test for injecting boxAnnotations, needed for using the most up to date package of annotations.
* Updated the heights for the existing content preview and sidebar stories