### PR TITLE
chore(explorer): expose staticPath and previewLibraryVersion props

### DIFF
--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -125,6 +125,7 @@ type Props = {
     onRename: Function,
     onSelect: Function,
     onUpload: Function,
+    previewLibraryVersion: string,
     requestInterceptor?: Function,
     responseInterceptor?: Function,
     rootFolderId: string,
@@ -133,6 +134,7 @@ type Props = {
     sortBy: SortBy,
     sortDirection: SortDirection,
     staticHost: string,
+    staticPath: String,
     token: Token,
     uploadHost: string,
 };
@@ -1577,6 +1579,8 @@ class ContentExplorer extends Component<Props, State> {
             sharedLink,
             sharedLinkPassword,
             staticHost,
+            staticPath,
+            previewLibraryVersion,
             token,
             uploadHost,
         }: Props = this.props;
@@ -1777,6 +1781,8 @@ class ContentExplorer extends Component<Props, State> {
                             apiHost={apiHost}
                             appHost={appHost}
                             staticHost={staticHost}
+                            staticPath={staticPath}
+                            previewLibraryVersion={previewLibraryVersion}
                             sharedLink={sharedLink}
                             sharedLinkPassword={sharedLinkPassword}
                             contentPreviewProps={contentPreviewProps}

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -134,7 +134,7 @@ type Props = {
     sortBy: SortBy,
     sortDirection: SortDirection,
     staticHost: string,
-    staticPath: String,
+    staticPath: string,
     token: Token,
     uploadHost: string,
 };

--- a/src/elements/content-explorer/PreviewDialog.js
+++ b/src/elements/content-explorer/PreviewDialog.js
@@ -30,11 +30,13 @@ type Props = {
     onDownload: Function,
     onPreview: Function,
     parentElement: HTMLElement,
+    previewLibraryVersion: string,
     requestInterceptor?: Function,
     responseInterceptor?: Function,
     sharedLink?: string,
     sharedLinkPassword?: string,
     staticHost: string,
+    staticPath: string,
     token: Token,
 } & InjectIntlProvidedProps;
 
@@ -53,6 +55,8 @@ const PreviewDialog = ({
     apiHost,
     appHost,
     staticHost,
+    staticPath,
+    previewLibraryVersion,
     sharedLink,
     sharedLinkPassword,
     contentPreviewProps,
@@ -87,6 +91,8 @@ const PreviewDialog = ({
                 apiHost={apiHost}
                 appHost={appHost}
                 staticHost={staticHost}
+                staticPath={staticPath}
+                previewLibraryVersion={previewLibraryVersion}
                 cache={cache}
                 token={token}
                 hasHeader


### PR DESCRIPTION
Expose `staticPath` and `previewLibraryVersion` props from `ContentExplorer` down to `ContentPreview`