### PR TITLE
feat(usm): add ability to trigger copy to clipboard on modal open

### DIFF
--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -107,6 +107,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             autoCreateSharedLink,
             addSharedLink,
             submitting,
+            triggerCopyOnLoad,
             onCopyError = () => {},
             onCopySuccess = () => {},
             onCopyInit = () => {},
@@ -129,7 +130,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             this.setState({ isAutoCreatingSharedLink: false });
         }
 
-        if (Browser.canWriteToClipboard() && autoCreateSharedLink && !isAutoCreatingSharedLink && sharedLink.url) {
+        if (Browser.canWriteToClipboard() && triggerCopyOnLoad && !isAutoCreatingSharedLink && sharedLink.url) {
             onCopyInit();
             navigator.clipboard
                 .writeText(sharedLink.url)

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -15,6 +15,7 @@ import IconGlobe from '../../icons/general/IconGlobe';
 import { bdlWatermelonRed } from '../../styles/variables';
 import type { ItemType } from '../../common/types/core';
 import { isBoxNote } from '../../utils/file';
+import Browser from '../../utils/Browser';
 
 import convertToBoxItem from './utils/item';
 import SharedLinkAccessMenu from './SharedLinkAccessMenu';
@@ -41,6 +42,9 @@ type Props = {
     intl: any,
     item: itemtype,
     itemType: ItemType,
+    onCopyError?: () => void,
+    onCopyInit?: () => void,
+    onCopySuccess?: () => void,
     onDismissTooltip: (componentIdentifier: tooltipComponentIdentifierType) => void,
     onEmailSharedLinkClick: Function,
     onSettingsClick?: Function,
@@ -55,6 +59,7 @@ type Props = {
 
 type State = {
     isAutoCreatingSharedLink: boolean,
+    isCopySuccessful: ?boolean,
 };
 
 class SharedLinkSection extends React.Component<Props, State> {
@@ -68,6 +73,7 @@ class SharedLinkSection extends React.Component<Props, State> {
 
         this.state = {
             isAutoCreatingSharedLink: false,
+            isCopySuccessful: null,
         };
     }
 
@@ -96,11 +102,21 @@ class SharedLinkSection extends React.Component<Props, State> {
     // Note: we are assuming the 2nd render is safe
     // to start doing this check.
     componentDidUpdate(prevProps: Props) {
-        const { sharedLink, autoCreateSharedLink, addSharedLink, submitting } = this.props;
+        const {
+            sharedLink,
+            autoCreateSharedLink,
+            addSharedLink,
+            submitting,
+            onCopyError = () => {},
+            onCopySuccess = () => {},
+            onCopyInit = () => {},
+        } = this.props;
+
+        const { isAutoCreatingSharedLink } = this.state;
 
         if (
             autoCreateSharedLink &&
-            !this.state.isAutoCreatingSharedLink &&
+            !isAutoCreatingSharedLink &&
             !sharedLink.url &&
             !submitting &&
             !sharedLink.isNewSharedLink
@@ -111,6 +127,20 @@ class SharedLinkSection extends React.Component<Props, State> {
 
         if (!prevProps.sharedLink.url && sharedLink.url) {
             this.setState({ isAutoCreatingSharedLink: false });
+        }
+
+        if (Browser.canWriteToClipboard() && autoCreateSharedLink && !isAutoCreatingSharedLink && sharedLink.url) {
+            onCopyInit();
+            navigator.clipboard
+                .writeText(sharedLink.url)
+                .then(() => {
+                    this.setState({ isCopySuccessful: true });
+                    onCopySuccess();
+                })
+                .catch(() => {
+                    this.setState({ isCopySuccessful: false });
+                    onCopyError();
+                });
         }
     }
 
@@ -124,7 +154,6 @@ class SharedLinkSection extends React.Component<Props, State> {
 
     renderSharedLink() {
         const {
-            autoCreateSharedLink,
             autofocusSharedLink,
             changeSharedLinkAccessLevel,
             changeSharedLinkPermissionLevel,
@@ -139,6 +168,9 @@ class SharedLinkSection extends React.Component<Props, State> {
             triggerCopyOnLoad,
             tooltips,
         } = this.props;
+
+        const { isCopySuccessful } = this.state;
+
         const {
             accessLevel,
             accessLevelsDisabledReason,
@@ -162,7 +194,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             sharedLinkPermissionsMenuButtonProps,
         } = trackingProps;
 
-        const shouldTriggerCopyOnLoad = autoCreateSharedLink ? false : triggerCopyOnLoad;
+        const shouldTriggerCopyOnLoad = !!triggerCopyOnLoad && !!isCopySuccessful;
 
         const isEditableBoxNote = isBoxNote(convertToBoxItem(item)) && isEditAllowed;
         let allowedPermissionLevels = [CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -82,6 +82,12 @@ type Props = {
     item: ItemType,
     /** Handler function that adds the shared link */
     onAddLink: () => void,
+    /** Handler for when there is an error copying to clipboard after modal open */
+    onCopyError?: () => void,
+    /** Handler for when we initiate copying from to clipboard on modal open */
+    onCopyInit?: () => void,
+    /** Handler for when successfully copying to clipboard after modal open */
+    onCopySuccess?: () => void,
     /** Handler function that gets called whenever the user dismisses a tooltip on the given component identifier */
     onDismissTooltip?: (componentIdentifier: tooltipComponentIdentifierType) => void,
     /** Handler function that removes the shared link */
@@ -658,6 +664,9 @@ class UnifiedShareModal extends React.Component<Props, State> {
             createSharedLinkOnLoad,
             focusSharedLinkOnLoad,
             item,
+            onCopyInit,
+            onCopySuccess,
+            onCopyError,
             onSettingsClick,
             sharedLink,
             intl,
@@ -733,7 +742,7 @@ class UnifiedShareModal extends React.Component<Props, State> {
                                 addSharedLink={onAddLink}
                                 autofocusSharedLink={this.shouldAutoFocusSharedLink()}
                                 autoCreateSharedLink={createSharedLinkOnLoad}
-                                triggerCopyOnLoad={focusSharedLinkOnLoad}
+                                triggerCopyOnLoad={createSharedLinkOnLoad && focusSharedLinkOnLoad}
                                 changeSharedLinkAccessLevel={changeSharedLinkAccessLevel}
                                 changeSharedLinkPermissionLevel={changeSharedLinkPermissionLevel}
                                 intl={intl}
@@ -743,6 +752,9 @@ class UnifiedShareModal extends React.Component<Props, State> {
                                 onEmailSharedLinkClick={this.openEmailSharedLinkForm}
                                 onSettingsClick={onSettingsClick}
                                 onToggleSharedLink={this.onToggleSharedLink}
+                                onCopyInit={onCopyInit}
+                                onCopySuccess={onCopySuccess}
+                                onCopyError={onCopyError}
                                 sharedLink={sharedLink}
                                 showSharedLinkSettingsCallout={showSharedLinkSettingsCallout}
                                 submitting={submitting || isFetching}

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -318,6 +318,38 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
             }
         });
 
+        test('should only initiate copy when we specifically request a copy to be triggered', () => {
+            const sharedLink = { url: '', isNewSharedLink: false };
+            const addSharedLink = jest.fn();
+            const onCopyInitMock = jest.fn();
+            const onCopySuccessMock = jest.fn();
+            const onCopyErrorMock = jest.fn();
+            const writeTextSuccessMock = jest.fn(() => Promise.resolve());
+            navigator.clipboard = {
+                writeText: writeTextSuccessMock,
+            };
+
+            const wrapper = getWrapper({
+                addSharedLink,
+                autoCreateSharedLink: true,
+                autofocusSharedLink: true,
+                onCopyError: onCopyErrorMock,
+                onCopyInit: onCopyInitMock,
+                onCopySuccess: onCopySuccessMock,
+                sharedLink,
+                submitting: true,
+                triggerCopyOnLoad: false,
+            });
+
+            wrapper.setProps({ submitting: false });
+            wrapper.setProps({ sharedLink: { url: 'http://example.com/', isNewSharedLink: true } });
+
+            expect(onCopyInitMock).toBeCalledTimes(0);
+            expect(writeTextSuccessMock).toBeCalledTimes(0);
+            expect(onCopySuccessMock).toBeCalledTimes(0);
+            expect(onCopyErrorMock).toBeCalledTimes(0);
+        });
+
         test('should handle attempt to copy when the clipboard request fails', async () => {
             expect.assertions(3);
             const sharedLink = { url: '', isNewSharedLink: false };

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -94,6 +94,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
         label=""
         readOnly={true}
         successStateDuration={3000}
+        triggerCopyOnLoad={false}
         type="url"
         value="https://example.com/shared-link"
       />
@@ -241,6 +242,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
         label=""
         readOnly={true}
         successStateDuration={3000}
+        triggerCopyOnLoad={false}
         type="url"
         value="https://example.com/shared-link"
       />
@@ -418,6 +420,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         label=""
         readOnly={true}
         successStateDuration={3000}
+        triggerCopyOnLoad={false}
         type="url"
         value="https://example.com/shared-link"
       />
@@ -666,6 +669,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
         label=""
         readOnly={true}
         successStateDuration={3000}
+        triggerCopyOnLoad={false}
         type="url"
         value="http://example.com/s/abc"
       />
@@ -804,6 +808,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         label=""
         readOnly={true}
         successStateDuration={3000}
+        triggerCopyOnLoad={false}
         type="url"
         value="https://example.com/shared-link"
       />
@@ -937,6 +942,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         label=""
         readOnly={true}
         successStateDuration={3000}
+        triggerCopyOnLoad={false}
         type="url"
         value="https://example.com/shared-link"
       />
@@ -1095,6 +1101,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
         label=""
         readOnly={true}
         successStateDuration={3000}
+        triggerCopyOnLoad={false}
         type="url"
         value="https://example.com/shared-link"
       />

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
@@ -802,7 +802,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         submitting={true}
         tooltips={Object {}}
         trackingProps={Object {}}
-        triggerCopyOnLoad={true}
+        triggerCopyOnLoad={false}
       />
     </LoadingIndicatorWrapper>
   </Modal>
@@ -2496,7 +2496,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         submitting={true}
         tooltips={Object {}}
         trackingProps={Object {}}
-        triggerCopyOnLoad={true}
+        triggerCopyOnLoad={false}
       />
     </LoadingIndicatorWrapper>
   </Modal>

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -42,7 +42,7 @@ class Browser {
      * to the H264 container (since we use H264 and not webm)
      *
      * @public
-     * @param { boolean} recheck - recheck support
+     * @param {boolean} recheck - recheck support
      * @return {boolean} true if dash is usable
      */
     static canPlayDash(recheck: boolean = false) {
@@ -55,6 +55,34 @@ class Browser {
         }
 
         return isDashSupported;
+    }
+
+    /**
+     * Checks whether the browser has support for the Clipboard API. This new API supercedes
+     * the `execCommand`-based API and uses Promises for detecting whether it works or not.
+     *
+     * This check determines if the browser can support writing to the clipboard.
+     * @see https://www.w3.org/TR/clipboard-apis/#async-clipboard-api
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
+     *
+     * @return {boolean} whether writing to the clipboard is possible
+     */
+    static canWriteToClipboard() {
+        return !!(global.navigator.clipboard && global.navigator.clipboard.writeText);
+    }
+
+    /**
+     * Checks whether the browser has support for the Clipboard API. This new API supercedes
+     * the `execCommand`-based API and uses Promises for detecting whether it works or not.
+     *
+     * This check determines if the browser can support reading from the clipboard.
+     * @see https://www.w3.org/TR/clipboard-apis/#async-clipboard-api
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
+     *
+     * @return {boolean} whether reading from the clipboard is possible
+     */
+    static canReadFromClipboard() {
+        return !!(global.navigator.clipboard && global.navigator.clipboard.readText);
     }
 }
 

--- a/src/utils/__tests__/Browser.test.js
+++ b/src/utils/__tests__/Browser.test.js
@@ -58,3 +58,37 @@ describe('util/Browser/canPlayDash()', () => {
         expect(isTypeSupportedMock).toHaveBeenCalledWith('video/mp4; codecs="avc1.64001E"');
     });
 });
+
+describe('Browser clipboard API', () => {
+    // @see https://caniuse.com/#search=clipboard
+    afterEach(() => {
+        global.navigator.clipboard = undefined;
+    });
+
+    test('should return false when clipboard is unavailable', () => {
+        expect(browser.canWriteToClipboard()).toBe(false);
+        expect(browser.canReadFromClipboard()).toBe(false);
+    });
+
+    test('should return false when clipboard is partially available', () => {
+        global.navigator.clipboard = {
+            read: jest.fn(),
+            write: jest.fn(),
+        };
+
+        expect(browser.canWriteToClipboard()).toBe(false);
+        expect(browser.canReadFromClipboard()).toBe(false);
+    });
+
+    test('should return true when clipboard is fully available', () => {
+        global.navigator.clipboard = {
+            read: jest.fn(),
+            write: jest.fn(),
+            readText: jest.fn(),
+            writeText: jest.fn(),
+        };
+
+        expect(browser.canWriteToClipboard()).toBe(true);
+        expect(browser.canReadFromClipboard()).toBe(true);
+    });
+});


### PR DESCRIPTION
by using the two onLoad props on the USM (`createSharedLinkOnLoad` and `focusSharedLinkOnLoad`), enable copying the URL to the clipboard for new and existing shared links.