### PR TITLE
fix(annotations): scroll to annotation on load

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -211,6 +211,12 @@ class Feed extends Base {
         return cache.get(cacheKey);
     }
 
+    getCachedItem(cacheId: string, itemId: string): ?FeedItem {
+        const { items = [] } = this.getCachedItems(cacheId) || {};
+
+        return items.find(item => item.id === itemId);
+    }
+
     /**
      * Sets the items in the cache
      *

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -55,15 +55,15 @@ import {
     ORIGIN_CONTENT_PREVIEW,
     ERROR_CODE_UNKNOWN,
 } from '../../constants';
+import type APICache from '../../utils/Cache';
 import type { Annotation } from '../../common/types/feed';
 import type { ErrorType, AdditionalVersionInfo } from '../common/flowTypes';
-import type { WithLoggerProps } from '../../common/types/logging';
+import type { FeatureConfig } from '../common/feature-checking';
 import type { FetchOptions, ErrorContextProps, ElementsXhrError } from '../../common/types/api';
 import type { StringMap, Token, BoxItem, BoxItemVersion } from '../../common/types/core';
 import type { Target } from '../../common/types/annotations';
 import type { VersionChangeCallback } from '../content-sidebar/versions';
-import type { FeatureConfig } from '../common/feature-checking';
-import type APICache from '../../utils/Cache';
+import type { WithLoggerProps } from '../../common/types/logging';
 
 import '../common/fonts.scss';
 import '../common/base.scss';

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -1145,11 +1145,8 @@ describe('elements/content-preview/ContentPreview', () => {
                     },
                 };
 
-                const emit = jest.fn();
                 const wrapper = getWrapper();
                 const instance = wrapper.instance();
-
-                jest.spyOn(instance, 'getViewer').mockReturnValue({ emit });
 
                 wrapper.setState({ selectedVersion: { id: selectedVersionId } });
                 instance.setState = jest.fn();
@@ -1157,7 +1154,6 @@ describe('elements/content-preview/ContentPreview', () => {
                 instance.handleAnnotationSelect(annotation);
 
                 expect(instance.setState).toHaveBeenCalledTimes(setStateCount);
-                expect(emit).toBeCalledWith('scrolltoannotation', { id: annotation.id, target: annotation.target });
             },
         );
     });

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -141,15 +141,15 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
 
     componentDidUpdate({ isViewerReady: prevIsViewerReady }: Props, { feedItems: prevFeedItems }: State) {
         const { getAnnotationsMatchPath, isViewerReady, location } = this.props;
-        const match = getProp(getAnnotationsMatchPath(location), 'params.annotationId', null);
+        const activeAnnotationId = getProp(getAnnotationsMatchPath(location), 'params.annotationId', null);
 
         // Fetch feed items once viewer is ready
         if (prevIsViewerReady !== isViewerReady) {
             this.fetchFeedItems(true);
         }
 
-        if (this.didLoadFeedItems(prevFeedItems) && match) {
-            this.handleScrollToAnnotationOnLoad(match);
+        if (this.didLoadFeedItems(prevFeedItems) && activeAnnotationId) {
+            this.handleScrollToAnnotationOnLoad(activeAnnotationId);
         }
     }
 

--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -61,10 +61,12 @@ type Props = {
     hasVersions: boolean,
     history?: RouterHistory,
     isDefaultOpen?: boolean,
+    isViewerReady?: boolean,
     language?: string,
     messages?: StringMap,
     metadataSidebarProps: MetadataSidebarProps,
     onAnnotationSelect?: Function,
+    onScrollToAnnotation?: Function,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     requestInterceptor?: Function,
@@ -330,9 +332,11 @@ class ContentSidebar extends React.Component<Props, State> {
             hasVersions,
             history,
             isDefaultOpen,
+            isViewerReady,
             language,
             messages,
             metadataSidebarProps,
+            onScrollToAnnotation,
             onAnnotationSelect,
             onVersionChange,
             onVersionHistoryClick,
@@ -366,9 +370,11 @@ class ContentSidebar extends React.Component<Props, State> {
                             hasVersions={hasVersions}
                             isDefaultOpen={isDefaultOpen}
                             isLoading={isLoading}
+                            isViewerReady={isViewerReady}
                             metadataEditors={metadataEditors}
                             metadataSidebarProps={metadataSidebarProps}
                             onAnnotationSelect={onAnnotationSelect}
+                            onScrollToAnnotation={onScrollToAnnotation}
                             onVersionChange={onVersionChange}
                             onVersionHistoryClick={onVersionHistoryClick}
                             versionsSidebarProps={versionsSidebarProps}

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -46,10 +46,12 @@ type Props = {
     history: RouterHistory,
     isDefaultOpen?: boolean,
     isLoading?: boolean,
+    isViewerReady?: boolean,
     location: Location,
     metadataEditors?: Array<MetadataEditor>,
     metadataSidebarProps: MetadataSidebarProps,
     onAnnotationSelect?: Function,
+    onScrollToAnnotation?: Function,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     versionsSidebarProps: VersionsSidebarProps,
@@ -218,9 +220,11 @@ class Sidebar extends React.Component<Props, State> {
             hasVersions,
             isDefaultOpen,
             isLoading,
+            isViewerReady,
             metadataEditors,
             metadataSidebarProps,
             onAnnotationSelect,
+            onScrollToAnnotation,
             onVersionChange,
             versionsSidebarProps,
         }: Props = this.props;
@@ -268,9 +272,11 @@ class Sidebar extends React.Component<Props, State> {
                             hasSkills={hasSkills}
                             hasVersions={hasVersions}
                             isOpen={isOpen}
+                            isViewerReady={isViewerReady}
                             key={file.id}
                             metadataSidebarProps={metadataSidebarProps}
                             onAnnotationSelect={onAnnotationSelect}
+                            onScrollToAnnotation={onScrollToAnnotation}
                             onVersionChange={onVersionChange}
                             onVersionHistoryClick={onVersionHistoryClick}
                             ref={this.sidebarPanels}

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -45,8 +45,10 @@ type Props = {
     hasSkills: boolean,
     hasVersions: boolean,
     isOpen: boolean,
+    isViewerReady?: boolean,
     metadataSidebarProps: MetadataSidebarProps,
     onAnnotationSelect?: Function,
+    onScrollToAnnotation?: Function,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
     versionsSidebarProps: VersionsSidebarProps,
@@ -143,8 +145,10 @@ class SidebarPanels extends React.Component<Props, State> {
             hasSkills,
             hasVersions,
             isOpen,
+            isViewerReady,
             metadataSidebarProps,
             onAnnotationSelect,
+            onScrollToAnnotation,
             onVersionChange,
             onVersionHistoryClick,
             versionsSidebarProps,
@@ -196,7 +200,9 @@ class SidebarPanels extends React.Component<Props, State> {
                                     currentUser={currentUser}
                                     file={file}
                                     hasSidebarInitialized={isInitialized}
+                                    isViewerReady={isViewerReady}
                                     onAnnotationSelect={onAnnotationSelect}
+                                    onScrollToAnnotation={onScrollToAnnotation}
                                     onVersionChange={onVersionChange}
                                     onVersionHistoryClick={onVersionHistoryClick}
                                     ref={this.activitySidebar}

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -10,6 +10,7 @@ jest.mock('lodash/debounce', () => jest.fn(i => i));
 describe('elements/content-sidebar/ActivitySidebar', () => {
     const feedAPI = {
         feedItems: jest.fn(),
+        getCachedItem: jest.fn(),
         deleteAnnotation: jest.fn(),
         deleteComment: jest.fn(),
         deleteTaskNew: jest.fn(),
@@ -95,7 +96,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         });
 
         test('should fetch the file and refresh the cache and fetch the current user', () => {
-            expect(instance.fetchFeedItems).toHaveBeenCalledWith(true);
             expect(instance.fetchCurrentUser).toHaveBeenCalledWith(currentUser);
         });
     });
@@ -331,7 +331,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         beforeEach(() => {
             wrapper = getWrapper();
             instance = wrapper.instance();
-            instance.fetchFeedItems = jest.fn();
         });
 
         test('should fetch the feed items', () => {


### PR DESCRIPTION
Adding logic that will scroll to an annotation from a hard load.

* Add logic to let Activity sidebar know when the viewer is ready.
* Handle scrolling to annotation in Activity Sidebar
* Add method to find cached item

- [ ] Unit Tests