### PR TITLE
feat(annotations): Rewrite deep-linked file version to current

### DIFF
--- a/src/elements/common/annotator-context/withAnnotations.tsx
+++ b/src/elements/common/annotator-context/withAnnotations.tsx
@@ -85,7 +85,7 @@ export default function withAnnotations<P extends object>(
         getMatchPath(history?: History): matchType<MatchParams> | null {
             const pathname = getProp(history, 'location.pathname');
             return matchPath<MatchParams>(pathname, {
-                path: '/:sidebar/annotations/:fileVersionId/:annotationId',
+                path: '/:sidebar/annotations/:fileVersionId/:annotationId?',
                 exact: true,
             });
         }

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -151,7 +151,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         const currentFileVersionId = getProp(file, 'file_version.id');
         const fileVersionId = getProp(match, 'params.fileVersionId');
 
-        if (fileVersionId && annotationId && fileVersionId !== currentFileVersionId) {
+        if (fileVersionId && fileVersionId !== currentFileVersionId) {
             history.replace(this.getAnnotationsPath(currentFileVersionId, annotationId));
         }
     };

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -863,7 +863,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             ${'124'}      | ${undefined} | ${1}              | ${'/activity/annotations/123'}
         `(
             'should call history.replace appropriately if router location annotationId=$annotationId and fileVersionId=$fileVersionId',
-            ({ annotationId, fileVersionId, expectedCallCount }) => {
+            ({ annotationId, fileVersionId, expectedCallCount, expectedPath }) => {
                 const wrapper = getWrapper({ file, getAnnotationsMatchPath, history });
                 const instance = wrapper.instance();
                 getAnnotationsMatchPath.mockReturnValue({ params: { annotationId, fileVersionId } });
@@ -871,6 +871,10 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.redirectDeeplinkedAnnotation();
 
                 expect(history.replace).toHaveBeenCalledTimes(expectedCallCount);
+
+                if (expectedCallCount) {
+                    expect(history.replace).toHaveBeenCalledWith(expectedPath);
+                }
             },
         );
     });

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -856,11 +856,11 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         });
 
         test.each`
-            fileVersionId | annotationId | expectedCallCount
-            ${undefined}  | ${'987'}     | ${0}
-            ${'123'}      | ${'987'}     | ${0}
-            ${'124'}      | ${'987'}     | ${1}
-            ${'124'}      | ${undefined} | ${0}
+            fileVersionId | annotationId | expectedCallCount | expectedPath
+            ${undefined}  | ${'987'}     | ${0}              | ${undefined}
+            ${'123'}      | ${'987'}     | ${0}              | ${undefined}
+            ${'124'}      | ${'987'}     | ${1}              | ${'/activity/annotations/123/987'}
+            ${'124'}      | ${undefined} | ${1}              | ${'/activity/annotations/123'}
         `(
             'should call history.replace appropriately if router location annotationId=$annotationId and fileVersionId=$fileVersionId',
             ({ annotationId, fileVersionId, expectedCallCount }) => {


### PR DESCRIPTION
Handles the scenario where preview is direct loaded with a partial deep link to an annotation, i.e. `?sb=/activity/annotations/:fileVersionId` instead of `?sb=/activity/annotations/:fileVersionId/:annotationId`.

This can lead to a bug where clicking on an annotation that is actually on the previous file version will not trigger a file version change because according to the location, we're already on that file version.

In this scenario we will rewrite the url to be the current file version id, so as to maintain the consistency of the `sb` location being the source of truth for which version is being previewed