### PR TITLE
fix(content-explorer): Add URL parameter to folders API call

### DIFF
--- a/src/utils/__tests__/fields.test.js
+++ b/src/utils/__tests__/fields.test.js
@@ -54,6 +54,7 @@ import {
     FIELD_STATUS,
     FIELD_RESTORED_FROM,
     FIELD_RETENTION,
+    FIELD_URL,
     PLACEHOLDER_USER,
 } from '../../constants';
 
@@ -77,6 +78,7 @@ describe('util/fields', () => {
             FIELD_AUTHENTICATED_DOWNLOAD_URL,
             FIELD_IS_DOWNLOAD_AVAILABLE,
             FIELD_REPRESENTATIONS,
+            FIELD_URL,
         ]);
     });
 

--- a/src/utils/fields.js
+++ b/src/utils/fields.js
@@ -55,6 +55,7 @@ import {
     FIELD_OCCURRED_AT,
     FIELD_RENDERED_TEXT,
     FIELD_RETENTION,
+    FIELD_URL,
     PLACEHOLDER_USER,
 } from '../constants';
 
@@ -77,6 +78,7 @@ const FOLDER_FIELDS_TO_FETCH = [
     FIELD_AUTHENTICATED_DOWNLOAD_URL,
     FIELD_IS_DOWNLOAD_AVAILABLE,
     FIELD_REPRESENTATIONS,
+    FIELD_URL,
 ];
 
 // Fields needed for the sidebar


### PR DESCRIPTION
This PR fixes a bug in which bookmarks in the Content Explorer pointed to blank pages.