### PR TITLE
fix(select-field): no longer selecting the wrong item

### DIFF
--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -336,9 +336,20 @@ class BaseSelectField extends React.Component<Props, State> {
         }
     };
 
+    getItemFromFilteredOptions = (index: number) => {
+        const { options } = this.props;
+        const { searchText } = this.state;
+
+        const filteredOptions = options.filter(option =>
+            searchText ? option.displayText.toLowerCase().includes(searchText.toLowerCase()) : true,
+        );
+
+        return filteredOptions[index];
+    };
+
     selectSingleOption(index: number) {
-        const { options, selectedValues } = this.props;
-        const item = options[index];
+        const { selectedValues } = this.props;
+        const item = this.getItemFromFilteredOptions(index);
         // If item not previously selected, fire change handler
         if (!selectedValues.includes(item.value)) {
             this.handleChange([item]);
@@ -349,7 +360,7 @@ class BaseSelectField extends React.Component<Props, State> {
     selectMultiOption = (index: number) => {
         const { defaultValue, options, selectedValues } = this.props;
         const hasDefaultValue = defaultValue != null; // Checks if not undefined or null
-        const item = options[index];
+        const item = this.getItemFromFilteredOptions(index);
 
         // If we are already using the default option, just return without firing onChange
         if (hasDefaultValue && defaultValue === item.value) {
@@ -469,7 +480,7 @@ class BaseSelectField extends React.Component<Props, State> {
 
             const isSelected = selectedValues.includes(value);
 
-            const isClearOption = shouldShowClearOption && index === 0;
+            const isClearOption = shouldShowClearOption && value === 'clear';
 
             const itemProps: Object = {
                 className: classNames('select-option', { 'is-clear-option': isClearOption }),

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -480,7 +480,7 @@ class BaseSelectField extends React.Component<Props, State> {
 
             const isSelected = selectedValues.includes(value);
 
-            const isClearOption = shouldShowClearOption && value === 'clear';
+            const isClearOption = shouldShowClearOption && value === 'clear' && index === 0;
 
             const itemProps: Object = {
                 className: classNames('select-option', { 'is-clear-option': isClearOption }),

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -337,7 +337,7 @@ class BaseSelectField extends React.Component<Props, State> {
         }
     };
 
-    getFilteredOptions = () => {
+    getFilteredOptions = (): Array<SelectOptionProp> => {
         const { options } = this.props;
         const { searchText } = this.state;
 

--- a/src/components/select-field/MultiSelectField.js
+++ b/src/components/select-field/MultiSelectField.js
@@ -4,6 +4,7 @@ import { injectIntl } from 'react-intl';
 
 import type { SelectOptionProp } from './props';
 import BaseSelectField from './BaseSelectField';
+import CLEAR from './constants';
 import messages from './messages';
 
 type Props = {
@@ -23,7 +24,7 @@ const optionsWithClearOption = (options: Array<Object>, shouldShowClearOption?: 
     return shouldShowClearOption
         ? [
               {
-                  value: 'clear',
+                  value: CLEAR,
                   displayText: intl.formatMessage(messages.clearAll),
               },
               ...options,

--- a/src/components/select-field/MultiSelectField.md
+++ b/src/components/select-field/MultiSelectField.md
@@ -81,6 +81,35 @@ const handleChange = selectedOptions => {
 />
 ```
 
+Search Input and Clear Option Enabled
+
+```
+initialState = {
+    selectedValues: [2, 3],
+};
+
+const options = [
+    { displayText: 'Option 1', value: 1 },
+    { displayText: 'Option 2', value: 2 },
+    { displayText: 'Option 3', value: 3 },
+];
+
+const handleChange = selectedOptions => {
+    setState({
+        selectedValues: selectedOptions.map(option => option.value),
+    });
+};
+
+<MultiSelectField
+    onChange={ handleChange }
+    options={ options }
+    placeholder="Choose something"
+    selectedValues={ state.selectedValues }
+    shouldShowSearchInput={true}
+    shouldShowClearOption={true}
+/>
+```
+
 Labeled
 
 ```

--- a/src/components/select-field/SingleSelectField.js
+++ b/src/components/select-field/SingleSelectField.js
@@ -5,6 +5,7 @@ import { injectIntl } from 'react-intl';
 
 import BaseSelectField from './BaseSelectField';
 import type { SelectOptionValueProp, SelectOptionProp } from './props';
+import CLEAR from './constants';
 import messages from './messages';
 
 type Props = {
@@ -57,7 +58,7 @@ class SingleSelectField extends React.Component<Props> {
         const optionsWithClearOption = shouldShowClearOption
             ? [
                   {
-                      value: 'clear',
+                      value: CLEAR,
                       displayText: intl.formatMessage(messages.clearAll),
                   },
                   ...options,

--- a/src/components/select-field/SingleSelectField.md
+++ b/src/components/select-field/SingleSelectField.md
@@ -59,6 +59,65 @@ const handleChange = selectedOption => {
 />
 ```
 
+Search Input Enabled
+
+```
+initialState = {
+    selectedValue: 'b',
+};
+
+const options = [
+    { displayText: 'Option A', value: 'a' },
+    { displayText: 'Option B', value: 'b' },
+    { displayText: 'Option C', value: 'c' },
+    { displayText: 'Option D', value: 'd' },
+    { displayText: 'Option E', value: 'e' },
+];
+
+const handleChange = selectedOption => {
+    setState({
+        selectedValue: selectedOption.value,
+    });
+};
+
+<SingleSelectField
+    onChange={ handleChange }
+    options={ options }
+    selectedValue={ state.selectedValue }
+    shouldShowSearchInput={true}
+/>
+```
+
+Search Input and Clear Option Enabled
+
+```
+initialState = {
+    selectedValue: 'b',
+};
+
+const options = [
+    { displayText: 'Option A', value: 'a' },
+    { displayText: 'Option B', value: 'b' },
+    { displayText: 'Option C', value: 'c' },
+    { displayText: 'Option D', value: 'd' },
+    { displayText: 'Option E', value: 'e' },
+];
+
+const handleChange = selectedOption => {
+    setState({
+        selectedValue: selectedOption.value,
+    });
+};
+
+<SingleSelectField
+    onChange={ handleChange }
+    options={ options }
+    selectedValue={ state.selectedValue }
+    shouldShowSearchInput={true}
+    shouldShowClearOption={true}
+/>
+```
+
 Disabled
 
 ```

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -232,8 +232,11 @@ describe('components/select-field/BaseSelectField', () => {
             expect(itemsWrapper).toMatchSnapshot();
         });
 
-        test('should render a clear option if shouldShowClearOption is true', () => {
-            const wrapper = shallowRenderSelectField({ shouldShowClearOption: true });
+        test('should render a clear option if shouldShowClearOption is true and value is "clear"', () => {
+            const wrapper = shallowRenderSelectField({
+                options: [{ displayText: 'Clear All', value: 'clear' }],
+                shouldShowClearOption: true,
+            });
             const itemsWrapper = wrapper.find('DatalistItem');
 
             expect(itemsWrapper.at(0).prop('className')).toEqual('select-option is-clear-option');
@@ -804,6 +807,7 @@ describe('components/select-field/BaseSelectField', () => {
     describe('onOptionClick', () => {
         test('should call handleClearClick if index is 0 and shouldShowClearOption is true', () => {
             const wrapper = shallowRenderSelectField({
+                options: [{ displayText: 'Clear All', value: 'clear' }],
                 shouldShowClearOption: true,
             });
             wrapper.setState({
@@ -1009,6 +1013,32 @@ describe('components/select-field/BaseSelectField', () => {
         });
     });
 
+    describe('getItemFromFilteredOptions', () => {
+        test('should return the correct item when searchText is empty string', () => {
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+
+            const index = 0;
+
+            const item = instance.getItemFromFilteredOptions(index);
+            expect(item).toEqual(options[index]);
+        });
+
+        test('should return the correct item when searchText is not empty string', () => {
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+            instance.setState({
+                searchText: 'Audio',
+            });
+
+            const indexBeforeFilter = 1; // Index of audio option in default options array
+            const indexAfterFilter = 0; // Index of audio option when user enters a search string of 'Audio'
+
+            const item = instance.getItemFromFilteredOptions(indexAfterFilter);
+            expect(item).toEqual(options[indexBeforeFilter]);
+        });
+    });
+
     describe('selectSingleOption()', () => {
         test('should call handleChange() when index selected was not selected previously', () => {
             const wrapper = shallowRenderSelectField();
@@ -1021,6 +1051,24 @@ describe('components/select-field/BaseSelectField', () => {
                 .withArgs([options[index]]);
 
             instance.selectSingleOption(index);
+        });
+
+        test('should call handleChange with the correct item when searchText is not empty string', () => {
+            const indexBeforeFilter = 1; // Index of audio option in default options array
+            const indexAfterFilter = 0; // Index of audio option after user inputs a search string of 'Audio'
+            const wrapper = shallowRenderSelectField();
+            const instance = wrapper.instance();
+
+            instance.setState({
+                searchText: 'Audio',
+            });
+
+            sandbox
+                .mock(instance)
+                .expects('handleChange')
+                .withArgs([options[indexBeforeFilter]]);
+
+            instance.selectSingleOption(indexAfterFilter);
         });
 
         test('should not call handleChange() when index selected was previously selected', () => {
@@ -1036,6 +1084,26 @@ describe('components/select-field/BaseSelectField', () => {
                 .never();
 
             instance.selectSingleOption(index);
+        });
+
+        test('should not call handleChange when index selected was previously selected and searchText is not empty string', () => {
+            const indexBeforeFilter = 1; // Index of audio option in default options array
+            const indexAfterFilter = 0; // Index of audio option after user inputs a search string of 'Audio'
+            const wrapper = shallowRenderSelectField({
+                selectedValues: [options[indexBeforeFilter].value],
+            });
+            const instance = wrapper.instance();
+
+            instance.setState({
+                searchText: 'Audio',
+            });
+
+            sandbox
+                .mock(instance)
+                .expects('handleChange')
+                .never();
+
+            instance.selectSingleOption(indexAfterFilter);
         });
 
         test('should call handleOptionSelect() even when index selected was previously selected', () => {
@@ -1135,6 +1203,27 @@ describe('components/select-field/BaseSelectField', () => {
                 .withArgs(options[index]); // audio + video
 
             instance.selectMultiOption(index);
+        });
+
+        test('should call handleOptionSelect with correct value when searchText is not empty string', () => {
+            const indexBeforeFilter = 3; // Matches video option in original options array
+            const indexAfterFilter = 0; // Matches index of video option after search filter is applied
+            const wrapper = shallowRenderSelectField({
+                defaultValue: '',
+                selectedValues: ['audio'],
+            }); // default value index is 0 in this case
+            const instance = wrapper.instance();
+
+            instance.setState({
+                searchText: 'Video',
+            });
+
+            sandbox
+                .mock(instance)
+                .expects('handleOptionSelect')
+                .withArgs(options[indexBeforeFilter]); // audio + video
+
+            instance.selectMultiOption(indexAfterFilter);
         });
     });
 

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -241,6 +241,20 @@ describe('components/select-field/BaseSelectField', () => {
 
             expect(itemsWrapper.at(0).prop('className')).toEqual('select-option is-clear-option');
         });
+
+        test('should only set is-clear-option on the first item that has value: "clear"', () => {
+            const wrapper = shallowRenderSelectField({
+                options: [
+                    { displayText: 'Clear All', value: 'clear' },
+                    { displayText: 'User defined clear option', value: 'clear' },
+                ],
+                shouldShowClearOption: true,
+            });
+            const itemsWrapper = wrapper.find('DatalistItem');
+
+            expect(itemsWrapper.at(0).prop('className')).toEqual('select-option is-clear-option');
+            expect(itemsWrapper.at(1).prop('className')).toEqual('select-option');
+        });
     });
 
     describe('render()', () => {

--- a/src/components/select-field/__tests__/MultiSelectField.test.js
+++ b/src/components/select-field/__tests__/MultiSelectField.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { MultiSelectFieldBase } from '../MultiSelectField';
+import CLEAR from '../constants';
 
 describe('components/select-field/MultiSelectField', () => {
     const options = [
@@ -28,7 +29,7 @@ describe('components/select-field/MultiSelectField', () => {
             );
             const expectedOptions = [
                 {
-                    value: 'clear',
+                    value: CLEAR,
                     displayText: 'Clear All',
                 },
                 ...options,

--- a/src/components/select-field/__tests__/SingleSelectField.test.js
+++ b/src/components/select-field/__tests__/SingleSelectField.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 
 import { SingleSelectFieldBase } from '../SingleSelectField';
+import CLEAR from '../constants';
 
 const sandbox = sinon.sandbox.create();
 
@@ -57,7 +58,7 @@ describe('components/select-field/SingleSelectField', () => {
             const baseSelectFieldWrapper = wrapper.find('BaseSelectField');
             const expectedOptions = options;
             expectedOptions.unshift({
-                value: 'clear',
+                value: CLEAR,
                 displayText: 'Clear All',
             });
 

--- a/src/components/select-field/constants.js
+++ b/src/components/select-field/constants.js
@@ -1,0 +1,4 @@
+// @flow
+const CLEAR: '__clear__' = '__clear__'; // value of clear option used in select-field components
+
+export default CLEAR;


### PR DESCRIPTION
Changes in this PR:
- Bugfix for BaseSelectField: when a search filter is applied and the user tries to select an item, we should be updating the correct item in the original options array

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/7213887/81756652-2fa85e00-9471-11ea-9207-444041fd2d8e.gif)
