### PR TITLE
docs(theme): allow viewing defaultTheme in docs

### DIFF
--- a/src/utils/createTheme.stories.js
+++ b/src/utils/createTheme.stories.js
@@ -4,6 +4,7 @@ import styled, { ThemeProvider, keyframes } from 'styled-components';
 import { select } from '@storybook/addon-knobs';
 
 import * as vars from '../styles/variables';
+import defaultTheme from '../styles/theme';
 import BoxButton from '../components/button';
 import BoxLogo from '../icon/logo/BoxLogo';
 import { createTheme } from './createTheme';
@@ -189,7 +190,7 @@ const Footer = styled.div`
 
 export const ThemeExample = () => {
     const colorKey = select('Primary Color', options);
-    const theme = colorKey ? createTheme(colorKey) : {};
+    const theme = colorKey ? createTheme(colorKey) : defaultTheme;
 
     return (
         <ThemeProvider theme={theme}>


### PR DESCRIPTION
fixes theme docs page so you can show the default theme without the createTheme() logic

<img width="1201" alt="Screen Shot 2020-03-17 at 17 40 20" src="https://user-images.githubusercontent.com/1571667/76914429-86315b80-6877-11ea-9963-c3211304f287.png">
