### PR TITLE
fix(collapsiblesidebar): Update menu item to take text and content

### DIFF
--- a/src/features/collapsible-sidebar/CollapsibleSidebar.stories.js
+++ b/src/features/collapsible-sidebar/CollapsibleSidebar.stories.js
@@ -13,7 +13,7 @@ import CollapsibleSidebarLogo from './CollapsibleSidebarLogo';
 import CollapsibleSidebarFooter from './CollapsibleSidebarFooter';
 import CollapsibleSidebarNav from './CollapsibleSidebarNav';
 import CollapsibleSidebarItem from './CollapsibleSidebarItem';
-import CollapsibleSidebarMenuItem, { StyledMenuItemLabel } from './CollapsibleSidebarMenuItem';
+import CollapsibleSidebarMenuItem from './CollapsibleSidebarMenuItem';
 import notes from './CollapsibleSidebar.stories.md';
 
 import { BetaBadge, TrialBadge } from '../../components/badge';
@@ -61,16 +61,6 @@ export const basic = () => {
 
     const menuItemContent = (
         <>
-            <StyledMenuItemLabel
-                style={{
-                    marginLeft: 16,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    opacity: 0.85,
-                }}
-            >
-                Synced
-            </StyledMenuItemLabel>
             <BetaBadge
                 style={{
                     marginLeft: 8,
@@ -142,6 +132,7 @@ export const basic = () => {
                                         <CollapsibleSidebarMenuItem
                                             content={menuItemContent}
                                             icon={<CheckmarkBadge16 height={20} width={20} />}
+                                            text="Really really long synced link name synced Link"
                                         />
                                     }
                                     tooltipMessage="Synced Link"

--- a/src/features/collapsible-sidebar/CollapsibleSidebarMenuItem.js
+++ b/src/features/collapsible-sidebar/CollapsibleSidebarMenuItem.js
@@ -60,7 +60,7 @@ const StyledIconWrapper = styled.span`
     }
 `;
 
-export const StyledMenuItemLabel = styled.span`
+const StyledMenuItemLabel = styled.span`
     color: ${props => props.theme.primary.foreground};
 
     a:active &,
@@ -74,19 +74,10 @@ export const StyledMenuItemLabel = styled.span`
 type Props = {
     /** Additional classes */
     className?: string,
-    /**
-     * Custom menu item content. If passed in and "text" is not specified, component will render this content
-     *
-     * Required if "text" is not specified
-     */
+    /** Content to be  displayed next to item label. */
     content?: React.Node,
     icon?: React.Node,
     overflowAction?: React.Node,
-    /**
-     * Menu item label. If passed in, component will render the label irrespective of the presence of "content"
-     *
-     * Required if "content" is not specified
-     */
     text?: string,
 };
 
@@ -105,7 +96,7 @@ function CollapsibleSidebarMenuItem(props: Props) {
                         {text}
                     </StyledMenuItemLabel>
                 )}
-                {!text && content}
+                {content}
                 {overflowAction}
             </StyledMenuItem>
         );

--- a/src/features/collapsible-sidebar/__tests__/CollapsibleSidebarMenuItem.test.js
+++ b/src/features/collapsible-sidebar/__tests__/CollapsibleSidebarMenuItem.test.js
@@ -32,7 +32,7 @@ describe('components/core/collapsible-sidebar/__tests__/CollapsibleSidebarMenuIt
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should show custom content when content is passed but not the text', () => {
+    test('should show custom content when content is passed', () => {
         libDom.useIsContentOverflowed.mockReturnValue(false);
 
         const testContent = 'Custom Content';
@@ -41,29 +41,13 @@ describe('components/core/collapsible-sidebar/__tests__/CollapsibleSidebarMenuIt
                 className: 'foo',
                 content: <div className="custom-div">{testContent}</div>,
                 icon: 'bold',
+                text: 'bar',
             },
             { isScrolling: false },
         );
 
         expect(wrapper.find('.custom-div')).toHaveLength(1);
         expect(wrapper.find('.custom-div').text()).toBe(testContent);
-        expect(wrapper.find('span.bdl-CollapsibleSidebar-menuItemLabel')).toHaveLength(0);
-    });
-
-    test('should show just text when text and content is passed', () => {
-        libDom.useIsContentOverflowed.mockReturnValue(false);
-
-        const wrapper = getWrapper(
-            {
-                className: 'foo',
-                content: <div className="custom-div">Custom Content</div>,
-                icon: 'bold',
-                text: 'bar',
-            },
-            { isScrolling: false },
-        );
-
-        expect(wrapper.find('.custom-div')).toHaveLength(0);
         expect(wrapper.find('span.bdl-CollapsibleSidebar-menuItemLabel')).toHaveLength(1);
     });
 


### PR DESCRIPTION
Removing text and content from being mutually exclusive. Helps to make use of containers tooltip on overflowing text appropriately
<img width="461" alt="Screen Shot 2020-05-28 at 3 31 13 PM" src="https://user-images.githubusercontent.com/10932475/83200653-a5126080-a0f8-11ea-884d-34f8c60d1a7d.png">
