### PR TITLE
fix(select-field): use custom selector for SearchForm component

### DIFF
--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -425,6 +425,7 @@ class BaseSelectField extends React.Component<Props, State> {
 
         return (
             <SearchForm
+                className="select-field-search-container"
                 getSearchInput={getSearchInput}
                 onChange={this.updateSearchText}
                 placeholder={intl.formatMessage(messages.searchPlaceholder)}

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -12,6 +12,7 @@
     }
 
     .select-field-search-container {
+        width: 100%;
         padding-right: $bdl-grid-unit;
         padding-bottom: $bdl-grid-unit * 2;
         padding-left: $bdl-grid-unit;

--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -10,16 +10,15 @@
         margin: 10px 0;
         border-bottom: 1px solid $bdl-gray-20;
     }
-}
 
-.search-input-container {
-    width: 100%;
-    padding-right: $bdl-grid-unit;
-    padding-bottom: $bdl-grid-unit * 2;
-    padding-left: $bdl-grid-unit;
+    .select-field-search-container {
+        padding-right: $bdl-grid-unit;
+        padding-bottom: $bdl-grid-unit * 2;
+        padding-left: $bdl-grid-unit;
 
-    input {
-        width: 100%;
+        .search-input {
+            width: 100%;
+        }
     }
 }
 


### PR DESCRIPTION
Changes in this PR:
- we should be using a custom selector to target the search container when it is being used inside of SelectField components so that we are not affecting other components on the page that have a SearchForm even though the SearchForm does not live inside the SelectField component


<img width="289" alt="Screen Shot 2020-05-14 at 11 47 19 AM" src="https://user-images.githubusercontent.com/7213887/81973242-b75cac80-95d8-11ea-8393-25f2d92abf38.png">

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/7213887/81978906-0ad2f880-95e1-11ea-989c-476f3e9a3064.gif)


