### PR TITLE
feat(unified-share-modal): support method to get image url for avatars

### DIFF
--- a/src/components/contact-datalist-item/ContactDatalistItem.js
+++ b/src/components/contact-datalist-item/ContactDatalistItem.js
@@ -7,17 +7,25 @@ import DatalistItem from '../datalist-item';
 import './ContactDatalistItem.scss';
 
 type Props = {
-    id?: string | number | null,
+    getContactAvatarUrl?: (contact: { id: string | number, [key: string]: any }) => string,
+    id?: string | number,
     isExternal?: boolean,
     name: ?string,
     showAvatar?: boolean,
     subtitle?: React.Node,
 };
 
-const ContactDatalistItem = ({ id, isExternal, name, showAvatar, subtitle, ...rest }: Props) => (
+const ContactDatalistItem = ({ getContactAvatarUrl, id, isExternal, name, showAvatar, subtitle, ...rest }: Props) => (
     <DatalistItem className="contact-data-list-item" {...rest}>
         {showAvatar && (
-            <Avatar className="contact-avatar" id={id} name={name} isExternal={isExternal} shouldShowExternal />
+            <Avatar
+                className="contact-avatar"
+                id={id}
+                name={name}
+                isExternal={isExternal}
+                shouldShowExternal
+                avatarUrl={getContactAvatarUrl && id ? getContactAvatarUrl({ id }) : undefined}
+            />
         )}
         <div className="contact-name-container">
             <div className="contact-text contact-name">{name}</div>

--- a/src/components/contact-datalist-item/__tests__/ContactDatalistItem.test.js
+++ b/src/components/contact-datalist-item/__tests__/ContactDatalistItem.test.js
@@ -19,9 +19,38 @@ describe('components/contact-datalist-item/ContactDatalistItem', () => {
         expect(wrapper.find('Avatar').length).toBe(0);
     });
 
-    test('should show avatar component when specified', () => {
-        const wrapper = shallow(<ContactDatalistItem name="name" showAvatar />);
+    describe('avatars with or without image URLs', () => {
+        test('should show avatar component when specified', () => {
+            const wrapper = shallow(<ContactDatalistItem name="name" showAvatar />);
 
-        expect(wrapper.find('Avatar').length).toBe(1);
+            expect(wrapper.find('Avatar').length).toBe(1);
+        });
+
+        test('should use the avatar URL when the prop (and show avatar) are provided', () => {
+            const wrapper = shallow(
+                <ContactDatalistItem
+                    name="name"
+                    id="123"
+                    showAvatar
+                    getContactAvatarUrl={contact => `/test?id=${contact.id}`}
+                />,
+            );
+
+            expect(wrapper.find('Avatar').length).toBe(1);
+            expect(wrapper.find('Avatar').props().avatarUrl).toEqual('/test?id=123');
+        });
+
+        test('should not have the avatar URL when the id prop is missing', () => {
+            const wrapper = shallow(
+                <ContactDatalistItem
+                    name="name"
+                    showAvatar
+                    getContactAvatarUrl={contact => `/test?id=${contact.id}`}
+                />,
+            );
+
+            expect(wrapper.find('Avatar').length).toBe(1);
+            expect(wrapper.find('Avatar').props().avatarUrl).toBeUndefined();
+        });
     });
 });

--- a/src/features/unified-share-modal/ContactsField.js
+++ b/src/features/unified-share-modal/ContactsField.js
@@ -20,6 +20,7 @@ type Props = {
     disabled: boolean,
     error: string,
     fieldRef?: Object,
+    getContactAvatarUrl?: (contact: Contact) => string,
     getContacts: (query: string) => Promise<Array<Contact>>,
     intl: any,
     label: React.Node,
@@ -75,7 +76,6 @@ class ContactsField extends React.Component<Props, State> {
     filterContacts = (contacts: Array<Contact>): Array<Contact> => {
         const { pillSelectorInputValue } = this.state;
         const { selectedContacts, suggestedCollaborators } = this.props;
-
         if (pillSelectorInputValue && contacts) {
             let fullContacts = contacts
                 .filter(
@@ -149,15 +149,16 @@ class ContactsField extends React.Component<Props, State> {
 
     render() {
         const {
-            intl,
             disabled,
             error,
             fieldRef,
+            getContactAvatarUrl,
+            intl,
             label,
-            selectedContacts,
             onContactAdd,
             onContactRemove,
             onPillCreate,
+            selectedContacts,
             showContactAvatars,
             validateForError,
             validator,
@@ -196,6 +197,7 @@ class ContactsField extends React.Component<Props, State> {
             >
                 {contacts.map(({ email, isExternalUser, text = null, id }) => (
                     <ContactDatalistItem
+                        getContactAvatarUrl={getContactAvatarUrl}
                         key={id}
                         id={id}
                         isExternal={isExternalUser}

--- a/src/features/unified-share-modal/EmailForm.js
+++ b/src/features/unified-share-modal/EmailForm.js
@@ -28,6 +28,7 @@ type Props = {
     contactsFieldAvatars?: React.Node,
     contactsFieldDisabledTooltip: React.Node,
     contactsFieldLabel: React.Node,
+    getContactAvatarUrl?: (contact: Contact) => string,
     getContacts: (query: string) => Promise<Array<Contact>>,
     inlineNotice: {
         content: React.Node,
@@ -226,6 +227,7 @@ class EmailForm extends React.Component<Props, State> {
             inlineNotice,
             isContactsFieldEnabled,
             isExternalUserSelected,
+            getContactAvatarUrl,
             getContacts,
             intl,
             isExpanded,
@@ -272,6 +274,7 @@ class EmailForm extends React.Component<Props, State> {
                         error={contactsFieldError}
                         fieldRef={this.contactsFieldRef}
                         getContacts={getContacts}
+                        getContactAvatarUrl={getContactAvatarUrl}
                         label={contactsFieldLabel}
                         onContactAdd={this.handleContactAdd}
                         onContactRemove={this.handleContactRemove}

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -289,6 +289,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             collaborationRestrictionWarning,
             contactLimit,
             getCollaboratorContacts,
+            getContactAvatarUrl,
             handleFtuxCloseClick,
             item,
             recommendedSharingTooltipCalloutName = null,
@@ -359,6 +360,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             contactsFieldDisabledTooltip={contactsFieldDisabledTooltip}
                             contactsFieldLabel={<FormattedMessage {...messages.inviteFieldLabel} />}
                             getContacts={getCollaboratorContacts}
+                            getContactAvatarUrl={getContactAvatarUrl}
                             inlineNotice={inlineNotice}
                             isContactsFieldEnabled={canInvite}
                             isExpanded={isInviteSectionExpanded}
@@ -482,6 +484,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             changeSharedLinkPermissionLevel,
             focusSharedLinkOnLoad,
             getSharedLinkContacts,
+            getContactAvatarUrl,
             intl,
             isFetching,
             item,
@@ -546,6 +549,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                     {isEmailLinkSectionExpanded && !showCollaboratorList && (
                         <EmailForm
                             contactsFieldLabel={<FormattedMessage {...messages.sendSharedLinkFieldLabel} />}
+                            getContactAvatarUrl={getContactAvatarUrl}
                             getContacts={getSharedLinkContacts}
                             inlineNotice={{
                                 type: 'error',

--- a/src/features/unified-share-modal/__tests__/ContactsField.test.js
+++ b/src/features/unified-share-modal/__tests__/ContactsField.test.js
@@ -7,6 +7,13 @@ import messages from '../messages';
 describe('features/unified-share-modal/ContactsField', () => {
     const contactsFromServer = [
         {
+            email: 'w@example.com',
+            id: '9875',
+            isExternalUser: false,
+            name: 'W User',
+            type: 'user',
+        },
+        {
             email: 'x@example.com',
             id: '12345',
             isExternalUser: false,
@@ -252,6 +259,21 @@ describe('features/unified-share-modal/ContactsField', () => {
 
             expect(wrapper.state('pillSelectorInputValue')).toEqual('a');
             expect(onInput).toHaveBeenCalled();
+        });
+
+        test('should get avatar URLs when prop is provided', async () => {
+            const getContacts = jest.fn().mockReturnValue(Promise.resolve(contactsFromServer));
+            const getContactAvatarUrlMock = jest.fn(contact => `/test?id=${contact.id}`);
+
+            const wrapper = getWrapper({
+                getContactAvatarUrl: getContactAvatarUrlMock,
+                getContacts,
+                showContactAvatars: true,
+            });
+            wrapper.instance().handlePillSelectorInput('w');
+            await wrapper.instance().getContactsPromise('w');
+
+            expect(wrapper.find('PillSelectorDropdown ContactDatalistItem').props().getContactAvatarUrl).toBeDefined();
         });
 
         test('should reset contacts if input is empty', async () => {

--- a/src/features/unified-share-modal/__tests__/__snapshots__/ContactsField.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/ContactsField.test.js.snap
@@ -19,6 +19,14 @@ Array [
     "value": "z@example.com",
   },
   Object {
+    "email": "w@example.com",
+    "id": "9875",
+    "isExternalUser": false,
+    "text": "W User",
+    "type": "user",
+    "value": "w@example.com",
+  },
+  Object {
     "email": "x@example.com",
     "id": "12345",
     "isExternalUser": false,
@@ -58,6 +66,14 @@ exports[`features/unified-share-modal/ContactsField render should have scrollabl
   selectedOptions={Array []}
   selectorOptions={
     Array [
+      Object {
+        "email": "w@example.com",
+        "id": "9875",
+        "isExternalUser": false,
+        "text": "W User",
+        "type": "user",
+        "value": "w@example.com",
+      },
       Object {
         "email": "x@example.com",
         "id": "12345",
@@ -129,6 +145,15 @@ exports[`features/unified-share-modal/ContactsField render should have scrollabl
   validateForError={[MockFunction]}
   validator={[MockFunction]}
 >
+  <ContactDatalistItem
+    id="9875"
+    isExternal={false}
+    key="9875"
+    name="W User"
+    showAvatar={false}
+    subtitle="w@example.com"
+    title="W User"
+  />
   <ContactDatalistItem
     id="12345"
     isExternal={false}

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -248,6 +248,8 @@ type CollaboratorAvatarsTypes = {
 };
 
 type EmailFormTypes = {
+    /** Function to retrieve the URL for an avatar, given contact details */
+    getContactAvatarUrl?: (contact: contactType) => string,
     /** Handler function for when the user types into email shared link field to fetch contacts. */
     getSharedLinkContacts: (query: string) => Promise<Array<contactType>>,
     /**


### PR DESCRIPTION
allow for specifying a method for retrieving the avatar URL. flexible to support custom schemes or url patterns to tie into other systems, or refer to other assets