### PR TITLE
feat(content-sidebar): Support multifile tasks

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -186,6 +186,8 @@ be.contentSidebar.activityFeed.taskNew.tasksFeedStatusApproved = Approved {dateT
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusCompleted = Completed {dateTime}
 # Rejected task status, where dateTime is a readable time like "Today at 2pm"
 be.contentSidebar.activityFeed.taskNew.tasksFeedStatusRejected = Rejected {dateTime}
+# View the details for a task
+be.contentSidebar.activityFeed.taskNew.tasksFeedViewDetailsAction = View Task Details
 # label for button that opens task popup
 be.contentSidebar.addTask = Add Task
 # label for menu item that opens approval task popup

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -55,6 +55,7 @@ type ExternalProps = {
     onTaskCreate: Function,
     onTaskDelete: (id: string) => any,
     onTaskUpdate: () => any,
+    onTaskView: (id: string, isCreator: boolean) => any,
 } & ErrorContextProps;
 
 type PropsWithoutContext = {
@@ -591,6 +592,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             getUserProfileUrl,
             activeFeedEntryId,
             activeFeedEntryType,
+            onTaskView,
         } = this.props;
         const {
             currentUser,
@@ -623,6 +625,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     onTaskCreate={this.createTask}
                     onTaskDelete={this.deleteTask}
                     onTaskUpdate={this.updateTask}
+                    onTaskView={onTaskView}
                     onTaskModalClose={this.onTaskModalClose}
                     onTaskAssignmentUpdate={this.updateTaskAssignment}
                     getApproverWithQuery={this.getApproverWithQuery}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -34,6 +34,7 @@ type Props = {
     onTaskDelete?: Function,
     onTaskEdit?: Function,
     onTaskModalClose?: Function,
+    onTaskView?: Function,
     onVersionInfo?: Function,
     translations?: Translations,
 };
@@ -52,6 +53,7 @@ const ActiveState = ({
     onCommentEdit,
     onTaskDelete,
     onTaskEdit,
+    onTaskView,
     onTaskAssignmentUpdate,
     onTaskModalClose,
     onVersionInfo,
@@ -112,6 +114,7 @@ const ActiveState = ({
                                     onAssignmentUpdate={onTaskAssignmentUpdate}
                                     onDelete={onTaskDelete}
                                     onEdit={onTaskEdit}
+                                    onView={onTaskView}
                                     onModalClose={onTaskModalClose}
                                     translations={translations}
                                 />

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -45,6 +45,7 @@ type Props = {
     onTaskDelete?: Function,
     onTaskModalClose?: Function,
     onTaskUpdate?: Function,
+    onTaskView?: Function,
     onVersionHistoryClick?: Function,
     translations?: Translations,
 };
@@ -203,6 +204,7 @@ class ActivityFeed extends React.Component<Props, State> {
             onCommentUpdate,
             onTaskDelete,
             onTaskUpdate,
+            onTaskView,
             onTaskAssignmentUpdate,
             onTaskModalClose,
             feedItems,
@@ -259,6 +261,7 @@ class ActivityFeed extends React.Component<Props, State> {
                             onCommentEdit={hasCommentPermission ? onCommentUpdate : noop}
                             onTaskDelete={onTaskDelete}
                             onTaskEdit={onTaskUpdate}
+                            onTaskView={onTaskView}
                             onTaskModalClose={onTaskModalClose}
                             onVersionInfo={onVersionHistoryClick ? this.openVersionHistoryPopup : null}
                             translations={translations}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
@@ -31,7 +31,7 @@ const taskWithAssignment = {
     type: 'task',
     id: 't_345',
     created_at: '2018-07-03T14:43:52-07:00',
-    created_by: otherUser,
+    created_by: { target: otherUser },
     modified_at: '2018-07-03T14:43:52-07:00',
     description: 'test',
     due_at: '2018-07-03T14:43:52-07:00',

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
@@ -123,8 +123,10 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
       created_at="2018-07-03T14:43:52-07:00"
       created_by={
         Object {
-          "id": 11,
-          "name": "Akon",
+          "target": Object {
+            "id": 11,
+            "name": "Akon",
+          },
         }
       }
       currentUser={

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.js
@@ -9,8 +9,6 @@ import TetherComponent from 'react-tether';
 import { withFeatureConsumer, getFeatureConfig } from '../../../common/feature-checking';
 import { withAPIContext } from '../../../common/api-context';
 import Avatar from '../Avatar';
-// $FlowFixMe LabelPill is in typescript
-import LabelPill from '../../../../components/label-pill';
 import Media from '../../../../components/media';
 import { MenuItem } from '../../../../components/menu';
 import ActivityError from '../common/activity-error';
@@ -21,7 +19,6 @@ import IconTaskApproval from '../../../../icons/two-toned/IconTaskApproval';
 import IconTaskGeneral from '../../../../icons/two-toned/IconTaskGeneral';
 import IconTrash from '../../../../icons/general/IconTrash';
 import IconPencil from '../../../../icons/general/IconPencil';
-import MoveCopy16 from '../../../../icon/line/MoveCopy16';
 import UserLink from '../common/user-link';
 import API from '../../../../api/APIFactory';
 import {
@@ -44,6 +41,7 @@ import TaskDueDate from './TaskDueDate';
 import TaskStatus from './TaskStatus';
 import AssigneeList from './AssigneeList';
 import TaskModal from '../../TaskModal';
+import TaskMultiFileIcon from './TaskMultiFileIcon';
 import commonMessages from '../../../common/messages';
 import messages from './messages';
 import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
@@ -54,7 +52,6 @@ import type { Translations } from '../../flowTypes';
 import type { FeatureConfig } from '../../../common/feature-checking';
 
 import './Task.scss';
-import PrimaryButton from '../../../../components/primary-button';
 
 type Props = {|
     ...TaskNew,
@@ -338,11 +335,7 @@ class Task extends React.Component<Props, State> {
                         </div>
                         <div className="bcs-Task-status">
                             <TaskStatus status={status} />
-                            {isMultiFile && (
-                                <LabelPill.Pill data-testid="multifile-badge">
-                                    <LabelPill.Icon Component={MoveCopy16} />
-                                </LabelPill.Pill>
-                            )}
+                            <TaskMultiFileIcon isMultiFile={isMultiFile} />
                             <TaskCompletionRuleIcon completionRule={completion_rule} />
                         </div>
                         <div className="bcs-Task-dueDate">
@@ -369,52 +362,37 @@ class Task extends React.Component<Props, State> {
                             />
                         </div>
                         {shouldShowActions && (
-                            <div className="bcs-Task-actionsContainer">
-                                {isMultiFile
-                                    ? onView && (
-                                          <PrimaryButton
-                                              onClick={() => onView(id, isCreator)}
-                                              data-testid="view-details-button"
-                                          >
-                                              <FormattedMessage {...messages.tasksFeedViewDetailsAction} />
-                                          </PrimaryButton>
-                                      )
-                                    : currentUserAssignment && (
-                                          <TaskActions
-                                              taskType={task_type}
-                                              onTaskApproval={
-                                                  isPending
-                                                      ? noop
-                                                      : () => {
-                                                            this.handleTaskAction(
-                                                                id,
-                                                                currentUserAssignment.id,
-                                                                TASK_NEW_APPROVED,
-                                                            );
-                                                        }
-                                              }
-                                              onTaskReject={
-                                                  isPending
-                                                      ? noop
-                                                      : () =>
-                                                            this.handleTaskAction(
-                                                                id,
-                                                                currentUserAssignment.id,
-                                                                TASK_NEW_REJECTED,
-                                                            )
-                                              }
-                                              onTaskComplete={
-                                                  isPending
-                                                      ? noop
-                                                      : () =>
-                                                            this.handleTaskAction(
-                                                                id,
-                                                                currentUserAssignment.id,
-                                                                TASK_NEW_COMPLETED,
-                                                            )
-                                              }
-                                          />
-                                      )}
+                            <div className="bcs-Task-actionsContainer" data-testid="action-container">
+                                <TaskActions
+                                    isMultiFile={isMultiFile}
+                                    taskType={task_type}
+                                    onTaskApproval={
+                                        isPending
+                                            ? noop
+                                            : () =>
+                                                  // $FlowFixMe checked by shouldShowActions
+                                                  this.handleTaskAction(id, currentUserAssignment.id, TASK_NEW_APPROVED)
+                                    }
+                                    onTaskReject={
+                                        isPending
+                                            ? noop
+                                            : () =>
+                                                  // $FlowFixMe checked by shouldShowActions
+                                                  this.handleTaskAction(id, currentUserAssignment.id, TASK_NEW_REJECTED)
+                                    }
+                                    onTaskComplete={
+                                        isPending
+                                            ? noop
+                                            : () =>
+                                                  this.handleTaskAction(
+                                                      id,
+                                                      // $FlowFixMe checked by shouldShowActions
+                                                      currentUserAssignment.id,
+                                                      TASK_NEW_COMPLETED,
+                                                  )
+                                    }
+                                    onTaskView={onView && (() => onView(id, isCreator))}
+                                />
                             </div>
                         )}
                     </Media.Body>

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -1,8 +1,7 @@
 @import '../../../common/variables';
 @import './mixins';
 
-$bcs-task-grid: 4px;
-$bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
+$bcs-task-left-offset: 10 * $bdl-grid-unit + 2px;
 
 .bcs-Task-media {
     opacity: 1;
@@ -38,24 +37,24 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
 }
 
 .bcs-Task-status {
-    margin-top: 3 * $bcs-task-grid;
-    margin-bottom: 2 * $bcs-task-grid;
+    margin-top: 3 * $bdl-grid-unit;
+    margin-bottom: 2 * $bdl-grid-unit;
 
     & > * {
-        margin-right: 4px;
+        margin-right: $bdl-grid-unit;
     }
 }
 
 .bcs-Task-dueDate {
-    margin-bottom: 3 * $bcs-task-grid;
+    margin-bottom: 3 * $bdl-grid-unit;
 }
 
 .bcs-Task-assigneeListContainer {
-    margin-top: $bcs-task-grid;
+    margin-top: $bdl-grid-unit;
 }
 
 .bcs-Task-actionsContainer {
-    margin-top: 5 * $bcs-task-grid;
+    margin-top: 5 * $bdl-grid-unit;
 }
 
 // tethered styles for delete confirmation modal

--- a/src/elements/content-sidebar/activity-feed/task-new/Task.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/Task.scss
@@ -40,6 +40,10 @@ $bcs-task-left-offset: 10 * $bcs-task-grid + 2px;
 .bcs-Task-status {
     margin-top: 3 * $bcs-task-grid;
     margin-bottom: 2 * $bcs-task-grid;
+
+    & > * {
+        margin-right: 4px;
+    }
 }
 
 .bcs-Task-dueDate {

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskActions.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskActions.js
@@ -12,15 +12,30 @@ import type { TaskType } from '../../../../common/types/tasks';
 import './TaskActions.scss';
 
 type Props = {|
+    isMultiFile: boolean,
     onTaskApproval: Function,
     onTaskComplete: Function,
     onTaskReject: Function,
+    onTaskView: Function,
     taskType: TaskType,
 |};
 
-const TaskActions = ({ onTaskApproval, onTaskReject, onTaskComplete, taskType }: Props): React.Node => {
+const TaskActions = ({
+    isMultiFile,
+    onTaskApproval,
+    onTaskReject,
+    onTaskComplete,
+    onTaskView,
+    taskType,
+}: Props): React.Node => {
     let action = null;
-    if (taskType === TASK_TYPE_APPROVAL) {
+    if (isMultiFile) {
+        action = onTaskView && (
+            <PrimaryButton className="bcs-TaskActions-button" data-testid="view-task" onClick={onTaskView}>
+                <FormattedMessage {...messages.tasksFeedViewDetailsAction} />
+            </PrimaryButton>
+        );
+    } else if (taskType === TASK_TYPE_APPROVAL) {
         action = (
             <>
                 <Button

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskCompletionRuleIcon.scss
@@ -1,7 +1,3 @@
-.bcs-TaskCompletionRuleIcon {
-    margin-left: 4px;
-}
-
 .bcs-TaskCompletionRuleIcon-oneSize {
     margin-left: 0;
     font-weight: normal;

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskMultiFileIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskMultiFileIcon.js
@@ -1,7 +1,10 @@
 // @flow
 import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+import messages from './messages';
 // $FlowFixMe LabelPill is in typescript
 import LabelPill from '../../../../components/label-pill';
+import Tooltip from '../../../../components/tooltip';
 import MoveCopy16 from '../../../../icon/line/MoveCopy16';
 
 type Props = {|
@@ -11,9 +14,11 @@ type Props = {|
 const TaskMultiFileIcon = ({ isMultiFile }: Props): React.Node => {
     return (
         isMultiFile && (
-            <LabelPill.Pill data-testid="multifile-badge">
-                <LabelPill.Icon Component={MoveCopy16} />
-            </LabelPill.Pill>
+            <Tooltip position="top-center" text={<FormattedMessage {...messages.taskMultipleFilesAffordanceTooltip} />}>
+                <LabelPill.Pill data-testid="multifile-badge">
+                    <LabelPill.Icon Component={MoveCopy16} />
+                </LabelPill.Pill>
+            </Tooltip>
         )
     );
 };

--- a/src/elements/content-sidebar/activity-feed/task-new/TaskMultiFileIcon.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/TaskMultiFileIcon.js
@@ -1,0 +1,21 @@
+// @flow
+import * as React from 'react';
+// $FlowFixMe LabelPill is in typescript
+import LabelPill from '../../../../components/label-pill';
+import MoveCopy16 from '../../../../icon/line/MoveCopy16';
+
+type Props = {|
+    isMultiFile: boolean,
+|};
+
+const TaskMultiFileIcon = ({ isMultiFile }: Props): React.Node => {
+    return (
+        isMultiFile && (
+            <LabelPill.Pill data-testid="multifile-badge">
+                <LabelPill.Icon Component={MoveCopy16} />
+            </LabelPill.Pill>
+        )
+    );
+};
+
+export default TaskMultiFileIcon;

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { TaskComponent as Task } from '..';
 
@@ -18,7 +19,8 @@ const approverSelectorContacts = [];
 describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
     const currentUser = { name: 'Jake Thomas', id: '1', type: 'user' };
     const otherUser = { name: 'Patrick Paul', id: '3', type: 'user' };
-
+    const creatorUser = { name: 'Steven Yang', id: '5', type: 'user' };
+    const taskId = '123125';
     const task = {
         assigned_to: {
             entries: [
@@ -50,9 +52,9 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
         },
         completion_rule: 'ALL_ASSIGNEES',
         created_at: '2010-01-01',
-        created_by: { id: '0', target: currentUser, role: 'CREATOR', status: 'NOT_STARTED', type: 'task_collaborator' },
+        created_by: { id: '0', target: creatorUser, role: 'CREATOR', status: 'NOT_STARTED', type: 'task_collaborator' },
         due_at: null,
-        id: '123125',
+        id: taskId,
         description: 'This is where we tell each other what we need to do',
         status: 'NOT_STARTED',
         permissions: {
@@ -62,13 +64,46 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
             can_create_task_link: true,
         },
         task_links: {
-            entries: [],
+            entries: [
+                {
+                    type: 'task_link',
+                    id: '6231775',
+                    task: { id: taskId, type: 'task', due_at: null },
+                    target: {
+                        type: 'file',
+                        id: '7895970959',
+                        sequence_id: '1',
+                        etag: '1',
+                        sha1: '6cdf9453724469d11469d4f7c2f21dcb828073d5',
+                        name: 'file1.csv',
+                    },
+                    description: '',
+                    permissions: { can_update: true, can_delete: true },
+                },
+            ],
             limit: 1000,
             next_marker: null,
         },
         task_type: 'GENERAL',
         type: 'task',
     };
+
+    const taskMultifile = cloneDeep(task);
+    taskMultifile.task_links.entries.push({
+        type: 'task_link',
+        id: taskId,
+        task: { id: '16431755', type: 'task', due_at: null },
+        target: {
+            type: 'file',
+            id: '7895975164',
+            sequence_id: '1',
+            etag: '1',
+            sha1: 'b02ef8e024b1e654d050733c5bb12e6c83a5586c',
+            name: 'skynet-file2.csv',
+        },
+        description: '',
+        permissions: { can_update: true, can_delete: true },
+    });
 
     test('should correctly render task', () => {
         const wrapper = shallow(<Task currentUser={currentUser} onEdit={jest.fn()} onDelete={jest.fn()} {...task} />);
@@ -78,6 +113,11 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
     test('should show assignment status badges for each assignee', () => {
         const wrapper = mount(<Task currentUser={currentUser} onEdit={jest.fn()} onDelete={jest.fn()} {...task} />);
         expect(wrapper.find('[data-testid="avatar-group-avatar-container"]')).toHaveLength(2);
+    });
+
+    test('should show multifile badge if task has multiple files', () => {
+        const wrapper = shallow(<Task currentUser={currentUser} {...taskMultifile} />);
+        expect(wrapper.find('[data-testid="multifile-badge"]')).toHaveLength(1);
     });
 
     test('should not show due date container if not set', () => {
@@ -138,38 +178,50 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
     });
 
     test('should show actions when current user is assigned and task is incomplete', () => {
-        const wrapper = shallow(
-            <Task currentUser={currentUser} {...task} isPending={false} onAssignmentUpdate={jest.fn()} />,
-        );
-
-        expect(wrapper.find('TaskActions')).toHaveLength(1);
+        [task, taskMultifile].forEach(eachTask => {
+            const wrapper = shallow(
+                <Task currentUser={currentUser} {...eachTask} isPending={false} onAssignmentUpdate={jest.fn()} />,
+            );
+            expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(1);
+        });
     });
 
     test('should not show actions when current user is assigned and task is complete', () => {
-        const wrapper = shallow(
-            <Task
-                currentUser={currentUser}
-                {...task}
-                isPending={false}
-                onAssignmentUpdate={jest.fn()}
-                status="COMPLETED"
-            />,
-        );
-
-        expect(wrapper.find('TaskActions')).toHaveLength(0);
+        [task, taskMultifile].forEach(eachTask => {
+            const wrapper = shallow(
+                <Task
+                    currentUser={currentUser}
+                    {...eachTask}
+                    isPending={false}
+                    onAssignmentUpdate={jest.fn()}
+                    status="COMPLETED"
+                />,
+            );
+            expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(0);
+        });
     });
 
     test('should not show actions when current user is not assigned', () => {
-        const wrapper = shallow(
-            <Task
-                currentUser={{ ...currentUser, id: 'something-else-1' }}
-                {...task}
-                isPending={false}
-                onAssignmentUpdate={jest.fn()}
-            />,
-        );
+        [task, taskMultifile].forEach(eachTask => {
+            const wrapper = shallow(
+                <Task
+                    currentUser={{ ...currentUser, id: 'something-else-1' }}
+                    {...eachTask}
+                    isPending={false}
+                    onAssignmentUpdate={jest.fn()}
+                />,
+            );
+            expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(0);
+        });
+    });
 
-        expect(wrapper.find('TaskActions')).toHaveLength(0);
+    test.each`
+        eachTask         | expected
+        ${task}          | ${0}
+        ${taskMultifile} | ${1}
+    `('should show action for creator of task when task is multifile : $testcase', ({ eachTask, expected }) => {
+        const wrapper = shallow(<Task {...eachTask} currentUser={creatorUser} />);
+        expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(expected);
     });
 
     test('should show actions for task type', () => {
@@ -206,7 +258,19 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
         const checkButton = wrapper.find('[data-testid="complete-task"]').hostNodes();
         checkButton.simulate('click');
 
-        expect(onAssignmentUpdateSpy).toHaveBeenCalledWith('123125', 'current-user-assignment-id', 'COMPLETED');
+        expect(onAssignmentUpdateSpy).toHaveBeenCalledWith(taskId, 'current-user-assignment-id', 'COMPLETED');
+    });
+
+    test('should call onView when view-task-details button is clicked for multifile task', () => {
+        const onViewSpy = jest.fn();
+        const wrapper = shallow(<Task {...taskMultifile} currentUser={currentUser} onView={onViewSpy} />);
+        wrapper.find('[data-testid="view-details-button"]').simulate('click');
+        expect(onViewSpy).toHaveBeenCalledWith(taskId, false);
+    });
+
+    test('should not show view-task-details button for multifile task when onView callback is undefined', () => {
+        const wrapper = shallow(<Task {...taskMultifile} currentUser={currentUser} />);
+        expect(wrapper.find('[data-testid="view-details-button"]')).toHaveLength(0);
     });
 
     test('should not allow user to delete if the task permissions do not allow it', () => {

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/Task.test.js
@@ -116,8 +116,13 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
     });
 
     test('should show multifile badge if task has multiple files', () => {
-        const wrapper = shallow(<Task currentUser={currentUser} {...taskMultifile} />);
-        expect(wrapper.find('[data-testid="multifile-badge"]')).toHaveLength(1);
+        const wrapper = mount(<Task currentUser={currentUser} {...taskMultifile} />);
+        expect(wrapper.find('[data-testid="multifile-badge"]').hostNodes()).toHaveLength(1);
+    });
+
+    test('should not show multifile badge if task does not have multiple files', () => {
+        const wrapper = mount(<Task currentUser={currentUser} {...task} />);
+        expect(wrapper.find('[data-testid="multifile-badge"]').hostNodes()).toHaveLength(0);
     });
 
     test('should not show due date container if not set', () => {
@@ -182,7 +187,7 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
             const wrapper = shallow(
                 <Task currentUser={currentUser} {...eachTask} isPending={false} onAssignmentUpdate={jest.fn()} />,
             );
-            expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(1);
+            expect(wrapper.find('TaskActions')).toHaveLength(1);
         });
     });
 
@@ -197,7 +202,7 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
                     status="COMPLETED"
                 />,
             );
-            expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(0);
+            expect(wrapper.find('TaskActions')).toHaveLength(0);
         });
     });
 
@@ -211,7 +216,7 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
                     onAssignmentUpdate={jest.fn()}
                 />,
             );
-            expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(0);
+            expect(wrapper.find('TaskActions')).toHaveLength(0);
         });
     });
 
@@ -219,9 +224,9 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
         eachTask         | expected
         ${task}          | ${0}
         ${taskMultifile} | ${1}
-    `('should show action for creator of task when task is multifile : $testcase', ({ eachTask, expected }) => {
+    `('should show action for creator of task when task is multifile', ({ eachTask, expected }) => {
         const wrapper = shallow(<Task {...eachTask} currentUser={creatorUser} />);
-        expect(wrapper.find('.bcs-Task-actionsContainer')).toHaveLength(expected);
+        expect(wrapper.find('[data-testid="action-container"]')).toHaveLength(expected);
     });
 
     test('should show actions for task type', () => {
@@ -263,14 +268,17 @@ describe('elements/content-sidebar/ActivityFeed/task-new/Task', () => {
 
     test('should call onView when view-task-details button is clicked for multifile task', () => {
         const onViewSpy = jest.fn();
-        const wrapper = shallow(<Task {...taskMultifile} currentUser={currentUser} onView={onViewSpy} />);
-        wrapper.find('[data-testid="view-details-button"]').simulate('click');
+        const wrapper = mount(<Task {...taskMultifile} currentUser={currentUser} onView={onViewSpy} />);
+        wrapper
+            .find('[data-testid="view-task"]')
+            .hostNodes()
+            .simulate('click');
         expect(onViewSpy).toHaveBeenCalledWith(taskId, false);
     });
 
     test('should not show view-task-details button for multifile task when onView callback is undefined', () => {
-        const wrapper = shallow(<Task {...taskMultifile} currentUser={currentUser} />);
-        expect(wrapper.find('[data-testid="view-details-button"]')).toHaveLength(0);
+        const wrapper = mount(<Task {...taskMultifile} currentUser={currentUser} />);
+        expect(wrapper.find('[data-testid="view-task"]').hostNodes()).toHaveLength(0);
     });
 
     test('should not allow user to delete if the task permissions do not allow it', () => {

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
@@ -16,8 +16,8 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
       <Avatar
         user={
           Object {
-            "id": "1",
-            "name": "Jake Thomas",
+            "id": "5",
+            "name": "Steven Yang",
             "type": "user",
           }
         }
@@ -87,8 +87,8 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
       >
         <UserLink
           data-resin-target="activityfeed-profilelink"
-          id="1"
-          name="Jake Thomas"
+          id="5"
+          name="Steven Yang"
           type="user"
         />
       </div>

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/Task.test.js.snap
@@ -103,6 +103,9 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
         <Memo()
           status="NOT_STARTED"
         />
+        <TaskMultiFileIcon
+          isMultiFile={false}
+        />
         <TaskCompletionRuleIcon
           completionRule="ALL_ASSIGNEES"
         />
@@ -168,8 +171,10 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/Task should correctly re
       </div>
       <div
         className="bcs-Task-actionsContainer"
+        data-testid="action-container"
       >
         <TaskActions
+          isMultiFile={false}
           onTaskApproval={[Function]}
           onTaskComplete={[Function]}
           onTaskReject={[Function]}

--- a/src/elements/content-sidebar/activity-feed/task-new/messages.js
+++ b/src/elements/content-sidebar/activity-feed/task-new/messages.js
@@ -49,6 +49,11 @@ const messages = defineMessages({
         defaultMessage: 'Reject',
         description: 'Reject option for an approval task',
     },
+    tasksFeedViewDetailsAction: {
+        id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedViewDetailsAction',
+        defaultMessage: 'View Task Details',
+        description: 'View the details for a task',
+    },
     tasksFeedCompletedLabel: {
         id: 'be.contentSidebar.activityFeed.taskNew.tasksFeedCompletedLabel',
         defaultMessage: 'Completed',


### PR DESCRIPTION
Having the "View Task Details" button handler be a function instead of an href allows the consumer (e.g EUA) to route to the URL without causing a page refresh