### PR TITLE
feat(uploads): add conflictCallback option

### DIFF
--- a/src/api/uploads/BaseUpload.js
+++ b/src/api/uploads/BaseUpload.js
@@ -24,6 +24,8 @@ class BaseUpload extends Base {
 
     overwrite: boolean;
 
+    conflictCallback: ?(fileName: string) => string;
+
     preflightSuccessHandler: Function;
 
     retryCount: number = 0;
@@ -88,22 +90,23 @@ class BaseUpload extends Base {
             // Automatically handle name conflict errors
         } else if (errorData && errorData.status === 409) {
             if (this.overwrite) {
+                // Error response contains file ID to upload a new file version for
                 const conflictFileId = errorData.context_info.conflicts.id;
                 if (!this.fileId && !!conflictFileId) {
                     this.fileId = conflictFileId;
                 }
-
-                // Error response contains file ID to upload a new file version for
-                this.makePreflightRequest();
+            } else if (this.conflictCallback) {
+                // conflictCallback handler for setting new file name
+                this.fileName = this.conflictCallback(this.fileName);
             } else {
                 // Otherwise, reupload and append timestamp
                 // 'test.jpg' becomes 'test-TIMESTAMP.jpg'
                 const extension = this.fileName.substr(this.fileName.lastIndexOf('.')) || '';
                 this.fileName = `${this.fileName.substr(0, this.fileName.lastIndexOf('.'))}-${Date.now()}${extension}`;
-                this.makePreflightRequest();
             }
-
+            this.makePreflightRequest();
             this.retryCount += 1;
+
             // When rate limited, retry after interval defined in header
         } else if (errorData && (errorData.status === 429 || errorData.code === 'too_many_requests')) {
             let retryAfterMs = DEFAULT_RETRY_DELAY_MS;

--- a/src/api/uploads/PlainUpload.js
+++ b/src/api/uploads/PlainUpload.js
@@ -115,6 +115,7 @@ class PlainUpload extends BaseUpload {
      * @param {Function} [options.successCallback] - Function to call with response
      * @param {Function} [options.errorCallback] - Function to call with errors
      * @param {Function} [options.progressCallback] - Function to call with progress
+     * @param {Function} [options.conflictCallback] - Function to call on conflicting file names
      * @param {boolean} [overwrite] - Should upload overwrite file with same name
      * @return {void}
      */
@@ -126,8 +127,10 @@ class PlainUpload extends BaseUpload {
         successCallback = noop,
         errorCallback = noop,
         progressCallback = noop,
+        conflictCallback,
         overwrite = true,
     }: {
+        conflictCallback?: Function,
         errorCallback: Function,
         file: File,
         fileDescription: ?string,
@@ -151,6 +154,7 @@ class PlainUpload extends BaseUpload {
         this.errorCallback = errorCallback;
         this.progressCallback = progressCallback;
         this.overwrite = overwrite;
+        this.conflictCallback = conflictCallback;
 
         this.makePreflightRequest();
     }

--- a/src/api/uploads/__tests__/BaseUpload.test.js
+++ b/src/api/uploads/__tests__/BaseUpload.test.js
@@ -119,7 +119,27 @@ describe('api/uploads/BaseUpload', () => {
             expect(upload.makePreflightRequest).toHaveBeenCalled();
         });
 
-        test('should append timestamp and re-upload on 409 if overwrite property is false', () => {
+        test('should call callback on file on 409 if overwrite property is false and conflictCallback exists', () => {
+            upload.fileId = '123';
+            upload.overwrite = false;
+            upload.makePreflightRequest = jest.fn();
+            upload.conflictCallback = jest.fn().mockImplementation(name => `${name}_CONFLICT`);
+
+            upload.preflightErrorHandler({
+                status: 409,
+                context_info: {
+                    conflicts: {
+                        id: upload.fileId,
+                    },
+                },
+            });
+
+            expect(upload.makePreflightRequest).toHaveBeenCalled();
+            expect(upload.conflictCallback).toHaveBeenCalled();
+            expect(upload.fileName).toEqual('foo_CONFLICT');
+        });
+
+        test('should append timestamp and re-upload on 409 if overwrite property is false and no conflictCallback', () => {
             upload.file.name = 'foo.bar';
             upload.overwrite = false;
             Date.now = jest.fn().mockReturnValueOnce('1969-07-16');

--- a/src/api/uploads/__tests__/MultiputUpload.test.js
+++ b/src/api/uploads/__tests__/MultiputUpload.test.js
@@ -459,6 +459,52 @@ describe('api/uploads/MultiputUpload', () => {
                 JSON.stringify(error),
             );
         });
+
+        describe('resolveConflict', () => {
+            test('should overwrite if overwrite is set to true and has context_info', async () => {
+                const data = { status: 409, context_info: { conflicts: { id: '30' } } };
+                const error = {
+                    response: {
+                        data,
+                    },
+                };
+
+                multiputUploadTest.getErrorResponse = jest.fn().mockReturnValueOnce(data);
+                multiputUploadTest.sessionErrorHandler = jest.fn();
+                multiputUploadTest.xhr.post = jest.fn().mockReturnValueOnce(Promise.reject(error));
+                multiputUploadTest.getBaseUploadUrlFromPreflightResponse = jest.fn().mockReturnValueOnce(uploadHost);
+                multiputUploadTest.overwrite = true;
+                multiputUploadTest.conflictCallback = jest.fn();
+                multiputUploadTest.createSessionRetry = jest.fn();
+
+                await multiputUploadTest.preflightSuccessHandler(preflightResponse);
+
+                expect(multiputUploadTest.sessionErrorHandler).not.toHaveBeenCalled();
+                expect(multiputUploadTest.conflictCallback).not.toHaveBeenCalled();
+                expect(multiputUploadTest.createSessionRetry).toHaveBeenCalled();
+            });
+            test('should invoke conflictCallback if exists', async () => {
+                const data = { status: 409 };
+                const error = {
+                    response: {
+                        data,
+                    },
+                };
+
+                multiputUploadTest.getErrorResponse = jest.fn().mockReturnValueOnce(data);
+                multiputUploadTest.sessionErrorHandler = jest.fn();
+                multiputUploadTest.xhr.post = jest.fn().mockReturnValueOnce(Promise.reject(error));
+                multiputUploadTest.getBaseUploadUrlFromPreflightResponse = jest.fn().mockReturnValueOnce(uploadHost);
+                multiputUploadTest.conflictCallback = jest.fn();
+                multiputUploadTest.createSessionRetry = jest.fn();
+
+                await multiputUploadTest.preflightSuccessHandler(preflightResponse);
+
+                expect(multiputUploadTest.sessionErrorHandler).not.toHaveBeenCalled();
+                expect(multiputUploadTest.conflictCallback).toHaveBeenCalled();
+                expect(multiputUploadTest.createSessionRetry).toHaveBeenCalled();
+            });
+        });
     });
 
     describe('getSessionSuccessHandler()', () => {

--- a/src/api/uploads/__tests__/PlainUpload.test.js
+++ b/src/api/uploads/__tests__/PlainUpload.test.js
@@ -245,6 +245,7 @@ describe('api/uploads/PlainUpload', () => {
             const errorCallback = () => {};
             const progressCallback = () => {};
             const overwrite = true;
+            const conflictCallback = () => {};
 
             upload.isDestroyed = jest.fn().mockReturnValueOnce(false);
             upload.makePreflightRequest = jest.fn();
@@ -256,6 +257,7 @@ describe('api/uploads/PlainUpload', () => {
                 errorCallback,
                 progressCallback,
                 overwrite,
+                conflictCallback,
             });
 
             expect(upload.folderId).toBe(folderId);
@@ -265,6 +267,7 @@ describe('api/uploads/PlainUpload', () => {
             expect(upload.errorCallback).toBe(errorCallback);
             expect(upload.progressCallback).toBe(progressCallback);
             expect(upload.overwrite).toBe(overwrite);
+            expect(upload.conflictCallback).toBe(conflictCallback);
         });
     });
 


### PR DESCRIPTION
allows for an additional callback to be called on 409 where the client can specify how they want to rename the file they are trying to upload