### PR TITLE
feat(draftjs): Extract functions into utils for other libs to reuse

### DIFF
--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -2,15 +2,17 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import { EditorState, Modifier } from 'draft-js';
+import { EditorState } from 'draft-js';
 
 import DatalistItem from '../../datalist-item';
 import DraftJSEditor from '../../draft-js-editor';
 import SelectorDropdown from '../../selector-dropdown';
+import { getActiveMentionForEditorState, addMention } from './utils';
 
 import messages from './messages';
 
 import type { SelectorItems } from '../../../common/types/core';
+import type { Mention } from './utils';
 
 import './MentionSelector.scss';
 
@@ -56,7 +58,7 @@ type Props = {
 };
 
 type State = {
-    activeMention: Object | null,
+    activeMention: Mention | null,
     isFocused: boolean,
     mentionPattern: RegExp,
 };
@@ -110,42 +112,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
     getActiveMentionForEditorState(editorState: EditorState) {
         const { mentionPattern } = this.state;
 
-        const contentState = editorState.getCurrentContent();
-        const selectionState = editorState.getSelection();
-
-        const startKey = selectionState.getStartKey();
-        const activeBlock = contentState.getBlockForKey(startKey);
-
-        const cursorPosition = selectionState.getStartOffset();
-
-        let result = null;
-
-        // Break the active block into entity ranges.
-        activeBlock.findEntityRanges(
-            character => character.getEntity() === null,
-            (start, end) => {
-                // Find the active range (is the cursor inside this range?)
-                if (start <= cursorPosition && cursorPosition <= end) {
-                    // Determine if the active range contains a mention.
-                    const activeRangeText = activeBlock.getText().substr(start, cursorPosition - start);
-                    const mentionMatch = activeRangeText.match(mentionPattern);
-
-                    if (mentionMatch) {
-                        result = {
-                            blockID: startKey,
-                            mentionString: mentionMatch[2],
-                            mentionTrigger: mentionMatch[1],
-                            start: start + mentionMatch.index,
-                            end: cursorPosition,
-                        };
-                    }
-                }
-
-                return null;
-            },
-        );
-
-        return result;
+        return getActiveMentionForEditorState(editorState, mentionPattern);
     }
 
     /**
@@ -238,49 +205,8 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
     addMention(mention: Object) {
         const { activeMention } = this.state;
         const { editorState } = this.props;
-        const { start, end } = activeMention || {};
 
-        const { id, name } = mention;
-
-        const contentState = editorState.getCurrentContent();
-        const selectionState = editorState.getSelection();
-
-        const preInsertionSelectionState = selectionState.merge({
-            anchorOffset: start,
-            focusOffset: end,
-        });
-
-        const textToInsert = `@${name}`;
-
-        const contentStateWithEntity = contentState.createEntity('MENTION', 'IMMUTABLE', { id });
-
-        const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
-
-        const contentStateWithLink = Modifier.replaceText(
-            contentState,
-            preInsertionSelectionState,
-            textToInsert,
-            null,
-            entityKey,
-        );
-
-        const spaceOffset = preInsertionSelectionState.getStartOffset() + textToInsert.length;
-        const selectionStateForAddingSpace = preInsertionSelectionState.merge({
-            anchorOffset: spaceOffset,
-            focusOffset: spaceOffset,
-        });
-
-        const contentStateWithLinkAndExtraSpace = Modifier.insertText(
-            contentStateWithLink,
-            selectionStateForAddingSpace,
-            ' ',
-        );
-
-        const editorStateWithLink = EditorState.push(
-            editorState,
-            contentStateWithLinkAndExtraSpace,
-            'change-block-type',
-        );
+        const editorStateWithLink = addMention(editorState, activeMention, mention);
 
         this.setState(
             {

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -7,7 +7,7 @@ import { EditorState } from 'draft-js';
 import DatalistItem from '../../datalist-item';
 import DraftJSEditor from '../../draft-js-editor';
 import SelectorDropdown from '../../selector-dropdown';
-import { getActiveMentionForEditorState, addMention } from './utils';
+import { addMention, defaultMentionPattern, getActiveMentionForEditorState } from './utils';
 
 import messages from './messages';
 
@@ -69,19 +69,23 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
         contacts: [],
         isDisabled: false,
         isRequired: false,
-        mentionTriggers: ['@', '＠', '﹫'],
         selectorRow: <DefaultSelectorRow />,
         startMentionMessage: <DefaultStartMentionMessage />,
     };
 
     constructor(props: Props) {
         super(props);
-        const mentionTriggers = props.mentionTriggers.reduce((prev, current) => `${prev}\\${current}`, '');
+
+        let mentionPattern = defaultMentionPattern;
+        if (props.mentionTriggers) {
+            const mentionTriggers = props.mentionTriggers.reduce((prev, current) => `${prev}\\${current}`, '');
+            mentionPattern = new RegExp(`([${mentionTriggers}])([^${mentionTriggers}]*)$`);
+        }
 
         this.state = {
             activeMention: null,
             isFocused: false,
-            mentionPattern: new RegExp(`([${mentionTriggers}])([^${mentionTriggers}]*)$`),
+            mentionPattern,
         };
     }
 

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -7,7 +7,7 @@ import { EditorState } from 'draft-js';
 import DatalistItem from '../../datalist-item';
 import DraftJSEditor from '../../draft-js-editor';
 import SelectorDropdown from '../../selector-dropdown';
-import { addMention, defaultMentionPattern, getActiveMentionForEditorState } from './utils';
+import { addMention, defaultMentionTriggers, getActiveMentionForEditorState } from './utils';
 
 import messages from './messages';
 
@@ -69,23 +69,19 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
         contacts: [],
         isDisabled: false,
         isRequired: false,
+        mentionTriggers: defaultMentionTriggers,
         selectorRow: <DefaultSelectorRow />,
         startMentionMessage: <DefaultStartMentionMessage />,
     };
 
     constructor(props: Props) {
         super(props);
-
-        let mentionPattern = defaultMentionPattern;
-        if (props.mentionTriggers) {
-            const mentionTriggers = props.mentionTriggers.reduce((prev, current) => `${prev}\\${current}`, '');
-            mentionPattern = new RegExp(`([${mentionTriggers}])([^${mentionTriggers}]*)$`);
-        }
+        const mentionTriggers = props.mentionTriggers.reduce((prev, current) => `${prev}\\${current}`, '');
 
         this.state = {
             activeMention: null,
             isFocused: false,
-            mentionPattern,
+            mentionPattern: new RegExp(`([${mentionTriggers}])([^${mentionTriggers}]*)$`),
         };
     }
 

--- a/src/components/form-elements/draft-js-mention-selector/__tests__/utils.test.js
+++ b/src/components/form-elements/draft-js-mention-selector/__tests__/utils.test.js
@@ -1,0 +1,113 @@
+import { ContentState, EditorState } from 'draft-js';
+import { addMention, getActiveMentionForEditorState } from '../utils';
+
+const noMentionEditorState = EditorState.createWithContent(ContentState.createFromText('No mention here'));
+const oneMentionEditorState = EditorState.createWithContent(ContentState.createFromText('Hey @foo'));
+const twoMentionEditorState = EditorState.createWithContent(ContentState.createFromText('Hi @foo, meet @bar'));
+const oneMentionSelectionState = oneMentionEditorState.getSelection().merge({
+    anchorOffset: 8,
+    focusOffset: 8,
+});
+const twoMentionSelectionState = twoMentionEditorState.getSelection().merge({
+    anchorOffset: 18,
+    focusOffset: 18,
+});
+const twoMentionSelectionStateCursorInside = twoMentionEditorState.getSelection().merge({
+    anchorOffset: 17,
+    focusOffset: 17,
+});
+const oneMentionExpectedMention = {
+    mentionString: 'foo',
+    mentionTrigger: '@',
+    start: 4,
+    end: 8,
+};
+const twoMentionExpectedMention = {
+    mentionString: 'bar',
+    mentionTrigger: '@',
+    start: 14,
+    end: 18,
+};
+const twoMentionCursorInsideExpectedMention = {
+    mentionString: 'ba',
+    mentionTrigger: '@',
+    start: 14,
+    end: 17,
+};
+
+describe('components/form-elements/draft-js-mention-selector/DraftJSMentionSelector', () => {
+    describe('getActiveMentionForEditorState()', () => {
+        // TESTS
+        [
+            // empty input
+            {
+                editorState: EditorState.createEmpty(),
+            },
+            // input has ne mention
+            {
+                editorState: noMentionEditorState,
+            },
+        ].forEach(({ editorState }) => {
+            test('should return null', () => {
+                expect(getActiveMentionForEditorState(editorState)).toBeNull();
+            });
+        });
+
+        [
+            // one string beginning with "@"
+            {
+                editorState: oneMentionEditorState,
+                selectionState: oneMentionSelectionState,
+                expected: oneMentionExpectedMention,
+            },
+            // two strings beginning with "@"
+            {
+                editorState: twoMentionEditorState,
+                selectionState: twoMentionSelectionState,
+                expected: twoMentionExpectedMention,
+            },
+            // two strings beginning "@", cursor inside one
+            {
+                editorState: twoMentionEditorState,
+                selectionState: twoMentionSelectionStateCursorInside,
+                expected: twoMentionCursorInsideExpectedMention,
+            },
+        ].forEach(({ editorState, selectionState, expected }) => {
+            test('should return null when cursor is not over a mention', () => {
+                const selectionStateAtBeginning = editorState.getSelection().merge({
+                    anchorOffset: 0,
+                    focusOffset: 0,
+                });
+
+                const editorStateWithForcedSelection = EditorState.acceptSelection(
+                    editorState,
+                    selectionStateAtBeginning,
+                );
+
+                const result = getActiveMentionForEditorState(editorStateWithForcedSelection);
+
+                expect(result).toBeNull();
+            });
+
+            test('should return the selected mention when it is selected', () => {
+                const editorStateWithForcedSelection = EditorState.acceptSelection(editorState, selectionState);
+
+                const result = getActiveMentionForEditorState(editorStateWithForcedSelection);
+
+                Object.keys(expected).forEach(key => {
+                    expect(result[key]).toEqual(expected[key]);
+                });
+            });
+        });
+    });
+
+    describe('addMention()', () => {
+        test('should return updated string (plus space)', () => {
+            const mention = { id: 1, name: 'Fool Name' };
+
+            const editorStateWithLink = addMention(oneMentionEditorState, oneMentionExpectedMention, mention);
+
+            expect(editorStateWithLink.getCurrentContent().getPlainText()).toEqual('Hey @Fool Name ');
+        });
+    });
+});

--- a/src/components/form-elements/draft-js-mention-selector/index.js
+++ b/src/components/form-elements/draft-js-mention-selector/index.js
@@ -1,4 +1,5 @@
 // @flow
+export * from './utils';
 export { default } from './DraftJSMentionSelector';
 export { default as createMentionSelectorState } from './createMentionSelectorState';
 export { default as DraftMentionDecorator } from './DraftMentionDecorator';

--- a/src/components/form-elements/draft-js-mention-selector/utils.js
+++ b/src/components/form-elements/draft-js-mention-selector/utils.js
@@ -8,10 +8,17 @@ export type Mention = {
     mentionTrigger: string,
     start: number,
 };
+
+const defaultMentionTriggers = ['@', '＠', '﹫'].reduce((prev, current) => `${prev}\\${current}`, '');
+const defaultMentionPattern = new RegExp(`([${defaultMentionTriggers}])([^${defaultMentionTriggers}]*)$`);
+
 /**
  * Extracts the active mention from the editor state
  */
-function getActiveMentionForEditorState(editorState: EditorState, mentionPattern: RegExp): Mention | null {
+function getActiveMentionForEditorState(
+    editorState: EditorState,
+    mentionPattern: RegExp = defaultMentionPattern,
+): Mention | null {
     const contentState = editorState.getCurrentContent();
     const selectionState = editorState.getSelection();
 
@@ -97,4 +104,4 @@ function addMention(editorState: EditorState, activeMention: Mention | null, men
     return editorStateWithLink;
 }
 
-export { getActiveMentionForEditorState, addMention };
+export { addMention, defaultMentionPattern, getActiveMentionForEditorState };

--- a/src/components/form-elements/draft-js-mention-selector/utils.js
+++ b/src/components/form-elements/draft-js-mention-selector/utils.js
@@ -1,0 +1,100 @@
+// @flow
+import { EditorState, Modifier } from 'draft-js';
+
+export type Mention = {
+    blockID: string,
+    end: number,
+    mentionString: string,
+    mentionTrigger: string,
+    start: number,
+};
+/**
+ * Extracts the active mention from the editor state
+ */
+function getActiveMentionForEditorState(editorState: EditorState, mentionPattern: RegExp): Mention | null {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+
+    const startKey = selectionState.getStartKey();
+    const activeBlock = contentState.getBlockForKey(startKey);
+
+    const cursorPosition = selectionState.getStartOffset();
+
+    let result = null;
+
+    // Break the active block into entity ranges.
+    activeBlock.findEntityRanges(
+        character => character.getEntity() === null,
+        (start, end) => {
+            // Find the active range (is the cursor inside this range?)
+            if (start <= cursorPosition && cursorPosition <= end) {
+                // Determine if the active range contains a mention.
+                const activeRangeText = activeBlock.getText().substr(start, cursorPosition - start);
+                const mentionMatch = activeRangeText.match(mentionPattern);
+
+                if (mentionMatch) {
+                    result = {
+                        blockID: startKey,
+                        mentionString: mentionMatch[2],
+                        mentionTrigger: mentionMatch[1],
+                        start: start + mentionMatch.index,
+                        end: cursorPosition,
+                    };
+                }
+            }
+
+            return null;
+        },
+    );
+
+    return result;
+}
+
+/**
+ * Inserts a selected mention into the editor
+ */
+function addMention(editorState: EditorState, activeMention: Mention | null, mention: Object): EditorState {
+    const { start, end } = activeMention || {};
+
+    const { id, name } = mention;
+
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+
+    const preInsertionSelectionState = selectionState.merge({
+        anchorOffset: start,
+        focusOffset: end,
+    });
+
+    const textToInsert = `@${name}`;
+
+    const contentStateWithEntity = contentState.createEntity('MENTION', 'IMMUTABLE', { id });
+
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+
+    const contentStateWithLink = Modifier.replaceText(
+        contentState,
+        preInsertionSelectionState,
+        textToInsert,
+        null,
+        entityKey,
+    );
+
+    const spaceOffset = preInsertionSelectionState.getStartOffset() + textToInsert.length;
+    const selectionStateForAddingSpace = preInsertionSelectionState.merge({
+        anchorOffset: spaceOffset,
+        focusOffset: spaceOffset,
+    });
+
+    const contentStateWithLinkAndExtraSpace = Modifier.insertText(
+        contentStateWithLink,
+        selectionStateForAddingSpace,
+        ' ',
+    );
+
+    const editorStateWithLink = EditorState.push(editorState, contentStateWithLinkAndExtraSpace, 'change-block-type');
+
+    return editorStateWithLink;
+}
+
+export { getActiveMentionForEditorState, addMention };

--- a/src/components/form-elements/draft-js-mention-selector/utils.js
+++ b/src/components/form-elements/draft-js-mention-selector/utils.js
@@ -9,8 +9,9 @@ export type Mention = {
     start: number,
 };
 
-const defaultMentionTriggers = ['@', '＠', '﹫'].reduce((prev, current) => `${prev}\\${current}`, '');
-const defaultMentionPattern = new RegExp(`([${defaultMentionTriggers}])([^${defaultMentionTriggers}]*)$`);
+const defaultMentionTriggers = ['@', '＠', '﹫'];
+const defaultMentionTriggersString = defaultMentionTriggers.reduce((prev, current) => `${prev}\\${current}`, '');
+const defaultMentionPattern = new RegExp(`([${defaultMentionTriggersString}])([^${defaultMentionTriggersString}]*)$`);
 
 /**
  * Extracts the active mention from the editor state
@@ -104,4 +105,4 @@ function addMention(editorState: EditorState, activeMention: Mention | null, men
     return editorStateWithLink;
 }
 
-export { addMention, defaultMentionPattern, getActiveMentionForEditorState };
+export { addMention, defaultMentionTriggers, defaultMentionPattern, getActiveMentionForEditorState };


### PR DESCRIPTION
I think no new tests are needed cause the original tests have already covered all of the content in utils file.