### PR TITLE
fix(content-explorer): Get PDF reps in initial /folders call

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -329,9 +329,9 @@ export const X_REP_HINT_JPG_DIMENSIONS_DEFAULT: '1024x1024' = '1024x1024';
 // available dimensions for PNG: "1024x1024", "2048x2048"
 export const X_REP_HINT_PNG_DIMENSIONS_DEFAULT: '1024x1024' = '1024x1024';
 
-// if unable to fetch jpg thumbnail, grab png rep of first page. Certain file types do
-// not have a thumbnail rep but do have a first page rep.
-export const X_REP_HINT_HEADER_DIMENSIONS_DEFAULT = `[jpg?dimensions=${X_REP_HINT_JPG_DIMENSIONS_DEFAULT}&paged=false,png?dimensions=${X_REP_HINT_PNG_DIMENSIONS_DEFAULT}]`;
+// If unable to fetch jpg thumbnail, grab png rep of first page. Certain file types do not have a thumbnail rep but do have a first page rep.
+// Get the PDF rep as well, which ensures that the Preview SDK loads linearized reps for customers with PDF optimization enabled.
+export const X_REP_HINT_HEADER_DIMENSIONS_DEFAULT = `[jpg?dimensions=${X_REP_HINT_JPG_DIMENSIONS_DEFAULT}&paged=false,png?dimensions=${X_REP_HINT_PNG_DIMENSIONS_DEFAULT}][pdf]`;
 
 /* ------------------ Representations Response ---------- */
 export const REPRESENTATIONS_RESPONSE_ERROR: 'error' = 'error';


### PR DESCRIPTION
This PR enables customers with PDF optimization enabled to view linearized representations of PDFs within the Content Explorer.