### PR TITLE
fix(annotations): Avoid path rewrite when ActivitySidebar remounts

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -66,6 +66,7 @@ type ExternalProps = {
 type PropsWithoutContext = {
     elementId: string,
     file: BoxItem,
+    hasSidebarInitialized: boolean,
     isDisabled: boolean,
     onAnnotationSelect: Function,
     onVersionChange: Function,
@@ -122,17 +123,19 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
         // eslint-disable-next-line react/prop-types
-        const { logger } = this.props;
+        const { hasSidebarInitialized, logger } = this.props;
 
         logger.onReadyMetric({
             endMarkName: MARK_NAME_JS_READY,
         });
         this.state = {};
 
-        // On hard load with deep link for annotation on previous version -- replace the
-        // file version with the latest file version until ContentPreview can support loading
-        // a previous version on mount
-        this.redirectDeeplinkedAnnotation();
+        if (!hasSidebarInitialized) {
+            // On hard load with deep link for annotation on previous version -- replace the
+            // file version with the latest file version until ContentPreview can support loading
+            // a previous version on mount
+            this.redirectDeeplinkedAnnotation();
+        }
     }
 
     redirectDeeplinkedAnnotation = () => {

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -66,7 +66,7 @@ type ExternalProps = {
 type PropsWithoutContext = {
     elementId: string,
     file: BoxItem,
-    hasSidebarInitialized: boolean,
+    hasSidebarInitialized?: boolean,
     isDisabled: boolean,
     onAnnotationSelect: Function,
     onVersionChange: Function,

--- a/src/elements/content-sidebar/DetailsSidebar.js
+++ b/src/elements/content-sidebar/DetailsSidebar.js
@@ -47,6 +47,7 @@ type ExternalProps = {
     hasNotices?: boolean,
     hasProperties?: boolean,
     hasRetentionPolicy?: boolean,
+    hasSidebarInitialized: boolean,
     hasVersions?: boolean,
     onAccessStatsClick?: Function,
     onClassificationClick?: (e: SyntheticEvent<HTMLButtonElement>) => void,

--- a/src/elements/content-sidebar/DetailsSidebar.js
+++ b/src/elements/content-sidebar/DetailsSidebar.js
@@ -47,7 +47,7 @@ type ExternalProps = {
     hasNotices?: boolean,
     hasProperties?: boolean,
     hasRetentionPolicy?: boolean,
-    hasSidebarInitialized: boolean,
+    hasSidebarInitialized?: boolean,
     hasVersions?: boolean,
     onAccessStatsClick?: Function,
     onClassificationClick?: (e: SyntheticEvent<HTMLButtonElement>) => void,

--- a/src/elements/content-sidebar/MetadataSidebar.js
+++ b/src/elements/content-sidebar/MetadataSidebar.js
@@ -49,7 +49,7 @@ type ExternalProps = {
 type PropsWithoutContext = {
     elementId: string,
     fileId: string,
-    hasSidebarInitialized: boolean,
+    hasSidebarInitialized?: boolean,
 } & ExternalProps;
 
 type Props = {

--- a/src/elements/content-sidebar/MetadataSidebar.js
+++ b/src/elements/content-sidebar/MetadataSidebar.js
@@ -49,6 +49,7 @@ type ExternalProps = {
 type PropsWithoutContext = {
     elementId: string,
     fileId: string,
+    hasSidebarInitialized: boolean,
 } & ExternalProps;
 
 type Props = {

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -47,6 +47,10 @@ type Props = {
     versionsSidebarProps: VersionsSidebarProps,
 };
 
+type State = {
+    isInitialized: boolean,
+};
+
 type ElementRefType = {
     current: null | Object,
 };
@@ -76,14 +80,20 @@ const LoadableVersionsSidebar = SidebarUtils.getAsyncSidebarContent(
     MARK_NAME_JS_LOADING_VERSIONS,
 );
 
-class SidebarPanels extends React.Component<Props> {
+class SidebarPanels extends React.Component<Props, State> {
     activitySidebar: ElementRefType = React.createRef();
 
     detailsSidebar: ElementRefType = React.createRef();
 
     metadataSidebar: ElementRefType = React.createRef();
 
+    state: State = { isInitialized: false };
+
     versionsSidebar: ElementRefType = React.createRef();
+
+    componentDidMount() {
+        this.setState({ isInitialized: true });
+    }
 
     /**
      * Refreshes the contents of the active sidebar
@@ -135,6 +145,8 @@ class SidebarPanels extends React.Component<Props> {
             versionsSidebarProps,
         }: Props = this.props;
 
+        const { isInitialized } = this.state;
+
         if (!isOpen || (!hasActivity && !hasDetails && !hasMetadata && !hasSkills && !hasVersions)) {
             return null;
         }
@@ -152,6 +164,7 @@ class SidebarPanels extends React.Component<Props> {
                                 file={file}
                                 getPreview={getPreview}
                                 getViewer={getViewer}
+                                hasSidebarInitialized={isInitialized}
                                 startMarkName={MARK_NAME_JS_LOADING_SKILLS}
                             />
                         )}
@@ -177,6 +190,7 @@ class SidebarPanels extends React.Component<Props> {
                                     elementId={elementId}
                                     currentUser={currentUser}
                                     file={file}
+                                    hasSidebarInitialized={isInitialized}
                                     onAnnotationSelect={onAnnotationSelect}
                                     onVersionChange={onVersionChange}
                                     onVersionHistoryClick={onVersionHistoryClick}
@@ -198,6 +212,7 @@ class SidebarPanels extends React.Component<Props> {
                             <LoadableDetailsSidebar
                                 elementId={elementId}
                                 fileId={fileId}
+                                hasSidebarInitialized={isInitialized}
                                 key={fileId}
                                 hasVersions={hasVersions}
                                 onVersionHistoryClick={onVersionHistoryClick}
@@ -216,6 +231,7 @@ class SidebarPanels extends React.Component<Props> {
                             <LoadableMetadataSidebar
                                 elementId={elementId}
                                 fileId={fileId}
+                                hasSidebarInitialized={isInitialized}
                                 ref={this.metadataSidebar}
                                 startMarkName={MARK_NAME_JS_LOADING_METADATA}
                                 {...metadataSidebarProps}
@@ -229,6 +245,7 @@ class SidebarPanels extends React.Component<Props> {
                         render={({ match }) => (
                             <LoadableVersionsSidebar
                                 fileId={fileId}
+                                hasSidebarInitialized={isInitialized}
                                 key={fileId}
                                 onVersionChange={onVersionChange}
                                 parentName={match.params.sidebar}

--- a/src/elements/content-sidebar/SkillsSidebar.js
+++ b/src/elements/content-sidebar/SkillsSidebar.js
@@ -36,7 +36,7 @@ type PropsWithoutContext = {
     file: BoxItem,
     getPreview: Function,
     getViewer: Function,
-    hasSidebarInitialized: boolean,
+    hasSidebarInitialized?: boolean,
     refreshIdentity?: boolean,
 };
 

--- a/src/elements/content-sidebar/SkillsSidebar.js
+++ b/src/elements/content-sidebar/SkillsSidebar.js
@@ -36,6 +36,7 @@ type PropsWithoutContext = {
     file: BoxItem,
     getPreview: Function,
     getViewer: Function,
+    hasSidebarInitialized: boolean,
     refreshIdentity?: boolean,
 };
 

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -74,6 +74,23 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 endMarkName: expect.any(String),
             });
         });
+
+        test.each`
+            hasSidebarInitialized | expectedCount
+            ${false}              | ${1}
+            ${true}               | ${0}
+        `(
+            'should call redirectDeeplinkedAnnotation $expectedCount times when hasSidebarInitialized is $hasSidebarInitialized',
+            ({ expectedCount, hasSidebarInitialized }) => {
+                const getAnnotationsMatchPath = jest.fn();
+                const getAnnotationsPath = jest.fn();
+                const history = {
+                    replace: jest.fn(),
+                };
+                getWrapper({ getAnnotationsMatchPath, getAnnotationsPath, hasSidebarInitialized, history });
+                expect(getAnnotationsMatchPath).toHaveBeenCalledTimes(expectedCount);
+            },
+        );
     });
 
     describe('componentDidMount()', () => {

--- a/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
@@ -115,5 +115,13 @@ describe('elements/content-sidebar/SidebarPanels', () => {
                 });
             });
         });
+
+        describe('first loaded behavior', () => {
+            test('should update isFirstLoad on mount', () => {
+                const wrapper = getWrapper({ path: '/activity' });
+                const sidebarPanels = wrapper.find(SidebarPanels);
+                expect(sidebarPanels.state('isInitialized')).toBe(true);
+            });
+        });
     });
 });

--- a/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
@@ -117,7 +117,7 @@ describe('elements/content-sidebar/SidebarPanels', () => {
         });
 
         describe('first loaded behavior', () => {
-            test('should update isFirstLoad on mount', () => {
+            test('should update isInitialized state on mount', () => {
                 const wrapper = getWrapper({ path: '/activity' });
                 const sidebarPanels = wrapper.find(SidebarPanels);
                 expect(sidebarPanels.state('isInitialized')).toBe(true);

--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -24,7 +24,7 @@ import type { BoxItemVersion, BoxItem, FileVersions } from '../../../common/type
 type Props = {
     api: API,
     fileId: string,
-    hasSidebarInitialized: boolean,
+    hasSidebarInitialized?: boolean,
     history: RouterHistory,
     match: Match,
     onVersionChange: VersionChangeCallback,

--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -24,6 +24,7 @@ import type { BoxItemVersion, BoxItem, FileVersions } from '../../../common/type
 type Props = {
     api: API,
     fileId: string,
+    hasSidebarInitialized: boolean,
     history: RouterHistory,
     match: Match,
     onVersionChange: VersionChangeCallback,


### PR DESCRIPTION
Since Sidebar unmounts and mounts the individual Sidebar panels when collapsing and expanding, I added knowledge in the `SidebarPanels` to keep track of whether the component has loaded for the first time and pass that as a prop into the individual sidebars.

`ActivitySidebar` can use this knowledge to know whether or not to treat it as a first mount or a remount