### PR TITLE
fix(virtualized-table): Enforce fixed height on draggable table

### DIFF
--- a/src/features/virtualized-table/DraggableVirtualizedTable.js
+++ b/src/features/virtualized-table/DraggableVirtualizedTable.js
@@ -12,10 +12,12 @@ import { bdlGray } from '../../styles/variables';
 import IconDrag from '../../icons/general/IconDrag';
 import { draggableRowRenderer } from '../virtualized-table-renderers';
 
+import { VIRTUALIZED_TABLE_DEFAULTS } from './constants';
 import VirtualizedTable from './VirtualizedTable';
 
 import './DraggableVirtualizedTable.scss';
 
+const { HEADER_HEIGHT, ROW_HEIGHT } = VIRTUALIZED_TABLE_DEFAULTS;
 const ICON_SIZE = 24;
 
 type Props = VirtualizedTableProps & {
@@ -28,12 +30,19 @@ const DraggableVirtualizedTable = ({
     children,
     className,
     onDragEnd,
+    rowData,
     shouldShowDragHandle,
     tableId,
     ...rest
 }: Props) => {
     const tableClassName = classNames('bdl-DraggableVirtualizedTable', className);
     const draggableCellRenderer = () => <IconDrag color={bdlGray} height={ICON_SIZE} width={ICON_SIZE} />;
+    // Virtualized table's performance optimizations can not be used here since
+    // all rows need to be rendered in order for drag and drop to work properly.
+    // From a UX perspective, it also doesn't make sense to have drag and drop on
+    // very large tables that actually require optimizations, so this component
+    // always forces the table to be tall enough to fit all rows
+    const tableHeight = rowData.length * ROW_HEIGHT + HEADER_HEIGHT;
 
     const handleDragEnd = ({ destination, source }) => {
         const destinationIndex = destination ? destination.index : source.index;
@@ -45,7 +54,13 @@ const DraggableVirtualizedTable = ({
             <Droppable droppableId={tableId}>
                 {(droppableProvided: DroppableProvided) => (
                     <div ref={droppableProvided.innerRef}>
-                        <VirtualizedTable {...rest} className={tableClassName} rowRenderer={draggableRowRenderer}>
+                        <VirtualizedTable
+                            {...rest}
+                            className={tableClassName}
+                            rowRenderer={draggableRowRenderer}
+                            height={tableHeight}
+                            rowData={rowData}
+                        >
                             {shouldShowDragHandle && (
                                 <Column
                                     cellRenderer={draggableCellRenderer}

--- a/src/features/virtualized-table/__tests__/DraggableVirtualizedTable.test.js
+++ b/src/features/virtualized-table/__tests__/DraggableVirtualizedTable.test.js
@@ -4,8 +4,11 @@ import { shallow } from 'enzyme';
 import { Column } from 'react-virtualized/dist/es/Table';
 
 import { bdlGray } from '../../../styles/variables';
+import { VIRTUALIZED_TABLE_DEFAULTS } from '../constants';
 
 import DraggableVirtualizedTable from '../DraggableVirtualizedTable';
+
+const { ROW_HEIGHT, HEADER_HEIGHT } = VIRTUALIZED_TABLE_DEFAULTS;
 
 describe('features/virtualized-table/DraggableVirtualizedTable', () => {
     let wrapper;
@@ -88,6 +91,18 @@ describe('features/virtualized-table/DraggableVirtualizedTable', () => {
                 height: 24,
             }),
         );
+    });
+
+    test('should set fixed height on table based on row count', () => {
+        rowData.push({
+            name: 'name4',
+            description: 'description4',
+        });
+        wrapper.setProps({ rowData });
+        const expectedHeight = rowData.length * ROW_HEIGHT + HEADER_HEIGHT;
+        const renderPropWrapper = getRenderPropWrapper();
+
+        expect(renderPropWrapper.find('VirtualizedTable').props().height).toBe(expectedHeight);
     });
 
     test.each`

--- a/src/features/virtualized-table/__tests__/__snapshots__/DraggableVirtualizedTable.test.js.snap
+++ b/src/features/virtualized-table/__tests__/__snapshots__/DraggableVirtualizedTable.test.js.snap
@@ -4,6 +4,7 @@ exports[`features/virtualized-table/DraggableVirtualizedTable should render a Dr
 <div>
   <VirtualizedTable
     className="bdl-DraggableVirtualizedTable"
+    height={195}
     rowData={
       Array [
         Object {


### PR DESCRIPTION
In contrast to the regular `VirtualizedTable`, the new `DraggableVirtualizedTable` component is only meant to be used in circumstances in which all of the rows have been rendered by the time user interaction begins. 

This update will enforce a fixed height relative to the row count so that the `DraggableVirtualizedTable` component is not accidentally used in "scrollable window" mode, which is not supported. 