### PR TITLE
fix(baseselect): click to close dropdown for safari and firefox

### DIFF
--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -98,6 +98,8 @@ class BaseSelectField extends React.Component<Props, State> {
 
         this.selectFieldID = uniqueId('selectfield');
 
+        this.selectFieldContainerRef = React.createRef();
+
         this.state = {
             activeItemID: null,
             activeItemIndex: -1,
@@ -105,6 +107,24 @@ class BaseSelectField extends React.Component<Props, State> {
             shouldScrollIntoView: false,
         };
     }
+
+    componentWillUnmount() {
+        if (this.state.isOpen) {
+            // Clean-up global click handlers
+            document.removeEventListener('click', this.handleDocumentClick);
+        }
+    }
+
+    handleDocumentClick = (event: MouseEvent) => {
+        const container = this.selectFieldContainerRef.current;
+        const isInside =
+            (container && event.target instanceof Node && container.contains(event.target)) ||
+            container === event.target;
+
+        if (!isInside) {
+            this.closeDropdown();
+        }
+    };
 
     setActiveItem = (index: number, shouldScrollIntoView?: boolean = true) => {
         this.setState({ activeItemIndex: index, shouldScrollIntoView });
@@ -125,6 +145,8 @@ class BaseSelectField extends React.Component<Props, State> {
     };
 
     selectFieldID: string;
+
+    selectFieldContainerRef: { current: null | HTMLDivElement };
 
     handleChange = (selectedItems: Array<SelectOptionProp>) => {
         const { onChange } = this.props;
@@ -230,6 +252,7 @@ class BaseSelectField extends React.Component<Props, State> {
     openDropdown = () => {
         if (!this.state.isOpen) {
             this.setState({ isOpen: true });
+            document.addEventListener('click', this.handleDocumentClick);
         }
     };
 
@@ -240,6 +263,7 @@ class BaseSelectField extends React.Component<Props, State> {
                 activeItemIndex: -1,
                 isOpen: false,
             });
+            document.removeEventListener('click', this.handleDocumentClick);
         }
     };
 
@@ -425,6 +449,7 @@ class BaseSelectField extends React.Component<Props, State> {
                 className={classNames(className, 'bdl-SelectField', 'select-container')}
                 onBlur={this.handleBlur}
                 onKeyDown={this.handleKeyDown}
+                ref={this.selectFieldContainerRef}
             >
                 <PopperComponent placement={dropdownPlacement} isOpen={isOpen} modifiers={dropdownModifiers}>
                     {this.renderSelectButton()}

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -772,6 +772,16 @@ describe('components/select-field/BaseSelectField', () => {
 
             expect(wrapper.state('isOpen')).toBe(true);
         });
+
+        test('should add document click listener', () => {
+            document.addEventListener = jest.fn();
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+
+            instance.openDropdown();
+
+            expect(document.addEventListener).toHaveBeenCalled();
+        });
     });
 
     describe('closeDropdown()', () => {
@@ -789,6 +799,17 @@ describe('components/select-field/BaseSelectField', () => {
             expect(wrapper.state('isOpen')).toBe(false);
             expect(wrapper.state('activeItemID')).toEqual(null);
             expect(wrapper.state('activeItemIndex')).toEqual(-1);
+        });
+
+        test('should remove document click listener', () => {
+            document.removeEventListener = jest.fn();
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+            wrapper.setState({ isOpen: true });
+
+            instance.closeDropdown();
+
+            expect(document.removeEventListener).toHaveBeenCalled();
         });
     });
 
@@ -947,6 +968,55 @@ describe('components/select-field/BaseSelectField', () => {
                 .withArgs(options[index]); // audio + video
 
             instance.selectMultiOption(index);
+        });
+    });
+
+    describe('handleDocumentClick', () => {
+        test('should close dropdown when click occurs outside of select field', () => {
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+            instance.closeDropdown = jest.fn();
+            wrapper.setState({ isOpen: true });
+
+            instance.handleDocumentClick({
+                target: document.createElement('div'),
+            });
+
+            expect(instance.closeDropdown).toHaveBeenCalled();
+        });
+
+        test('should not close dropdown when click occurs on select field container', () => {
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+            instance.closeDropdown = jest.fn();
+            wrapper.setState({ isOpen: true });
+
+            wrapper.simulate('click');
+
+            expect(instance.closeDropdown).not.toHaveBeenCalled();
+        });
+
+        test('should not close dropdown when click occurs on select field dropdown', () => {
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+            instance.closeDropdown = jest.fn();
+            wrapper.setState({ isOpen: true });
+
+            instance.handleDocumentClick({
+                target: document.getElementById(instance.selectFieldID),
+            });
+
+            expect(instance.closeDropdown).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('componentWillUnmount()', () => {
+        test('should remove document click listener', () => {
+            document.removeEventListener = jest.fn();
+            const wrapper = shallowRenderSelectField();
+            wrapper.setState({ isOpen: true });
+            wrapper.unmount();
+            expect(document.removeEventListener).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/box/box-ui-elements/issues/1934. This issue is seen on both Mac Firefox & Mac Safari.

Tested fix in Mac Chrome/Safari/Firefox and Windows Edge.

For more info on the inconsistent Firefox & Safari behavior (we're using a div instead of a button in this component, but the same focus rules apply):
https://zellwk.com/blog/inconsistent-button-behavior/
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus