### PR TITLE
feat(dropdown-menu): add ability to pass down tetherProps to menu

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.js
+++ b/src/components/dropdown-menu/DropdownMenu.js
@@ -10,18 +10,19 @@ import './DropdownMenu.scss';
 type Props = {
     bodyElement?: HTMLElement,
     children: React.Node,
-    /** Forces menu to render within the scroll parent */
     className?: string,
-    /** Forces menu to render within the visible window */
+    /** Forces menu to render within the scroll parent */
     constrainToScrollParent: boolean,
-    /** Right aligns menu to button */
+    /** Forces menu to render within the visible window */
     constrainToWindow: boolean,
-    /** Function called when menu is opened */
+    /** Right aligns menu to button */
     isRightAligned: boolean,
     /** Handler for dropdown menu close events */
     onMenuClose?: (event: SyntheticEvent<> | MouseEvent) => void,
     /** Handler for dropdown menu open events */
     onMenuOpen?: () => void,
+    /** Options to pass to the tether component instance */
+    tetherProps?: {},
     /** Set true to close dropdown menu on event bubble instead of event capture */
     useBubble?: boolean,
 };
@@ -179,6 +180,7 @@ class DropdownMenu extends React.Component<Props, State> {
             constrainToScrollParent,
             constrainToWindow,
             className,
+            tetherProps,
         } = this.props;
         const { isOpen, initialFocusIndex } = this.state;
 
@@ -248,6 +250,7 @@ class DropdownMenu extends React.Component<Props, State> {
                 constraints={constraints}
                 enabled={isOpen}
                 targetAttachment={targetAttachment}
+                {...tetherProps}
             >
                 {React.cloneElement(menuButton, menuButtonProps)}
                 {isOpen ? React.cloneElement(menu, menuProps) : null}

--- a/src/components/media/MediaMenu.js
+++ b/src/components/media/MediaMenu.js
@@ -19,10 +19,12 @@ type Props = {
     isDisabled: boolean,
     /** Additional props for the Menu */
     menuProps?: {},
+    /** Options to pass to the tether component instance */
+    tetherProps?: {},
 };
 
-const MediaMenu = ({ className, children, isDisabled, dropdownProps, menuProps, ...rest }: Props) => (
-    <DropdownMenu constrainToScrollParent isRightAligned {...dropdownProps}>
+const MediaMenu = ({ className, children, isDisabled, dropdownProps, menuProps, tetherProps, ...rest }: Props) => (
+    <DropdownMenu constrainToScrollParent isRightAligned tetherProps={tetherProps} {...dropdownProps}>
         <PlainButton
             isDisabled={isDisabled}
             className={classnames('bdl-Media-menu', className)}


### PR DESCRIPTION
- reorder the documentation of the props as they were not aligned to the proper prop
- pass down `tetherProps` to corresponding menu components