### PR TITLE
feat(annotations): reset annotator context when destroying preview

### DIFF
--- a/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
@@ -20,7 +20,7 @@ describe('elements/common/annotator-context/withAnnotations', () => {
 
     const WrappedComponent = withAnnotations(MockComponent);
 
-    const defaultProps = { className: 'foo', onAnnotatorEvent: jest.fn() };
+    const defaultProps = { className: 'foo', onAnnotatorEvent: jest.fn(), onPreviewDestroy: jest.fn() };
 
     const getWrapper = (
         props: WrappedComponentProps = defaultProps,

--- a/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
@@ -45,8 +45,11 @@ describe('elements/common/annotator-context/withAnnotations', () => {
 
         const contextProvider = getContextProvider(wrapper);
         expect(contextProvider.exists()).toBeTruthy();
-        expect(contextProvider.props().value).toEqual({
+        expect(contextProvider.prop('value')).toEqual({
+            action: null,
             activeAnnotationId: null,
+            annotation: null,
+            error: null,
         });
     });
 
@@ -56,8 +59,8 @@ describe('elements/common/annotator-context/withAnnotations', () => {
 
         test.each`
             status       | annotation        | error        | expectedAction         | expectedAnnotation | expectedError
-            ${'pending'} | ${mockAnnotation} | ${undefined} | ${Action.CREATE_START} | ${mockAnnotation}  | ${undefined}
-            ${'success'} | ${mockAnnotation} | ${undefined} | ${Action.CREATE_END}   | ${mockAnnotation}  | ${undefined}
+            ${'pending'} | ${mockAnnotation} | ${undefined} | ${Action.CREATE_START} | ${mockAnnotation}  | ${null}
+            ${'success'} | ${mockAnnotation} | ${undefined} | ${Action.CREATE_END}   | ${mockAnnotation}  | ${null}
             ${'error'}   | ${mockAnnotation} | ${mockError} | ${Action.CREATE_END}   | ${mockAnnotation}  | ${mockError}
         `(
             'should update the context provider value if $status status received',
@@ -74,10 +77,10 @@ describe('elements/common/annotator-context/withAnnotations', () => {
                 wrapper.instance().handleAnnotationCreate(eventData);
                 const contextProvider = getContextProvider(wrapper);
                 expect(contextProvider.exists()).toBeTruthy();
-                expect(contextProvider.props().value).toEqual({
+                expect(contextProvider.prop('value')).toEqual({
+                    action: expectedAction,
                     activeAnnotationId: null,
                     annotation: expectedAnnotation,
-                    action: expectedAction,
                     error: expectedError,
                 });
             },
@@ -95,9 +98,7 @@ describe('elements/common/annotator-context/withAnnotations', () => {
             wrapper.instance().handleActiveChange(annotationId);
             const contextProvider = getContextProvider(wrapper);
             expect(contextProvider.exists()).toBeTruthy();
-            expect(contextProvider.props().value).toEqual({
-                activeAnnotationId: expected,
-            });
+            expect(contextProvider.prop('value').activeAnnotationId).toEqual(expected);
         });
     });
 
@@ -129,15 +130,11 @@ describe('elements/common/annotator-context/withAnnotations', () => {
 
             wrapper.instance().handleActiveChange('123');
             let contextProvider = getContextProvider(wrapper);
-            expect(contextProvider.props().value).toEqual({
-                activeAnnotationId: '123',
-            });
+            expect(contextProvider.prop('value').activeAnnotationId).toEqual('123');
 
             wrapper.instance().handlePreviewDestroy();
             contextProvider = getContextProvider(wrapper);
-            expect(contextProvider.props().value).toEqual({
-                activeAnnotationId: null,
-            });
+            expect(contextProvider.prop('value').activeAnnotationId).toEqual(null);
         });
     });
 });

--- a/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
+++ b/src/elements/common/annotator-context/__tests__/withAnnotations.test.tsx
@@ -31,12 +31,13 @@ describe('elements/common/annotator-context/withAnnotations', () => {
         wrapper: ShallowWrapper<WrappedComponentProps, {}, Component & ComponentWithAnnotations>,
     ) => wrapper.find<ContextProviderProps>(AnnotatorContext.Provider);
 
-    test('should pass onAnnotatorEvent as a prop on the wrapped component', () => {
+    test('should pass onAnnotatorEvent and onPreviewDestroy as props on the wrapped component', () => {
         const wrapper = getWrapper();
 
         const wrappedComponent = wrapper.find<WrappedComponentProps>(MockComponent);
         expect(wrappedComponent.exists()).toBeTruthy();
         expect(wrappedComponent.props().onAnnotatorEvent).toBeTruthy();
+        expect(wrappedComponent.props().onPreviewDestroy).toBeTruthy();
     });
 
     test('should pass the state on to the AnnotatorContext.Provider', () => {
@@ -120,5 +121,23 @@ describe('elements/common/annotator-context/withAnnotations', () => {
                 expect((instance.handleActiveChange as jest.Mock).mock.calls.length).toBe(numActiveChangeCalled);
             },
         );
+    });
+
+    describe('handlePreviewDestroy()', () => {
+        test('should reset state', () => {
+            const wrapper = getWrapper();
+
+            wrapper.instance().handleActiveChange('123');
+            let contextProvider = getContextProvider(wrapper);
+            expect(contextProvider.props().value).toEqual({
+                activeAnnotationId: '123',
+            });
+
+            wrapper.instance().handlePreviewDestroy();
+            contextProvider = getContextProvider(wrapper);
+            expect(contextProvider.props().value).toEqual({
+                activeAnnotationId: null,
+            });
+        });
     });
 });

--- a/src/elements/common/annotator-context/types.ts
+++ b/src/elements/common/annotator-context/types.ts
@@ -8,9 +8,9 @@ export enum Action {
 
 export interface AnnotatorState {
     activeAnnotationId?: string | null;
-    annotation?: object;
-    action?: Action;
-    error?: Error;
+    annotation?: object | null;
+    action?: Action | null;
+    error?: Error | null;
 }
 
 export enum Status {

--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -4,6 +4,7 @@ import { Action, AnnotationActionEvent, AnnotatorState, Status } from './types';
 
 export interface WithAnnotationsProps {
     onAnnotatorEvent: ({ event, data }: { event: string; data: unknown }) => void;
+    onPreviewDestroy: () => void;
 }
 
 export interface ComponentWithAnnotations {
@@ -52,10 +53,23 @@ export default function withAnnotations<P extends object>(
             }
         };
 
+        handlePreviewDestroy = (): void => {
+            this.setState({
+                activeAnnotationId: null,
+                annotation: undefined,
+                action: undefined,
+                error: undefined,
+            });
+        };
+
         render(): JSX.Element {
             return (
                 <AnnotatorContext.Provider value={this.state}>
-                    <WrappedComponent {...this.props} onAnnotatorEvent={this.handleAnnotatorEvent} />
+                    <WrappedComponent
+                        {...this.props}
+                        onAnnotatorEvent={this.handleAnnotatorEvent}
+                        onPreviewDestroy={this.handlePreviewDestroy}
+                    />
                 </AnnotatorContext.Provider>
             );
         }

--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -12,6 +12,7 @@ export interface ComponentWithAnnotations {
     handleActiveChange: (annotationId: string | null) => void;
     handleAnnotationCreate: (eventData: AnnotationActionEvent) => void;
     handleAnnotatorEvent: ({ event, data }: { event: string; data?: unknown }) => void;
+    handlePreviewDestroy: () => void;
 }
 
 export type WithAnnotationsComponent<P> = React.ComponentClass<P & WithAnnotationsProps>;

--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -17,22 +17,27 @@ export interface ComponentWithAnnotations {
 
 export type WithAnnotationsComponent<P> = React.ComponentClass<P & WithAnnotationsProps>;
 
+const defaultState: AnnotatorState = {
+    activeAnnotationId: null,
+    annotation: null,
+    action: null,
+    error: null,
+};
+
 export default function withAnnotations<P extends object>(
     WrappedComponent: React.ComponentType<P>,
 ): WithAnnotationsComponent<P> {
     class ComponentWithAnnotations extends React.Component<P & WithAnnotationsProps, AnnotatorState> {
         static displayName: string;
 
-        state: AnnotatorState = {
-            activeAnnotationId: null,
-        };
+        state = defaultState;
 
         getAction({ meta: { status }, error }: AnnotationActionEvent): Action {
             return status === Status.SUCCESS || error ? Action.CREATE_END : Action.CREATE_START;
         }
 
         handleAnnotationCreate = (eventData: AnnotationActionEvent): void => {
-            const { annotation, error } = eventData;
+            const { annotation = null, error = null } = eventData;
             const action = this.getAction(eventData);
             this.setState({ ...this.state, annotation, action, error });
         };
@@ -55,12 +60,7 @@ export default function withAnnotations<P extends object>(
         };
 
         handlePreviewDestroy = (): void => {
-            this.setState({
-                activeAnnotationId: null,
-                annotation: undefined,
-                action: undefined,
-                error: undefined,
-            });
+            this.setState(defaultState);
         };
 
         render(): JSX.Element {

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -287,8 +287,9 @@ class ContentPreview extends React.PureComponent<Props, State> {
             this.preview.destroy();
             this.preview.removeAllListeners();
             this.preview = undefined;
-            onPreviewDestroy();
         }
+
+        onPreviewDestroy();
 
         this.setState({ selectedVersion: undefined });
     }

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -34,7 +34,7 @@ import API from '../../api';
 import PreviewHeader from './preview-header';
 import PreviewNavigation from './PreviewNavigation';
 import PreviewLoading from './PreviewLoading';
-import { withAnnotations } from '../common/annotator-context';
+import { withAnnotations, WithAnnotationsProps } from '../common/annotator-context';
 import {
     DEFAULT_HOSTNAME_API,
     DEFAULT_HOSTNAME_APP,
@@ -83,7 +83,6 @@ type Props = {
     logoUrl?: string,
     measureRef: Function,
     messages?: StringMap,
-    onAnnotatorEvent: Function,
     onClose?: Function,
     onDownload: Function,
     onLoad: Function,
@@ -101,7 +100,8 @@ type Props = {
     token: Token,
     useHotkeys: boolean,
 } & ErrorContextProps &
-    WithLoggerProps;
+    WithLoggerProps &
+    WithAnnotationsProps;
 
 type State = {
     canPrint?: boolean,
@@ -205,6 +205,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
         onError: noop,
         onLoad: noop,
         onNavigate: noop,
+        onPreviewDestroy: noop,
         onVersionChange: noop,
         previewLibraryVersion: DEFAULT_PREVIEW_VERSION,
         showAnnotations: false,
@@ -281,10 +282,12 @@ class ContentPreview extends React.PureComponent<Props, State> {
      * Cleans up the preview instance
      */
     destroyPreview() {
+        const { onPreviewDestroy } = this.props;
         if (this.preview) {
             this.preview.destroy();
             this.preview.removeAllListeners();
             this.preview = undefined;
+            onPreviewDestroy();
         }
 
         this.setState({ selectedVersion: undefined });


### PR DESCRIPTION
Todo:
 - [x] unit tests