### PR TITLE
fix(usm): handle create disabled shared link toggle tooltip

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1352,6 +1352,8 @@ boxui.unifiedShare.coownerLevelButtonLabel = Invite as Co-owner
 boxui.unifiedShare.coownerLevelDescription = Manage security, upload, download, preview, share, edit, and delete
 # Text for Co-owner permission level in permissions table
 boxui.unifiedShare.coownerLevelText = Co-owner
+# Tooltip description for not having access to create link
+boxui.unifiedShare.disabledCreateLinkTooltip = You do not have permission to create the link.
 # Tooltip text for when shared permission option is not available due to restriction or classification
 boxui.unifiedShare.disabledShareLinkPermission = This option isn’t available for this item due to a security restriction or classification.
 # Text used in button label to describe permission level - editor

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1352,7 +1352,7 @@ boxui.unifiedShare.coownerLevelButtonLabel = Invite as Co-owner
 boxui.unifiedShare.coownerLevelDescription = Manage security, upload, download, preview, share, edit, and delete
 # Text for Co-owner permission level in permissions table
 boxui.unifiedShare.coownerLevelText = Co-owner
-# Tooltip description for not having access to create link
+# Tooltip description for users who do not have permission for link creation
 boxui.unifiedShare.disabledCreateLinkTooltip = You do not have permission to create the link.
 # Tooltip text for when shared permission option is not available due to restriction or classification
 boxui.unifiedShare.disabledShareLinkPermission = This option isn’t available for this item due to a security restriction or classification.

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -244,10 +244,12 @@ class SharedLinkSection extends React.Component<Props> {
 
     renderToggle() {
         const { item, onDismissTooltip, onToggleSharedLink, sharedLink, submitting, tooltips } = this.props;
+        const { canChangeAccessLevel, expirationTimestamp, url } = sharedLink;
+        const isSharedLinkEnabled = !!url;
+        const canAddSharedLink = this.canAddSharedLink(isSharedLinkEnabled, item.grantedPermissions.itemShare);
+        const canRemoveSharedLink = this.canRemoveSharedLink(isSharedLinkEnabled, canChangeAccessLevel);
+        const isToggleEnabled = (canAddSharedLink || canRemoveSharedLink) && !submitting;
 
-        const { canChangeAccessLevel, expirationTimestamp } = sharedLink;
-
-        const isSharedLinkEnabled = !!sharedLink.url;
         let linkText;
 
         if (isSharedLinkEnabled) {
@@ -278,11 +280,6 @@ class SharedLinkSection extends React.Component<Props> {
             linkText = <FormattedMessage {...messages.linkShareOff} />;
         }
 
-        const isToggleEnabled =
-            (this.canAddSharedLink(isSharedLinkEnabled, item.grantedPermissions.itemShare) ||
-                this.canRemoveSharedLink(isSharedLinkEnabled, canChangeAccessLevel)) &&
-            !submitting;
-
         const toggleComponent = (
             <div className="share-toggle-container">
                 <Toggle
@@ -296,7 +293,7 @@ class SharedLinkSection extends React.Component<Props> {
         );
 
         if (!submitting) {
-            if (this.canAddSharedLink(isSharedLinkEnabled, item.grantedPermissions.itemShare)) {
+            if (canAddSharedLink) {
                 const sharedLinkToggleTooltip = tooltips['shared-link-toggle'];
                 if (sharedLinkToggleTooltip) {
                     return (
@@ -323,9 +320,13 @@ class SharedLinkSection extends React.Component<Props> {
                 );
             }
 
-            if (!this.canRemoveSharedLink(isSharedLinkEnabled, canChangeAccessLevel)) {
+            if (!isToggleEnabled) {
+                const tooltipDisabledMessage = isSharedLinkEnabled
+                    ? messages.removeLinkTooltip
+                    : messages.disabledCreateLinkTooltip;
+
                 return (
-                    <Tooltip position="top-right" text={<FormattedMessage {...messages.removeLinkTooltip} />}>
+                    <Tooltip position="top-right" text={<FormattedMessage {...tooltipDisabledMessage} />}>
                         {toggleComponent}
                     </Tooltip>
                 );

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -326,7 +326,11 @@ class SharedLinkSection extends React.Component<Props> {
                     : messages.disabledCreateLinkTooltip;
 
                 return (
-                    <Tooltip position="top-right" text={<FormattedMessage {...tooltipDisabledMessage} />}>
+                    <Tooltip
+                        className="usm-disabled-message-tooltip"
+                        position="top-right"
+                        text={<FormattedMessage {...tooltipDisabledMessage} />}
+                    >
                         {toggleComponent}
                     </Tooltip>
                 );

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -186,16 +186,20 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
         });
     });
 
-    test('should render disabled create share link message', () => {
+    test('should render disabled create shared link message when item share is false and url is empty', () => {
         const sharedLink = { url: '', canChangeAccessLevel: true };
         const item = { grantedPermissions: { itemShare: false } };
+        const wrapper = getWrapper({ sharedLink, item });
+        const tooltip = wrapper.find('.usm-disabled-message-tooltip');
 
-        expect(getWrapper({ sharedLink, item })).toMatchSnapshot();
+        expect(tooltip).toMatchSnapshot();
     });
 
-    test('should render disabled remove share link message', () => {
+    test('should render disabled remove shared link message when url is not empty and canChangeAccessLevel is false', () => {
         const sharedLink = { url: 'https://example.com/shared-link', canChangeAccessLevel: false };
+        const wrapper = getWrapper({ sharedLink });
+        const tooltip = wrapper.find('.usm-disabled-message-tooltip');
 
-        expect(getWrapper({ sharedLink })).toMatchSnapshot();
+        expect(tooltip).toMatchSnapshot();
     });
 });

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -185,4 +185,17 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
             expect(wrapper).toMatchSnapshot();
         });
     });
+
+    test('should render disabled create share link message', () => {
+        const sharedLink = { url: '', canChangeAccessLevel: true };
+        const item = { grantedPermissions: { itemShare: false } };
+
+        expect(getWrapper({ sharedLink, item })).toMatchSnapshot();
+    });
+
+    test('should render disabled remove share link message', () => {
+        const sharedLink = { url: 'https://example.com/shared-link', canChangeAccessLevel: false };
+
+        expect(getWrapper({ sharedLink })).toMatchSnapshot();
+    });
 });

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -518,6 +518,195 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
 </div>
 `;
 
+exports[`features/unified-share-modal/SharedLinkSection should render disabled create share link message 1`] = `
+<div>
+  <hr />
+  <label>
+    <span
+      className="label bdl-Label"
+    >
+      <FormattedMessage
+        defaultMessage="Share Link"
+        id="boxui.unifiedShare.sharedLinkSectionLabel"
+      />
+    </span>
+  </label>
+  <div
+    className="shared-link-toggle-row"
+  >
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      position="top-right"
+      text={
+        <FormattedMessage
+          defaultMessage="You do not have permission to create the link."
+          id="boxui.unifiedShare.disabledCreateLinkTooltip"
+        />
+      }
+      theme="default"
+    >
+      <div
+        className="share-toggle-container"
+      >
+        <Toggle
+          isDisabled={true}
+          isOn={false}
+          label={
+            <FormattedMessage
+              defaultMessage="Enable shared link"
+              id="boxui.unifiedShare.linkShareOff"
+            />
+          }
+          name="toggle"
+        />
+      </div>
+    </Tooltip>
+  </div>
+</div>
+`;
+
+exports[`features/unified-share-modal/SharedLinkSection should render disabled remove share link message 1`] = `
+<div>
+  <hr />
+  <label>
+    <span
+      className="label bdl-Label"
+    >
+      <FormattedMessage
+        defaultMessage="Share Link"
+        id="boxui.unifiedShare.sharedLinkSectionLabel"
+      />
+    </span>
+  </label>
+  <div
+    className="shared-link-toggle-row"
+  >
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      position="top-right"
+      text={
+        <FormattedMessage
+          defaultMessage="You do not have permission to remove the link."
+          id="boxui.unifiedShare.removeLinkTooltip"
+        />
+      }
+      theme="default"
+    >
+      <div
+        className="share-toggle-container"
+      >
+        <Toggle
+          isDisabled={true}
+          isOn={true}
+          label={
+            <FormattedMessage
+              defaultMessage="Shared link is enabled"
+              id="boxui.unifiedShare.linkShareOn"
+            />
+          }
+          name="toggle"
+        />
+      </div>
+    </Tooltip>
+  </div>
+  <div
+    className="shared-link-field-row"
+  >
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      position="top-left"
+      text={
+        <FormattedMessage
+          defaultMessage="Send Shared Link"
+          id="boxui.unifiedShare.sendSharedLink"
+        />
+      }
+      theme="default"
+    >
+      <Button
+        className="email-shared-link-btn"
+        isLoading={false}
+        showRadar={false}
+        type="button"
+      >
+        <IconMail />
+      </Button>
+    </Tooltip>
+  </div>
+  <div
+    className="shared-link-access-row"
+  >
+    <SharedLinkAccessMenu
+      accessLevelsDisabledReason={Object {}}
+      allowedAccessLevels={Object {}}
+      changeAccessLevel={[Function]}
+      itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
+      trackingProps={
+        Object {
+          "onChangeSharedLinkAccessLevel": undefined,
+          "onSharedLinkAccessMenuOpen": undefined,
+          "sharedLinkAccessMenuButtonProps": undefined,
+        }
+      }
+    />
+    <SharedLinkPermissionMenu
+      allowedPermissionLevels={Array []}
+      canChangePermissionLevel={false}
+      changePermissionLevel={[Function]}
+      trackingProps={
+        Object {
+          "onChangeSharedLinkPermissionLevel": undefined,
+          "sharedLinkPermissionsMenuButtonProps": undefined,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`features/unified-share-modal/SharedLinkSection should render proper dropdown override when viewing an editable box note 1`] = `
 <div>
   <hr />

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -177,6 +177,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
     className="shared-link-toggle-row"
   >
     <Tooltip
+      className="usm-disabled-message-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
@@ -518,193 +519,70 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
 </div>
 `;
 
-exports[`features/unified-share-modal/SharedLinkSection should render disabled create share link message 1`] = `
-<div>
-  <hr />
-  <label>
-    <span
-      className="label bdl-Label"
-    >
-      <FormattedMessage
-        defaultMessage="Share Link"
-        id="boxui.unifiedShare.sharedLinkSectionLabel"
-      />
-    </span>
-  </label>
+exports[`features/unified-share-modal/SharedLinkSection should render disabled create shared link message when item share is false and url is empty 1`] = `
+<Tooltip
+  className="usm-disabled-message-tooltip"
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isDisabled={false}
+  position="top-right"
+  text={
+    <FormattedMessage
+      defaultMessage="You do not have permission to create the link."
+      id="boxui.unifiedShare.disabledCreateLinkTooltip"
+    />
+  }
+  theme="default"
+>
   <div
-    className="shared-link-toggle-row"
+    className="share-toggle-container"
   >
-    <Tooltip
-      constrainToScrollParent={false}
-      constrainToWindow={true}
-      isDisabled={false}
-      position="top-right"
-      text={
+    <Toggle
+      isDisabled={true}
+      isOn={false}
+      label={
         <FormattedMessage
-          defaultMessage="You do not have permission to create the link."
-          id="boxui.unifiedShare.disabledCreateLinkTooltip"
+          defaultMessage="Enable shared link"
+          id="boxui.unifiedShare.linkShareOff"
         />
       }
-      theme="default"
-    >
-      <div
-        className="share-toggle-container"
-      >
-        <Toggle
-          isDisabled={true}
-          isOn={false}
-          label={
-            <FormattedMessage
-              defaultMessage="Enable shared link"
-              id="boxui.unifiedShare.linkShareOff"
-            />
-          }
-          name="toggle"
-        />
-      </div>
-    </Tooltip>
+      name="toggle"
+    />
   </div>
-</div>
+</Tooltip>
 `;
 
-exports[`features/unified-share-modal/SharedLinkSection should render disabled remove share link message 1`] = `
-<div>
-  <hr />
-  <label>
-    <span
-      className="label bdl-Label"
-    >
-      <FormattedMessage
-        defaultMessage="Share Link"
-        id="boxui.unifiedShare.sharedLinkSectionLabel"
-      />
-    </span>
-  </label>
-  <div
-    className="shared-link-toggle-row"
-  >
-    <Tooltip
-      constrainToScrollParent={false}
-      constrainToWindow={true}
-      isDisabled={false}
-      position="top-right"
-      text={
-        <FormattedMessage
-          defaultMessage="You do not have permission to remove the link."
-          id="boxui.unifiedShare.removeLinkTooltip"
-        />
-      }
-      theme="default"
-    >
-      <div
-        className="share-toggle-container"
-      >
-        <Toggle
-          isDisabled={true}
-          isOn={true}
-          label={
-            <FormattedMessage
-              defaultMessage="Shared link is enabled"
-              id="boxui.unifiedShare.linkShareOn"
-            />
-          }
-          name="toggle"
-        />
-      </div>
-    </Tooltip>
-  </div>
-  <div
-    className="shared-link-field-row"
-  >
-    <Tooltip
-      className="usm-ftux-tooltip"
-      constrainToScrollParent={false}
-      constrainToWindow={true}
-      isDisabled={false}
-      isShown={false}
-      onDismiss={[Function]}
-      position="middle-right"
-      showCloseButton={true}
-      theme="callout"
-    >
-      <TextInputWithCopyButton
-        autofocus={false}
-        buttonDefaultText={
-          <FormattedMessage
-            defaultMessage="Copy"
-            id="boxui.core.copy"
-          />
-        }
-        buttonProps={Object {}}
-        buttonSuccessText={
-          <FormattedMessage
-            defaultMessage="Copied"
-            id="boxui.core.copied"
-          />
-        }
-        className="shared-link-field-container"
-        hideOptionalLabel={true}
-        label=""
-        readOnly={true}
-        successStateDuration={3000}
-        type="url"
-        value="https://example.com/shared-link"
-      />
-    </Tooltip>
-    <Tooltip
-      constrainToScrollParent={false}
-      constrainToWindow={true}
-      isDisabled={false}
-      position="top-left"
-      text={
-        <FormattedMessage
-          defaultMessage="Send Shared Link"
-          id="boxui.unifiedShare.sendSharedLink"
-        />
-      }
-      theme="default"
-    >
-      <Button
-        className="email-shared-link-btn"
-        isLoading={false}
-        showRadar={false}
-        type="button"
-      >
-        <IconMail />
-      </Button>
-    </Tooltip>
-  </div>
-  <div
-    className="shared-link-access-row"
-  >
-    <SharedLinkAccessMenu
-      accessLevelsDisabledReason={Object {}}
-      allowedAccessLevels={Object {}}
-      changeAccessLevel={[Function]}
-      itemType="file"
-      onDismissTooltip={[Function]}
-      tooltipContent={null}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkAccessLevel": undefined,
-          "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
-        }
-      }
+exports[`features/unified-share-modal/SharedLinkSection should render disabled remove shared link message when url is not empty and canChangeAccessLevel is false 1`] = `
+<Tooltip
+  className="usm-disabled-message-tooltip"
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isDisabled={false}
+  position="top-right"
+  text={
+    <FormattedMessage
+      defaultMessage="You do not have permission to remove the link."
+      id="boxui.unifiedShare.removeLinkTooltip"
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={Array []}
-      canChangePermissionLevel={false}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
-        }
+  }
+  theme="default"
+>
+  <div
+    className="share-toggle-container"
+  >
+    <Toggle
+      isDisabled={true}
+      isOn={true}
+      label={
+        <FormattedMessage
+          defaultMessage="Shared link is enabled"
+          id="boxui.unifiedShare.linkShareOn"
+        />
       }
+      name="toggle"
     />
   </div>
-</div>
+</Tooltip>
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render proper dropdown override when viewing an editable box note 1`] = `
@@ -724,6 +602,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
     className="shared-link-toggle-row"
   >
     <Tooltip
+      className="usm-disabled-message-tooltip"
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -165,6 +165,11 @@ const messages = defineMessages({
         description: 'Tooltip description for not having access to remove link',
         id: 'boxui.unifiedShare.removeLinkTooltip',
     },
+    disabledCreateLinkTooltip: {
+        defaultMessage: 'You do not have permission to create the link.',
+        description: 'Tooltip description for not having access to create link',
+        id: 'boxui.unifiedShare.disabledCreateLinkTooltip',
+    },
     sendSharedLink: {
         defaultMessage: 'Send Shared Link',
         description: 'Label for text input to enter email addresses to send Shared Link to',

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -167,7 +167,7 @@ const messages = defineMessages({
     },
     disabledCreateLinkTooltip: {
         defaultMessage: 'You do not have permission to create the link.',
-        description: 'Tooltip description for not having access to create link',
+        description: 'Tooltip description for users who do not have permission for link creation',
         id: 'boxui.unifiedShare.disabledCreateLinkTooltip',
     },
     sendSharedLink: {


### PR DESCRIPTION
Problem:

The current shared link toggle shows the wrong message when it's
disabled for creation

Fix:

Add new condition to show the create disable message