### PR TITLE
build(node): update node version to min for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         }
     },
     "engines": {
-        "node": ">=10.x",
+        "node": ">=12.x",
         "yarn": ">=1.10.0"
     },
     "devDependencies": {


### PR DESCRIPTION
- this will warn devs if their node version is out of date
- the .nvmrc has pointed to 12 for 3 months
- CI runs on Node 12
- the test suite depends on Intl & ICU data which is available in Node 12 without polyfilling