### PR TITLE
fix(getfilesize): locale is not being set to format number

### DIFF
--- a/src/utils/__tests__/getFileSize.test.js
+++ b/src/utils/__tests__/getFileSize.test.js
@@ -7,7 +7,16 @@ describe('utils/getFileSize', () => {
     });
 
     test('should return formatted file size in a specified locale', () => {
-        const size = getFileSize(629644, 'ru');
-        expect(size).toBe('614.9 КБ');
+        let size = getFileSize(629644, 'ru');
+        expect(size).toBe('614,9 КБ');
+
+        size = getFileSize(629644, 'fr');
+        expect(size).toBe('614,9 Ko');
+
+        size = getFileSize(629644, 'de');
+        expect(size).toBe('614,9 KB');
+
+        size = getFileSize(629644, 'ja');
+        expect(size).toBe('614.9 KB');
     });
 });

--- a/src/utils/getFileSize.js
+++ b/src/utils/getFileSize.js
@@ -14,7 +14,7 @@ const bcp47TagToDigitalUnits = {
  * @returns {string} The size as a localized string
  */
 const getFileSize = (size, locale = 'en') => {
-    const settings = { round: 1 };
+    const settings = { round: 1, locale };
 
     const localizedUnits = bcp47TagToDigitalUnits[locale];
     if (localizedUnits) {


### PR DESCRIPTION
This causes incorect number format in getFileSize. For example,
123.4 KB should be 123,4 KB when the locale is German.