### PR TITLE
feat(pill-selector-dropdown): add ability to set round pill image urls

### DIFF
--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -22,6 +22,8 @@ type Props = {
     className?: string,
     disabled?: boolean,
     error?: React.Node,
+    /** Function to retrieve the image URL associated with a pill */
+    getPillImageUrl?: (data: { id: string | number, [key: string]: any }) => string,
     inputProps: Object,
     onInput: Function,
     onRemove: Function,
@@ -168,6 +170,7 @@ class PillSelector extends React.Component<Props, State> {
             className,
             disabled,
             error,
+            getPillImageUrl,
             inputProps,
             onInput,
             onRemove,
@@ -211,6 +214,7 @@ class PillSelector extends React.Component<Props, State> {
                         ? selectedOptions.map((option: RoundOption, index: number) => {
                               return (
                                   <RoundPill
+                                      getPillImageUrl={getPillImageUrl}
                                       isValid={allowInvalidPills ? validator(option) : true}
                                       isDisabled={disabled}
                                       isSelected={index === selectedIndex}

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.js
@@ -32,6 +32,8 @@ type Props = {
     dropdownScrollBoundarySelector?: string,
     /** Error message */
     error?: React.Node,
+    /** Function to retrieve the image URL associated with a pill */
+    getPillImageUrl?: (data: { id: string | number, [key: string]: any }) => string,
     /** Passed in by `SelectorDropdown` for accessibility */
     inputProps: Object,
     /** Input label */
@@ -232,6 +234,7 @@ class PillSelectorDropdown extends React.Component<Props, State> {
             dividerIndex,
             dropdownScrollBoundarySelector,
             error,
+            getPillImageUrl,
             inputProps,
             label,
             onRemove,
@@ -267,6 +270,7 @@ class PillSelectorDropdown extends React.Component<Props, State> {
                             allowInvalidPills={allowInvalidPills}
                             disabled={disabled}
                             error={error}
+                            getPillImageUrl={getPillImageUrl}
                             onBlur={this.handleBlur}
                             onInput={this.handleInput}
                             onPaste={this.handlePaste}

--- a/src/components/pill-selector-dropdown/RoundPill.js
+++ b/src/components/pill-selector-dropdown/RoundPill.js
@@ -11,6 +11,8 @@ import './RoundPill.scss';
 
 type Props = {
     className?: string,
+    /** Function to retrieve the image URL associated with a pill */
+    getPillImageUrl?: (data: { id: string | number, [key: string]: any }) => string,
     hasWarning?: boolean,
     id?: string | number,
     isDisabled?: boolean,
@@ -27,6 +29,7 @@ const RemoveButton = ({ onClick, ...rest }: { onClick: () => any }) => (
 );
 
 const RoundPill = ({
+    getPillImageUrl,
     isDisabled = false,
     isSelected = false,
     hasWarning = false,
@@ -60,6 +63,7 @@ const RoundPill = ({
     const avatar = showAvatar ? (
         <LabelPill.Icon
             Component={Avatar}
+            avatarUrl={getPillImageUrl && id ? getPillImageUrl({ id }) : undefined}
             id={id}
             isExternal={isExternal}
             name={text}

--- a/src/components/pill-selector-dropdown/__tests__/RoundPill.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/RoundPill.test.js
@@ -8,51 +8,13 @@ describe('components/RoundPill-selector-dropdown/RoundPill', () => {
     test('should render default component', () => {
         const wrapper = shallow(<RoundPill onRemove={onRemoveStub} text="box" />);
 
-        expect(wrapper).toMatchInlineSnapshot(`
-            <LabelPill
-              className="bdl-RoundPill"
-              size="large"
-            >
-              <LabelPillText
-                className="bdl-RoundPill-text"
-              >
-                box
-              </LabelPillText>
-              <LabelPillIcon
-                Component={[Function]}
-                className="bdl-RoundPill-closeBtn"
-                onClick={[MockFunction]}
-              />
-            </LabelPill>
-        `);
+        expect(wrapper).toMatchSnapshot();
     });
 
     test('should render avatar if showAvatar prop is true', () => {
         const wrapper = shallow(<RoundPill onRemove={onRemoveStub} showAvatar text="box" />);
 
-        expect(wrapper).toMatchInlineSnapshot(`
-            <LabelPill
-              className="bdl-RoundPill"
-              size="large"
-            >
-              <LabelPillIcon
-                Component={[Function]}
-                name="box"
-                shouldShowExternal={true}
-                size="small"
-              />
-              <LabelPillText
-                className="bdl-RoundPill-text"
-              >
-                box
-              </LabelPillText>
-              <LabelPillIcon
-                Component={[Function]}
-                className="bdl-RoundPill-closeBtn"
-                onClick={[MockFunction]}
-              />
-            </LabelPill>
-        `);
+        expect(wrapper).toMatchSnapshot();
 
         expect(wrapper.find('LabelPillIcon')).toHaveLength(2);
     });
@@ -103,5 +65,23 @@ describe('components/RoundPill-selector-dropdown/RoundPill', () => {
         wrapper.setProps({ isDisabled: false });
         wrapper.find('LabelPillIcon').simulate('click');
         expect(onRemoveStub).toHaveBeenCalledTimes(1);
+    });
+
+    test('should use the avatar URL when the prop (and show avatar) are provided', () => {
+        const wrapper = shallow(
+            <RoundPill name="name" id="123" showAvatar getPillImageUrl={contact => `/test?id=${contact.id}`} />,
+        );
+
+        expect(wrapper.find('LabelPillIcon').length).toBe(2);
+        expect(wrapper.find('LabelPillIcon[avatarUrl]').props().avatarUrl).toEqual('/test?id=123');
+    });
+
+    test('should not have the avatar URL when the id prop is missing', () => {
+        const wrapper = shallow(
+            <RoundPill name="name" showAvatar getPillImageUrl={contact => `/test?id=${contact.id}`} />,
+        );
+
+        expect(wrapper.find('LabelPillIcon').length).toBe(2);
+        expect(wrapper.find('LabelPillIcon[avatarUrl]').length).toBe(0);
     });
 });

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/RoundPill.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/RoundPill.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/RoundPill-selector-dropdown/RoundPill should render avatar if showAvatar prop is true 1`] = `
+<LabelPill
+  className="bdl-RoundPill"
+  size="large"
+>
+  <LabelPillIcon
+    Component={[Function]}
+    name="box"
+    shouldShowExternal={true}
+    size="small"
+  />
+  <LabelPillText
+    className="bdl-RoundPill-text"
+  >
+    box
+  </LabelPillText>
+  <LabelPillIcon
+    Component={[Function]}
+    className="bdl-RoundPill-closeBtn"
+    onClick={[MockFunction]}
+  />
+</LabelPill>
+`;
+
+exports[`components/RoundPill-selector-dropdown/RoundPill should render default component 1`] = `
+<LabelPill
+  className="bdl-RoundPill"
+  size="large"
+>
+  <LabelPillText
+    className="bdl-RoundPill-text"
+  >
+    box
+  </LabelPillText>
+  <LabelPillIcon
+    Component={[Function]}
+    className="bdl-RoundPill-closeBtn"
+    onClick={[MockFunction]}
+  />
+</LabelPill>
+`;

--- a/src/features/unified-share-modal/ContactsField.js
+++ b/src/features/unified-share-modal/ContactsField.js
@@ -177,6 +177,7 @@ class ContactsField extends React.Component<Props, State> {
                 dividerIndex={shouldShowSuggested ? numSuggestedShowing : undefined}
                 disabled={disabled}
                 error={error}
+                getPillImageUrl={getContactAvatarUrl}
                 inputProps={{
                     autoFocus: true,
                     onChange: noop,


### PR DESCRIPTION
use the existing support for avatar images on round pills, which allows the selected pills to fetch an avatar via URL