### PR TITLE
feat(annotations): support partial link to file versions

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1145,30 +1145,23 @@ class ContentPreview extends React.PureComponent<Props, State> {
         });
     };
 
-    handleAnnotationSelect = (
-        { file_version: { id: annotationFileVersionId }, target: { location = {} } }: Annotation,
-        version: BoxItemVersion,
-    ) => {
+    handleAnnotationSelect = ({
+        file_version: { id: annotationFileVersionId },
+        target: { location = {} },
+    }: Annotation) => {
         const { selectedVersion } = this.state;
         const { file } = this.state;
         const currentFileVersionId = getProp(file, 'file_version.id');
         const currentPreviewFileVersionId = getProp(selectedVersion, 'id', currentFileVersionId);
         const unit = startAtTypes[location.type];
 
-        if (annotationFileVersionId !== currentPreviewFileVersionId && version) {
-            this.onVersionChange(version, {
-                currentVersionId: currentFileVersionId,
-                updateVersionToCurrent: () => this.setState({ selectedVersion: undefined }),
+        if (unit && annotationFileVersionId !== currentPreviewFileVersionId) {
+            this.setState({
+                startAt: {
+                    unit,
+                    value: location.value,
+                },
             });
-
-            if (unit) {
-                this.setState({
-                    startAt: {
-                        unit,
-                        value: location.value,
-                    },
-                });
-            }
         }
     };
 

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -1126,21 +1126,13 @@ describe('elements/content-preview/ContentPreview', () => {
 
     describe('handleAnnotationSelect', () => {
         test.each`
-            annotationFileVersionId | selectedVersionId | version | locationType | onVersionChangeCount | setStateCount
-            ${'123'}                | ${'124'}          | ${{}}   | ${'page'}    | ${1}                 | ${1}
-            ${'123'}                | ${'124'}          | ${null} | ${'page'}    | ${0}                 | ${0}
-            ${'124'}                | ${'124'}          | ${{}}   | ${'page'}    | ${0}                 | ${0}
-            ${'123'}                | ${'124'}          | ${{}}   | ${''}        | ${1}                 | ${0}
+            annotationFileVersionId | selectedVersionId | locationType | setStateCount
+            ${'123'}                | ${'124'}          | ${'page'}    | ${1}
+            ${'124'}                | ${'124'}          | ${'page'}    | ${0}
+            ${'123'}                | ${'124'}          | ${''}        | ${0}
         `(
             'should call onVersionChange $onVersionChangeCount times and setState $setStateCount times',
-            ({
-                annotationFileVersionId,
-                selectedVersionId,
-                locationType,
-                version,
-                onVersionChangeCount,
-                setStateCount,
-            }) => {
+            ({ annotationFileVersionId, selectedVersionId, locationType, setStateCount }) => {
                 const wrapper = getWrapper();
                 const instance = wrapper.instance();
                 const annotation = {
@@ -1155,12 +1147,10 @@ describe('elements/content-preview/ContentPreview', () => {
                 };
 
                 wrapper.setState({ selectedVersion: { id: selectedVersionId } });
-                instance.onVersionChange = jest.fn();
                 instance.setState = jest.fn();
 
-                instance.handleAnnotationSelect(annotation, version);
+                instance.handleAnnotationSelect(annotation);
 
-                expect(instance.onVersionChange).toHaveBeenCalledTimes(onVersionChangeCount);
                 expect(instance.setState).toHaveBeenCalledTimes(setStateCount);
             },
         );

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -10,7 +10,7 @@ import flow from 'lodash/flow';
 import getProp from 'lodash/get';
 import noop from 'lodash/noop';
 import { FormattedMessage } from 'react-intl';
-import { withRouter, type ContextRouter } from 'react-router-dom';
+import { generatePath, withRouter, type ContextRouter } from 'react-router-dom';
 import ActivityFeed from './activity-feed';
 import AddTaskButton from './AddTaskButton';
 import API from '../../api';
@@ -138,17 +138,18 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             return '/activity';
         }
 
-        const pathParams = ['activity', 'annotations', fileVersionId, annotationId];
-        const path = pathParams.filter(param => !!param).join('/');
-        return `/${path}`;
+        return generatePath('/activity/annotations/:fileVersionId/:annotationId?', {
+            annotationId,
+            fileVersionId,
+        });
     };
 
     redirectDeeplinkedAnnotation = () => {
         const { file, getAnnotationsMatchPath, history } = this.props;
-        const currentFileVersionId = getProp(file, 'file_version.id');
         const match = getAnnotationsMatchPath(history);
-        const fileVersionId = getProp(match, 'params.fileVersionId');
         const annotationId = getProp(match, 'params.annotationId');
+        const currentFileVersionId = getProp(file, 'file_version.id');
+        const fileVersionId = getProp(match, 'params.fileVersionId');
 
         if (fileVersionId && annotationId && fileVersionId !== currentFileVersionId) {
             history.replace(this.getAnnotationsPath(currentFileVersionId, annotationId));

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -183,7 +183,7 @@ class SidebarPanels extends React.Component<Props> {
                                     ref={this.activitySidebar}
                                     startMarkName={MARK_NAME_JS_LOADING_ACTIVITY}
                                     activeFeedEntryId={match.params.activeFeedEntryId}
-                                    activeFeedEntryType={activeFeedEntryType}
+                                    activeFeedEntryType={match.params.activeFeedEntryId && activeFeedEntryType}
                                     {...activitySidebarProps}
                                 />
                             );

--- a/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
@@ -26,21 +26,23 @@ describe('elements/content-sidebar/SidebarPanels', () => {
 
     describe('render', () => {
         test.each`
-            path                         | sidebar
-            ${'/activity'}               | ${'ActivitySidebar'}
-            ${'/activity/comments'}      | ${'ActivitySidebar'}
-            ${'/activity/comments/1234'} | ${'ActivitySidebar'}
-            ${'/activity/tasks'}         | ${'ActivitySidebar'}
-            ${'/activity/tasks/1234'}    | ${'ActivitySidebar'}
-            ${'/activity/versions'}      | ${'VersionsSidebar'}
-            ${'/activity/versions/1234'} | ${'VersionsSidebar'}
-            ${'/details'}                | ${'DetailsSidebar'}
-            ${'/details/versions'}       | ${'VersionsSidebar'}
-            ${'/details/versions/1234'}  | ${'VersionsSidebar'}
-            ${'/metadata'}               | ${'MetadataSidebar'}
-            ${'/skills'}                 | ${'SkillsSidebar'}
-            ${'/nonsense'}               | ${'SkillsSidebar'}
-            ${'/'}                       | ${'SkillsSidebar'}
+            path                                 | sidebar
+            ${'/activity'}                       | ${'ActivitySidebar'}
+            ${'/activity/comments'}              | ${'ActivitySidebar'}
+            ${'/activity/comments/1234'}         | ${'ActivitySidebar'}
+            ${'/activity/tasks'}                 | ${'ActivitySidebar'}
+            ${'/activity/tasks/1234'}            | ${'ActivitySidebar'}
+            ${'/activity/annotations/1234/5678'} | ${'ActivitySidebar'}
+            ${'/activity/annotations/1234'}      | ${'ActivitySidebar'}
+            ${'/activity/versions'}              | ${'VersionsSidebar'}
+            ${'/activity/versions/1234'}         | ${'VersionsSidebar'}
+            ${'/details'}                        | ${'DetailsSidebar'}
+            ${'/details/versions'}               | ${'VersionsSidebar'}
+            ${'/details/versions/1234'}          | ${'VersionsSidebar'}
+            ${'/metadata'}                       | ${'MetadataSidebar'}
+            ${'/skills'}                         | ${'SkillsSidebar'}
+            ${'/nonsense'}                       | ${'SkillsSidebar'}
+            ${'/'}                               | ${'SkillsSidebar'}
         `('should render $sidebar given the path $path', ({ path, sidebar }) => {
             const wrapper = getWrapper({ path });
             expect(wrapper.exists(sidebar)).toBe(true);
@@ -85,6 +87,22 @@ describe('elements/content-sidebar/SidebarPanels', () => {
                 const wrapper = getWrapper({ path: '/activity/versions/12345' });
                 expect(wrapper.find('VersionsSidebar').props()).toMatchObject({
                     versionId: '12345',
+                });
+            });
+
+            test('should render with annotations deeplink', () => {
+                const wrapper = getWrapper({ path: '/activity/annotations/12345/67890' });
+                expect(wrapper.find('ActivitySidebar').props()).toMatchObject({
+                    activeFeedEntryType: 'annotation',
+                    activeFeedEntryId: '67890',
+                });
+            });
+
+            test('should not pass down activeFeedEntry props with partial annotations deeplink', () => {
+                const wrapper = getWrapper({ path: '/activity/annotations/12345' });
+                expect(wrapper.find('ActivitySidebar').props()).toMatchObject({
+                    activeFeedEntryType: undefined,
+                    activeFeedEntryId: undefined,
                 });
             });
         });

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
@@ -33,6 +33,9 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
   <ActivityFeed
     file={
       Object {
+        "file_version": Object {
+          "id": "123",
+        },
         "id": "I_AM_A_FILE",
       }
     }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -245,10 +245,7 @@ class ActivityFeed extends React.Component<Props, State> {
             ? errorMessageByEntryType[activeFeedEntryType]
             : undefined;
 
-        // Annotation deeplink allows for activeFeedEntryType but no activeFeedEntryId
-        const isAnnotationPartialLink = activeFeedEntryType === 'annotation' && !activeFeedEntryId;
-        const isInlineFeedItemErrorVisible =
-            !isLoading && activeFeedEntryType && !isAnnotationPartialLink && !activeEntry;
+        const isInlineFeedItemErrorVisible = !isLoading && activeFeedEntryType && !activeEntry;
         const currentFileVersionId = getProp(file, 'file_version.id');
 
         return (

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -245,7 +245,8 @@ class ActivityFeed extends React.Component<Props, State> {
             ? errorMessageByEntryType[activeFeedEntryType]
             : undefined;
 
-        const isInlineFeedItemErrorVisible = !isLoading && activeFeedEntryType && !activeEntry;
+        const isInlineFeedItemErrorVisible =
+            !isLoading && activeFeedEntryType && activeFeedEntryType !== 'annotation' && !activeEntry;
         const currentFileVersionId = getProp(file, 'file_version.id');
 
         return (

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -245,8 +245,10 @@ class ActivityFeed extends React.Component<Props, State> {
             ? errorMessageByEntryType[activeFeedEntryType]
             : undefined;
 
+        // Annotation deeplink allows for activeFeedEntryType but no activeFeedEntryId
+        const isAnnotationPartialLink = activeFeedEntryType === 'annotation' && !activeFeedEntryId;
         const isInlineFeedItemErrorVisible =
-            !isLoading && activeFeedEntryType && activeFeedEntryType !== 'annotation' && !activeEntry;
+            !isLoading && activeFeedEntryType && !isAnnotationPartialLink && !activeEntry;
         const currentFileVersionId = getProp(file, 'file_version.id');
 
         return (

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -445,15 +445,6 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
         expect(wrapper.exists('InlineError')).toBe(true);
     });
 
-    test('should correctly handle an annotation id being undefined', () => {
-        const wrapper = getWrapper({
-            feedItems,
-            activeFeedEntryId: undefined,
-            activeFeedEntryType: annotations.entries[0].type,
-        });
-        expect(wrapper.exists('InlineError')).toBe(false);
-    });
-
     test('should not render inline error if the type is invalid', () => {
         const wrapper = getWrapper({
             feedItems,

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -9,6 +9,24 @@ jest.mock('../../Avatar', () => 'Avatar');
 jest.mock('../ActiveState', () => 'ActiveState');
 
 const otherUser = { name: 'Akon', id: 11 };
+
+const annotations = {
+    entries: [
+        {
+            created_at: '2020-01-01T00:00:00Z',
+            created_by: otherUser,
+            id: '123',
+            modified_at: '2020-01-02T00:00:00Z',
+            modified_by: otherUser,
+            permissions: {
+                can_delete: true,
+                can_edit: true,
+            },
+            type: 'annotation',
+        },
+    ],
+};
+
 const comments = {
     total_count: 1,
     entries: [
@@ -416,6 +434,24 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
             activeFeedEntryType: taskWithAssignment.type,
         });
         expect(wrapper.exists('InlineError')).toBe(true);
+    });
+
+    test('should correctly handle an inline error for an annotation id being invalid', () => {
+        const wrapper = getWrapper({
+            feedItems,
+            activeFeedEntryId: 'invalid id',
+            activeFeedEntryType: annotations.entries[0].type,
+        });
+        expect(wrapper.exists('InlineError')).toBe(true);
+    });
+
+    test('should correctly handle an annotation id being undefined', () => {
+        const wrapper = getWrapper({
+            feedItems,
+            activeFeedEntryId: undefined,
+            activeFeedEntryType: annotations.entries[0].type,
+        });
+        expect(wrapper.exists('InlineError')).toBe(false);
     });
 
     test('should not render inline error if the type is invalid', () => {


### PR DESCRIPTION
This allows partial links to previous file versions from annotation deep links. 

For example:

Selecting an annotation will change the `sb` param to: `/activity/annotations/123/456`
Deselecting the annotation will change the `sb` param to: `/activity/annotations/123`

The same applies to previous file versions.

This will enable another app to control the file versioning via the url 

TODO
 - [x] unit tests