### PR TITLE
feat(annotations): update url on annotation selection

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -284,10 +284,6 @@ be.executeIntegrationOpenWithErrorSubHeader = Please try again later.
 be.expand = Expand
 # Label for face skill section in the preview sidebar
 be.faceSkill = Faces
-# Call-to-action text describing what to do to navigate to specified feedback form
-be.feedbackCtaText = Click to provide feedback
-# Accessible text used to describe the form used for feedback
-be.feedbackFormDescription = Beta Feedback Form
 # File access stats error message
 be.fileAccessStatsErrorHeaderMessage = Something went wrong when fetching the access stats.
 # File classification error message
@@ -794,18 +790,6 @@ boxui.datePicker.iconAlertText = Invalid Date
 boxui.draftjs.mentionSelector.startMention = Mention someone to notify them
 # Icon showing a sad Box cloud
 boxui.errorMask.iconSadCloudText = Sad Box Cloud
-# Text to show when root folder is external
-boxui.features.VirtualizedTableRenderers.allFiles = All Files
-# The user is an anonymous user
-boxui.features.VirtualizedTableRenderers.anonymousUser = Anonymous User
-# Text to show when a file is external
-boxui.features.VirtualizedTableRenderers.externalFile = External File
-# Text to show when a folder is external
-boxui.features.VirtualizedTableRenderers.externalFolder = External Folder
-# Text to show on "modified by" table cell. Note that "lastModified" will contain additional localized text. Example: 2 days ago by John Smith
-boxui.features.VirtualizedTableRenderers.lastModifiedBy = {lastModified} by {user}
-# The user is unknown in the database.
-boxui.features.VirtualizedTableRenderers.unknownUser = Unknown User
 # Warning message in the sidebar that this bookmark will be automatically deleted on a certain date, {expiration} is the date
 boxui.itemDetails.bookmarkExpiration = This bookmark will be deleted on {expiration}.
 # Label for created date under item properties in the sidebar

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -4,6 +4,8 @@ be.accessStatsPermissionsError = Sorry, you do not have permission to see the ac
 be.activityFeed.fullDateTime = {time, date, full} at {time, time, short}
 # Error message for feed item API errors
 be.activityFeedItemApiError = There was a problem loading the activity feed. Please refresh the page or try again later.
+# Text to show when an annotation activity no longer exists
+be.activitySidebar.activityFeed.annotationMissingError = This comment no longer exists
 # Text to show when comment no longer exists
 be.activitySidebar.activityFeed.commentMissingError = This comment no longer exists
 # Error title
@@ -284,6 +286,10 @@ be.executeIntegrationOpenWithErrorSubHeader = Please try again later.
 be.expand = Expand
 # Label for face skill section in the preview sidebar
 be.faceSkill = Faces
+# Call-to-action text describing what to do to navigate to specified feedback form
+be.feedbackCtaText = Click to provide feedback
+# Accessible text used to describe the form used for feedback
+be.feedbackFormDescription = Beta Feedback Form
 # File access stats error message
 be.fileAccessStatsErrorHeaderMessage = Something went wrong when fetching the access stats.
 # File classification error message
@@ -790,6 +796,18 @@ boxui.datePicker.iconAlertText = Invalid Date
 boxui.draftjs.mentionSelector.startMention = Mention someone to notify them
 # Icon showing a sad Box cloud
 boxui.errorMask.iconSadCloudText = Sad Box Cloud
+# Text to show when root folder is external
+boxui.features.VirtualizedTableRenderers.allFiles = All Files
+# The user is an anonymous user
+boxui.features.VirtualizedTableRenderers.anonymousUser = Anonymous User
+# Text to show when a file is external
+boxui.features.VirtualizedTableRenderers.externalFile = External File
+# Text to show when a folder is external
+boxui.features.VirtualizedTableRenderers.externalFolder = External Folder
+# Text to show on "modified by" table cell. Note that "lastModified" will contain additional localized text. Example: 2 days ago by John Smith
+boxui.features.VirtualizedTableRenderers.lastModifiedBy = {lastModified} by {user}
+# The user is unknown in the database.
+boxui.features.VirtualizedTableRenderers.unknownUser = Unknown User
 # Warning message in the sidebar that this bookmark will be automatically deleted on a certain date, {expiration} is the date
 boxui.itemDetails.bookmarkExpiration = This bookmark will be deleted on {expiration}.
 # Label for created date under item properties in the sidebar

--- a/src/common/types/feed.js
+++ b/src/common/types/feed.js
@@ -4,7 +4,7 @@ import type { BoxItemPermission, BoxItemVersion, BoxItemVersionMini, User } from
 import type { Target } from './annotations';
 
 // Feed item types that can receive deeplinks inline in the feed
-type FocusableFeedItemType = 'annotation' | ' task' | 'comment';
+type FocusableFeedItemType = 'task' | 'comment' | 'annotation';
 
 type BoxCommentPermission = {
     can_delete?: boolean,

--- a/src/common/types/feed.js
+++ b/src/common/types/feed.js
@@ -4,7 +4,7 @@ import type { BoxItemPermission, BoxItemVersion, BoxItemVersionMini, User } from
 import type { Target } from './annotations';
 
 // Feed item types that can receive deeplinks inline in the feed
-type FocusableFeedItemType = 'task' | 'comment';
+type FocusableFeedItemType = 'annotation' | ' task' | 'comment';
 
 type BoxCommentPermission = {
     can_delete?: boolean,

--- a/src/elements/common/annotator-context/AnnotatorContext.ts
+++ b/src/elements/common/annotator-context/AnnotatorContext.ts
@@ -1,4 +1,4 @@
 import * as React from 'react';
-import { AnnotatorState } from './types';
+import { AnnotatorContext } from './types';
 
-export default React.createContext({} as AnnotatorState);
+export default React.createContext({} as AnnotatorContext);

--- a/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
@@ -50,9 +50,9 @@ describe('elements/common/annotator-context/withAnnotations', () => {
         expect(contextProvider.prop('value')).toEqual({
             action: null,
             activeAnnotationId: null,
-            setActiveAnnotationId: instance.handleActiveChange,
             annotation: null,
             error: null,
+            setActiveAnnotationId: instance.handleAnnotationChangeEvent,
         });
     });
 
@@ -88,7 +88,7 @@ describe('elements/common/annotator-context/withAnnotations', () => {
                     activeAnnotationId: null,
                     annotation: expectedAnnotation,
                     error: expectedError,
-                    setActiveAnnotationId: instance.handleActiveChange,
+                    setActiveAnnotationId: instance.handleAnnotationChangeEvent,
                 });
             },
         );

--- a/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
@@ -20,7 +20,12 @@ describe('elements/common/annotator-context/withAnnotations', () => {
 
     const WrappedComponent = withAnnotations(MockComponent);
 
-    const defaultProps = { className: 'foo', onAnnotatorEvent: jest.fn(), onPreviewDestroy: jest.fn() };
+    const defaultProps = {
+        className: 'foo',
+        onAnnotator: jest.fn(),
+        onAnnotatorEvent: jest.fn(),
+        onPreviewDestroy: jest.fn(),
+    };
 
     const getWrapper = (
         props: WrappedComponentProps = defaultProps,
@@ -36,6 +41,7 @@ describe('elements/common/annotator-context/withAnnotations', () => {
 
         const wrappedComponent = wrapper.find<WrappedComponentProps>(MockComponent);
         expect(wrappedComponent.exists()).toBeTruthy();
+        expect(wrappedComponent.props().onAnnotator).toBeTruthy();
         expect(wrappedComponent.props().onAnnotatorEvent).toBeTruthy();
         expect(wrappedComponent.props().onPreviewDestroy).toBeTruthy();
     });
@@ -51,8 +57,9 @@ describe('elements/common/annotator-context/withAnnotations', () => {
             action: null,
             activeAnnotationId: null,
             annotation: null,
+            annotator: null,
             error: null,
-            setActiveAnnotationId: instance.handleAnnotationChangeEvent,
+            setActiveAnnotationId: instance.emitActiveChangeEvent,
         });
     });
 
@@ -87,8 +94,9 @@ describe('elements/common/annotator-context/withAnnotations', () => {
                     action: expectedAction,
                     activeAnnotationId: null,
                     annotation: expectedAnnotation,
+                    annotator: null,
                     error: expectedError,
-                    setActiveAnnotationId: instance.handleAnnotationChangeEvent,
+                    setActiveAnnotationId: instance.emitActiveChangeEvent,
                 });
             },
         );
@@ -133,6 +141,36 @@ describe('elements/common/annotator-context/withAnnotations', () => {
         );
     });
 
+    describe('handleOnAnnotator', () => {
+        test('should add annotator to state', () => {
+            const mockAnnotator = {
+                emit: jest.fn(),
+            };
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+
+            instance.handleOnAnnotator(mockAnnotator);
+
+            expect(wrapper.state('annotator')).toEqual(mockAnnotator);
+        });
+    });
+
+    describe('emitActiveChangeEvent', () => {
+        test('should call annotator emit on action', () => {
+            const mockAnnotator = {
+                emit: jest.fn(),
+            };
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+
+            wrapper.setState({ annotator: mockAnnotator });
+            instance.emitActiveChangeEvent('123');
+
+            expect(mockAnnotator.emit).toBeCalled();
+            expect(mockAnnotator.emit).toBeCalledWith('annotations_active_change', '123');
+        });
+    });
+
     describe('handlePreviewDestroy()', () => {
         test('should reset state', () => {
             const wrapper = getWrapper();
@@ -144,6 +182,7 @@ describe('elements/common/annotator-context/withAnnotations', () => {
             wrapper.instance().handlePreviewDestroy();
             contextProvider = getContextProvider(wrapper);
             expect(contextProvider.prop('value').activeAnnotationId).toEqual(null);
+            expect(contextProvider.prop('value').annotator).toEqual(null);
         });
     });
 });

--- a/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
@@ -3,7 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 
 import { AnnotatorContext, withAnnotations } from '../index';
 import { WithAnnotationsProps, ComponentWithAnnotations } from '../withAnnotations';
-import { AnnotatorState, Action } from '../types';
+import { AnnotatorContext as AnnotatorContextType, Action } from '../types';
 
 type ComponentProps = {
     className: string;
@@ -12,7 +12,7 @@ type ComponentProps = {
 type WrappedComponentProps = ComponentProps & WithAnnotationsProps;
 
 type ContextProviderProps = {
-    value: AnnotatorState;
+    value: AnnotatorContextType;
 };
 
 describe('elements/common/annotator-context/withAnnotations', () => {
@@ -46,20 +46,35 @@ describe('elements/common/annotator-context/withAnnotations', () => {
         expect(wrappedComponent.props().onPreviewDestroy).toBeTruthy();
     });
 
-    test('should pass the state on to the AnnotatorContext.Provider', () => {
+    test('should pass the context on to the AnnotatorContext.Provider', () => {
         const wrapper = getWrapper();
-
-        const contextProvider = getContextProvider(wrapper);
         const instance = wrapper.instance();
+        const contextProvider = getContextProvider(wrapper);
 
         expect(contextProvider.exists()).toBeTruthy();
-        expect(contextProvider.prop('value')).toEqual({
+        expect(contextProvider.prop('value').emitActiveChangeEvent).toEqual(instance.emitActiveChangeEvent);
+        expect(contextProvider.prop('value').state).toEqual({
             action: null,
             activeAnnotationId: null,
             annotation: null,
-            annotator: null,
             error: null,
-            setActiveAnnotationId: instance.emitActiveChangeEvent,
+        });
+    });
+
+    describe('emitActiveChangeEvent', () => {
+        test('should call annotator emit on action', () => {
+            const mockAnnotator = {
+                emit: jest.fn(),
+            };
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+
+            // Set the annotator on the withAnnotations instance
+            instance.handleOnAnnotator(mockAnnotator);
+            instance.emitActiveChangeEvent('123');
+
+            expect(mockAnnotator.emit).toBeCalled();
+            expect(mockAnnotator.emit).toBeCalledWith('annotations_active_set', '123');
         });
     });
 
@@ -84,19 +99,14 @@ describe('elements/common/annotator-context/withAnnotations', () => {
                     error,
                 };
 
-                const instance = wrapper.instance();
-
-                instance.handleAnnotationCreate(eventData);
-
+                wrapper.instance().handleAnnotationCreate(eventData);
                 const contextProvider = getContextProvider(wrapper);
                 expect(contextProvider.exists()).toBeTruthy();
-                expect(contextProvider.prop('value')).toEqual({
+                expect(contextProvider.prop('value').state).toEqual({
                     action: expectedAction,
                     activeAnnotationId: null,
                     annotation: expectedAnnotation,
-                    annotator: null,
                     error: expectedError,
-                    setActiveAnnotationId: instance.emitActiveChangeEvent,
                 });
             },
         );
@@ -109,13 +119,11 @@ describe('elements/common/annotator-context/withAnnotations', () => {
             ${'123'}     | ${'123'}
         `('should update activeAnnotationId state to reflect value $annotationId', ({ annotationId, expected }) => {
             const wrapper = getWrapper();
-            const instance = wrapper.instance();
 
-            instance.handleActiveChange(annotationId);
-
+            wrapper.instance().handleActiveChange(annotationId);
             const contextProvider = getContextProvider(wrapper);
             expect(contextProvider.exists()).toBeTruthy();
-            expect(contextProvider.prop('value').activeAnnotationId).toEqual(expected);
+            expect(contextProvider.prop('value').state.activeAnnotationId).toEqual(expected);
         });
     });
 
@@ -141,48 +149,17 @@ describe('elements/common/annotator-context/withAnnotations', () => {
         );
     });
 
-    describe('handleOnAnnotator', () => {
-        test('should add annotator to state', () => {
-            const mockAnnotator = {
-                emit: jest.fn(),
-            };
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-
-            instance.handleOnAnnotator(mockAnnotator);
-
-            expect(wrapper.state('annotator')).toEqual(mockAnnotator);
-        });
-    });
-
-    describe('emitActiveChangeEvent', () => {
-        test('should call annotator emit on action', () => {
-            const mockAnnotator = {
-                emit: jest.fn(),
-            };
-            const wrapper = getWrapper();
-            const instance = wrapper.instance();
-
-            wrapper.setState({ annotator: mockAnnotator });
-            instance.emitActiveChangeEvent('123');
-
-            expect(mockAnnotator.emit).toBeCalled();
-            expect(mockAnnotator.emit).toBeCalledWith('annotations_active_change', '123');
-        });
-    });
-
     describe('handlePreviewDestroy()', () => {
-        test('should reset state', () => {
+        test('should reset state and annotator', () => {
             const wrapper = getWrapper();
-
-            wrapper.instance().handleActiveChange('123');
+            const instance = wrapper.instance();
+            instance.handleActiveChange('123');
             let contextProvider = getContextProvider(wrapper);
-            expect(contextProvider.prop('value').activeAnnotationId).toEqual('123');
+            expect(contextProvider.prop('value').state.activeAnnotationId).toEqual('123');
 
             wrapper.instance().handlePreviewDestroy();
             contextProvider = getContextProvider(wrapper);
-            expect(contextProvider.prop('value').activeAnnotationId).toEqual(null);
-            expect(contextProvider.prop('value').annotator).toEqual(null);
+            expect(contextProvider.prop('value').state.activeAnnotationId).toEqual(null);
         });
     });
 });

--- a/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
@@ -44,10 +44,13 @@ describe('elements/common/annotator-context/withAnnotations', () => {
         const wrapper = getWrapper();
 
         const contextProvider = getContextProvider(wrapper);
+        const instance = wrapper.instance();
+
         expect(contextProvider.exists()).toBeTruthy();
         expect(contextProvider.prop('value')).toEqual({
             action: null,
             activeAnnotationId: null,
+            setActiveAnnotationId: instance.handleActiveChange,
             annotation: null,
             error: null,
         });
@@ -74,7 +77,10 @@ describe('elements/common/annotator-context/withAnnotations', () => {
                     error,
                 };
 
-                wrapper.instance().handleAnnotationCreate(eventData);
+                const instance = wrapper.instance();
+
+                instance.handleAnnotationCreate(eventData);
+
                 const contextProvider = getContextProvider(wrapper);
                 expect(contextProvider.exists()).toBeTruthy();
                 expect(contextProvider.prop('value')).toEqual({
@@ -82,6 +88,7 @@ describe('elements/common/annotator-context/withAnnotations', () => {
                     activeAnnotationId: null,
                     annotation: expectedAnnotation,
                     error: expectedError,
+                    setActiveAnnotationId: instance.handleActiveChange,
                 });
             },
         );
@@ -94,8 +101,10 @@ describe('elements/common/annotator-context/withAnnotations', () => {
             ${'123'}     | ${'123'}
         `('should update activeAnnotationId state to reflect value $annotationId', ({ annotationId, expected }) => {
             const wrapper = getWrapper();
+            const instance = wrapper.instance();
 
-            wrapper.instance().handleActiveChange(annotationId);
+            instance.handleActiveChange(annotationId);
+
             const contextProvider = getContextProvider(wrapper);
             expect(contextProvider.exists()).toBeTruthy();
             expect(contextProvider.prop('value').activeAnnotationId).toEqual(expected);

--- a/src/elements/common/annotator-context/__tests__/withAnnotatorContext.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotatorContext.test.tsx
@@ -28,15 +28,22 @@ describe('elements/common/annotator-context/withAnnotatorContext', () => {
             annotation: { foo: 'bar' },
             action: Action.CREATE_START,
         };
+        const mockEmitAnnotatorChangeEvent = jest.fn();
 
-        mockContext.mockReturnValue(annotatorState);
+        mockContext.mockReturnValue({
+            state: annotatorState,
+            emitActiveChangeEvent: mockEmitAnnotatorChangeEvent,
+        });
 
         const wrapper = getWrapper();
         const wrappedComponent = wrapper.dive().find(Component);
+        const props = wrappedComponent.props() as WrappedComponentProps<HTMLDivElement>;
+
         expect(wrappedComponent.exists()).toBeTruthy();
-        expect((wrappedComponent.props() as WrappedComponentProps<HTMLDivElement>).annotatorState).toEqual({
+        expect(props.annotatorState).toEqual({
             annotation: { foo: 'bar' },
             action: Action.CREATE_START,
         });
+        expect(props.emitAnnotatorActiveChangeEvent).toEqual(mockEmitAnnotatorChangeEvent);
     });
 });

--- a/src/elements/common/annotator-context/types.ts
+++ b/src/elements/common/annotator-context/types.ts
@@ -7,6 +7,7 @@ export enum Action {
 }
 
 export interface Annotator {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     emit: (event: string | symbol, ...args: any[]) => void;
 }
 

--- a/src/elements/common/annotator-context/types.ts
+++ b/src/elements/common/annotator-context/types.ts
@@ -14,10 +14,13 @@ export interface Annotator {
 export interface AnnotatorState {
     activeAnnotationId?: string | null;
     annotation?: object | null;
-    annotator: Annotator | null;
     action?: Action | null;
     error?: Error | null;
-    setActiveAnnotationId: (annotationId: string) => void;
+}
+
+export interface AnnotatorContext {
+    state: AnnotatorState;
+    emitActiveChangeEvent: (id: string) => void;
 }
 
 export enum Status {

--- a/src/elements/common/annotator-context/types.ts
+++ b/src/elements/common/annotator-context/types.ts
@@ -6,6 +6,10 @@ export enum Action {
     // Can extend to other actions: update_start, update_end, delete_start, delete_end
 }
 
+export interface Annotator {
+    emit: (event: string | symbol, ...args: any[]) => void;
+}
+
 export interface AnnotatorState {
     activeAnnotationId?: string | null;
     annotation?: object | null;

--- a/src/elements/common/annotator-context/types.ts
+++ b/src/elements/common/annotator-context/types.ts
@@ -11,6 +11,7 @@ export interface AnnotatorState {
     annotation?: object | null;
     action?: Action | null;
     error?: Error | null;
+    setActiveAnnotationId: (annotationId: string) => void;
 }
 
 export enum Status {

--- a/src/elements/common/annotator-context/types.ts
+++ b/src/elements/common/annotator-context/types.ts
@@ -14,6 +14,7 @@ export interface Annotator {
 export interface AnnotatorState {
     activeAnnotationId?: string | null;
     annotation?: object | null;
+    annotator: Annotator | null;
     action?: Action | null;
     error?: Error | null;
     setActiveAnnotationId: (annotationId: string) => void;

--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -13,19 +13,11 @@ export interface ComponentWithAnnotations {
     handleAnnotationChangeEvent: (id: string | null) => void;
     handleAnnotationCreate: (eventData: AnnotationActionEvent) => void;
     handleAnnotatorEvent: ({ event, data }: { event: string; data?: unknown }) => void;
-    handlePreviewDestroy: () => void;
     handleOnAnnotator: (annotator: Annotator) => void;
+    handlePreviewDestroy: () => void;
 }
 
 export type WithAnnotationsComponent<P> = React.ComponentClass<P & WithAnnotationsProps>;
-
-const defaultState: AnnotatorState = {
-    activeAnnotationId: null,
-    annotation: null,
-    action: null,
-    error: null,
-    setActiveAnnotationId: id => {},
-};
 
 export default function withAnnotations<P extends object>(
     WrappedComponent: React.ComponentType<P>,
@@ -35,7 +27,7 @@ export default function withAnnotations<P extends object>(
 
         annotator: Annotator | undefined;
 
-        handleAnnotationChangeEvent = (id: string | null) => {
+        emitActiveChangeEvent = (id: string | null) => {
             if (!this.annotator) {
                 return;
             }
@@ -43,7 +35,15 @@ export default function withAnnotations<P extends object>(
             this.annotator.emit('annotations_active_change', id);
         };
 
-        state = defaultState;
+        defaultState: AnnotatorState = {
+            activeAnnotationId: null,
+            annotation: null,
+            action: null,
+            error: null,
+            setActiveAnnotationId: this.emitActiveChangeEvent,
+        };
+
+        state = this.defaultState;
 
         getAction({ meta: { status }, error }: AnnotationActionEvent): Action {
             return status === Status.SUCCESS || error ? Action.CREATE_END : Action.CREATE_START;
@@ -77,7 +77,8 @@ export default function withAnnotations<P extends object>(
         };
 
         handlePreviewDestroy = (): void => {
-            this.setState(defaultState);
+            this.setState(this.defaultState);
+            this.annotator = undefined;
         };
 
         render(): JSX.Element {

--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -3,11 +3,13 @@ import AnnotatorContext from './AnnotatorContext';
 import { Action, Annotator, AnnotationActionEvent, AnnotatorState, Status } from './types';
 
 export interface WithAnnotationsProps {
+    onAnnotator: (annotator: Annotator) => void;
     onAnnotatorEvent: ({ event, data }: { event: string; data: unknown }) => void;
     onPreviewDestroy: () => void;
 }
 
 export interface ComponentWithAnnotations {
+    emitActiveChangeEvent: (id: string | null) => void;
     getAction: (eventData: AnnotationActionEvent) => Action;
     handleActiveChange: (annotationId: string | null) => void;
     handleAnnotationChangeEvent: (id: string | null) => void;
@@ -25,19 +27,20 @@ export default function withAnnotations<P extends object>(
     class ComponentWithAnnotations extends React.Component<P & WithAnnotationsProps, AnnotatorState> {
         static displayName: string;
 
-        annotator: Annotator | undefined;
-
         emitActiveChangeEvent = (id: string | null) => {
-            if (!this.annotator) {
+            const { annotator } = this.state;
+
+            if (!annotator || !annotator.emit) {
                 return;
             }
 
-            this.annotator.emit('annotations_active_change', id);
+            annotator.emit('annotations_active_change', id);
         };
 
         defaultState: AnnotatorState = {
             activeAnnotationId: null,
             annotation: null,
+            annotator: null,
             action: null,
             error: null,
             setActiveAnnotationId: this.emitActiveChangeEvent,
@@ -73,12 +76,11 @@ export default function withAnnotations<P extends object>(
         };
 
         handleOnAnnotator = (annotator: Annotator): void => {
-            this.annotator = annotator;
+            this.setState({ annotator });
         };
 
         handlePreviewDestroy = (): void => {
             this.setState(this.defaultState);
-            this.annotator = undefined;
         };
 
         render(): JSX.Element {

--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import AnnotatorContext from './AnnotatorContext';
 import { Action, AnnotationActionEvent, AnnotatorState, Status } from './types';
-import {noop} from "@babel/types";
 
 export interface WithAnnotationsProps {
     onAnnotatorEvent: ({ event, data }: { event: string; data: unknown }) => void;
@@ -32,7 +31,7 @@ export default function withAnnotations<P extends object>(
     class ComponentWithAnnotations extends React.Component<P & WithAnnotationsProps, AnnotatorState> {
         static displayName: string;
 
-        handleSetActiveAnnotationId = (annotationId: string) => {
+        handleActiveChange = (annotationId: string | null): void => {
             this.setState({ activeAnnotationId: annotationId });
         };
 
@@ -46,10 +45,6 @@ export default function withAnnotations<P extends object>(
             const { annotation = null, error = null } = eventData;
             const action = this.getAction(eventData);
             this.setState({ ...this.state, annotation, action, error });
-        };
-
-        handleActiveChange = (annotationId: string | null): void => {
-            this.setState({ activeAnnotationId: annotationId });
         };
 
         handleAnnotatorEvent = ({ event, data }: { event: string; data: unknown }): void => {

--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import AnnotatorContext from './AnnotatorContext';
 import { Action, AnnotationActionEvent, AnnotatorState, Status } from './types';
+import {noop} from "@babel/types";
 
 export interface WithAnnotationsProps {
     onAnnotatorEvent: ({ event, data }: { event: string; data: unknown }) => void;
@@ -22,6 +23,7 @@ const defaultState: AnnotatorState = {
     annotation: null,
     action: null,
     error: null,
+    setActiveAnnotationId: id => {},
 };
 
 export default function withAnnotations<P extends object>(
@@ -29,6 +31,10 @@ export default function withAnnotations<P extends object>(
 ): WithAnnotationsComponent<P> {
     class ComponentWithAnnotations extends React.Component<P & WithAnnotationsProps, AnnotatorState> {
         static displayName: string;
+
+        handleSetActiveAnnotationId = (annotationId: string) => {
+            this.setState({ activeAnnotationId: annotationId });
+        };
 
         state = defaultState;
 

--- a/src/elements/common/annotator-context/withAnnotatorContext.tsx
+++ b/src/elements/common/annotator-context/withAnnotatorContext.tsx
@@ -4,12 +4,20 @@ import { AnnotatorState } from './types';
 
 export interface WithAnnotatorContextProps {
     annotatorState?: AnnotatorState;
+    emitAnnotatorActiveChangeEvent?: (id: string) => void;
 }
 
 export default function withAnnotatorContext<P extends {}>(WrappedComponent: React.ComponentType<P>) {
     return React.forwardRef<React.RefForwardingComponent<React.ComponentType<P>>, P>((props, ref) => (
         <AnnotatorContext.Consumer>
-            {annotatorState => <WrappedComponent ref={ref} {...props} annotatorState={annotatorState} />}
+            {({ emitActiveChangeEvent, state }) => (
+                <WrappedComponent
+                    ref={ref}
+                    {...props}
+                    annotatorState={state}
+                    emitAnnotatorActiveChangeEvent={emitActiveChangeEvent}
+                />
+            )}
         </AnnotatorContext.Consumer>
     ));
 }

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1134,6 +1134,10 @@ class ContentPreview extends React.PureComponent<Props, State> {
         }
     }
 
+    handleAnnotationSelect = (): void => {
+        // TODO Call select annotation in preview
+    };
+
     /**
      * Renders the file preview
      *
@@ -1157,6 +1161,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
             logoUrl,
             onClose,
             measureRef,
+            showAnnotationsControls,
             sharedLink,
             sharedLinkPassword,
             requestInterceptor,
@@ -1189,6 +1194,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
         const currentVersionId = getProp(file, 'file_version.id');
         const selectedVersionId = getProp(selectedVersion, 'id', currentVersionId);
         const onHeaderClose = currentVersionId === selectedVersionId ? onClose : this.updateVersionToCurrent;
+        const handleAnnotationSelect = showAnnotationsControls ? this.handleAnnotationSelect : noop;
 
         /* eslint-disable jsx-a11y/no-static-element-interactions */
         /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
@@ -1252,6 +1258,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
                                 sharedLinkPassword={sharedLinkPassword}
                                 requestInterceptor={requestInterceptor}
                                 responseInterceptor={responseInterceptor}
+                                onAnnotationSelect={handleAnnotationSelect}
                                 onVersionChange={this.onVersionChange}
                             />
                         )}

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1134,10 +1134,6 @@ class ContentPreview extends React.PureComponent<Props, State> {
         }
     }
 
-    handleAnnotationSelect = (): void => {
-        // TODO Call select annotation in preview
-    };
-
     /**
      * Renders the file preview
      *
@@ -1161,7 +1157,6 @@ class ContentPreview extends React.PureComponent<Props, State> {
             logoUrl,
             onClose,
             measureRef,
-            showAnnotationsControls,
             sharedLink,
             sharedLinkPassword,
             requestInterceptor,
@@ -1194,7 +1189,6 @@ class ContentPreview extends React.PureComponent<Props, State> {
         const currentVersionId = getProp(file, 'file_version.id');
         const selectedVersionId = getProp(selectedVersion, 'id', currentVersionId);
         const onHeaderClose = currentVersionId === selectedVersionId ? onClose : this.updateVersionToCurrent;
-        const handleAnnotationSelect = showAnnotationsControls ? this.handleAnnotationSelect : noop;
 
         /* eslint-disable jsx-a11y/no-static-element-interactions */
         /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
@@ -1258,7 +1252,6 @@ class ContentPreview extends React.PureComponent<Props, State> {
                                 sharedLinkPassword={sharedLinkPassword}
                                 requestInterceptor={requestInterceptor}
                                 responseInterceptor={responseInterceptor}
-                                onAnnotationSelect={handleAnnotationSelect}
                                 onVersionChange={this.onVersionChange}
                             />
                         )}

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -202,6 +202,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
         enableThumbnailsSidebar: false,
         hasHeader: false,
         language: DEFAULT_LOCALE,
+        onAnnotator: noop,
         onAnnotatorEvent: noop,
         onDownload: noop,
         onError: noop,

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -83,6 +83,8 @@ type Props = {
     logoUrl?: string,
     measureRef: Function,
     messages?: StringMap,
+    onAnnotator: Function,
+    onAnnotatorEvent: Function,
     onClose?: Function,
     onDownload: Function,
     onLoad: Function,
@@ -714,6 +716,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
             enableThumbnailsSidebar,
             fileOptions,
             onAnnotatorEvent,
+            onAnnotator,
             showAnnotationsControls,
             token: tokenOrTokenFunction,
             ...rest
@@ -760,6 +763,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
 
         if (showAnnotationsControls) {
             this.preview.addListener('annotatorevent', onAnnotatorEvent);
+            this.preview.addListener('annotator', onAnnotator);
         }
 
         this.preview.updateFileCache([file]);

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -14,6 +14,7 @@ import AddTaskButton from './AddTaskButton';
 import API from '../../api';
 import messages from '../common/messages';
 import SidebarContent from './SidebarContent';
+import { AnnotatorState, withAnnotatorContext } from '../common/annotator-context';
 import { EVENT_JS_READY } from '../common/logger/constants';
 import { getBadUserError, getBadItemError } from '../../utils/error';
 import { mark } from '../../utils/performance';
@@ -46,9 +47,9 @@ import './ActivitySidebar.scss';
 type ExternalProps = {
     activeFeedEntryId?: string,
     activeFeedEntryType?: FocusableFeedItemType,
+    annotatorState?: AnnotatorState,
     currentUser?: User,
     getUserProfileUrl?: GetProfileUrlCallback,
-    onAnnotationSelect: (annotationId: string) => void,
     onCommentCreate: Function,
     onCommentDelete: (comment: Comment) => any,
     onCommentUpdate: () => any,
@@ -590,12 +591,12 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             elementId,
             file,
             isDisabled = false,
-            onAnnotationSelect,
             onVersionHistoryClick,
             getUserProfileUrl,
             activeFeedEntryId,
             activeFeedEntryType,
             onTaskView,
+            annotatorState = {},
         } = this.props;
         const {
             currentUser,
@@ -621,7 +622,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     mentionSelectorContacts={mentionSelectorContacts}
                     currentUser={currentUser}
                     isDisabled={isDisabled}
-                    onAnnotationSelect={onAnnotationSelect}
+                    onAnnotationSelect={annotatorState.setActiveAnnotationId}
                     onAppActivityDelete={this.deleteAppActivity}
                     onCommentCreate={this.createComment}
                     onCommentDelete={this.deleteComment}
@@ -654,4 +655,5 @@ export default flow([
     withErrorBoundary(ORIGIN_ACTIVITY_SIDEBAR),
     withAPIContext,
     withFeatureConsumer,
+    withAnnotatorContext,
 ])(ActivitySidebar);

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -48,6 +48,7 @@ type ExternalProps = {
     activeFeedEntryType?: FocusableFeedItemType,
     currentUser?: User,
     getUserProfileUrl?: GetProfileUrlCallback,
+    onAnnotationSelect: (annotationId: string) => void,
     onCommentCreate: Function,
     onCommentDelete: (comment: Comment) => any,
     onCommentUpdate: () => any,
@@ -589,6 +590,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             elementId,
             file,
             isDisabled = false,
+            onAnnotationSelect,
             onVersionHistoryClick,
             getUserProfileUrl,
             activeFeedEntryId,
@@ -619,6 +621,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     mentionSelectorContacts={mentionSelectorContacts}
                     currentUser={currentUser}
                     isDisabled={isDisabled}
+                    onAnnotationSelect={onAnnotationSelect}
                     onAppActivityDelete={this.deleteAppActivity}
                     onCommentCreate={this.createComment}
                     onCommentDelete={this.deleteComment}

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -14,7 +14,7 @@ import AddTaskButton from './AddTaskButton';
 import API from '../../api';
 import messages from '../common/messages';
 import SidebarContent from './SidebarContent';
-import { AnnotatorState, withAnnotatorContext } from '../common/annotator-context';
+import { WithAnnotatorContextProps, withAnnotatorContext } from '../common/annotator-context';
 import { EVENT_JS_READY } from '../common/logger/constants';
 import { getBadUserError, getBadItemError } from '../../utils/error';
 import { mark } from '../../utils/performance';
@@ -47,7 +47,6 @@ import './ActivitySidebar.scss';
 type ExternalProps = {
     activeFeedEntryId?: string,
     activeFeedEntryType?: FocusableFeedItemType,
-    annotatorState?: AnnotatorState,
     currentUser?: User,
     getUserProfileUrl?: GetProfileUrlCallback,
     onCommentCreate: Function,
@@ -58,7 +57,8 @@ type ExternalProps = {
     onTaskDelete: (id: string) => any,
     onTaskUpdate: () => any,
     onTaskView: (id: string, isCreator: boolean) => any,
-} & ErrorContextProps;
+} & ErrorContextProps &
+    WithAnnotatorContextProps;
 
 type PropsWithoutContext = {
     elementId: string,
@@ -96,6 +96,7 @@ mark(MARK_NAME_JS_READY);
 
 class ActivitySidebar extends React.PureComponent<Props, State> {
     static defaultProps = {
+        annotatorState: {},
         isDisabled: false,
         onCommentCreate: noop,
         onCommentDelete: noop,
@@ -596,7 +597,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             activeFeedEntryId,
             activeFeedEntryType,
             onTaskView,
-            annotatorState = {},
+            annotatorState,
         } = this.props;
         const {
             currentUser,

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -96,7 +96,7 @@ mark(MARK_NAME_JS_READY);
 
 class ActivitySidebar extends React.PureComponent<Props, State> {
     static defaultProps = {
-        annotatorState: {},
+        emitAnnotatorActiveChangeEvent: noop,
         isDisabled: false,
         onCommentCreate: noop,
         onCommentDelete: noop,
@@ -597,7 +597,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             activeFeedEntryId,
             activeFeedEntryType,
             onTaskView,
-            annotatorState,
+            emitAnnotatorActiveChangeEvent,
         } = this.props;
         const {
             currentUser,
@@ -623,7 +623,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     mentionSelectorContacts={mentionSelectorContacts}
                     currentUser={currentUser}
                     isDisabled={isDisabled}
-                    onAnnotationSelect={annotatorState.setActiveAnnotationId}
+                    onAnnotationSelect={emitAnnotatorActiveChangeEvent}
                     onAppActivityDelete={this.deleteAppActivity}
                     onCommentCreate={this.createComment}
                     onCommentDelete={this.deleteComment}

--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -64,6 +64,7 @@ type Props = {
     language?: string,
     messages?: StringMap,
     metadataSidebarProps: MetadataSidebarProps,
+    onAnnotationSelect: (annotationId: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     requestInterceptor?: Function,
@@ -332,6 +333,7 @@ class ContentSidebar extends React.Component<Props, State> {
             language,
             messages,
             metadataSidebarProps,
+            onAnnotationSelect,
             onVersionChange,
             onVersionHistoryClick,
             versionsSidebarProps,
@@ -366,6 +368,7 @@ class ContentSidebar extends React.Component<Props, State> {
                             isLoading={isLoading}
                             metadataEditors={metadataEditors}
                             metadataSidebarProps={metadataSidebarProps}
+                            onAnnotationSelect={onAnnotationSelect}
                             onVersionChange={onVersionChange}
                             onVersionHistoryClick={onVersionHistoryClick}
                             versionsSidebarProps={versionsSidebarProps}

--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -64,7 +64,6 @@ type Props = {
     language?: string,
     messages?: StringMap,
     metadataSidebarProps: MetadataSidebarProps,
-    onAnnotationSelect: (annotationId: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     requestInterceptor?: Function,
@@ -333,7 +332,6 @@ class ContentSidebar extends React.Component<Props, State> {
             language,
             messages,
             metadataSidebarProps,
-            onAnnotationSelect,
             onVersionChange,
             onVersionHistoryClick,
             versionsSidebarProps,
@@ -368,7 +366,6 @@ class ContentSidebar extends React.Component<Props, State> {
                             isLoading={isLoading}
                             metadataEditors={metadataEditors}
                             metadataSidebarProps={metadataSidebarProps}
-                            onAnnotationSelect={onAnnotationSelect}
                             onVersionChange={onVersionChange}
                             onVersionHistoryClick={onVersionHistoryClick}
                             versionsSidebarProps={versionsSidebarProps}

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -16,6 +16,7 @@ import LocalStore from '../../utils/LocalStore';
 import SidebarNav from './SidebarNav';
 import SidebarPanels from './SidebarPanels';
 import SidebarUtils from './SidebarUtils';
+import { AnnotatorState, withAnnotatorContext } from '../common/annotator-context';
 import { withFeatureConsumer } from '../common/feature-checking';
 import type { FeatureConfig } from '../common/feature-checking';
 import type { ActivitySidebarProps } from './ActivitySidebar';
@@ -29,6 +30,7 @@ import type { BoxItem, User } from '../../common/types/core';
 type Props = {
     activitySidebarProps: ActivitySidebarProps,
     additionalTabs?: Array<AdditionalSidebarTab>,
+    annotatorState: AnnotatorState,
     className: string,
     currentUser?: User,
     detailsSidebarProps: DetailsSidebarProps,
@@ -48,7 +50,6 @@ type Props = {
     location: Location,
     metadataEditors?: Array<MetadataEditor>,
     metadataSidebarProps: MetadataSidebarProps,
-    onAnnotationSelect: (annotationId: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     versionsSidebarProps: VersionsSidebarProps,
@@ -89,8 +90,17 @@ class Sidebar extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props): void {
-        const { fileId, history, location }: Props = this.props;
-        const { fileId: prevFileId, location: prevLocation }: Props = prevProps;
+        const {
+            annotatorState: { activeAnnotationId },
+            fileId,
+            history,
+            location,
+        }: Props = this.props;
+        const {
+            annotatorState: { activeAnnotationId: prevActiveAnnotationId },
+            fileId: prevFileId,
+            location: prevLocation,
+        }: Props = prevProps;
         const { isDirty }: State = this.state;
 
         // User navigated to a different file without ever navigating the sidebar
@@ -102,6 +112,10 @@ class Sidebar extends React.Component<Props, State> {
         if (location !== prevLocation && !this.getLocationState('silent')) {
             this.setForcedByLocation();
             this.setState({ isDirty: true });
+        }
+
+        if (activeAnnotationId !== prevActiveAnnotationId) {
+            this.handleAnnotationSelect(activeAnnotationId);
         }
     }
 
@@ -118,12 +132,10 @@ class Sidebar extends React.Component<Props, State> {
      */
 
     handleAnnotationSelect = (annotationId: string): void => {
-        const { history, onAnnotationSelect } = this.props;
+        const { history } = this.props;
 
         const urlPrefix = this.getUrlPrefix(history.location.pathname);
         history.replace(`/${urlPrefix}/annotations/${annotationId}`);
-
-        onAnnotationSelect(annotationId);
     };
 
     /**
@@ -281,7 +293,6 @@ class Sidebar extends React.Component<Props, State> {
                             isOpen={isOpen}
                             key={file.id}
                             metadataSidebarProps={metadataSidebarProps}
-                            onAnnotationSelect={this.handleAnnotationSelect}
                             onVersionChange={onVersionChange}
                             onVersionHistoryClick={onVersionHistoryClick}
                             ref={this.sidebarPanels}
@@ -295,4 +306,4 @@ class Sidebar extends React.Component<Props, State> {
 }
 
 export { Sidebar as SidebarComponent };
-export default flow([withFeatureConsumer, withRouter])(Sidebar);
+export default flow([withFeatureConsumer, withAnnotatorContext, withRouter])(Sidebar);

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -132,14 +132,11 @@ class Sidebar extends React.Component<Props, State> {
      */
 
     handleAnnotationSelect = (annotationId: string | null): void => {
-        if (!annotationId) {
-            return;
-        }
-
         const { history } = this.props;
-
         const urlPrefix = this.getUrlPrefix(history.location.pathname);
-        history.replace(`/${urlPrefix}/annotations/${annotationId}`);
+        const annotationUrl = annotationId ? `/${urlPrefix}/annotations/${annotationId}` : '/';
+
+        history.push(annotationUrl);
     };
 
     /**

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -48,6 +48,7 @@ type Props = {
     location: Location,
     metadataEditors?: Array<MetadataEditor>,
     metadataSidebarProps: MetadataSidebarProps,
+    onAnnotationSelect: (annotationId: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     versionsSidebarProps: VersionsSidebarProps,
@@ -107,6 +108,22 @@ class Sidebar extends React.Component<Props, State> {
     getUrlPrefix = (pathname: string) => {
         const basePath = pathname.substring(1).split('/')[0];
         return basePath;
+    };
+
+    /**
+     * Handle annotation selection
+     *
+     * @param {string} annotationId - The id of the annotation being selected
+     * @return {void}
+     */
+
+    handleAnnotationSelect = (annotationId: string): void => {
+        const { history, onAnnotationSelect } = this.props;
+
+        const urlPrefix = this.getUrlPrefix(history.location.pathname);
+        history.replace(`/${urlPrefix}/annotations/${annotationId}`);
+
+        onAnnotationSelect(annotationId);
     };
 
     /**
@@ -264,6 +281,7 @@ class Sidebar extends React.Component<Props, State> {
                             isOpen={isOpen}
                             key={file.id}
                             metadataSidebarProps={metadataSidebarProps}
+                            onAnnotationSelect={this.handleAnnotationSelect}
                             onVersionChange={onVersionChange}
                             onVersionHistoryClick={onVersionHistoryClick}
                             ref={this.sidebarPanels}

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -65,6 +65,7 @@ export const SIDEBAR_FORCE_VALUE_OPEN: 'open' = 'open';
 
 class Sidebar extends React.Component<Props, State> {
     static defaultProps = {
+        annotatorState: {},
         isDefaultOpen: true,
         isLoading: false,
     };

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -131,7 +131,11 @@ class Sidebar extends React.Component<Props, State> {
      * @return {void}
      */
 
-    handleAnnotationSelect = (annotationId: string): void => {
+    handleAnnotationSelect = (annotationId: string | null): void => {
+        if (!annotationId) {
+            return;
+        }
+
         const { history } = this.props;
 
         const urlPrefix = this.getUrlPrefix(history.location.pathname);

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -41,7 +41,6 @@ type Props = {
     hasVersions: boolean,
     isOpen: boolean,
     metadataSidebarProps: MetadataSidebarProps,
-    onAnnotationSelect: (annotationId: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     versionsSidebarProps: VersionsSidebarProps,
@@ -129,7 +128,6 @@ class SidebarPanels extends React.Component<Props> {
             hasVersions,
             isOpen,
             metadataSidebarProps,
-            onAnnotationSelect,
             onVersionChange,
             onVersionHistoryClick,
             versionsSidebarProps,
@@ -176,7 +174,6 @@ class SidebarPanels extends React.Component<Props> {
                                     elementId={elementId}
                                     currentUser={currentUser}
                                     file={file}
-                                    onAnnotationSelect={onAnnotationSelect}
                                     onVersionHistoryClick={onVersionHistoryClick}
                                     ref={this.activitySidebar}
                                     startMarkName={MARK_NAME_JS_LOADING_ACTIVITY}

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -41,6 +41,7 @@ type Props = {
     hasVersions: boolean,
     isOpen: boolean,
     metadataSidebarProps: MetadataSidebarProps,
+    onAnnotationSelect: (annotationId: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     versionsSidebarProps: VersionsSidebarProps,
@@ -58,7 +59,7 @@ const MARK_NAME_JS_LOADING_SKILLS = `${ORIGIN_SKILLS_SIDEBAR}${BASE_EVENT_NAME}`
 const MARK_NAME_JS_LOADING_METADATA = `${ORIGIN_METADATA_SIDEBAR}${BASE_EVENT_NAME}`;
 const MARK_NAME_JS_LOADING_VERSIONS = `${ORIGIN_VERSIONS_SIDEBAR}${BASE_EVENT_NAME}`;
 
-const URL_TO_FEED_ITEM_TYPE = { comments: 'comment', tasks: 'task' };
+const URL_TO_FEED_ITEM_TYPE = { annotations: 'annotation', comments: 'comment', tasks: 'task' };
 
 const LoadableDetailsSidebar = SidebarUtils.getAsyncSidebarContent(SIDEBAR_VIEW_DETAILS, MARK_NAME_JS_LOADING_DETAILS);
 const LoadableActivitySidebar = SidebarUtils.getAsyncSidebarContent(
@@ -128,6 +129,7 @@ class SidebarPanels extends React.Component<Props> {
             hasVersions,
             isOpen,
             metadataSidebarProps,
+            onAnnotationSelect,
             onVersionChange,
             onVersionHistoryClick,
             versionsSidebarProps,
@@ -162,7 +164,7 @@ class SidebarPanels extends React.Component<Props> {
                         exact
                         path={[
                             `/${SIDEBAR_VIEW_ACTIVITY}`,
-                            `/${SIDEBAR_VIEW_ACTIVITY}/:activeFeedEntryType(comments|tasks)/:activeFeedEntryId?`,
+                            `/${SIDEBAR_VIEW_ACTIVITY}/:activeFeedEntryType(annotations|comments|tasks)/:activeFeedEntryId?`,
                         ]}
                         render={({ match }) => {
                             const matchEntryType = match.params.activeFeedEntryType;
@@ -174,6 +176,7 @@ class SidebarPanels extends React.Component<Props> {
                                     elementId={elementId}
                                     currentUser={currentUser}
                                     file={file}
+                                    onAnnotationSelect={onAnnotationSelect}
                                     onVersionHistoryClick={onVersionHistoryClick}
                                     ref={this.activitySidebar}
                                     startMarkName={MARK_NAME_JS_LOADING_ACTIVITY}

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -121,7 +121,7 @@ describe('elements/content-sidebar/Sidebar', () => {
     describe('handleAnnotationSelect', () => {
         test('should handle updating url', () => {
             const historyMock = {
-                replace: jest.fn(),
+                push: jest.fn(),
                 location: {
                     pathname: '/activity',
                 },
@@ -132,7 +132,23 @@ describe('elements/content-sidebar/Sidebar', () => {
 
             instance.handleAnnotationSelect('123');
 
-            expect(historyMock.replace).toHaveBeenCalledWith('/activity/annotations/123');
+            expect(historyMock.push).toHaveBeenCalledWith('/activity/annotations/123');
+        });
+
+        test('should handle setting url back to / if no id provided', () => {
+            const historyMock = {
+                push: jest.fn(),
+                location: {
+                    pathname: '/activity/annotations/123',
+                },
+            };
+
+            const wrapper = getWrapper({ history: historyMock, file: { id: '1234' } });
+            const instance = wrapper.instance();
+
+            instance.handleAnnotationSelect(null);
+
+            expect(historyMock.push).toHaveBeenCalledWith('/');
         });
     });
 

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -68,6 +68,19 @@ describe('elements/content-sidebar/Sidebar', () => {
             wrapper.setProps({ location: { pathname: '/', state: { open: false } } });
             expect(instance.isForced).toHaveBeenCalledWith(false);
         });
+
+        test('should call handleAnnotationSelect if active annotation has changed', () => {
+            const mockAnnotatorState = {
+                activeAnnotationId: '123',
+            };
+            const mockHandleAnnotationSelect = jest.fn();
+            const wrapper = getWrapper({ annotatorState: mockAnnotatorState });
+
+            wrapper.instance().handleAnnotationSelect = mockHandleAnnotationSelect;
+            wrapper.setProps({ annotatorState: '321' });
+
+            expect(mockHandleAnnotationSelect).toBeCalled();
+        });
     });
 
     describe('handleVersionHistoryClick', () => {

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -12,7 +12,8 @@ jest.mock('../../common/async-load', () => () => 'LoadableComponent');
 jest.mock('../../../utils/LocalStore');
 
 describe('elements/content-sidebar/Sidebar', () => {
-    const getWrapper = props => shallow(<Sidebar file={{ id: 'id' }} location={{ pathname: '/' }} {...props} />);
+    const getWrapper = props =>
+        shallow(<Sidebar file={{ id: 'id' }} annotatorState={{}} location={{ pathname: '/' }} {...props} />);
 
     beforeEach(() => {
         LocalStore.mockClear();
@@ -119,7 +120,6 @@ describe('elements/content-sidebar/Sidebar', () => {
 
     describe('handleAnnotationSelect', () => {
         test('should handle updating url', () => {
-            const onAnnotationSelect = jest.fn();
             const historyMock = {
                 replace: jest.fn(),
                 location: {
@@ -127,12 +127,11 @@ describe('elements/content-sidebar/Sidebar', () => {
                 },
             };
 
-            const wrapper = getWrapper({ history: historyMock, file: { id: '1234' }, onAnnotationSelect });
+            const wrapper = getWrapper({ history: historyMock, file: { id: '1234' } });
             const instance = wrapper.instance();
 
             instance.handleAnnotationSelect('123');
 
-            expect(onAnnotationSelect).toHaveBeenCalled();
             expect(historyMock.replace).toHaveBeenCalledWith('/activity/annotations/123');
         });
     });

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -117,6 +117,26 @@ describe('elements/content-sidebar/Sidebar', () => {
         });
     });
 
+    describe('handleAnnotationSelect', () => {
+        test('should handle updating url', () => {
+            const onAnnotationSelect = jest.fn();
+            const historyMock = {
+                replace: jest.fn(),
+                location: {
+                    pathname: '/activity',
+                },
+            };
+
+            const wrapper = getWrapper({ history: historyMock, file: { id: '1234' }, onAnnotationSelect });
+            const instance = wrapper.instance();
+
+            instance.handleAnnotationSelect('123');
+
+            expect(onAnnotationSelect).toHaveBeenCalled();
+            expect(historyMock.replace).toHaveBeenCalledWith('/activity/annotations/123');
+        });
+    });
+
     describe('isForced', () => {
         test('returns the current value from the localStore', () => {
             LocalStore.mockImplementationOnce(() => ({

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
@@ -40,6 +40,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
     getAvatarUrl={[Function]}
     getMentionWithQuery={[Function]}
     isDisabled={false}
+    onAnnotationSelect={[Function]}
     onAppActivityDelete={[Function]}
     onCommentCreate={[Function]}
     onCommentDelete={[Function]}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -156,7 +156,9 @@ const ActiveState = ({
                         return (
                             <li
                                 key={item.type + item.id}
-                                className="bcs-activity-feed-annotation-activity"
+                                className={classNames('bcs-activity-feed-annotation-activity', {
+                                    'bcs-is-focused': isFocused,
+                                })}
                                 data-testid="annotation-activity"
                             >
                                 <AnnotationActivity

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -37,6 +37,7 @@ type Props = {
     isDisabled?: boolean,
     mentionSelectorContacts?: SelectorItems<User>,
     onAnnotationDelete?: ({ id: string, permissions?: BoxAnnotationPermission }) => void,
+    onAnnotationSelect?: (id: string) => void,
     onAppActivityDelete?: Function,
     onCommentCreate?: Function,
     onCommentDelete?: Function,
@@ -201,6 +202,7 @@ class ActivityFeed extends React.Component<Props, State> {
             getApproverWithQuery,
             getMentionWithQuery,
             activityFeedError,
+            onAnnotationSelect,
             onVersionHistoryClick,
             onCommentDelete,
             onCommentUpdate,
@@ -259,6 +261,7 @@ class ActivityFeed extends React.Component<Props, State> {
                             isDisabled={isDisabled}
                             currentUser={currentUser}
                             onTaskAssignmentUpdate={onTaskAssignmentUpdate}
+                            onAnnotationSelect={onAnnotationSelect}
                             onAnnotationDelete={onAnnotationDelete}
                             onAppActivityDelete={onAppActivityDelete}
                             onCommentDelete={hasCommentPermission ? onCommentDelete : noop}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -196,7 +196,6 @@ class ActivityFeed extends React.Component<Props, State> {
             getUserProfileUrl,
             file,
             onAnnotationDelete,
-            onAnnotationSelect,
             onAppActivityDelete,
             onCommentCreate,
             getApproverWithQuery,
@@ -261,7 +260,6 @@ class ActivityFeed extends React.Component<Props, State> {
                             currentUser={currentUser}
                             onTaskAssignmentUpdate={onTaskAssignmentUpdate}
                             onAnnotationDelete={onAnnotationDelete}
-                            onAnnotationSelect={onAnnotationSelect}
                             onAppActivityDelete={onAppActivityDelete}
                             onCommentDelete={hasCommentPermission ? onCommentDelete : noop}
                             onCommentEdit={hasCommentPermission ? onCommentUpdate : noop}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -188,32 +188,32 @@ class ActivityFeed extends React.Component<Props, State> {
 
     render(): React.Node {
         const {
-            translations,
-            approverSelectorContacts,
-            mentionSelectorContacts,
-            currentUser,
-            isDisabled,
-            getAvatarUrl,
-            getUserProfileUrl,
-            file,
-            onAnnotationDelete,
-            onAppActivityDelete,
-            onCommentCreate,
-            getApproverWithQuery,
-            getMentionWithQuery,
-            activityFeedError,
-            onAnnotationSelect,
-            onVersionHistoryClick,
-            onCommentDelete,
-            onCommentUpdate,
-            onTaskDelete,
-            onTaskUpdate,
-            onTaskView,
-            onTaskAssignmentUpdate,
-            onTaskModalClose,
-            feedItems,
             activeFeedEntryId,
             activeFeedEntryType,
+            activityFeedError,
+            approverSelectorContacts,
+            currentUser,
+            feedItems,
+            file,
+            getApproverWithQuery,
+            getAvatarUrl,
+            getMentionWithQuery,
+            getUserProfileUrl,
+            isDisabled,
+            mentionSelectorContacts,
+            onAnnotationDelete,
+            onAnnotationSelect,
+            onAppActivityDelete,
+            onCommentCreate,
+            onCommentDelete,
+            onCommentUpdate,
+            onTaskAssignmentUpdate,
+            onTaskDelete,
+            onTaskModalClose,
+            onTaskUpdate,
+            onTaskView,
+            onVersionHistoryClick,
+            translations,
         } = this.props;
         const { isInputOpen } = this.state;
         const hasCommentPermission = getProp(file, 'permissions.can_comment', false);
@@ -261,8 +261,8 @@ class ActivityFeed extends React.Component<Props, State> {
                             isDisabled={isDisabled}
                             currentUser={currentUser}
                             onTaskAssignmentUpdate={onTaskAssignmentUpdate}
-                            onAnnotationSelect={onAnnotationSelect}
                             onAnnotationDelete={onAnnotationDelete}
+                            onAnnotationSelect={onAnnotationSelect}
                             onAppActivityDelete={onAppActivityDelete}
                             onCommentDelete={hasCommentPermission ? onCommentDelete : noop}
                             onCommentEdit={hasCommentPermission ? onCommentUpdate : noop}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -37,7 +37,6 @@ type Props = {
     isDisabled?: boolean,
     mentionSelectorContacts?: SelectorItems<User>,
     onAnnotationDelete?: ({ id: string, permissions?: BoxAnnotationPermission }) => void,
-    onAnnotationSelect?: (id: string) => void,
     onAppActivityDelete?: Function,
     onCommentCreate?: Function,
     onCommentDelete?: Function,

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -227,6 +227,7 @@ class ActivityFeed extends React.Component<Props, State> {
             feedItems.find(({ id, type }) => id === activeFeedEntryId && type === activeFeedEntryType);
 
         const errorMessageByEntryType = {
+            annotation: messages.annotationMissingError,
             comment: messages.commentMissingError,
             task: messages.taskMissingError,
         };

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -133,7 +133,7 @@
         background-color: $white;
 
         &.bcs-is-disabled {
-            opacity: 0.4;
+            opacity: 4;
             pointer-events: none;
         }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -133,7 +133,7 @@
         background-color: $white;
 
         &.bcs-is-disabled {
-            opacity: 4;
+            opacity: .4;
             pointer-events: none;
         }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -72,6 +72,11 @@
             }
         }
 
+        .bcs-activity-feed-annotation-activity.bcs-is-focused {
+            padding-left: 21px;
+            border-left: 4px solid $bdl-yellorange;
+        }
+
         .bcs-activity-feed-task {
             padding-bottom: 28px;
         }
@@ -128,7 +133,7 @@
         background-color: $white;
 
         &.bcs-is-disabled {
-            opacity: .4;
+            opacity: 0.4;
             pointer-events: none;
         }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
@@ -10,6 +10,23 @@ const currentUser = {
 
 const otherUser = { name: 'Akon', id: 11 };
 
+const annotation = {
+    type: 'annotation',
+    id: 'anno_123',
+    created_at: '2018-07-03T14:43:52-07:00',
+    description: {
+        message: 'This is an annotation',
+    },
+    target: {
+        location: {
+            type: 'page',
+            value: 1,
+        },
+        type: 'region',
+    },
+    created_by: currentUser,
+};
+
 const comment = {
     type: 'comment',
     id: 'c_123',
@@ -95,7 +112,7 @@ const activityFeedError = { title: 't', content: 'm' };
 const getWrapper = (params = {}) =>
     mount(
         <ActiveState
-            items={[comment, fileVersion, taskWithAssignment, appActivity]}
+            items={[annotation, comment, fileVersion, taskWithAssignment, appActivity]}
             currentUser={currentUser}
             {...params}
         />,
@@ -109,7 +126,10 @@ describe('elements/content-sidebar/ActiveState/activity-feed/ActiveState', () =>
 
     test('should render items', () => {
         const wrapper = shallow(
-            <ActiveState items={[comment, fileVersion, taskWithAssignment, appActivity]} currentUser={currentUser} />,
+            <ActiveState
+                items={[annotation, comment, fileVersion, taskWithAssignment, appActivity]}
+                currentUser={currentUser}
+            />,
         ).dive();
 
         expect(wrapper).toMatchSnapshot();
@@ -121,6 +141,7 @@ describe('elements/content-sidebar/ActiveState/activity-feed/ActiveState', () =>
         expect(wrapper.find('[data-testid="version"]')).toHaveLength(1);
         expect(wrapper.find('[data-testid="task"]')).toHaveLength(1);
         expect(wrapper.find('[data-testid="app-activity"]')).toHaveLength(1);
+        expect(wrapper.find('[data-testid="annotation-activity"]')).toHaveLength(1);
     });
 
     test('should correctly render with an inline error if some feed items fail to fetch', () => {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
@@ -42,6 +42,43 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
   className="bcs-activity-feed-active-state"
 >
   <li
+    className="bcs-activity-feed-annotation-activity"
+    data-testid="annotation-activity"
+    key="annotationanno_123"
+  >
+    <AnnotationActivity
+      created_at="2018-07-03T14:43:52-07:00"
+      created_by={
+        Object {
+          "id": "user_123445",
+          "name": "Rihanna",
+        }
+      }
+      currentUser={
+        Object {
+          "id": "user_123445",
+          "name": "Rihanna",
+        }
+      }
+      description={
+        Object {
+          "message": "This is an annotation",
+        }
+      }
+      id="anno_123"
+      target={
+        Object {
+          "location": Object {
+            "type": "page",
+            "value": 1,
+          },
+          "type": "region",
+        }
+      }
+      type="annotation"
+    />
+  </li>
+  <li
     className="bcs-activity-feed-comment"
     data-testid="comment"
     key="commentc_123"

--- a/src/elements/content-sidebar/activity-feed/activity-feed/messages.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/messages.js
@@ -7,6 +7,11 @@
 import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
+    annotationMissingError: {
+        id: 'be.activitySidebar.activityFeed.annotationMissingError',
+        defaultMessage: 'This comment no longer exists',
+        description: 'Text to show when an annotation activity no longer exists',
+    },
     feedInlineErrorTitle: {
         id: 'be.activitySidebar.activityFeed.feedInlineErrorTitle',
         defaultMessage: 'Error',

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -24,7 +24,6 @@ type Props = {
     error?: ActionItemError,
     getAvatarUrl: GetAvatarUrlCallback,
     getUserProfileUrl?: GetProfileUrlCallback,
-    isActive?: boolean,
     isDisabled?: boolean,
     isPending?: boolean,
     onDelete?: ({ id: string, permissions?: BoxAnnotationPermission }) => any,
@@ -40,7 +39,6 @@ const AnnotationActivity = (props: Props) => {
         getAvatarUrl,
         getUserProfileUrl,
         id,
-        isActive = false,
         isPending,
         onDelete = noop,
         onSelect = noop,
@@ -63,7 +61,7 @@ const AnnotationActivity = (props: Props) => {
     const message = (description && description.message) || '';
 
     return (
-        <div className={`bcs-AnnotationActivity ${classNames({ 'is-active': isActive })}`}>
+        <div className="bcs-AnnotationActivity">
             <Media
                 className={classNames('bcs-AnnotationActivity-media', {
                     'bcs-is-pending': isPending || error,

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.scss
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.scss
@@ -3,11 +3,6 @@
 .bcs-AnnotationActivity {
     position: relative;
     z-index: 1;
-
-    &.is-active {
-        background-color: $bdl-box-blue-05;
-        border-left: 4px solid $bdl-yellorange;
-    }
 }
 
 // the comment activity item


### PR DESCRIPTION
Adding handler to update URL from annotation activity card, and call the callback from contentPreview to handle selecting annotation in Preview

- [x] Tests