### PR TITLE
feat(classification): add tooltip to display all applications name list

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1057,9 +1057,9 @@ boxui.securityCloudGame.success = Success!
 # Name list of all applications download restriction applied to classification
 boxui.securityControls.allAppNames = All applications: {appsList}
 # Bullet point that summarizes application download restriction applied to classification
-boxui.securityControls.appDownloadBlacklist = Some applications will be restricted: {appNames}
+boxui.securityControls.appDownloadBlacklist = Download restricted for some applications: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
-boxui.securityControls.appDownloadBlacklistOverflow = Some applications will be restricted: {appNames} +{remainingAppCount} more
+boxui.securityControls.appDownloadBlacklistOverflow = Download restricted for some applications: {appNames} +{remainingAppCount} more
 # Bullet point that summarizes application download blocked restriction applied to classification
 boxui.securityControls.appDownloadBlock = Some application restrictions apply.
 # Bullet point that summarizes application download restriction applied to classification

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1054,6 +1054,8 @@ boxui.searchForm.searchLabel = Search query
 boxui.securityCloudGame.instructions = For security purposes, please drag the white cloud into the dark cloud.
 # Success message shown when a user successfully drags the cloud into position.
 boxui.securityCloudGame.success = Success!
+# Name list of all applications download restriction applied to classification
+boxui.securityControls.allAppNames = All applications: {appsList}
 # Bullet point that summarizes application download restriction applied to classification
 boxui.securityControls.appDownloadBlacklist = Some applications will be restricted: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold

--- a/src/features/classification/flowTypes.js
+++ b/src/features/classification/flowTypes.js
@@ -1,4 +1,6 @@
 // @flow
+import type { MessageDescriptor } from 'react-intl';
+
 import {
     LIST_ACCESS_LEVEL,
     MANAGED_USERS_ACCESS_LEVEL,
@@ -51,11 +53,17 @@ type Controls = {
 
 type ControlsFormat = $Values<typeof SECURITY_CONTROLS_FORMAT>;
 
+type MessageItem = {
+    message: MessageDescriptor,
+    tooltipMessage?: MessageDescriptor,
+};
+
 export type {
     ApplicationRestriction,
     Controls,
     ControlsFormat,
     DownloadRestrictions,
     ExternalCollabRestriction,
+    MessageItem,
     SharedLinkRestrictions,
 };

--- a/src/features/classification/security-controls/SecurityControls.js
+++ b/src/features/classification/security-controls/SecurityControls.js
@@ -66,7 +66,7 @@ class SecurityControls extends React.Component<Props, State> {
             items = getFullSecurityControlsMessages(controls, maxAppCount);
         } else {
             const shortMessage = getShortSecurityControlsMessage(controls);
-            items = shortMessage.message ? [shortMessage] : [];
+            items = shortMessage ? [shortMessage] : [];
 
             if (items.length && controlsFormat === SHORT_WITH_BTN) {
                 modalItems = getFullSecurityControlsMessages(controls, maxAppCount);
@@ -80,16 +80,14 @@ class SecurityControls extends React.Component<Props, State> {
         const { isSecurityControlsModalOpen } = this.state;
         const shouldShowSecurityControlsModal =
             controlsFormat === SHORT_WITH_BTN && !!itemName && !!classificationName && !!definition;
-        const securityControlsItems = items.map(({ message, tooltipMessage }) => {
-            if (message) {
-                return <SecurityControlsItem key={message.id} message={message} appNames={tooltipMessage} />;
-            }
-            return null;
-        });
 
         return (
             <>
-                <ul className="bdl-SecurityControls">{securityControlsItems}</ul>
+                <ul className="bdl-SecurityControls">
+                    {items.map(({ message, tooltipMessage }) => (
+                        <SecurityControlsItem key={message.id} message={message} tooltipMessage={tooltipMessage} />
+                    ))}
+                </ul>
                 {shouldShowSecurityControlsModal && (
                     <>
                         <PlainButton className="lnk" onClick={this.openModal} type="button">

--- a/src/features/classification/security-controls/SecurityControls.js
+++ b/src/features/classification/security-controls/SecurityControls.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { DEFAULT_MAX_APP_COUNT, SECURITY_CONTROLS_FORMAT } from '../constants';
-import { getAppsTooltip, getShortSecurityControlsMessage, getFullSecurityControlsMessages } from './utils';
+import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from './utils';
 import messages from './messages';
 import PlainButton from '../../../components/plain-button';
 import SecurityControlsItem from './SecurityControlsItem';
@@ -61,13 +61,12 @@ class SecurityControls extends React.Component<Props, State> {
 
         let items = [];
         let modalItems;
-        let appNames;
 
         if (controlsFormat === FULL) {
             items = getFullSecurityControlsMessages(controls, maxAppCount);
         } else {
             const shortMessage = getShortSecurityControlsMessage(controls);
-            items = shortMessage ? [shortMessage] : [];
+            items = shortMessage.message ? [shortMessage] : [];
 
             if (items.length && controlsFormat === SHORT_WITH_BTN) {
                 modalItems = getFullSecurityControlsMessages(controls, maxAppCount);
@@ -78,29 +77,25 @@ class SecurityControls extends React.Component<Props, State> {
             return null;
         }
 
-        // get applications name list for use in classify modal and security controls modal
-        if (controlsFormat !== SHORT) {
-            appNames = getAppsTooltip(controls, maxAppCount);
-        }
-
         const { isSecurityControlsModalOpen } = this.state;
         const shouldShowSecurityControlsModal =
             controlsFormat === SHORT_WITH_BTN && !!itemName && !!classificationName && !!definition;
+        const securityControlsItems = items.map(({ message, tooltipMessage }) => {
+            if (message) {
+                return <SecurityControlsItem key={message.id} message={message} appNames={tooltipMessage} />;
+            }
+            return null;
+        });
 
         return (
             <>
-                <ul className="bdl-SecurityControls">
-                    {items.map(item => (
-                        <SecurityControlsItem key={item.id} message={item} appNames={appNames} />
-                    ))}
-                </ul>
+                <ul className="bdl-SecurityControls">{securityControlsItems}</ul>
                 {shouldShowSecurityControlsModal && (
                     <>
                         <PlainButton className="lnk" onClick={this.openModal} type="button">
                             <FormattedMessage {...messages.viewAll} />
                         </PlainButton>
                         <SecurityControlsModal
-                            appNames={appNames}
                             fillColor={fillColor}
                             strokeColor={strokeColor}
                             classificationName={classificationName}

--- a/src/features/classification/security-controls/SecurityControls.js
+++ b/src/features/classification/security-controls/SecurityControls.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { DEFAULT_MAX_APP_COUNT, SECURITY_CONTROLS_FORMAT } from '../constants';
-import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from './utils';
+import { getAppsTooltip, getShortSecurityControlsMessage, getFullSecurityControlsMessages } from './utils';
 import messages from './messages';
 import PlainButton from '../../../components/plain-button';
 import SecurityControlsItem from './SecurityControlsItem';
@@ -61,6 +61,7 @@ class SecurityControls extends React.Component<Props, State> {
 
         let items = [];
         let modalItems;
+        let appNames;
 
         if (controlsFormat === FULL) {
             items = getFullSecurityControlsMessages(controls, maxAppCount);
@@ -77,6 +78,11 @@ class SecurityControls extends React.Component<Props, State> {
             return null;
         }
 
+        // get applications name list for use in classify modal and security controls modal
+        if (controlsFormat !== SHORT) {
+            appNames = getAppsTooltip(controls, maxAppCount);
+        }
+
         const { isSecurityControlsModalOpen } = this.state;
         const shouldShowSecurityControlsModal =
             controlsFormat === SHORT_WITH_BTN && !!itemName && !!classificationName && !!definition;
@@ -85,7 +91,7 @@ class SecurityControls extends React.Component<Props, State> {
             <>
                 <ul className="bdl-SecurityControls">
                     {items.map(item => (
-                        <SecurityControlsItem key={item.id} message={item} />
+                        <SecurityControlsItem key={item.id} message={item} appNames={appNames} />
                     ))}
                 </ul>
                 {shouldShowSecurityControlsModal && (
@@ -94,6 +100,7 @@ class SecurityControls extends React.Component<Props, State> {
                             <FormattedMessage {...messages.viewAll} />
                         </PlainButton>
                         <SecurityControlsModal
+                            appNames={appNames}
                             fillColor={fillColor}
                             strokeColor={strokeColor}
                             classificationName={classificationName}

--- a/src/features/classification/security-controls/SecurityControlsItem.js
+++ b/src/features/classification/security-controls/SecurityControlsItem.js
@@ -1,11 +1,10 @@
 // @flow
 import * as React from 'react';
 import { FormattedMessage, type MessageDescriptor } from 'react-intl';
+
 import { bdlBoxBlue } from '../../../styles/variables';
 import Tooltip from '../../../components/tooltip';
 import IconInfo from '../../../icons/general/IconInfo';
-import messages from './messages';
-
 import './SecurityControlsItem.scss';
 
 type Props = {
@@ -15,35 +14,22 @@ type Props = {
 
 const ICON_SIZE = 13;
 
-const SecurityControlsItem = ({ message, appNames }: Props) => {
-    const shouldRenderTooltip =
-        appNames &&
-        (message.id === messages.appDownloadWhitelistOverflow.id ||
-            message.id === messages.appDownloadBlacklistOverflow.id);
-
-    const tooltipContent = shouldRenderTooltip ? (
-        <div className="bdl-SecurityControlsItem-tooltipContent">
-            <FormattedMessage {...appNames} />
-        </div>
-    ) : null;
-
-    return (
-        <li className="bdl-SecurityControlsItem">
-            <FormattedMessage {...message} />
-            {shouldRenderTooltip && (
-                <Tooltip
-                    className="bdl-SecurityControlsItem-tooltip"
-                    text={tooltipContent}
-                    position="middle-right"
-                    isTabbable={false}
-                >
-                    <span className="bdl-SecurityControlsItem-tooltipIcon">
-                        <IconInfo color={bdlBoxBlue} width={ICON_SIZE} height={ICON_SIZE} />
-                    </span>
-                </Tooltip>
-            )}
-        </li>
-    );
-};
+const SecurityControlsItem = ({ message, appNames }: Props) => (
+    <li className="bdl-SecurityControlsItem">
+        <FormattedMessage {...message} />
+        {appNames && (
+            <Tooltip
+                className="bdl-SecurityControlsItem-tooltip"
+                text={<FormattedMessage {...appNames} />}
+                position="middle-right"
+                isTabbable={false}
+            >
+                <span className="bdl-SecurityControlsItem-tooltipIcon">
+                    <IconInfo color={bdlBoxBlue} width={ICON_SIZE} height={ICON_SIZE} />
+                </span>
+            </Tooltip>
+        )}
+    </li>
+);
 
 export default SecurityControlsItem;

--- a/src/features/classification/security-controls/SecurityControlsItem.js
+++ b/src/features/classification/security-controls/SecurityControlsItem.js
@@ -1,26 +1,25 @@
 // @flow
 import * as React from 'react';
-import { FormattedMessage, type MessageDescriptor } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { bdlBoxBlue } from '../../../styles/variables';
 import Tooltip from '../../../components/tooltip';
 import IconInfo from '../../../icons/general/IconInfo';
+import type { MessageItem } from '../flowTypes';
+
 import './SecurityControlsItem.scss';
 
-type Props = {
-    appNames: ?MessageDescriptor,
-    message: MessageDescriptor,
-};
+type Props = MessageItem;
 
 const ICON_SIZE = 13;
 
-const SecurityControlsItem = ({ message, appNames }: Props) => (
+const SecurityControlsItem = ({ message, tooltipMessage }: Props) => (
     <li className="bdl-SecurityControlsItem">
         <FormattedMessage {...message} />
-        {appNames && (
+        {tooltipMessage && (
             <Tooltip
                 className="bdl-SecurityControlsItem-tooltip"
-                text={<FormattedMessage {...appNames} />}
+                text={<FormattedMessage {...tooltipMessage} />}
                 position="middle-right"
                 isTabbable={false}
             >

--- a/src/features/classification/security-controls/SecurityControlsItem.js
+++ b/src/features/classification/security-controls/SecurityControlsItem.js
@@ -1,17 +1,47 @@
 // @flow
 import * as React from 'react';
 import { FormattedMessage, type MessageDescriptor } from 'react-intl';
+import { bdlBoxBlue } from '../../../styles/variables';
+import Tooltip from '../../../components/tooltip';
+import IconInfo from '../../../icons/general/IconInfo';
+import messages from './messages';
 
 import './SecurityControlsItem.scss';
 
 type Props = {
+    appNames: ?MessageDescriptor,
     message: MessageDescriptor,
 };
 
-const SecurityControlsItem = ({ message }: Props) => {
+const ICON_SIZE = 13;
+
+const SecurityControlsItem = ({ message, appNames }: Props) => {
+    const shouldRenderTooltip =
+        appNames &&
+        (message.id === messages.appDownloadWhitelistOverflow.id ||
+            message.id === messages.appDownloadBlacklistOverflow.id);
+
+    const tooltipContent = shouldRenderTooltip ? (
+        <div className="bdl-SecurityControlsItem-tooltipContent">
+            <FormattedMessage {...appNames} />
+        </div>
+    ) : null;
+
     return (
         <li className="bdl-SecurityControlsItem">
             <FormattedMessage {...message} />
+            {shouldRenderTooltip && (
+                <Tooltip
+                    className="bdl-SecurityControlsItem-tooltip"
+                    text={tooltipContent}
+                    position="middle-right"
+                    isTabbable={false}
+                >
+                    <span className="bdl-SecurityControlsItem-tooltipIcon">
+                        <IconInfo color={bdlBoxBlue} width={ICON_SIZE} height={ICON_SIZE} />
+                    </span>
+                </Tooltip>
+            )}
         </li>
     );
 };

--- a/src/features/classification/security-controls/SecurityControlsModal.js
+++ b/src/features/classification/security-controls/SecurityControlsModal.js
@@ -11,7 +11,7 @@ import Label from '../../../components/label/Label';
 import messages from './messages';
 import SecurityControlsItem from './SecurityControlsItem';
 import './SecurityControlsModal.scss';
-import type { MessageItem } from './utils';
+import type { MessageItem } from '../flowTypes';
 
 type Props = {
     classificationName?: string,
@@ -39,12 +39,6 @@ const SecurityControlsModal = ({
     }
 
     const title = <FormattedMessage {...messages.modalTitle} values={{ itemName }} />;
-    const securityControlsItems = modalItems.map(({ message, tooltipMessage }) => {
-        if (message) {
-            return <SecurityControlsItem key={message.id} message={message} appNames={tooltipMessage} />;
-        }
-        return null;
-    });
 
     return (
         <Modal
@@ -64,7 +58,11 @@ const SecurityControlsModal = ({
             <Label text={<FormattedMessage {...classificationMessages.definition} />}>
                 <p className="bdl-SecurityControlsModal-definition">{definition}</p>
             </Label>
-            <ul className="bdl-SecurityControlsModal-controlsItemList">{securityControlsItems}</ul>
+            <ul className="bdl-SecurityControlsModal-controlsItemList">
+                {modalItems.map(({ message, tooltipMessage }) => (
+                    <SecurityControlsItem key={message.id} message={message} tooltipMessage={tooltipMessage} />
+                ))}
+            </ul>
             <ModalActions>
                 <Button onClick={closeModal} type="button">
                     <FormattedMessage {...commonMessages.close} />

--- a/src/features/classification/security-controls/SecurityControlsModal.js
+++ b/src/features/classification/security-controls/SecurityControlsModal.js
@@ -13,6 +13,7 @@ import SecurityControlsItem from './SecurityControlsItem';
 import './SecurityControlsModal.scss';
 
 type Props = {
+    appNames: ?MessageDescriptor,
     classificationName?: string,
     closeModal: Function,
     definition?: string,
@@ -24,6 +25,7 @@ type Props = {
 };
 
 const SecurityControlsModal = ({
+    appNames,
     closeModal,
     definition,
     fillColor,
@@ -59,7 +61,7 @@ const SecurityControlsModal = ({
             </Label>
             <ul className="bdl-SecurityControlsModal-controlsItemList">
                 {modalItems.map(item => (
-                    <SecurityControlsItem key={item.id} message={item} />
+                    <SecurityControlsItem appNames={appNames} key={item.id} message={item} />
                 ))}
             </ul>
             <ModalActions>

--- a/src/features/classification/security-controls/SecurityControlsModal.js
+++ b/src/features/classification/security-controls/SecurityControlsModal.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { FormattedMessage, type MessageDescriptor } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Modal, ModalActions } from '../../../components/modal';
 import commonMessages from '../../../common/messages';
@@ -11,21 +11,20 @@ import Label from '../../../components/label/Label';
 import messages from './messages';
 import SecurityControlsItem from './SecurityControlsItem';
 import './SecurityControlsModal.scss';
+import type { MessageItem } from './utils';
 
 type Props = {
-    appNames: ?MessageDescriptor,
     classificationName?: string,
     closeModal: Function,
     definition?: string,
     fillColor?: string,
     isSecurityControlsModalOpen: boolean,
     itemName?: string,
-    modalItems: Array<MessageDescriptor>,
+    modalItems: Array<MessageItem>,
     strokeColor?: string,
 };
 
 const SecurityControlsModal = ({
-    appNames,
     closeModal,
     definition,
     fillColor,
@@ -40,6 +39,12 @@ const SecurityControlsModal = ({
     }
 
     const title = <FormattedMessage {...messages.modalTitle} values={{ itemName }} />;
+    const securityControlsItems = modalItems.map(({ message, tooltipMessage }) => {
+        if (message) {
+            return <SecurityControlsItem key={message.id} message={message} appNames={tooltipMessage} />;
+        }
+        return null;
+    });
 
     return (
         <Modal
@@ -59,11 +64,7 @@ const SecurityControlsModal = ({
             <Label text={<FormattedMessage {...classificationMessages.definition} />}>
                 <p className="bdl-SecurityControlsModal-definition">{definition}</p>
             </Label>
-            <ul className="bdl-SecurityControlsModal-controlsItemList">
-                {modalItems.map(item => (
-                    <SecurityControlsItem appNames={appNames} key={item.id} message={item} />
-                ))}
-            </ul>
+            <ul className="bdl-SecurityControlsModal-controlsItemList">{securityControlsItems}</ul>
             <ModalActions>
                 <Button onClick={closeModal} type="button">
                     <FormattedMessage {...commonMessages.close} />

--- a/src/features/classification/security-controls/__tests__/SecurityControls.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControls.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import SecurityControlsItem from '../SecurityControlsItem';
 import SecurityControls from '../SecurityControls';
 import { SECURITY_CONTROLS_FORMAT } from '../../constants';
+import messages from '../messages';
 
 const { FULL, SHORT, SHORT_WITH_BTN } = SECURITY_CONTROLS_FORMAT;
 
@@ -75,6 +76,21 @@ describe('features/classification/security-controls/SecurityControls', () => {
         ).toEqual({
             appNames: 'App 1, App 2',
             remainingAppCount: 2,
+        });
+    });
+
+    test('should pass appNames to SecurityControlsItem if exceeds maxAppCount', () => {
+        controls.app.apps = [{ displayText: 'App 1' }, { displayText: 'App 2' }, { displayText: 'App 3' }];
+        wrapper.setProps({ controlsFormat: FULL, controls, maxAppCount: 2 });
+
+        expect(
+            wrapper
+                .find(SecurityControlsItem)
+                .findWhere(item => item.props().message.id === 'boxui.securityControls.appDownloadWhitelistOverflow')
+                .props().appNames,
+        ).toEqual({
+            ...messages.allAppNames,
+            values: { appsList: 'App 1, App 2, App 3' },
         });
     });
 });

--- a/src/features/classification/security-controls/__tests__/SecurityControls.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControls.test.js
@@ -79,7 +79,7 @@ describe('features/classification/security-controls/SecurityControls', () => {
         });
     });
 
-    test('should pass appNames to SecurityControlsItem if exceeds maxAppCount', () => {
+    test('should pass tooltipMessage to SecurityControlsItem if exceeds maxAppCount', () => {
         controls.app.apps = [{ displayText: 'App 1' }, { displayText: 'App 2' }, { displayText: 'App 3' }];
         wrapper.setProps({ controlsFormat: FULL, controls, maxAppCount: 2 });
 
@@ -87,7 +87,7 @@ describe('features/classification/security-controls/SecurityControls', () => {
             wrapper
                 .find(SecurityControlsItem)
                 .findWhere(item => item.props().message.id === 'boxui.securityControls.appDownloadWhitelistOverflow')
-                .props().appNames,
+                .props().tooltipMessage,
         ).toEqual({
             ...messages.allAppNames,
             values: { appsList: 'App 1, App 2, App 3' },

--- a/src/features/classification/security-controls/__tests__/SecurityControlsItem.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControlsItem.test.js
@@ -1,21 +1,46 @@
 import React from 'react';
 import SecurityControlsItem from '../SecurityControlsItem';
+import Tooltip from '../../../../components/tooltip';
+import IconInfo from '../../../../icons/general/IconInfo';
 
 describe('features/classification/security-controls/SecurityControlsItem', () => {
     let wrapper;
     let message;
+    let appNames;
 
     const getWrapper = (props = {}) => shallow(<SecurityControlsItem {...props} />);
 
     beforeEach(() => {
         message = {
-            id: 'msg1',
+            id: 'boxui.securityControls.appDownloadWhitelistOverflow',
             defaultMessage: 'message',
         };
-        wrapper = getWrapper({ message });
+        appNames = {
+            id: 'id2',
+            defaultMessage: 'message2',
+        };
+        wrapper = getWrapper({ message, appNames });
     });
 
-    test('should render a SecurityControlsItem with a message', () => {
+    test('should render a SecurityControlsItem with a message and Tooltip', () => {
         expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find(Tooltip)).toHaveLength(1);
+        expect(wrapper.find(IconInfo)).toHaveLength(1);
+    });
+
+    test('should not render Tooltip if appNames is received as null', () => {
+        wrapper.setProps({ appNames: null });
+        expect(wrapper.find(Tooltip).length).toBe(0);
+        expect(wrapper.find(IconInfo).length).toBe(0);
+    });
+
+    test('should not render Tooltip if not related to app restriction', () => {
+        message = {
+            id: 'id1',
+            defaultMessage: 'message1',
+        };
+        wrapper.setProps({ message });
+        expect(wrapper.find(Tooltip).length).toBe(0);
+        expect(wrapper.find(IconInfo).length).toBe(0);
     });
 });

--- a/src/features/classification/security-controls/__tests__/SecurityControlsItem.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControlsItem.test.js
@@ -6,7 +6,7 @@ import IconInfo from '../../../../icons/general/IconInfo';
 describe('features/classification/security-controls/SecurityControlsItem', () => {
     let wrapper;
     let message;
-    let appNames;
+    let tooltipMessage;
 
     const getWrapper = (props = {}) => shallow(<SecurityControlsItem {...props} />);
 
@@ -15,11 +15,11 @@ describe('features/classification/security-controls/SecurityControlsItem', () =>
             id: 'id1',
             defaultMessage: 'message',
         };
-        appNames = {
+        tooltipMessage = {
             id: 'id2',
             defaultMessage: 'message2',
         };
-        wrapper = getWrapper({ message, appNames });
+        wrapper = getWrapper({ message, tooltipMessage });
     });
 
     test('should render a SecurityControlsItem with a message and Tooltip', () => {
@@ -28,8 +28,8 @@ describe('features/classification/security-controls/SecurityControlsItem', () =>
         expect(wrapper.find(IconInfo)).toHaveLength(1);
     });
 
-    test('should not render Tooltip if appNames is received as null', () => {
-        wrapper = getWrapper({ message });
+    test('should not render Tooltip if tooltipMessage is received as undefined', () => {
+        wrapper.setProps({ tooltipMessage: undefined });
         expect(wrapper.find(Tooltip).length).toBe(0);
         expect(wrapper.find(IconInfo).length).toBe(0);
     });

--- a/src/features/classification/security-controls/__tests__/SecurityControlsItem.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControlsItem.test.js
@@ -12,7 +12,7 @@ describe('features/classification/security-controls/SecurityControlsItem', () =>
 
     beforeEach(() => {
         message = {
-            id: 'boxui.securityControls.appDownloadWhitelistOverflow',
+            id: 'id1',
             defaultMessage: 'message',
         };
         appNames = {
@@ -29,17 +29,7 @@ describe('features/classification/security-controls/SecurityControlsItem', () =>
     });
 
     test('should not render Tooltip if appNames is received as null', () => {
-        wrapper.setProps({ appNames: null });
-        expect(wrapper.find(Tooltip).length).toBe(0);
-        expect(wrapper.find(IconInfo).length).toBe(0);
-    });
-
-    test('should not render Tooltip if not related to app restriction', () => {
-        message = {
-            id: 'id1',
-            defaultMessage: 'message1',
-        };
-        wrapper.setProps({ message });
+        wrapper = getWrapper({ message });
         expect(wrapper.find(Tooltip).length).toBe(0);
         expect(wrapper.find(IconInfo).length).toBe(0);
     });

--- a/src/features/classification/security-controls/__tests__/SecurityControlsModal.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControlsModal.test.js
@@ -6,10 +6,12 @@ import SecurityControlsItem from '../SecurityControlsItem';
 describe('features/classification/security-controls/SecurityControlsModal', () => {
     let wrapper;
     let modalItems;
+    let appNames;
 
     const getWrapper = props =>
         shallow(
             <SecurityControlsModal
+                appNames={null}
                 closeModal={jest.fn()}
                 definition="classification definition"
                 classificationName="internal"
@@ -47,5 +49,17 @@ describe('features/classification/security-controls/SecurityControlsModal', () =
         wrapper = getWrapper({ modalItems, itemName: 'welcome.pdf' });
 
         expect(wrapper.find(SecurityControlsItem)).toHaveLength(3);
+    });
+
+    test('should pass appNames to SecurityControlsItem', () => {
+        appNames = '123';
+
+        wrapper.setProps({ appNames });
+        expect(
+            wrapper
+                .find(SecurityControlsItem)
+                .findWhere(item => item.props().message.id === 'msg1')
+                .props().appNames,
+        ).toEqual('123');
     });
 });

--- a/src/features/classification/security-controls/__tests__/SecurityControlsModal.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControlsModal.test.js
@@ -6,12 +6,10 @@ import SecurityControlsItem from '../SecurityControlsItem';
 describe('features/classification/security-controls/SecurityControlsModal', () => {
     let wrapper;
     let modalItems;
-    let appNames;
 
     const getWrapper = props =>
         shallow(
             <SecurityControlsModal
-                appNames={null}
                 closeModal={jest.fn()}
                 definition="classification definition"
                 classificationName="internal"
@@ -24,8 +22,8 @@ describe('features/classification/security-controls/SecurityControlsModal', () =
 
     beforeEach(() => {
         modalItems = [
-            { id: 'msg1', defaultMessage: 'message1' },
-            { id: 'msg2', defaultMessage: 'message2' },
+            { message: { id: 'msg1', defaultMessage: 'message1' } },
+            { message: { id: 'msg2', defaultMessage: 'message2' } },
         ];
         wrapper = getWrapper();
     });
@@ -42,9 +40,9 @@ describe('features/classification/security-controls/SecurityControlsModal', () =
 
     test('should render with correct number of security controls items', () => {
         modalItems = [
-            { id: 'msg1', defaultMessage: 'message1' },
-            { id: 'msg2', defaultMessage: 'message2' },
-            { id: 'msg3', defaultMessage: 'message3' },
+            { message: { id: 'msg1', defaultMessage: 'message1' } },
+            { message: { id: 'msg2', defaultMessage: 'message2' } },
+            { message: { id: 'msg3', defaultMessage: 'message3' } },
         ];
         wrapper = getWrapper({ modalItems, itemName: 'welcome.pdf' });
 
@@ -52,14 +50,20 @@ describe('features/classification/security-controls/SecurityControlsModal', () =
     });
 
     test('should pass appNames to SecurityControlsItem', () => {
-        appNames = '123';
-
-        wrapper.setProps({ appNames });
+        const tooltipMessage = { tooltipMessage: { id: 'msg3', defaultMessage: 'message3' } };
+        modalItems = [
+            { message: { id: 'msg1', defaultMessage: 'message1' } },
+            {
+                message: { id: 'msg2', defaultMessage: 'message2' },
+                tooltipMessage,
+            },
+        ];
+        wrapper.setProps({ modalItems });
         expect(
             wrapper
                 .find(SecurityControlsItem)
-                .findWhere(item => item.props().message.id === 'msg1')
+                .findWhere(item => item.props().message.id === 'msg2')
                 .props().appNames,
-        ).toEqual('123');
+        ).toEqual(tooltipMessage);
     });
 });

--- a/src/features/classification/security-controls/__tests__/SecurityControlsModal.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControlsModal.test.js
@@ -49,7 +49,7 @@ describe('features/classification/security-controls/SecurityControlsModal', () =
         expect(wrapper.find(SecurityControlsItem)).toHaveLength(3);
     });
 
-    test('should pass appNames to SecurityControlsItem', () => {
+    test('should pass tooltipMessage to SecurityControlsItem', () => {
         const tooltipMessage = { tooltipMessage: { id: 'msg3', defaultMessage: 'message3' } };
         modalItems = [
             { message: { id: 'msg1', defaultMessage: 'message1' } },
@@ -63,7 +63,7 @@ describe('features/classification/security-controls/SecurityControlsModal', () =
             wrapper
                 .find(SecurityControlsItem)
                 .findWhere(item => item.props().message.id === 'msg2')
-                .props().appNames,
+                .props().tooltipMessage,
         ).toEqual(tooltipMessage);
     });
 });

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
@@ -6,7 +6,6 @@ exports[`features/classification/security-controls/SecurityControls should rende
     className="bdl-SecurityControls"
   >
     <SecurityControlsItem
-      appNames={null}
       key="boxui.securityControls.sharingCollabOnly"
       message={
         Object {
@@ -16,7 +15,6 @@ exports[`features/classification/security-controls/SecurityControls should rende
       }
     />
     <SecurityControlsItem
-      appNames={null}
       key="boxui.securityControls.externalCollabDomainList"
       message={
         Object {
@@ -26,7 +24,6 @@ exports[`features/classification/security-controls/SecurityControls should rende
       }
     />
     <SecurityControlsItem
-      appNames={null}
       key="boxui.securityControls.desktopDownloadOwners"
       message={
         Object {
@@ -36,7 +33,6 @@ exports[`features/classification/security-controls/SecurityControls should rende
       }
     />
     <SecurityControlsItem
-      appNames={null}
       key="boxui.securityControls.appDownloadWhitelist"
       message={
         Object {
@@ -58,7 +54,6 @@ exports[`features/classification/security-controls/SecurityControls should rende
     className="bdl-SecurityControls"
   >
     <SecurityControlsItem
-      appNames={null}
       key="boxui.securityControls.shortAllRestrictions"
       message={
         Object {
@@ -79,7 +74,6 @@ exports[`features/classification/security-controls/SecurityControls should rende
     />
   </PlainButton>
   <SecurityControlsModal
-    appNames={null}
     classificationName="internal only"
     closeModal={[Function]}
     definition="classification definition"
@@ -88,22 +82,30 @@ exports[`features/classification/security-controls/SecurityControls should rende
     modalItems={
       Array [
         Object {
-          "defaultMessage": "Shared links allowed for collaborators only.",
-          "id": "boxui.securityControls.sharingCollabOnly",
+          "message": Object {
+            "defaultMessage": "Shared links allowed for collaborators only.",
+            "id": "boxui.securityControls.sharingCollabOnly",
+          },
         },
         Object {
-          "defaultMessage": "External collaboration limited to approved domains.",
-          "id": "boxui.securityControls.externalCollabDomainList",
+          "message": Object {
+            "defaultMessage": "External collaboration limited to approved domains.",
+            "id": "boxui.securityControls.externalCollabDomainList",
+          },
         },
         Object {
-          "defaultMessage": "Download restricted on Box Drive, except Owners/Co-Owners.",
-          "id": "boxui.securityControls.desktopDownloadOwners",
+          "message": Object {
+            "defaultMessage": "Download restricted on Box Drive, except Owners/Co-Owners.",
+            "id": "boxui.securityControls.desktopDownloadOwners",
+          },
         },
         Object {
-          "defaultMessage": "Only select applications are allowed: {appNames}",
-          "id": "boxui.securityControls.appDownloadWhitelist",
-          "values": Object {
-            "appNames": "",
+          "message": Object {
+            "defaultMessage": "Only select applications are allowed: {appNames}",
+            "id": "boxui.securityControls.appDownloadWhitelist",
+            "values": Object {
+              "appNames": "",
+            },
           },
         },
       ]

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
@@ -6,6 +6,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     className="bdl-SecurityControls"
   >
     <SecurityControlsItem
+      appNames={null}
       key="boxui.securityControls.sharingCollabOnly"
       message={
         Object {
@@ -15,6 +16,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
       }
     />
     <SecurityControlsItem
+      appNames={null}
       key="boxui.securityControls.externalCollabDomainList"
       message={
         Object {
@@ -24,6 +26,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
       }
     />
     <SecurityControlsItem
+      appNames={null}
       key="boxui.securityControls.desktopDownloadOwners"
       message={
         Object {
@@ -33,6 +36,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
       }
     />
     <SecurityControlsItem
+      appNames={null}
       key="boxui.securityControls.appDownloadWhitelist"
       message={
         Object {
@@ -54,6 +58,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     className="bdl-SecurityControls"
   >
     <SecurityControlsItem
+      appNames={null}
       key="boxui.securityControls.shortAllRestrictions"
       message={
         Object {
@@ -74,6 +79,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
     />
   </PlainButton>
   <SecurityControlsModal
+    appNames={null}
     classificationName="internal only"
     closeModal={[Function]}
     definition="classification definition"

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsItem.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsItem.test.js.snap
@@ -6,7 +6,7 @@ exports[`features/classification/security-controls/SecurityControlsItem should r
 >
   <FormattedMessage
     defaultMessage="message"
-    id="boxui.securityControls.appDownloadWhitelistOverflow"
+    id="id1"
   />
   <Tooltip
     className="bdl-SecurityControlsItem-tooltip"
@@ -16,14 +16,10 @@ exports[`features/classification/security-controls/SecurityControlsItem should r
     isTabbable={false}
     position="middle-right"
     text={
-      <div
-        className="bdl-SecurityControlsItem-tooltipContent"
-      >
-        <FormattedMessage
-          defaultMessage="message2"
-          id="id2"
-        />
-      </div>
+      <FormattedMessage
+        defaultMessage="message2"
+        id="id2"
+      />
     }
     theme="default"
   >

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsItem.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsItem.test.js.snap
@@ -1,12 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/classification/security-controls/SecurityControlsItem should render a SecurityControlsItem with a message 1`] = `
+exports[`features/classification/security-controls/SecurityControlsItem should render a SecurityControlsItem with a message and Tooltip 1`] = `
 <li
   className="bdl-SecurityControlsItem"
 >
   <FormattedMessage
     defaultMessage="message"
-    id="msg1"
+    id="boxui.securityControls.appDownloadWhitelistOverflow"
   />
+  <Tooltip
+    className="bdl-SecurityControlsItem-tooltip"
+    constrainToScrollParent={false}
+    constrainToWindow={true}
+    isDisabled={false}
+    isTabbable={false}
+    position="middle-right"
+    text={
+      <div
+        className="bdl-SecurityControlsItem-tooltipContent"
+      >
+        <FormattedMessage
+          defaultMessage="message2"
+          id="id2"
+        />
+      </div>
+    }
+    theme="default"
+  >
+    <span
+      className="bdl-SecurityControlsItem-tooltipIcon"
+    >
+      <IconInfo
+        color="#0061d5"
+        height={13}
+        width={13}
+      />
+    </span>
+  </Tooltip>
 </li>
 `;

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
@@ -52,6 +52,7 @@ exports[`features/classification/security-controls/SecurityControlsModal should 
     className="bdl-SecurityControlsModal-controlsItemList"
   >
     <SecurityControlsItem
+      appNames={null}
       key="msg1"
       message={
         Object {
@@ -61,6 +62,7 @@ exports[`features/classification/security-controls/SecurityControlsModal should 
       }
     />
     <SecurityControlsItem
+      appNames={null}
       key="msg2"
       message={
         Object {

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
@@ -52,7 +52,6 @@ exports[`features/classification/security-controls/SecurityControlsModal should 
     className="bdl-SecurityControlsModal-controlsItemList"
   >
     <SecurityControlsItem
-      appNames={null}
       key="msg1"
       message={
         Object {
@@ -62,7 +61,6 @@ exports[`features/classification/security-controls/SecurityControlsModal should 
       }
     />
     <SecurityControlsItem
-      appNames={null}
       key="msg2"
       message={
         Object {

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -1,7 +1,7 @@
 import messages from '../messages';
 import appRestrictionsMessageMap from '../appRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from '../downloadRestrictionsMessageMap';
-import { getAppsTooltip, getShortSecurityControlsMessage, getFullSecurityControlsMessages } from '../utils';
+import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from '../utils';
 import {
     DOWNLOAD_CONTROL,
     LIST_ACCESS_LEVEL,
@@ -21,90 +21,71 @@ describe('features/classification/security-controls/utils', () => {
         accessPolicy = {};
     });
 
-    describe('getAppsTooltip()', () => {
-        test('should return null when there are no restrictions', () => {
-            expect(getAppsTooltip({})).toBeNull();
-        });
-        test('should return allAppNames message all conditions met', () => {
-            accessPolicy = {
-                app: {
-                    accessLevel: BLACKLIST,
-                    apps: [
-                        { displayText: 'a' },
-                        { displayText: 'b' },
-                        { displayText: 'c' },
-                        { displayText: 'd' },
-                        { displayText: 'e' },
-                    ],
-                },
-            };
-            expect(getAppsTooltip(accessPolicy, 3)).toEqual({
-                ...messages.allAppNames,
-                values: { appsList: 'a, b, c, d, e' },
-            });
-        });
-    });
-
     describe('getShortSecurityControlsMessage()', () => {
-        test('should return null when there are no restrictions', () => {
-            expect(getShortSecurityControlsMessage({})).toBeNull();
+        test('should return null message when there are no restrictions', () => {
+            expect(getShortSecurityControlsMessage({}).message).toBeNull();
         });
 
         test('should not return messages when shared link restriction has a "public" access level', () => {
             accessPolicy = { sharedLink: { accessLevel: PUBLIC } };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBeNull();
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBeNull();
         });
 
         test('should return all restrictions message when all restrictions are present', () => {
             accessPolicy = { sharedLink: {}, download: {}, externalCollab: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortAllRestrictions);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortAllRestrictions);
         });
 
         test('should return all restrictions message when download, app and either shared link, or external collab restrictions are present', () => {
             accessPolicy = { sharedLink: {}, download: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortAllRestrictions);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortAllRestrictions);
             accessPolicy = { externalCollab: {}, download: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortAllRestrictions);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortAllRestrictions);
         });
 
         test('should return correct message when download and either shared link, or external collab restrictions are present', () => {
             accessPolicy = { sharedLink: {}, download: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortSharingDownload);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortSharingDownload);
             accessPolicy = { externalCollab: {}, download: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortSharingDownload);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortSharingDownload);
         });
 
         test('should return correct message when app and either shared link, or external collab restrictions are present', () => {
             accessPolicy = { sharedLink: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortSharingApp);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortSharingApp);
             accessPolicy = { externalCollab: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortSharingApp);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortSharingApp);
         });
 
         test('should return correct message when app and download restrictions are present', () => {
             accessPolicy = { download: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortDownloadApp);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortDownloadApp);
         });
 
         test('should return correct message when there are shared link or external collab restrictions', () => {
             accessPolicy = { sharedLink: {}, externalCollab: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortSharing);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortSharing);
 
             accessPolicy = { sharedLink: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortSharing);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortSharing);
 
             accessPolicy = { externalCollab: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortSharing);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortSharing);
         });
 
         test('should return correct message when there is a download restriction', () => {
             accessPolicy = { download: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortDownload);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortDownload);
         });
 
         test('should return correct message when there is a download restriction', () => {
             accessPolicy = { app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toBe(messages.shortApp);
+            expect(getShortSecurityControlsMessage(accessPolicy).message).toBe(messages.shortApp);
+        });
+
+        test('should not return tooltipMessage', () => {
+            accessPolicy = { sharedLink: {}, download: {}, externalCollab: {}, app: {} };
+            expect(getShortSecurityControlsMessage(accessPolicy).tooltipMessage).toBeUndefined();
         });
     });
 
@@ -115,7 +96,7 @@ describe('features/classification/security-controls/utils', () => {
                     accessLevel: COLLAB_ONLY,
                 },
             };
-            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([messages.sharingCollabOnly]);
+            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([{ message: messages.sharingCollabOnly }]);
         });
 
         test('should include correct message when shared link is restricted to collaborators and company', () => {
@@ -124,7 +105,9 @@ describe('features/classification/security-controls/utils', () => {
                     accessLevel: COLLAB_AND_COMPANY_ONLY,
                 },
             };
-            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([messages.sharingCollabAndCompanyOnly]);
+            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([
+                { message: messages.sharingCollabAndCompanyOnly },
+            ]);
         });
 
         test('should include correct message when external collab is blocked', () => {
@@ -133,7 +116,7 @@ describe('features/classification/security-controls/utils', () => {
                     accessLevel: BLOCK,
                 },
             };
-            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([messages.externalCollabBlock]);
+            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([{ message: messages.externalCollabBlock }]);
         });
 
         test.each([WHITELIST, BLACKLIST])(
@@ -144,7 +127,9 @@ describe('features/classification/security-controls/utils', () => {
                         accessLevel: listType,
                     },
                 };
-                expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([messages.externalCollabDomainList]);
+                expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([
+                    { message: messages.externalCollabDomainList },
+                ]);
             },
         );
 
@@ -154,7 +139,7 @@ describe('features/classification/security-controls/utils', () => {
                     accessLevel: BLOCK,
                 },
             };
-            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([messages.appDownloadBlock]);
+            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([{ message: messages.appDownloadBlock }]);
         });
 
         test.each([WHITELIST, BLACKLIST])(
@@ -167,13 +152,13 @@ describe('features/classification/security-controls/utils', () => {
                     },
                 };
                 expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
-                    { ...appRestrictionsMessageMap[listType].default, values: { appNames: 'a, b, c' } },
+                    { message: { ...appRestrictionsMessageMap[listType].default, values: { appNames: 'a, b, c' } } },
                 ]);
             },
         );
 
         test.each([WHITELIST, BLACKLIST])(
-            'should include correct message when app download is restricted by %s and apps are maxAppCount or more',
+            'should include correct message and tooltipMessage when app download is restricted by %s and apps are maxAppCount or more',
             listType => {
                 accessPolicy = {
                     app: {
@@ -189,8 +174,14 @@ describe('features/classification/security-controls/utils', () => {
                 };
                 expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
                     {
-                        ...appRestrictionsMessageMap[listType].overflow,
-                        values: { appNames: 'a, b, c', remainingAppCount: 2 },
+                        message: {
+                            ...appRestrictionsMessageMap[listType].overflow,
+                            values: { appNames: 'a, b, c', remainingAppCount: 2 },
+                        },
+                        tooltipMessage: {
+                            ...messages.allAppNames,
+                            values: { appsList: 'a, b, c, d, e' },
+                        },
                     },
                 ]);
             },
@@ -208,7 +199,7 @@ describe('features/classification/security-controls/utils', () => {
                     };
 
                     expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([
-                        downloadRestrictionsMessageMap[platform].externalRestricted[managedUsersCombo],
+                        { message: downloadRestrictionsMessageMap[platform].externalRestricted[managedUsersCombo] },
                     ]);
                 },
             );
@@ -224,7 +215,7 @@ describe('features/classification/security-controls/utils', () => {
                     };
 
                     expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([
-                        downloadRestrictionsMessageMap[platform].externalAllowed[managedUsersCombo],
+                        { message: downloadRestrictionsMessageMap[platform].externalAllowed[managedUsersCombo] },
                     ]);
                 },
             );
@@ -237,7 +228,7 @@ describe('features/classification/security-controls/utils', () => {
                 };
 
                 expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([
-                    downloadRestrictionsMessageMap[platform].externalRestricted.default,
+                    { message: downloadRestrictionsMessageMap[platform].externalRestricted.default },
                 ]);
             });
         });

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -22,13 +22,13 @@ describe('features/classification/security-controls/utils', () => {
     });
 
     describe('getShortSecurityControlsMessage()', () => {
-        test('should return null message when there are no restrictions', () => {
-            expect(getShortSecurityControlsMessage({}).message).toBeNull();
+        test('should return null when there are no restrictions', () => {
+            expect(getShortSecurityControlsMessage({})).toBeNull();
         });
 
         test('should not return messages when shared link restriction has a "public" access level', () => {
             accessPolicy = { sharedLink: { accessLevel: PUBLIC } };
-            expect(getShortSecurityControlsMessage(accessPolicy).message).toBeNull();
+            expect(getShortSecurityControlsMessage(accessPolicy)).toBeNull();
         });
 
         test('should return all restrictions message when all restrictions are present', () => {

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -1,7 +1,7 @@
 import messages from '../messages';
 import appRestrictionsMessageMap from '../appRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from '../downloadRestrictionsMessageMap';
-import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from '../utils';
+import { getAppsTooltip, getShortSecurityControlsMessage, getFullSecurityControlsMessages } from '../utils';
 import {
     DOWNLOAD_CONTROL,
     LIST_ACCESS_LEVEL,
@@ -19,6 +19,30 @@ describe('features/classification/security-controls/utils', () => {
 
     beforeEach(() => {
         accessPolicy = {};
+    });
+
+    describe('getAppsTooltip()', () => {
+        test('should return null when there are no restrictions', () => {
+            expect(getAppsTooltip({})).toBeNull();
+        });
+        test('should return allAppNames message all conditions met', () => {
+            accessPolicy = {
+                app: {
+                    accessLevel: BLACKLIST,
+                    apps: [
+                        { displayText: 'a' },
+                        { displayText: 'b' },
+                        { displayText: 'c' },
+                        { displayText: 'd' },
+                        { displayText: 'e' },
+                    ],
+                },
+            };
+            expect(getAppsTooltip(accessPolicy, 3)).toEqual({
+                ...messages.allAppNames,
+                values: { appsList: 'a, b, c, d, e' },
+            });
+        });
     });
 
     describe('getShortSecurityControlsMessage()', () => {

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -90,6 +90,11 @@ const messages = defineMessages({
             'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
         id: 'boxui.securityControls.appDownloadWhitelistOverflow',
     },
+    allAppNames: {
+        defaultMessage: 'All applications: {appsList}',
+        description: 'Name list of all applications download restriction applied to classification',
+        id: 'boxui.securityControls.allAppNames',
+    },
     // Web Download Restrictions
     webDownloadOwners: {
         defaultMessage: 'Download restricted on web, except Owners/Co-Owners.',

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -69,12 +69,12 @@ const messages = defineMessages({
         id: 'boxui.securityControls.appDownloadBlock',
     },
     appDownloadBlacklist: {
-        defaultMessage: 'Some applications will be restricted: {appNames}',
+        defaultMessage: 'Download restricted for some applications: {appNames}',
         description: 'Bullet point that summarizes application download restriction applied to classification',
         id: 'boxui.securityControls.appDownloadBlacklist',
     },
     appDownloadBlacklistOverflow: {
-        defaultMessage: 'Some applications will be restricted: {appNames} +{remainingAppCount} more',
+        defaultMessage: 'Download restricted for some applications: {appNames} +{remainingAppCount} more',
         description:
             'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
         id: 'boxui.securityControls.appDownloadBlacklistOverflow',

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -10,58 +10,63 @@ import downloadRestrictionsMessageMap from './downloadRestrictionsMessageMap';
 import messages from './messages';
 import { ACCESS_POLICY_RESTRICTION, DOWNLOAD_CONTROL, LIST_ACCESS_LEVEL, SHARED_LINK_ACCESS_LEVEL } from '../constants';
 
+type MessageItem = {
+    message: ?MessageDescriptor,
+    tooltipMessage?: MessageDescriptor,
+};
+
 const { SHARED_LINK, DOWNLOAD, EXTERNAL_COLLAB, APP } = ACCESS_POLICY_RESTRICTION;
 const { DESKTOP, MOBILE, WEB } = DOWNLOAD_CONTROL;
 const { BLOCK, WHITELIST, BLACKLIST } = LIST_ACCESS_LEVEL;
 const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVEL;
 
-const getShortSecurityControlsMessage = (controls: Controls): ?MessageDescriptor => {
+const getShortSecurityControlsMessage = (controls: Controls): MessageItem => {
     const { sharedLink, download, externalCollab, app } = controls;
     // Shared link and external collab restrictions are grouped
     // together as generic "sharing" restrictions
     const sharing = (sharedLink && sharedLink.accessLevel !== PUBLIC) || externalCollab;
 
     if (sharing && download && app) {
-        return messages.shortAllRestrictions;
+        return { message: messages.shortAllRestrictions };
     }
 
     if (sharing && download) {
-        return messages.shortSharingDownload;
+        return { message: messages.shortSharingDownload };
     }
 
     if (sharing && app) {
-        return messages.shortSharingApp;
+        return { message: messages.shortSharingApp };
     }
 
     if (download && app) {
-        return messages.shortDownloadApp;
+        return { message: messages.shortDownloadApp };
     }
 
     if (sharing) {
-        return messages.shortSharing;
+        return { message: messages.shortSharing };
     }
 
     if (download) {
-        return messages.shortDownload;
+        return { message: messages.shortDownload };
     }
 
     if (app) {
-        return messages.shortApp;
+        return { message: messages.shortApp };
     }
 
-    return null;
+    return { message: null };
 };
 
-const getSharedLinkMessages = (controls: Controls): Array<MessageDescriptor> => {
+const getSharedLinkMessages = (controls: Controls): Array<MessageItem> => {
     const items = [];
     const accessLevel = getProp(controls, `${SHARED_LINK}.accessLevel`);
 
     switch (accessLevel) {
         case COLLAB_ONLY:
-            items.push(messages.sharingCollabOnly);
+            items.push({ message: messages.sharingCollabOnly });
             break;
         case COLLAB_AND_COMPANY_ONLY:
-            items.push(messages.sharingCollabAndCompanyOnly);
+            items.push({ message: messages.sharingCollabAndCompanyOnly });
             break;
         default:
             // no-op
@@ -70,17 +75,17 @@ const getSharedLinkMessages = (controls: Controls): Array<MessageDescriptor> => 
     return items;
 };
 
-const getExternalCollabMessages = (controls: Controls): Array<MessageDescriptor> => {
+const getExternalCollabMessages = (controls: Controls): Array<MessageItem> => {
     const items = [];
     const accessLevel = getProp(controls, `${EXTERNAL_COLLAB}.accessLevel`);
 
     switch (accessLevel) {
         case BLOCK:
-            items.push(messages.externalCollabBlock);
+            items.push({ message: messages.externalCollabBlock });
             break;
         case WHITELIST:
         case BLACKLIST:
-            items.push(messages.externalCollabDomainList);
+            items.push({ message: messages.externalCollabDomainList });
             break;
         default:
             // no-op
@@ -89,13 +94,13 @@ const getExternalCollabMessages = (controls: Controls): Array<MessageDescriptor>
     return items;
 };
 
-const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array<MessageDescriptor> => {
+const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array<MessageItem> => {
     const items = [];
     const accessLevel = getProp(controls, `${APP}.accessLevel`);
 
     switch (accessLevel) {
         case BLOCK:
-            items.push(messages.appDownloadBlock);
+            items.push({ message: messages.appDownloadBlock });
             break;
         case WHITELIST:
         case BLACKLIST: {
@@ -107,12 +112,25 @@ const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array
             const appNames = appsToDisplay.map(({ displayText }) => displayText).join(', ');
 
             if (remainingAppCount) {
+                const appsList = apps.map(({ displayText }) => displayText).join(', ');
+
                 items.push({
-                    ...appRestrictionsMessageMap[accessLevel].overflow,
-                    values: { appNames, remainingAppCount },
+                    message: {
+                        ...appRestrictionsMessageMap[accessLevel].overflow,
+                        values: { appNames, remainingAppCount },
+                    },
+                    tooltipMessage: {
+                        ...messages.allAppNames,
+                        values: { appsList },
+                    },
                 });
             } else {
-                items.push({ ...appRestrictionsMessageMap[accessLevel].default, values: { appNames } });
+                items.push({
+                    message: {
+                        ...appRestrictionsMessageMap[accessLevel].default,
+                        values: { appNames },
+                    },
+                });
             }
             break;
         }
@@ -123,25 +141,7 @@ const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array
     return items;
 };
 
-const getAppsTooltip = (controls: Controls, maxAppCount?: number): ?MessageDescriptor => {
-    let appNames = null;
-    const accessLevel = getProp(controls, `${APP}.accessLevel`);
-
-    if (accessLevel === WHITELIST || accessLevel === BLACKLIST) {
-        const apps = getProp(controls, `${APP}.apps`, []);
-        maxAppCount = isNil(maxAppCount) ? apps.length : maxAppCount;
-        if (apps.length > maxAppCount) {
-            const appsList = apps.map(({ displayText }) => displayText).join(', ');
-            appNames = {
-                ...messages.allAppNames,
-                values: { appsList },
-            };
-        }
-    }
-    return appNames;
-};
-
-const getDownloadMessages = (controls: Controls): Array<MessageDescriptor> => {
+const getDownloadMessages = (controls: Controls): Array<MessageItem> => {
     const items = [];
     const { web, mobile, desktop } = getProp(controls, DOWNLOAD, {});
 
@@ -169,18 +169,18 @@ const getDownloadMessages = (controls: Controls): Array<MessageDescriptor> => {
         const { restrictExternalUsers, restrictManagedUsers } = restrictions;
 
         if (restrictManagedUsers && restrictExternalUsers) {
-            items.push(downloadRestrictionsMessageMap[platform].externalRestricted[restrictManagedUsers]);
+            items.push({ message: downloadRestrictionsMessageMap[platform].externalRestricted[restrictManagedUsers] });
         } else if (restrictManagedUsers) {
-            items.push(downloadRestrictionsMessageMap[platform].externalAllowed[restrictManagedUsers]);
+            items.push({ message: downloadRestrictionsMessageMap[platform].externalAllowed[restrictManagedUsers] });
         } else if (restrictExternalUsers) {
-            items.push(downloadRestrictionsMessageMap[platform].externalRestricted.default);
+            items.push({ message: downloadRestrictionsMessageMap[platform].externalRestricted.default });
         }
     });
 
     return items;
 };
 
-const getFullSecurityControlsMessages = (controls: Controls, maxAppCount?: number): Array<MessageDescriptor> => {
+const getFullSecurityControlsMessages = (controls: Controls, maxAppCount?: number): Array<MessageItem> => {
     const items = [
         ...getSharedLinkMessages(controls),
         ...getExternalCollabMessages(controls),
@@ -190,4 +190,6 @@ const getFullSecurityControlsMessages = (controls: Controls, maxAppCount?: numbe
     return items;
 };
 
-export { getAppsTooltip, getShortSecurityControlsMessage, getFullSecurityControlsMessages };
+export { getShortSecurityControlsMessage, getFullSecurityControlsMessages };
+
+export type { MessageItem };

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -123,6 +123,24 @@ const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array
     return items;
 };
 
+const getAppsTooltip = (controls: Controls, maxAppCount?: number): ?MessageDescriptor => {
+    let appNames = null;
+    const accessLevel = getProp(controls, `${APP}.accessLevel`);
+
+    if (accessLevel === WHITELIST || accessLevel === BLACKLIST) {
+        const apps = getProp(controls, `${APP}.apps`, []);
+        maxAppCount = isNil(maxAppCount) ? apps.length : maxAppCount;
+        if (apps.length > maxAppCount) {
+            const appsList = apps.map(({ displayText }) => displayText).join(', ');
+            appNames = {
+                ...messages.allAppNames,
+                values: { appsList },
+            };
+        }
+    }
+    return appNames;
+};
+
 const getDownloadMessages = (controls: Controls): Array<MessageDescriptor> => {
     const items = [];
     const { web, mobile, desktop } = getProp(controls, DOWNLOAD, {});
@@ -172,4 +190,4 @@ const getFullSecurityControlsMessages = (controls: Controls, maxAppCount?: numbe
     return items;
 };
 
-export { getShortSecurityControlsMessage, getFullSecurityControlsMessages };
+export { getAppsTooltip, getShortSecurityControlsMessage, getFullSecurityControlsMessages };

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -2,25 +2,19 @@
 import getProp from 'lodash/get';
 import isNil from 'lodash/isNil';
 
-import type { MessageDescriptor } from 'react-intl';
-import type { Controls } from '../flowTypes';
+import type { Controls, MessageItem } from '../flowTypes';
 
 import appRestrictionsMessageMap from './appRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from './downloadRestrictionsMessageMap';
 import messages from './messages';
 import { ACCESS_POLICY_RESTRICTION, DOWNLOAD_CONTROL, LIST_ACCESS_LEVEL, SHARED_LINK_ACCESS_LEVEL } from '../constants';
 
-type MessageItem = {
-    message: ?MessageDescriptor,
-    tooltipMessage?: MessageDescriptor,
-};
-
 const { SHARED_LINK, DOWNLOAD, EXTERNAL_COLLAB, APP } = ACCESS_POLICY_RESTRICTION;
 const { DESKTOP, MOBILE, WEB } = DOWNLOAD_CONTROL;
 const { BLOCK, WHITELIST, BLACKLIST } = LIST_ACCESS_LEVEL;
 const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVEL;
 
-const getShortSecurityControlsMessage = (controls: Controls): MessageItem => {
+const getShortSecurityControlsMessage = (controls: Controls): ?MessageItem => {
     const { sharedLink, download, externalCollab, app } = controls;
     // Shared link and external collab restrictions are grouped
     // together as generic "sharing" restrictions
@@ -54,7 +48,7 @@ const getShortSecurityControlsMessage = (controls: Controls): MessageItem => {
         return { message: messages.shortApp };
     }
 
-    return { message: null };
+    return null;
 };
 
 const getSharedLinkMessages = (controls: Controls): Array<MessageItem> => {
@@ -191,5 +185,3 @@ const getFullSecurityControlsMessages = (controls: Controls, maxAppCount?: numbe
 };
 
 export { getShortSecurityControlsMessage, getFullSecurityControlsMessages };
-
-export type { MessageItem };


### PR DESCRIPTION
![Screen Shot 2020-03-18 at 10 52 04 AM](https://user-images.githubusercontent.com/20669641/76991265-862c6c80-6906-11ea-8fc2-4ec407cc7a0e.png)

This PR adds a tooltip at the end of FULL formatted security controls for application restrictions when the number of apps exceeds maximum. 
The tooltip content displays the list of all applications' names.
