### PR TITLE
feat(pill-selector-dropdown): add new avatar pill for pill selector

### DIFF
--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -2,13 +2,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
+import { List } from 'immutable';
 
 import Tooltip from '../tooltip';
 import { KEYS } from '../../constants';
 
+import RoundPill from './RoundPill';
 import Pill from './Pill';
 import SuggestedPillsRow from './SuggestedPillsRow';
-import type { Option, OptionValue, SelectedOptions, SuggestedPillsFilter } from './flowTypes';
+import type { RoundOption, Option, OptionValue, SuggestedPillsFilter } from './flowTypes';
 
 function stopDefaultEvent(event) {
     event.preventDefault();
@@ -25,7 +27,11 @@ type Props = {
     onRemove: Function,
     onSuggestedPillAdd?: Function,
     placeholder: string,
-    selectedOptions: SelectedOptions,
+    selectedOptions: Array<Object> | List<Object>,
+    /** Whether to show avatars in pills (if rounded style is enabled) */
+    showAvatars?: boolean,
+    /** Whether to use rounded style for pills */
+    showRoundedPills?: boolean,
     suggestedPillsData?: Array<Object>,
     suggestedPillsFilter?: SuggestedPillsFilter,
     suggestedPillsTitle?: string,
@@ -168,6 +174,8 @@ class PillSelector extends React.Component<Props, State> {
             onSuggestedPillAdd,
             placeholder,
             selectedOptions,
+            showAvatars,
+            showRoundedPills,
             suggestedPillsData,
             suggestedPillsFilter,
             suggestedPillsTitle,
@@ -199,17 +207,39 @@ class PillSelector extends React.Component<Props, State> {
                     onFocus={this.handleFocus}
                     onKeyDown={this.handleKeyDown}
                 >
-                    {selectedOptions.map((option: Option, index: number) => (
-                        <Pill
-                            isValid={allowInvalidPills ? validator(option) : true}
-                            isDisabled={disabled}
-                            isSelected={index === selectedIndex}
-                            key={option.value}
-                            onRemove={onRemove.bind(this, option, index)}
-                            // $FlowFixMe option.text is for backwards compatibility
-                            text={option.displayText || option.text}
-                        />
-                    ))}
+                    {showRoundedPills
+                        ? selectedOptions.map((option: RoundOption, index: number) => {
+                              return (
+                                  <RoundPill
+                                      isValid={allowInvalidPills ? validator(option) : true}
+                                      isDisabled={disabled}
+                                      isSelected={index === selectedIndex}
+                                      key={option.value}
+                                      onRemove={onRemove.bind(this, option, index)}
+                                      // $FlowFixMe option.text is for backwards compatibility
+                                      text={option.displayText || option.text}
+                                      showAvatar
+                                      id={option.id}
+                                      hasWarning={option.hasWarning}
+                                      isExternal={option.isExternalUser}
+                                  />
+                              );
+                          })
+                        : selectedOptions.map((option: Option, index: number) => {
+                              // TODO: This and associated types will be removed once all views are updates with round pills.
+                              return (
+                                  <Pill
+                                      isValid={allowInvalidPills ? validator(option) : true}
+                                      isDisabled={disabled}
+                                      isSelected={index === selectedIndex}
+                                      key={option.value}
+                                      onRemove={onRemove.bind(this, option, index)}
+                                      // $FlowFixMe option.text is for backwards compatibility
+                                      text={option.displayText || option.text}
+                                  />
+                              );
+                          })}
+
                     {/* hidden element for focus/key events during pill selection */}
                     <span
                         aria-hidden="true"
@@ -224,7 +254,9 @@ class PillSelector extends React.Component<Props, State> {
                         {...rest}
                         {...inputProps}
                         autoComplete="off"
-                        className={classNames('bdl-PillSelector-input', 'pill-selector-input', className)}
+                        className={classNames('bdl-PillSelector-input', 'pill-selector-input', className, {
+                            'bdl-PillSelector-input--showAvatars': showAvatars,
+                        })}
                         disabled={disabled}
                         onInput={onInput}
                         placeholder={this.getNumSelected() === 0 ? placeholder : ''}

--- a/src/components/pill-selector-dropdown/PillSelector.scss
+++ b/src/components/pill-selector-dropdown/PillSelector.scss
@@ -114,6 +114,13 @@
                 outline: none;
             }
         }
+
+        // when using the larger pills with user avatars,
+        // increase textarea line height to align text with pill content
+        .bdl-RoundPill ~ .bdl-PillSelector-input {
+            height: $bdl-line-height + $bdl-grid-unit * 2;
+            line-height: $bdl-line-height + $bdl-grid-unit * 2;
+        }
     }
 }
 

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.js
@@ -62,6 +62,10 @@ type Props = {
     shouldClearUnmatchedInput?: boolean,
     /** Determines whether or not the first item is highlighted automatically when the dropdown opens */
     shouldSetActiveItemOnOpen?: boolean,
+    /** show avatars (uses showRoundedPills) */
+    showAvatars?: boolean,
+    /** Use rounded style for pills */
+    showRoundedPills?: boolean,
     /** Array of suggested collaborators */
     suggestedPillsData?: Array<Object>,
     /** String decribes the datapoint to filter by so that items in the form are not shown in suggestions. */
@@ -235,6 +239,8 @@ class PillSelectorDropdown extends React.Component<Props, State> {
             overlayTitle,
             placeholder,
             selectedOptions,
+            showAvatars,
+            showRoundedPills,
             suggestedPillsData,
             suggestedPillsFilter,
             suggestedPillsTitle,
@@ -268,6 +274,8 @@ class PillSelectorDropdown extends React.Component<Props, State> {
                             onSuggestedPillAdd={onSuggestedPillAdd}
                             placeholder={placeholder}
                             selectedOptions={selectedOptions}
+                            showRoundedPills={showRoundedPills}
+                            showAvatars={showAvatars && showRoundedPills}
                             suggestedPillsData={suggestedPillsData}
                             suggestedPillsFilter={suggestedPillsFilter}
                             suggestedPillsTitle={suggestedPillsTitle}

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.stories.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.stories.js
@@ -2,13 +2,13 @@
 import * as React from 'react';
 import { State, Store } from '@sambego/storybook-state';
 
-import DatalistItem from '../datalist-item/DatalistItem';
+import ContactDatalistItem from '../contact-datalist-item';
 import PillSelectorDropdown from './PillSelectorDropdown';
 import notes from './PillSelectorDropdown.notes.md';
 
 const users = [
     { id: 0, name: 'bob@foo.bar' },
-    { id: 1, name: 'sally@foo.bar' },
+    { id: 1, name: 'sally@foo.bar', isExternalUser: true },
     { id: 2, name: 'jean@foo.bar' },
     { id: 3, name: 'longlonglonglonglonglonglonglonglonglonglonglongemail@foo.bar' },
     { id: 4, name: 'anotherlonglonglonglonglonglonglonglonglonglonglonglongemail@foo.bar' },
@@ -99,7 +99,9 @@ export const empty = () => {
                     validator={validator}
                 >
                     {state.selectorOptions.map(option => (
-                        <DatalistItem key={option.value}>{option.displayText}</DatalistItem>
+                        <ContactDatalistItem key={option.value} name={option.value}>
+                            {option.displayText}
+                        </ContactDatalistItem>
                     ))}
                 </PillSelectorDropdown>
             )}
@@ -143,7 +145,108 @@ export const withPills = () => {
                     validator={validator}
                 >
                     {state.selectorOptions.map(option => (
-                        <DatalistItem key={option.value}>{option.displayText}</DatalistItem>
+                        <ContactDatalistItem key={option.value} name={option.value}>
+                            {option.displayText}
+                        </ContactDatalistItem>
+                    ))}
+                </PillSelectorDropdown>
+            )}
+        </State>
+    );
+};
+
+export const showRoundedPills = () => {
+    const storeWithPills = new Store({
+        error: '',
+        selectedOptions: [
+            {
+                displayText: users[2].name,
+                value: users[2].name,
+            },
+            {
+                displayText: users[1].name,
+                value: users[1].name,
+            },
+            {
+                displayText: users[4].name,
+                value: users[4].name,
+            },
+        ],
+        selectorOptions: [],
+    });
+    const { handleInput, handleRemove, handleSelect, validator, validateForError } = generateProps(storeWithPills);
+    return (
+        <State store={storeWithPills}>
+            {state => (
+                <PillSelectorDropdown
+                    allowCustomPills
+                    error={state.error}
+                    placeholder="Names or email addresses"
+                    onInput={handleInput}
+                    onRemove={handleRemove}
+                    onSelect={handleSelect}
+                    selectedOptions={state.selectedOptions}
+                    selectorOptions={state.selectorOptions}
+                    showRoundedPills
+                    validateForError={validateForError}
+                    validator={validator}
+                >
+                    {state.selectorOptions.map(option => (
+                        <ContactDatalistItem key={option.value} name={option.value}>
+                            {option.displayText}
+                        </ContactDatalistItem>
+                    ))}
+                </PillSelectorDropdown>
+            )}
+        </State>
+    );
+};
+
+export const showAvatars = () => {
+    const storeWithPills = new Store({
+        error: '',
+        selectedOptions: [
+            {
+                text: users[2].name,
+                value: users[2].name,
+                id: users[2].id,
+            },
+            {
+                text: users[1].name,
+                value: users[1].name,
+                id: users[1].id,
+                isExternalUser: users[1].isExternalUser,
+            },
+            {
+                text: users[3].name,
+                value: users[3].name,
+                id: users[3].id,
+            },
+        ],
+        selectorOptions: [],
+    });
+    const { handleInput, handleRemove, handleSelect, validator, validateForError } = generateProps(storeWithPills);
+    return (
+        <State store={storeWithPills}>
+            {state => (
+                <PillSelectorDropdown
+                    allowCustomPills
+                    error={state.error}
+                    placeholder="Names or email addresses"
+                    onInput={handleInput}
+                    onRemove={handleRemove}
+                    onSelect={handleSelect}
+                    selectedOptions={state.selectedOptions}
+                    selectorOptions={state.selectorOptions}
+                    showRoundedPills
+                    showAvatars
+                    validateForError={validateForError}
+                    validator={validator}
+                >
+                    {state.selectorOptions.map(option => (
+                        <ContactDatalistItem key={option.value} name={option.value}>
+                            {option.displayText}
+                        </ContactDatalistItem>
                     ))}
                 </PillSelectorDropdown>
             )}

--- a/src/components/pill-selector-dropdown/RoundPill.js
+++ b/src/components/pill-selector-dropdown/RoundPill.js
@@ -1,0 +1,80 @@
+// @flow
+import React from 'react';
+import noop from 'lodash/noop';
+import classNames from 'classnames';
+import X from '../../icon/fill/X16';
+// $FlowFixMe this imports from a typescript file
+import LabelPill from '../label-pill';
+import Avatar from '../avatar';
+
+import './RoundPill.scss';
+
+type Props = {
+    className?: string,
+    hasWarning?: boolean,
+    id?: string | number,
+    isDisabled?: boolean,
+    isExternal?: boolean,
+    isSelected?: boolean,
+    isValid?: boolean,
+    onRemove: () => any,
+    showAvatar?: boolean,
+    text: string,
+};
+
+const RemoveButton = ({ onClick, ...rest }: { onClick: () => any }) => (
+    <X {...rest} aria-hidden="true" onClick={onClick} />
+);
+
+const RoundPill = ({
+    isDisabled = false,
+    isSelected = false,
+    hasWarning = false,
+    isExternal,
+    isValid = true,
+    onRemove,
+    text,
+    className,
+    showAvatar = false,
+    id,
+}: Props) => {
+    const styles = classNames('bdl-RoundPill', className, {
+        'bdl-RoundPill--selected': isSelected && !isDisabled,
+        'bdl-RoundPill--disabled': isDisabled,
+        'bdl-RoundPill--warning': hasWarning,
+        'bdl-RoundPill--error': !isValid,
+    });
+
+    let pillType;
+
+    if (hasWarning) {
+        pillType = 'warning';
+    }
+
+    if (!isValid) {
+        pillType = 'error';
+    }
+
+    const handleClickRemove = isDisabled ? noop : onRemove;
+
+    const avatar = showAvatar ? (
+        <LabelPill.Icon
+            Component={Avatar}
+            id={id}
+            isExternal={isExternal}
+            name={text}
+            size="small"
+            shouldShowExternal
+        />
+    ) : null;
+
+    return (
+        <LabelPill.Pill size="large" className={styles} type={pillType}>
+            {avatar}
+            <LabelPill.Text className="bdl-RoundPill-text">{text}</LabelPill.Text>
+            <LabelPill.Icon className="bdl-RoundPill-closeBtn" Component={RemoveButton} onClick={handleClickRemove} />
+        </LabelPill.Pill>
+    );
+};
+
+export default RoundPill;

--- a/src/components/pill-selector-dropdown/RoundPill.scss
+++ b/src/components/pill-selector-dropdown/RoundPill.scss
@@ -1,0 +1,78 @@
+/**************************************
+ * Round Pill
+ **************************************/
+@import '../../styles/variables';
+
+.bdl-RoundPill {
+    display: flex;
+    align-items: center;
+    max-width: 100%;
+    height: 28px;
+    margin: $bdl-grid-unit - 1px $bdl-grid-unit / 2;
+    padding-top: 2px;
+    padding-left: 2px;
+    overflow: hidden;
+    font-weight: normal;
+    line-height: $bdl-line-height + $bdl-grid-unit;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    border: 0;
+    border-radius: 14px;
+
+    &.bdl-RoundPill--selected {
+        font-weight: bold;
+        background-color: $bdl-gray-20;
+        box-shadow: inset 0 0 0 1px $white;
+    }
+
+    .bdl-Avatar-externalBadge {
+        border-color: $bdl-gray-10;
+    }
+}
+
+.bdl-RoundPill-text {
+    flex-grow: 1;
+    flex-shrink: 1;
+    margin: 0 $bdl-grid-unit * 2 !important;
+    padding-top: 1px; // offset for aligning "average" string that doesn't have descender chars
+    overflow: hidden;
+    line-height: $bdl-fontSize + $bdl-grid-unit; // for vertical centering using flex;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.bdl-RoundPill-closeBtn {
+    position: unset;
+    top: unset;
+    flex-grow: 0;
+    flex-shrink: 0;
+    height: 12px;
+    margin-right: $bdl-grid-unit * 2;
+    cursor: pointer;
+}
+
+.bdl-RoundPill--warning {
+    .bdl-Avatar-externalBadge {
+        border-color: $bdl-yellorange-10;
+    }
+}
+
+.bdl-RoundPill--error {
+    .bdl-Avatar-externalBadge {
+        border-color: $bdl-watermelon-red-10;
+    }
+}
+
+.bdl-RoundPill--selected {
+    .bdl-Avatar-externalBadge {
+        border-color: $bdl-gray-20;
+    }
+}
+
+.bdl-RoundPill--disabled {
+    opacity: .5;
+
+    .bdl-RoundPill-closeBtn {
+        cursor: default;
+    }
+}

--- a/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
@@ -79,6 +79,20 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
             expect(wrapper.find('Pill').length).toBe(2);
         });
 
+        test('should render RoundPill instead of standard Pill when showRoundedPills prop is true', () => {
+            const options = [{ text: 'test', value: 'test' }];
+            const wrapper = shallow(
+                <PillSelector
+                    onInput={onInputStub}
+                    onRemove={onRemoveStub}
+                    selectedOptions={options}
+                    showRoundedPills
+                />,
+            );
+
+            expect(wrapper.find('RoundPill').length).toBe(1);
+        });
+
         test('should render pills when there are selected options', () => {
             const options = [
                 { displayText: 'test', value: 'test' },

--- a/src/components/pill-selector-dropdown/__tests__/RoundPill.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/RoundPill.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import RoundPill from '../RoundPill';
+
+describe('components/RoundPill-selector-dropdown/RoundPill', () => {
+    const onRemoveStub = jest.fn();
+
+    test('should render default component', () => {
+        const wrapper = shallow(<RoundPill onRemove={onRemoveStub} text="box" />);
+
+        expect(wrapper).toMatchInlineSnapshot(`
+            <LabelPill
+              className="bdl-RoundPill"
+              size="large"
+            >
+              <LabelPillText
+                className="bdl-RoundPill-text"
+              >
+                box
+              </LabelPillText>
+              <LabelPillIcon
+                Component={[Function]}
+                className="bdl-RoundPill-closeBtn"
+                onClick={[MockFunction]}
+              />
+            </LabelPill>
+        `);
+    });
+
+    test('should render avatar if showAvatar prop is true', () => {
+        const wrapper = shallow(<RoundPill onRemove={onRemoveStub} showAvatar text="box" />);
+
+        expect(wrapper).toMatchInlineSnapshot(`
+            <LabelPill
+              className="bdl-RoundPill"
+              size="large"
+            >
+              <LabelPillIcon
+                Component={[Function]}
+                name="box"
+                shouldShowExternal={true}
+                size="small"
+              />
+              <LabelPillText
+                className="bdl-RoundPill-text"
+              >
+                box
+              </LabelPillText>
+              <LabelPillIcon
+                Component={[Function]}
+                className="bdl-RoundPill-closeBtn"
+                onClick={[MockFunction]}
+              />
+            </LabelPill>
+        `);
+
+        expect(wrapper.find('LabelPillIcon')).toHaveLength(2);
+    });
+
+    test('should have the selected class when isSelected is true', () => {
+        const wrapper = shallow(<RoundPill isSelected isDisabled={false} onRemove={onRemoveStub} text="box" />);
+
+        expect(wrapper.hasClass('bdl-RoundPill--selected')).toBe(true);
+    });
+
+    test('should generate LabelPill with error type when isValid prop is false', () => {
+        const wrapper = shallow(<RoundPill isValid={false} onRemove={onRemoveStub} text="box" />);
+
+        expect(wrapper.find('LabelPill').prop('type')).toBe('error');
+        expect(wrapper.hasClass('bdl-RoundPill--error')).toBe(true);
+    });
+
+    test('should generate LabelPill with warning type when hasWarning prop is true', () => {
+        const wrapper = shallow(<RoundPill hasWarning onRemove={onRemoveStub} text="box" />);
+
+        expect(wrapper.find('LabelPill').prop('type')).toBe('warning');
+        expect(wrapper.hasClass('bdl-RoundPill--warning')).toBe(true);
+    });
+
+    test('should generate LabelPill with error type when isValid is false and hasWarning is true', () => {
+        const wrapper = shallow(<RoundPill isValid={false} hasWarning onRemove={onRemoveStub} text="box" />);
+
+        expect(wrapper.find('LabelPill').prop('type')).toBe('error');
+        expect(wrapper.hasClass('bdl-RoundPill--error')).toBe(true);
+    });
+
+    test('should disable click handler and add class when disabled', () => {
+        const onRemoveMock = jest.fn();
+        const wrapper = shallow(<RoundPill isDisabled isValid onRemove={onRemoveMock} text="box" />);
+        wrapper.simulate('click');
+        expect(onRemoveMock).not.toBeCalled();
+        expect(wrapper.childAt(0).hasClass('is-disabled'));
+        expect(wrapper.hasClass('bdl-RoundPill--disabled')).toBe(true);
+    });
+
+    test('should not call click handler when isDisabled is true', () => {
+        const wrapper = shallow(<RoundPill onRemove={onRemoveStub} text="box" />);
+
+        wrapper.setProps({ isDisabled: true });
+        wrapper.find('LabelPillIcon').simulate('click');
+        expect(onRemoveStub).toHaveBeenCalledTimes(0);
+
+        wrapper.setProps({ isDisabled: false });
+        wrapper.find('LabelPillIcon').simulate('click');
+        expect(onRemoveStub).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/pill-selector-dropdown/flowTypes.js
+++ b/src/components/pill-selector-dropdown/flowTypes.js
@@ -15,6 +15,14 @@ export type SuggestedPill = {
     value?: string,
 };
 
+export type RoundOption = {
+    hasWarning: boolean,
+    id?: number | string,
+    isExternalUser: boolean,
+} & Option;
+
+export type SelectedRoundOptions = Array<RoundOption> | List<RoundOption>;
+
 export type SuggestedPills = Array<SuggestedPill>;
 
 export type SuggestedPillsFilter = $Keys<SuggestedPill>;


### PR DESCRIPTION
Storybook updates for rounded pills (non-avatar pills) and imageless avatar pills (with and without external badge). These pills will be used in USM.

Rounded Pills (Non-Avatar Pills) - if `showRoundedPills` is true and `showAvatars` is false
![image](https://user-images.githubusercontent.com/1657938/83594159-5d823f00-a513-11ea-9b78-e80fee8bd0b4.png)

Avatar Pills - if `showRoundedPills` and `showAvatar` is true
![image](https://user-images.githubusercontent.com/1657938/83697319-8a862e80-a5b3-11ea-9436-787b59057f66.png)

Additional pill states appear in order: 

1. error - if prop `isValid` is false. error trumps warning.
2. warning - if prop `hasWarning` is true
3. disabled - if prop `isDisabled` is true. disabled trumps all.
4. selected - if prop `isSelected` is true and `isDisabled` is false. selected trumps errors and warnings.

Rounded Pills (Non-Avatar Pills) Additional States in Pill Selector Dropdown
![image](https://user-images.githubusercontent.com/1657938/83701190-b8707080-a5bd-11ea-9320-7a0449116f48.png)

Avatar Pills Additional States in Pill Selector Dropdown
![image](https://user-images.githubusercontent.com/1657938/83701193-bc9c8e00-a5bd-11ea-8a65-5e7ab5e593fc.png)

