### PR TITLE
feat(annotation): scroll into view on activeEntryId change

### DIFF
--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -160,6 +160,7 @@ const ActiveState = ({
                                     'bcs-is-focused': isFocused,
                                 })}
                                 data-testid="annotation-activity"
+                                ref={refValue}
                             >
                                 <AnnotationActivity
                                     currentUser={currentUser}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -83,7 +83,7 @@ class ActivityFeed extends React.Component<Props, State> {
         const hasMoreItems = prevFeedItems && currFeedItems && prevFeedItems.length < currFeedItems.length;
         const didLoadFeedItems = prevFeedItems === undefined && currFeedItems !== undefined;
         const hasInputOpened = currIsInputOpen !== prevIsInputOpen;
-        const hasActiveFeedEntryIdChanged = activeFeedEntryId && prevActiveFeedEntryId;
+        const hasActiveFeedEntryIdChanged = activeFeedEntryId !== prevActiveFeedEntryId;
 
         if ((hasLoaded || hasMoreItems || didLoadFeedItems || hasInputOpened) && activeFeedEntryId === undefined) {
             this.resetFeedScroll();

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -70,7 +70,11 @@ class ActivityFeed extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props, prevState: State) {
-        const { currentUser: prevCurrentUser, feedItems: prevFeedItems } = prevProps;
+        const {
+            activeFeedEntryId: prevActiveFeedEntryId,
+            currentUser: prevCurrentUser,
+            feedItems: prevFeedItems,
+        } = prevProps;
         const { feedItems: currFeedItems, activeFeedEntryId } = this.props;
         const { isInputOpen: prevIsInputOpen } = prevState;
         const { isInputOpen: currIsInputOpen } = this.state;
@@ -79,13 +83,14 @@ class ActivityFeed extends React.Component<Props, State> {
         const hasMoreItems = prevFeedItems && currFeedItems && prevFeedItems.length < currFeedItems.length;
         const didLoadFeedItems = prevFeedItems === undefined && currFeedItems !== undefined;
         const hasInputOpened = currIsInputOpen !== prevIsInputOpen;
+        const hasActiveFeedEntryIdChanged = activeFeedEntryId && prevActiveFeedEntryId;
 
         if ((hasLoaded || hasMoreItems || didLoadFeedItems || hasInputOpened) && activeFeedEntryId === undefined) {
             this.resetFeedScroll();
         }
 
         // do the scroll only once after first fetch of feed items
-        if (didLoadFeedItems) {
+        if (didLoadFeedItems || hasActiveFeedEntryIdChanged) {
             this.scrollToActiveFeedItemOrErrorMessage();
         }
     }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -89,7 +89,6 @@ class ActivityFeed extends React.Component<Props, State> {
             this.resetFeedScroll();
         }
 
-        // do the scroll only once after first fetch of feed items
         if (didLoadFeedItems || hasActiveFeedEntryIdChanged) {
             this.scrollToActiveFeedItemOrErrorMessage();
         }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -173,92 +173,124 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
         expect(instance.feedContainer.scrollTop).toEqual(100);
     });
 
-    test('should set scrollTop to be the scrollHeight if feedContainer exists and prevProps feedItems is undefined and this.props.feedItems is defined', () => {
-        const wrapper = getWrapper({
-            feedItems: [{ type: 'comment' }],
-        });
-        const instance = wrapper.instance();
-        instance.feedContainer = {
-            scrollTop: 0,
-            scrollHeight: 100,
-        };
-
-        instance.componentDidUpdate(
-            {
-                feedItems: undefined,
-                currentUser,
-            },
-            { isInputOpen: false },
-        );
-
-        expect(instance.feedContainer.scrollTop).toEqual(100);
-    });
-
-    test('should set scrollTop to be the scrollHeight if more feedItems are added', () => {
-        const wrapper = getWrapper({
-            feedItems: [{ type: 'comment' }, { type: 'comment' }],
-        });
-
-        const instance = wrapper.instance();
-        instance.feedContainer = {
-            scrollTop: 0,
-            scrollHeight: 100,
-        };
-
-        instance.componentDidUpdate(
-            {
+    describe('componentDidUpdate()', () => {
+        test('should set scrollTop to be the scrollHeight if feedContainer exists and prevProps feedItems is undefined and this.props.feedItems is defined', () => {
+            const wrapper = getWrapper({
                 feedItems: [{ type: 'comment' }],
-                currentUser,
-            },
-            { isInputOpen: false },
-        );
+            });
+            const instance = wrapper.instance();
+            instance.feedContainer = {
+                scrollTop: 0,
+                scrollHeight: 100,
+            };
 
-        expect(instance.feedContainer.scrollTop).toEqual(100);
-    });
+            instance.componentDidUpdate(
+                {
+                    feedItems: undefined,
+                    currentUser,
+                },
+                { isInputOpen: false },
+            );
 
-    test('should set scrollTop to be the scrollHeight if the user becomes defined', () => {
-        const wrapper = getWrapper({
-            feedItems: [{ type: 'comment' }],
+            expect(instance.feedContainer.scrollTop).toEqual(100);
         });
-        const instance = wrapper.instance();
-        instance.feedContainer = {
-            scrollTop: 0,
-            scrollHeight: 100,
-        };
 
-        instance.componentDidUpdate(
-            {
+        test('should set scrollTop to be the scrollHeight if more feedItems are added', () => {
+            const wrapper = getWrapper({
+                feedItems: [{ type: 'comment' }, { type: 'comment' }],
+            });
+
+            const instance = wrapper.instance();
+            instance.feedContainer = {
+                scrollTop: 0,
+                scrollHeight: 100,
+            };
+
+            instance.componentDidUpdate(
+                {
+                    feedItems: [{ type: 'comment' }],
+                    currentUser,
+                },
+                { isInputOpen: false },
+            );
+
+            expect(instance.feedContainer.scrollTop).toEqual(100);
+        });
+
+        test('should set scrollTop to be the scrollHeight if the user becomes defined', () => {
+            const wrapper = getWrapper({
                 feedItems: [{ type: 'comment' }],
-                currentUser: undefined,
-            },
-            { isInputOpen: false },
-        );
+            });
+            const instance = wrapper.instance();
+            instance.feedContainer = {
+                scrollTop: 0,
+                scrollHeight: 100,
+            };
 
-        expect(instance.feedContainer.scrollTop).toEqual(100);
-    });
+            instance.componentDidUpdate(
+                {
+                    feedItems: [{ type: 'comment' }],
+                    currentUser: undefined,
+                },
+                { isInputOpen: false },
+            );
 
-    test('should set scrollTop to be the scrollHeight if input opens', () => {
-        const wrapper = getWrapper({
-            feedItems: [{ type: 'comment' }],
+            expect(instance.feedContainer.scrollTop).toEqual(100);
         });
-        wrapper.setState({
-            isInputOpen: true,
-        });
-        const instance = wrapper.instance();
-        instance.feedContainer = {
-            scrollTop: 0,
-            scrollHeight: 100,
-        };
 
-        instance.componentDidUpdate(
-            {
+        test('should set scrollTop to be the scrollHeight if input opens', () => {
+            const wrapper = getWrapper({
                 feedItems: [{ type: 'comment' }],
-                currentUser,
-            },
-            { isInputOpen: false },
-        );
+            });
+            wrapper.setState({
+                isInputOpen: true,
+            });
+            const instance = wrapper.instance();
+            instance.feedContainer = {
+                scrollTop: 0,
+                scrollHeight: 100,
+            };
 
-        expect(instance.feedContainer.scrollTop).toEqual(100);
+            instance.componentDidUpdate(
+                {
+                    feedItems: [{ type: 'comment' }],
+                    currentUser,
+                },
+                { isInputOpen: false },
+            );
+
+            expect(instance.feedContainer.scrollTop).toEqual(100);
+        });
+
+        test('should call scrollToActiveFeedItemOrErrorMessage if feed items loaded', () => {
+            const wrapper = getWrapper({ feedItems: [{ type: 'comment' }] });
+            const instance = wrapper.instance();
+            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+
+            instance.componentDidUpdate(
+                {
+                    feedItems: undefined,
+                },
+                { isInputOpen: false },
+            );
+
+            expect(instance.scrollToActiveFeedItemOrErrorMessage).toHaveBeenCalled();
+        });
+
+        test('should call scrollToActiveFeedItemOrErrorMessage if activeFeedEntryId changed', () => {
+            const wrapper = getWrapper({ activeFeedEntryId: '123' });
+            const instance = wrapper.instance();
+            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+
+            instance.componentDidUpdate(
+                {
+                    activeFeedEntryId: '456',
+                },
+                { isInputOpen: false },
+            );
+
+            expect(instance.scrollToActiveFeedItemOrErrorMessage).toHaveBeenCalled();
+        });
     });
 
     test('should pass activeFeedItemRef to the ActiveState', () => {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -291,6 +291,21 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
 
             expect(instance.scrollToActiveFeedItemOrErrorMessage).toHaveBeenCalled();
         });
+
+        test('should not call scrollToActiveFeedItemOrErrorMessage if activeFeedEntryId changed', () => {
+            const wrapper = getWrapper({ activeFeedEntryId: '456' });
+            const instance = wrapper.instance();
+            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+
+            instance.componentDidUpdate(
+                {
+                    activeFeedEntryId: '456',
+                },
+                { isInputOpen: false },
+            );
+
+            expect(instance.scrollToActiveFeedItemOrErrorMessage).not.toHaveBeenCalled();
+        });
     });
 
     test('should pass activeFeedItemRef to the ActiveState', () => {


### PR DESCRIPTION
Add support for:

-  `AnnotationActivity` being scrolled into view. 
- Add support for `activeEntryId` changing triggering scroll into view logic