### PR TITLE
fix(select-field): enable onblur for select field

### DIFF
--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -425,6 +425,8 @@ class BaseSelectField extends React.Component<Props, State> {
                 className={classNames(className, 'bdl-SelectField', 'select-container')}
                 onBlur={this.handleBlur}
                 onKeyDown={this.handleKeyDown}
+                // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                tabIndex="0"
             >
                 <PopperComponent placement={dropdownPlacement} isOpen={isOpen} modifiers={dropdownModifiers}>
                     {this.renderSelectButton()}

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -2,6 +2,8 @@
 
 .bdl-SelectField,
 .select-field {
+    outline: none;
+
     .overlay {
         min-width: 100%;
     }


### PR DESCRIPTION
Fixes https://github.com/box/box-ui-elements/issues/1934

Adds a tabIndex to the div component and sets outline:none to avoid
blue border on focus.

Eventually this should be made more accessible, but this fixes the
current bug.