### PR TITLE
fix(copy): update casing and language for shared links in components

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1170,7 +1170,7 @@ boxui.share.downloadTableHeaderText = Download
 boxui.share.editTableHeaderText = Edit
 # Text for Editor permission level in permissions table
 boxui.share.editorLevelText = Editor
-# Label for text input to enter email addresses to send shared link to (title-case)
+# Field label for shared link recipient list (title-case)
 boxui.share.emailSharedLink = Email Shared Link
 # Error message when user tries to send shared link as email without entering any recipients
 boxui.share.enterAtLeastOneEmail = Enter at least one valid email
@@ -1476,9 +1476,9 @@ boxui.unifiedShare.removeLinkConfirmationDescription = This will permanently rem
 boxui.unifiedShare.removeLinkConfirmationTitle = Remove Shared Link
 # Tooltip description for not having access to remove link
 boxui.unifiedShare.removeLinkTooltip = You do not have permission to remove the link.
-# Label for text input to enter email addresses to send shared link to (title-case)
+# Tooltip text for email shared link button (title-case)
 boxui.unifiedShare.sendSharedLink = Send Shared Link
-# Label of the field where a user designates who to send shared link to (title-case)
+# Field label for shared link recipient list (title-case)
 boxui.unifiedShare.sendSharedLinkFieldLabel = Email Shared Link
 # Accessible label for button that loads share settings popup
 boxui.unifiedShare.settingsButtonLabel = Open shared link settings popup

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1156,9 +1156,9 @@ boxui.selectField.noResults = No Results
 boxui.selectField.searchPlaceholder = Search
 # Title for "Access Type" menu, in all capital letters
 boxui.share.accessType = ACCESS TYPE
-# Label for a Shared Link permission level
+# Label for a shared link permission level
 boxui.share.canEdit = Can edit
-# Label for a Shared Link permission level
+# Label for a shared link permission level
 boxui.share.canView = Can view
 # Text for Co-owner permission level in permissions table
 boxui.share.coownerLevelText = Co-owner
@@ -1170,9 +1170,9 @@ boxui.share.downloadTableHeaderText = Download
 boxui.share.editTableHeaderText = Edit
 # Text for Editor permission level in permissions table
 boxui.share.editorLevelText = Editor
-# Label for text input to enter email addresses to send Shared Link to
+# Label for text input to enter email addresses to send shared link to (title-case)
 boxui.share.emailSharedLink = Email Shared Link
-# Error message when user tries to send Shared Link as email without entering any recipients
+# Error message when user tries to send shared link as email without entering any recipients
 boxui.share.enterAtLeastOneEmail = Enter at least one valid email
 # Text for permissions table Get Link column
 boxui.share.getLinkTableHeaderText = Get Link
@@ -1192,7 +1192,7 @@ boxui.share.inviteFileEditorsLabel = Invite people to become editors of this fil
 boxui.share.inviteePermissionsFieldLabel = Invitee Permissions
 # Tooltip text a user can use to learn more about collaborator permission options
 boxui.share.inviteePermissionsLearnMore = Learn More
-# Label for "Message" text box to email the Shared Link
+# Label for "Message" text box to email the shared link (title-case)
 boxui.share.message = Message
 # Placeholder text for message section
 boxui.share.messageSelectorPlaceholder = Add a message
@@ -1274,19 +1274,19 @@ boxui.share.referAFriendBadgeText = REFER
 boxui.share.referAFriendRewardCenterLinkText = Click Here
 # Text encouraging users to refer a friend to sign up for Box
 boxui.share.referAFriendText = Want a free month of Box? Refer your friend!
-# Label for option to remove Shared Link
+# Label for option to remove shared link
 boxui.share.removeLink = Remove Link
-# Description for confirmation modal to remove a Shared Link
+# Description for confirmation modal to remove a shared link
 boxui.share.removeLinkConfirmationDescription = This will permanently remove the shared link. If this item is embedded on other sites it will also become inaccessible. Any custom properties, settings and expirations will be removed as well. Do you want to continue?
-# Label for confirmation modal to remove a Shared Link
+# Label for confirmation modal to remove a shared link (title-case)
 boxui.share.removeLinkConfirmationTitle = Remove Shared Link
 # Accessible label for button that loads share settings popup
 boxui.share.settingsButtonLabel = Open shared link settings popup
 # Tooltip describing when this shared link will expire. {expiration, date, long} is the formatted date
 boxui.share.sharedLinkExpirationTooltip = This link will expire on {expiration, date, long}
-# Label for field to copy Shared Link URL
+# Label for field to copy shared link URL (title-case)
 boxui.share.sharedLinkLabel = Shared Link
-# Title for Shared Link Modal
+# Title for shared link modal (title-case)
 boxui.share.sharedLinkModalTitle = Shared Link for {itemName}
 # Text to show when the access level of people in company and user can view only
 boxui.share.sharedLinkSettings.accessLevel.inCompanyView = This content is available to anyone within your company with the link, and can be viewed.
@@ -1298,8 +1298,8 @@ boxui.share.sharedLinkSettings.accessLevel.inItem = This content is available to
 boxui.share.sharedLinkSettings.accessLevel.withLinkView = This content is publicly available to anyone with the link, and can be viewed.
 # Text to show when the access level of people with link and user can view and download
 boxui.share.sharedLinkSettings.accessLevel.withLinkViewDownload = This content is publicly available to anyone with the link, and can be viewed or downloaded.
-# Label for option to enable downloads on a Shared Link
-boxui.share.sharedLinkSettings.allowDownloadLabel = Allow users with the Shared Link to download this item
+# Label for option to enable downloads on a shared link
+boxui.share.sharedLinkSettings.allowDownloadLabel = Allow users with the shared link to download this item
 # Title for Allow Download section
 boxui.share.sharedLinkSettings.allowDownloadTitle = Allow Download
 # Label for Custom URL text input field
@@ -1312,13 +1312,13 @@ boxui.share.sharedLinkSettings.directDownloadBlockedByAccessPolicyWithoutClassif
 boxui.share.sharedLinkSettings.directDownloadBlockedByMaliciousContent = Download for this content has been disabled due to a security policy.
 # Title for Direct Link section
 boxui.share.sharedLinkSettings.directLinkLabel = Direct Link
-# Label for option to enable expiration on a Shared Link
+# Label for option to enable expiration on a shared link
 boxui.share.sharedLinkSettings.expirationLabel = Disable Shared Link on
 # Title for Link Expiration section
 boxui.share.sharedLinkSettings.expirationTitle = Link Expiration
 # Notice shown at top of modal when one or more settings are unavailable due to permission settings
 boxui.share.sharedLinkSettings.inaccessibleSettingsNotice = Certain settings may not be available for this item due to permissions.
-# Title for Shared Link Settings modal
+# Title for shared link settings modal (title-case)
 boxui.share.sharedLinkSettings.modalTitle = Shared Link Settings
 # Label for checkbox to enable password on shared link
 boxui.share.sharedLinkSettings.passwordLabel = Require password
@@ -1354,7 +1354,7 @@ boxui.share.viewerUploaderLevelText = Viewer Uploader
 boxui.shareMenu.downloadOnly = Download Only
 # Description of permissions granted when inviting a collab to this item
 boxui.shareMenu.editAndComment = Edit and Comment
-# Label for menu option to get shared link for item
+# Label for menu option to get shared link for item (title-case)
 boxui.shareMenu.getSharedLink = Get Shared Link
 # Label for disabled menu option when user does not have permission to get shared link for item
 boxui.shareMenu.insufficientPermissionsMenuOption = Insufficient sharing permissions. Please contact the folder owner.
@@ -1424,11 +1424,11 @@ boxui.unifiedShare.inviteDisabledTooltip = You do not have permission to invite 
 boxui.unifiedShare.inviteDisabledWeblinkTooltip = Collaborators cannot be added to bookmarks.
 # Label of the field where a user designates who to invite to collaborate on an item
 boxui.unifiedShare.inviteFieldLabel = Invite People
-# Enable shared link
-boxui.unifiedShare.linkShareOff = Enable shared link
-# Link sharing is on
-boxui.unifiedShare.linkShareOn = Shared link is enabled
-# Label for "Message" text box to email the Shared Link
+# Call to action text for allowing the user to create a new shared link
+boxui.unifiedShare.linkShareOff = Create shared link
+# Call to action text for allowing the user to remove an existing shared link
+boxui.unifiedShare.linkShareOn = Shared link is created
+# Label for "Message" text box to email the shared Link
 boxui.unifiedShare.message = Message
 # Title of the Unified Share Modal. {itemName} is the name of the file / folder being shared
 boxui.unifiedShare.modalTitle = Share ‘{itemName}’
@@ -1470,15 +1470,15 @@ boxui.unifiedShare.previewerUploaderLevelDescription = Upload and preview
 boxui.unifiedShare.previewerUploaderLevelText = Previewer Uploader
 # Tooltip description to explain recommendation for sharing tooltip
 boxui.unifiedShare.recommendedSharingTooltipCalloutText = Based on your usage, we think {fullName} would be interested in this file.
-# Description for confirmation modal to remove a Shared Link
+# Description for confirmation modal to remove a shared link
 boxui.unifiedShare.removeLinkConfirmationDescription = This will permanently remove the shared link. If this item is embedded on other sites it will also become inaccessible. Any custom properties, settings and expirations will be removed as well. Do you want to continue?
-# Label for confirmation modal to remove a Shared Link
+# Label for confirmation modal to remove a shared link (title-case)
 boxui.unifiedShare.removeLinkConfirmationTitle = Remove Shared Link
 # Tooltip description for not having access to remove link
 boxui.unifiedShare.removeLinkTooltip = You do not have permission to remove the link.
-# Label for text input to enter email addresses to send Shared Link to
+# Label for text input to enter email addresses to send shared link to (title-case)
 boxui.unifiedShare.sendSharedLink = Send Shared Link
-# Label of the field where a user designates who to send shared link to
+# Label of the field where a user designates who to send shared link to (title-case)
 boxui.unifiedShare.sendSharedLinkFieldLabel = Email Shared Link
 # Accessible label for button that loads share settings popup
 boxui.unifiedShare.settingsButtonLabel = Open shared link settings popup
@@ -1486,15 +1486,15 @@ boxui.unifiedShare.settingsButtonLabel = Open shared link settings popup
 boxui.unifiedShare.sharedLinkDisabledTooltipCopy = Create and copy link for sharing
 # Tooltip describing when this shared link will expire. {expiration, date, long} is the formatted date
 boxui.unifiedShare.sharedLinkExpirationTooltip = This link will expire and be inaccessible on {expiration, date, long}.
-# Label for a Shared Link permission to show for editable box notes
+# Label for a shared link permission to show for editable box notes
 boxui.unifiedShare.sharedLinkPermissionsEdit = Can edit
 # Text to use in the tooltip when presenting an editable Box Note (DO NOT TRANSLATE "Box Notes")
 boxui.unifiedShare.sharedLinkPermissionsEditTooltip = This permission can only be changed in Box Notes
-# Label for a Shared Link permission level
+# Label for a shared link permission level
 boxui.unifiedShare.sharedLinkPermissionsViewDownload = Can view and download
 # Description for Can view and download option
 boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription = Users can view and download
-# Label for a Shared Link permission level
+# Label for a shared link permission level
 boxui.unifiedShare.sharedLinkPermissionsViewOnly = Can view only
 # Description for Can view only option
 boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription = Users can view only

--- a/src/features/share/__tests__/ShareMenu.test.js
+++ b/src/features/share/__tests__/ShareMenu.test.js
@@ -23,7 +23,7 @@ describe('features/share/ShareMenu', () => {
         sandbox.verifyAndRestore();
     });
 
-    test('should render a Menu with Invite Collab and Get Shared Link options', () => {
+    test('should render a Menu component with invite collab and get shared link options', () => {
         const wrapper = getWrapper({
             onGetSharedLinkSelect: sandbox.mock(),
             onInviteCollabSelect: sandbox.mock(),

--- a/src/features/share/messages.js
+++ b/src/features/share/messages.js
@@ -24,7 +24,7 @@ const messages = defineMessages({
     },
     getSharedLink: {
         defaultMessage: 'Get Shared Link',
-        description: 'Label for menu option to get shared link for item',
+        description: 'Label for menu option to get shared link for item (title-case)',
         id: 'boxui.shareMenu.getSharedLink',
     },
     viewAndDownload: {

--- a/src/features/shared-link-modal/SharedLinkModal.js
+++ b/src/features/shared-link-modal/SharedLinkModal.js
@@ -17,7 +17,7 @@ type Props = {
     accessMenuButtonProps?: Object,
     /** The selectable access levels. Should be an object { peopleWithTheLink: true/false, peopleInYourCompany: true/false, peopleInThisItem: true/false } */
     allowedAccessLevels?: allowedAccessLevelsPropType,
-    /** Determines whether or not user is allowed to remove Shared Link */
+    /** Determines whether or not user is allowed to remove shared link */
     canRemoveLink?: boolean,
     /** Function that changes access level; (newAccessLevel: 'peopleWithTheLink' | 'peopleInYourCompany' | 'peopleInThisItem') => void */
     changeAccessLevel: Function,
@@ -52,10 +52,10 @@ type Props = {
     onSettingsClick?: Function,
     /** Current permission level for this item; one of 'canView' | 'canEdit'. If not provided, then the permission menu won't show up. */
     permissionLevel?: permissionLevelPropType,
-    /** Function that removes the Shared Link; () => void */
+    /** Function that removes the shared link; () => void */
     removeLink: Function,
     removeLinkButtonProps?: Object,
-    /** Function to send the Shared Link to the entered emails. Calls function with an object in the format { emails: Array<string>, emailMessage: string }.
+    /** Function to send the shared link to the entered emails. Calls function with an object in the format { emails: Array<string>, emailMessage: string }.
      *  If not provided, "Email Shared Link" section will not appear. */
     sendEmail?: Function,
     /** Share URL of the item */

--- a/src/features/shared-link-modal/messages.js
+++ b/src/features/shared-link-modal/messages.js
@@ -8,27 +8,27 @@ const messages = defineMessages({
     },
     canEdit: {
         defaultMessage: 'Can edit',
-        description: 'Label for a Shared Link permission level',
+        description: 'Label for a shared link permission level',
         id: 'boxui.share.canEdit',
     },
     canView: {
         defaultMessage: 'Can view',
-        description: 'Label for a Shared Link permission level',
+        description: 'Label for a shared link permission level',
         id: 'boxui.share.canView',
     },
     enterAtLeastOneEmailError: {
         defaultMessage: 'Enter at least one valid email',
-        description: 'Error message when user tries to send Shared Link as email without entering any recipients',
+        description: 'Error message when user tries to send shared link as email without entering any recipients',
         id: 'boxui.share.enterAtLeastOneEmail',
     },
     emailSharedLink: {
         defaultMessage: 'Email Shared Link',
-        description: 'Label for text input to enter email addresses to send Shared Link to',
+        description: 'Label for text input to enter email addresses to send shared link to (title-case)',
         id: 'boxui.share.emailSharedLink',
     },
     removeLink: {
         defaultMessage: 'Remove Link',
-        description: 'Label for option to remove Shared Link',
+        description: 'Label for option to remove shared link',
         id: 'boxui.share.removeLink',
     },
     settingsButtonLabel: {
@@ -38,17 +38,17 @@ const messages = defineMessages({
     },
     sharedLinkLabel: {
         defaultMessage: 'Shared Link',
-        description: 'Label for field to copy Shared Link URL',
+        description: 'Label for field to copy shared link URL (title-case)',
         id: 'boxui.share.sharedLinkLabel',
     },
     sharedLinkModalTitle: {
         defaultMessage: 'Shared Link for {itemName}',
-        description: 'Title for Shared Link Modal',
+        description: 'Title for shared link modal (title-case)',
         id: 'boxui.share.sharedLinkModalTitle',
     },
     messageTitle: {
         defaultMessage: 'Message',
-        description: 'Label for "Message" text box to email the Shared Link',
+        description: 'Label for "Message" text box to email the shared link (title-case)',
         id: 'boxui.share.message',
     },
     peopleWithTheLink: {
@@ -79,13 +79,13 @@ const messages = defineMessages({
     },
     removeLinkConfirmationTitle: {
         defaultMessage: 'Remove Shared Link',
-        description: 'Label for confirmation modal to remove a Shared Link',
+        description: 'Label for confirmation modal to remove a shared link (title-case)',
         id: 'boxui.share.removeLinkConfirmationTitle',
     },
     removeLinkConfirmationDescription: {
         defaultMessage:
             'This will permanently remove the shared link. If this item is embedded on other sites it will also become inaccessible. Any custom properties, settings and expirations will be removed as well. Do you want to continue?',
-        description: 'Description for confirmation modal to remove a Shared Link',
+        description: 'Description for confirmation modal to remove a shared link',
         id: 'boxui.share.removeLinkConfirmationDescription',
     },
     sharedLinkExpirationTooltip: {

--- a/src/features/shared-link-modal/messages.js
+++ b/src/features/shared-link-modal/messages.js
@@ -23,7 +23,7 @@ const messages = defineMessages({
     },
     emailSharedLink: {
         defaultMessage: 'Email Shared Link',
-        description: 'Label for text input to enter email addresses to send shared link to (title-case)',
+        description: 'Field label for shared link recipient list (title-case)',
         id: 'boxui.share.emailSharedLink',
     },
     removeLink: {

--- a/src/features/shared-link-settings-modal/messages.js
+++ b/src/features/shared-link-settings-modal/messages.js
@@ -2,8 +2,8 @@ import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
     allowDownloadLabel: {
-        defaultMessage: 'Allow users with the Shared Link to download this item',
-        description: 'Label for option to enable downloads on a Shared Link',
+        defaultMessage: 'Allow users with the shared link to download this item',
+        description: 'Label for option to enable downloads on a shared link',
         id: 'boxui.share.sharedLinkSettings.allowDownloadLabel',
     },
     allowDownloadTitle: {
@@ -41,7 +41,7 @@ const messages = defineMessages({
     },
     modalTitle: {
         defaultMessage: 'Shared Link Settings',
-        description: 'Title for Shared Link Settings modal',
+        description: 'Title for shared link settings modal (title-case)',
         id: 'boxui.share.sharedLinkSettings.modalTitle',
     },
     customURLLabel: {
@@ -56,7 +56,7 @@ const messages = defineMessages({
     },
     expirationLabel: {
         defaultMessage: 'Disable Shared Link on',
-        description: 'Label for option to enable expiration on a Shared Link',
+        description: 'Label for option to enable expiration on a shared link',
         id: 'boxui.share.sharedLinkSettings.expirationLabel',
     },
     passwordLabel: {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareModal.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareModal.test.js
@@ -780,7 +780,7 @@ describe('features/unified-share-modal/UnifiedShareModal', () => {
             expect(wrapper.instance().hasExternalContact('inviteCollabsContacts')).toBe(false);
         });
 
-        test('should return true if the Email Shared Link contacts include at least one external user', () => {
+        test('should return true if the "Email Shared Link" contacts include at least one external user', () => {
             const contacts = [
                 {
                     email: 'x@example.com',
@@ -810,7 +810,7 @@ describe('features/unified-share-modal/UnifiedShareModal', () => {
             expect(wrapper.instance().hasExternalContact('emailSharedLinkContacts')).toBe(true);
         });
 
-        test('should not set isExternalUserInEmailSharedLinkContacts to true if the Email Shared Link contacts does not include any external user', () => {
+        test('should not set isExternalUserInEmailSharedLinkContacts to true if the "Email Shared Link" contacts does not include any external user', () => {
             const contacts = [
                 {
                     email: 'x@example.com',

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -25,7 +25,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
         label={
           <span>
             <FormattedMessage
-              defaultMessage="Shared link is enabled"
+              defaultMessage="Shared link is created"
               id="boxui.unifiedShare.linkShareOn"
             />
             <Tooltip
@@ -199,7 +199,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
           isOn={true}
           label={
             <FormattedMessage
-              defaultMessage="Shared link is enabled"
+              defaultMessage="Shared link is created"
               id="boxui.unifiedShare.linkShareOn"
             />
           }
@@ -342,7 +342,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
           isOn={false}
           label={
             <FormattedMessage
-              defaultMessage="Enable shared link"
+              defaultMessage="Create shared link"
               id="boxui.unifiedShare.linkShareOff"
             />
           }
@@ -378,7 +378,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Shared link is enabled"
+            defaultMessage="Shared link is created"
             id="boxui.unifiedShare.linkShareOn"
           />
         }
@@ -511,7 +511,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         isOn={false}
         label={
           <FormattedMessage
-            defaultMessage="Enable shared link"
+            defaultMessage="Create shared link"
             id="boxui.unifiedShare.linkShareOff"
           />
         }
@@ -545,7 +545,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled c
       isOn={false}
       label={
         <FormattedMessage
-          defaultMessage="Enable shared link"
+          defaultMessage="Create shared link"
           id="boxui.unifiedShare.linkShareOff"
         />
       }
@@ -578,7 +578,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled r
       isOn={true}
       label={
         <FormattedMessage
-          defaultMessage="Shared link is enabled"
+          defaultMessage="Shared link is created"
           id="boxui.unifiedShare.linkShareOn"
         />
       }
@@ -626,7 +626,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
           isOn={true}
           label={
             <FormattedMessage
-              defaultMessage="Shared link is enabled"
+              defaultMessage="Shared link is created"
               id="boxui.unifiedShare.linkShareOn"
             />
           }
@@ -766,7 +766,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Shared link is enabled"
+            defaultMessage="Shared link is created"
             id="boxui.unifiedShare.linkShareOn"
           />
         }
@@ -900,7 +900,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Shared link is enabled"
+            defaultMessage="Shared link is created"
             id="boxui.unifiedShare.linkShareOn"
           />
         }
@@ -1059,7 +1059,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
         isOn={true}
         label={
           <FormattedMessage
-            defaultMessage="Shared link is enabled"
+            defaultMessage="Shared link is created"
             id="boxui.unifiedShare.linkShareOn"
           />
         }

--- a/src/features/unified-share-modal/constants.js
+++ b/src/features/unified-share-modal/constants.js
@@ -1,15 +1,15 @@
 // @flow
 
-// Shared Link Access Level Constants
+// Shared link access level constants
 const ANYONE_WITH_LINK = 'peopleWithTheLink';
 const ANYONE_IN_COMPANY = 'peopleInYourCompany';
 const PEOPLE_IN_ITEM = 'peopleInThisItem';
 
-// Shared Link Permission Level Constants
+// Shared link permission level constants
 const CAN_VIEW_DOWNLOAD = 'canViewDownload';
 const CAN_VIEW_ONLY = 'canViewOnly';
 
-// Invitee Permission Level Constants
+// Invitee permission level constants
 const EDITOR = 'Editor';
 const CO_OWNER = 'Co-owner';
 const PREVIEWER = 'Previewer';

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -112,18 +112,18 @@ const messages = defineMessages({
         id: 'boxui.unifiedShare.settingsButtonLabel',
     },
     linkShareOff: {
-        defaultMessage: 'Enable shared link',
-        description: 'Enable shared link',
+        defaultMessage: 'Create shared link',
+        description: 'Call to action text for allowing the user to create a new shared link',
         id: 'boxui.unifiedShare.linkShareOff',
     },
     linkShareOn: {
-        defaultMessage: 'Shared link is enabled',
-        description: 'Link sharing is on',
+        defaultMessage: 'Shared link is created',
+        description: 'Call to action text for allowing the user to remove an existing shared link',
         id: 'boxui.unifiedShare.linkShareOn',
     },
     messageTitle: {
         defaultMessage: 'Message',
-        description: 'Label for "Message" text box to email the Shared Link',
+        description: 'Label for "Message" text box to email the shared Link',
         id: 'boxui.unifiedShare.message',
     },
     suggestedCollabsTitle: {
@@ -161,13 +161,13 @@ const messages = defineMessages({
 
     removeLinkConfirmationTitle: {
         defaultMessage: 'Remove Shared Link',
-        description: 'Label for confirmation modal to remove a Shared Link',
+        description: 'Label for confirmation modal to remove a shared link (title-case)',
         id: 'boxui.unifiedShare.removeLinkConfirmationTitle',
     },
     removeLinkConfirmationDescription: {
         defaultMessage:
             'This will permanently remove the shared link. If this item is embedded on other sites it will also become inaccessible. Any custom properties, settings and expirations will be removed as well. Do you want to continue?',
-        description: 'Description for confirmation modal to remove a Shared Link',
+        description: 'Description for confirmation modal to remove a shared link',
         id: 'boxui.unifiedShare.removeLinkConfirmationDescription',
     },
     removeLinkTooltip: {
@@ -182,12 +182,12 @@ const messages = defineMessages({
     },
     sendSharedLink: {
         defaultMessage: 'Send Shared Link',
-        description: 'Label for text input to enter email addresses to send Shared Link to',
+        description: 'Label for text input to enter email addresses to send shared link to (title-case)',
         id: 'boxui.unifiedShare.sendSharedLink',
     },
     sendSharedLinkFieldLabel: {
         defaultMessage: 'Email Shared Link',
-        description: 'Label of the field where a user designates who to send shared link to',
+        description: 'Label of the field where a user designates who to send shared link to (title-case)',
         id: 'boxui.unifiedShare.sendSharedLinkFieldLabel',
     },
     sharedLinkExpirationTooltip: {
@@ -200,7 +200,7 @@ const messages = defineMessages({
     // shared link permissions
     sharedLinkPermissionsViewDownload: {
         defaultMessage: 'Can view and download',
-        description: 'Label for a Shared Link permission level',
+        description: 'Label for a shared link permission level',
         id: 'boxui.unifiedShare.sharedLinkPermissionsViewDownload',
     },
     sharedLinkPermissionsViewDownloadDescription: {
@@ -210,12 +210,12 @@ const messages = defineMessages({
     },
     sharedLinkPermissionsViewOnly: {
         defaultMessage: 'Can view only',
-        description: 'Label for a Shared Link permission level',
+        description: 'Label for a shared link permission level',
         id: 'boxui.unifiedShare.sharedLinkPermissionsViewOnly',
     },
     sharedLinkPermissionsEdit: {
         defaultMessage: 'Can edit',
-        description: 'Label for a Shared Link permission to show for editable box notes',
+        description: 'Label for a shared link permission to show for editable box notes',
         id: 'boxui.unifiedShare.sharedLinkPermissionsEdit',
     },
     sharedLinkPermissionsEditTooltip: {

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -182,12 +182,12 @@ const messages = defineMessages({
     },
     sendSharedLink: {
         defaultMessage: 'Send Shared Link',
-        description: 'Label for text input to enter email addresses to send shared link to (title-case)',
+        description: 'Tooltip text for email shared link button (title-case)',
         id: 'boxui.unifiedShare.sendSharedLink',
     },
     sendSharedLinkFieldLabel: {
         defaultMessage: 'Email Shared Link',
-        description: 'Label of the field where a user designates who to send shared link to (title-case)',
+        description: 'Field label for shared link recipient list (title-case)',
         id: 'boxui.unifiedShare.sendSharedLinkFieldLabel',
     },
     sharedLinkExpirationTooltip: {


### PR DESCRIPTION
- string changes for references to shared links, descriptions, and labels to use shared terminology