### PR TITLE
fix(folder-upload-node): fix subfolder name conflict errors

### DIFF
--- a/src/api/uploads/FolderUploadNode.js
+++ b/src/api/uploads/FolderUploadNode.js
@@ -147,7 +147,7 @@ class FolderUploadNode {
             progress: 100,
         };
 
-        if (errorEncountered) {
+        if (errorEncountered && errorCode !== ERROR_CODE_ITEM_NAME_IN_USE) {
             folderObject.status = STATUS_ERROR;
             folderObject.error = { code: errorCode };
         }

--- a/src/api/uploads/__tests__/FolderUploadNode.test.js
+++ b/src/api/uploads/__tests__/FolderUploadNode.test.js
@@ -116,6 +116,26 @@ describe('api/uploads/FolderUploadNode', () => {
             expect(folderUploadNodeInstance.folderId).toBe(folderId);
         });
 
+        test('should not set error for non-root folders if error is ITEM_NAME_IN_USE', async () => {
+            const folderId = '1';
+            const errorCallback = jest.fn();
+            const isRoot = false;
+            const error = {
+                code: ERROR_CODE_ITEM_NAME_IN_USE,
+                context_info: { conflicts: [{ id: folderId }] },
+            };
+            folderUploadNodeInstance.name = name;
+            folderUploadNodeInstance.createFolder = jest.fn(() => ({
+                id: folderId,
+            }));
+            folderUploadNodeInstance.addFolderToUploadQueue = jest.fn();
+
+            await folderUploadNodeInstance.createAndUploadFolder(errorCallback, isRoot);
+
+            expect(errorCallback).not.toHaveBeenCalledWith(error);
+            expect(folderUploadNodeInstance.error).toBeUndefined();
+        });
+
         test('should call addFolderToUploadQueue when folder is created successfully for non-root folder', async () => {
             const folderId = '1';
             const errorCallback = () => 'errorCallback';


### PR DESCRIPTION
Omits incorrect setting of subfolder name conflict errors so that files
in subfolders can continue uploading after being added to the upload
queue.

If there are files/folders in error, the view would be set to
`VIEW_ERROR` and any subsequent uploads would be stopped until the upload
errors were resolved. In this case, subfolders will always hit a name
conflict so we shouldn't block uploading subfiles, and we want view to
be set to `VIEW_UPLOAD_IN_PROGRESS` to continue automatic uploads in
`ContentUploader.updateViewAndCollection`.

Original Bug:
![image](https://user-images.githubusercontent.com/1657938/79925203-a318fb80-83ee-11ea-8657-9a883a5b9458.png)

Valid Subfolder Errors continue to block subfile uploads:
![image](https://user-images.githubusercontent.com/1657938/79925454-410cc600-83ef-11ea-8739-8735c2a73180.png)
