### PR TITLE
feat(table): Add option for blur detection to selectable tables

### DIFF
--- a/examples/src/SelectableTableExamples.js
+++ b/examples/src/SelectableTableExamples.js
@@ -128,6 +128,7 @@ class SelectableTableExamples extends Component {
                 <SelectableTable
                     data={data.map(user => user[2])}
                     enableHotkeys
+                    enableBlurDetection
                     hotkeyType="Item Selection"
                     // eslint-disable-next-line react/no-unused-state
                     onSelect={(selectedItems, focusedItem) => this.setState({ selectedItems, focusedItem })}

--- a/examples/src/SelectableTableExamples.js
+++ b/examples/src/SelectableTableExamples.js
@@ -73,48 +73,50 @@ class FocusableTableRow extends Component {
     }
 }
 
-const SelectableTable = makeSelectable(({ className, onRowClick, onRowFocus, focusedItem, selectedItems }) => {
-    return (
-        <Table className={`has-hover-styles ${className}`}>
-            <TableHeader>
-                {columnHeaders.map(header => (
-                    <TableHeaderCell key={header}>{header}</TableHeaderCell>
-                ))}
-                <TableHeaderCell>Actions</TableHeaderCell>
-            </TableHeader>
-            <TableBody>
-                {data.map((row, index) => (
-                    <ContextMenu key={index}>
-                        <FocusableTableRow
-                            className={selectedItems.has(row[2]) ? 'is-selected ' : ''}
-                            isFocused={row[2] === focusedItem}
-                            onClick={event => onRowClick(event, index)}
-                            onFocus={event => onRowFocus(event, index)}
-                            tabIndex={0}
-                        >
-                            {row.map(cell => (
-                                <TableCell key={cell}>{cell}</TableCell>
-                            ))}
-                            <TableCell>
-                                <DropdownMenu className="dropdown-menu-test">
-                                    <Button type="button">•••</Button>
-                                    <Menu>
-                                        <MenuItem>View Profile</MenuItem>
-                                        <MenuItem>Help</MenuItem>
-                                    </Menu>
-                                </DropdownMenu>
-                            </TableCell>
-                        </FocusableTableRow>
-                        <Menu>
-                            <MenuItem>View Profile</MenuItem>
-                            <MenuItem>Help</MenuItem>
-                        </Menu>
-                    </ContextMenu>
-                ))}
-            </TableBody>
-        </Table>
-    );
-});
+const SelectableTable = makeSelectable(
+    ({ className, onRowClick, onRowFocus, focusedItem, selectedItems, onTableBlur, onTableFocus }) => {
+        return (
+            <Table className={`has-hover-styles ${className}`} onBlur={onTableBlur} onFocus={onTableFocus}>
+                <TableHeader>
+                    {columnHeaders.map(header => (
+                        <TableHeaderCell key={header}>{header}</TableHeaderCell>
+                    ))}
+                    <TableHeaderCell>Actions</TableHeaderCell>
+                </TableHeader>
+                <TableBody>
+                    {data.map((row, index) => (
+                        <ContextMenu key={index}>
+                            <FocusableTableRow
+                                className={selectedItems.has(row[2]) ? 'is-selected ' : ''}
+                                isFocused={row[2] === focusedItem}
+                                onClick={event => onRowClick(event, index)}
+                                onFocus={event => onRowFocus(event, index)}
+                                tabIndex={0}
+                            >
+                                {row.map(cell => (
+                                    <TableCell key={cell}>{cell}</TableCell>
+                                ))}
+                                <TableCell>
+                                    <DropdownMenu className="dropdown-menu-test">
+                                        <Button type="button">•••</Button>
+                                        <Menu>
+                                            <MenuItem>View Profile</MenuItem>
+                                            <MenuItem>Help</MenuItem>
+                                        </Menu>
+                                    </DropdownMenu>
+                                </TableCell>
+                            </FocusableTableRow>
+                            <Menu>
+                                <MenuItem>View Profile</MenuItem>
+                                <MenuItem>Help</MenuItem>
+                            </Menu>
+                        </ContextMenu>
+                    ))}
+                </TableBody>
+            </Table>
+        );
+    },
+);
 
 // eslint-disable-next-line
 class SelectableTableExamples extends Component {
@@ -128,7 +130,6 @@ class SelectableTableExamples extends Component {
                 <SelectableTable
                     data={data.map(user => user[2])}
                     enableHotkeys
-                    enableBlurDetection
                     hotkeyType="Item Selection"
                     // eslint-disable-next-line react/no-unused-state
                     onSelect={(selectedItems, focusedItem) => this.setState({ selectedItems, focusedItem })}

--- a/src/components/table/__tests__/makeSelectable.test.js
+++ b/src/components/table/__tests__/makeSelectable.test.js
@@ -709,6 +709,7 @@ describe('components/table/makeSelectable', () => {
     describe('render()', () => {
         test('should add "is-selectable" class and pass props to table', () => {
             const wrapper = getWrapper({});
+            const instance = wrapper.instance();
             wrapper.setState({ focusedIndex: 1 });
 
             const table = wrapper.find('Table');
@@ -717,23 +718,8 @@ describe('components/table/makeSelectable', () => {
             expect(table.prop('onRowFocus')).toEqual(wrapper.instance().handleRowFocus);
             expect(table.prop('focusedItem')).toEqual('b');
             expect(table.prop('focusedIndex')).toEqual(1);
-        });
-
-        test('should wrap in div for blur detection if enabled', () => {
-            const wrapper = getWrapper({ enableBlurDetection: true });
-            const instance = wrapper.instance();
-
-            const div = wrapper.find('div');
-            expect(div).toHaveLength(1);
-            expect(div.prop('onBlur')).toBe(instance.handleTableBlur);
-            expect(div.prop('onFocus')).toBe(instance.handleTableFocus);
-        });
-
-        test('should not wrap in div for blur detection if disabled', () => {
-            const wrapper = getWrapper();
-
-            const div = wrapper.find('div');
-            expect(div).toHaveLength(0);
+            expect(table.prop('onTableBlur')).toBe(instance.handleTableBlur);
+            expect(table.prop('onTableFocus')).toBe(instance.handleTableFocus);
         });
     });
 });

--- a/src/components/table/makeSelectable.js
+++ b/src/components/table/makeSelectable.js
@@ -39,7 +39,6 @@ function makeSelectable(BaseTable) {
              */
             selectedItems: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.set]),
             enableHotkeys: PropTypes.bool,
-            enableBlurDetection: PropTypes.bool,
             /** Translated type for hotkeys. If not provided, then the hotkeys will not appear in the help modal. */
             hotkeyType: PropTypes.string,
         };
@@ -370,30 +369,24 @@ function makeSelectable(BaseTable) {
         };
 
         render() {
-            const { className, data, enableBlurDetection } = this.props;
+            const { className, data } = this.props;
             const { focusedIndex } = this.state;
             const focusedItem = data[focusedIndex];
 
-            let table = (
-                <BaseTable
-                    {...this.props}
-                    className={classNames(className, 'is-selectable')}
-                    focusedIndex={focusedIndex}
-                    focusedItem={focusedItem}
-                    onRowClick={this.handleRowClick}
-                    onRowFocus={this.handleRowFocus}
-                />
+            return (
+                <Hotkeys configs={this.getHotkeyConfigs()}>
+                    <BaseTable
+                        {...this.props}
+                        className={classNames(className, 'is-selectable')}
+                        focusedIndex={focusedIndex}
+                        focusedItem={focusedItem}
+                        onRowClick={this.handleRowClick}
+                        onRowFocus={this.handleRowFocus}
+                        onTableBlur={this.handleTableBlur}
+                        onTableFocus={this.handleTableFocus}
+                    />
+                </Hotkeys>
             );
-
-            if (enableBlurDetection) {
-                table = (
-                    <div onBlur={this.handleTableBlur} onFocus={this.handleTableFocus}>
-                        {table}
-                    </div>
-                );
-            }
-
-            return <Hotkeys configs={this.getHotkeyConfigs()}>{table}</Hotkeys>;
         }
     };
 }

--- a/src/components/table/makeSelectable.js
+++ b/src/components/table/makeSelectable.js
@@ -39,6 +39,7 @@ function makeSelectable(BaseTable) {
              */
             selectedItems: PropTypes.oneOfType([PropTypes.array, ImmutablePropTypes.set]),
             enableHotkeys: PropTypes.bool,
+            enableBlurDetection: PropTypes.bool,
             /** Translated type for hotkeys. If not provided, then the hotkeys will not appear in the help modal. */
             hotkeyType: PropTypes.string,
         };
@@ -59,6 +60,8 @@ function makeSelectable(BaseTable) {
             // will be fired before the click event; thus, in the click handler,
             // the focusedItem will already be the new item
             this.previousIndex = 0;
+
+            this.blurTimerID = null;
         }
 
         state = {
@@ -77,6 +80,7 @@ function makeSelectable(BaseTable) {
 
         componentWillUnmount() {
             document.removeEventListener('keypress', this.handleKeyboardSearch);
+            clearTimeout(this.blurTimerID);
         }
 
         onSelect = (selectedItems, newFocusedIndex) => {
@@ -265,6 +269,12 @@ function makeSelectable(BaseTable) {
             this.anchorIndex = rowIndex;
         };
 
+        clearFocus = () => {
+            this.setState({
+                focusedIndex: undefined,
+            });
+        };
+
         handleRowClick = (event, index) => {
             if (event.metaKey || event.ctrlKey) {
                 this.selectToggle(index);
@@ -278,6 +288,18 @@ function makeSelectable(BaseTable) {
         handleRowFocus = (event, index) => {
             const { selectedItems } = this.getProcessedProps();
             this.onSelect(selectedItems, index);
+        };
+
+        handleTableBlur = () => {
+            const { focusedIndex } = this.state;
+            if (focusedIndex !== undefined) {
+                // table may get focus back right away in the same tick, in which case we shouldn't clear focus
+                this.blurTimerID = setTimeout(this.clearFocus);
+            }
+        };
+
+        handleTableFocus = () => {
+            clearTimeout(this.blurTimerID);
         };
 
         handleShiftKeyDown = (newFocusedIndex, boundary) => {
@@ -348,22 +370,30 @@ function makeSelectable(BaseTable) {
         };
 
         render() {
-            const { className, data } = this.props;
+            const { className, data, enableBlurDetection } = this.props;
             const { focusedIndex } = this.state;
             const focusedItem = data[focusedIndex];
 
-            return (
-                <Hotkeys configs={this.getHotkeyConfigs()}>
-                    <BaseTable
-                        {...this.props}
-                        className={classNames(className, 'is-selectable')}
-                        focusedIndex={focusedIndex}
-                        focusedItem={focusedItem}
-                        onRowClick={this.handleRowClick}
-                        onRowFocus={this.handleRowFocus}
-                    />
-                </Hotkeys>
+            let table = (
+                <BaseTable
+                    {...this.props}
+                    className={classNames(className, 'is-selectable')}
+                    focusedIndex={focusedIndex}
+                    focusedItem={focusedItem}
+                    onRowClick={this.handleRowClick}
+                    onRowFocus={this.handleRowFocus}
+                />
             );
+
+            if (enableBlurDetection) {
+                table = (
+                    <div onBlur={this.handleTableBlur} onFocus={this.handleTableFocus}>
+                        {table}
+                    </div>
+                );
+            }
+
+            return <Hotkeys configs={this.getHotkeyConfigs()}>{table}</Hotkeys>;
         }
     };
 }


### PR DESCRIPTION
The `makeSelectable` function takes a component (let's call it `BaseTable`) and returns another (let's call this one `SelectableTable`.)

`SelectableTable`, under the hood, renders the `BaseTable` and adds selection-related functionality to it. It provides specific functions as props such as `onRowClick` and `onRowFocus` to the `BaseTable` which in turn calls those functions upon the appropriate user actions (i.e. DOM events.)

`SelectableTable` internally manages a `focusIndex` state which determines which item in the list is considered "focused." The `BaseTable` implementation may show a different UI treatment for the focused item.

The problem this change solves is: Once `focusIndex` gets set, it never gets unset. As a result, once a `BaseTable` implementation shows an item as focused, there will always be an item that has focus in that table, regardless of where the actual user focus is. For example, if the user focuses the file list (to select a few items, or preview an item), even after clearing the selection or coming back from preview, an item will remain focused (with the gray highlight).

This change enables underlying `BaseTable` implementations to cause the clearing of the internal `focusIndex` state when the entire table loses focus. The underlying `BaseTable` would need to wire up the `onTableBlur` and `onTableFocus` props to the appropriate user actions (i.e. DOM events.)