### PR TITLE
feat(annotations): Handle file versions unavailable

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -70,6 +70,8 @@ be.contentSidebar.activityFeed.annotationActivity.annotationActivityPostedFullDa
 be.contentSidebar.activityFeed.annotationActivityPageItem = Page {number}
 # Annotation activity item link shown on annotation activity for previous file version
 be.contentSidebar.activityFeed.annotationActivityVersionLink = Version {number}
+# Annotation activity item link shown on annotation activity for previous file version that is unavailable
+be.contentSidebar.activityFeed.annotationActivityVersionUnavailable = Version Unavailable
 # Text to show on menu item to delete comment
 be.contentSidebar.activityFeed.comment.commentDeleteMenuItem = Delete
 # Confirmation prompt text to delete comment

--- a/src/common/types/annotations.js
+++ b/src/common/types/annotations.js
@@ -41,7 +41,7 @@ export type Annotation = {
     created_by: User,
     description?: Reply,
     error?: ActionItemError, // Doesn't come from the API but used in the FeedItems
-    file_version: BoxItemVersionMini,
+    file_version: BoxItemVersionMini | null,
     id: string,
     isPending?: boolean, // Doesn't come from the API but used in the FeedItems
     modified_at: string,

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1145,9 +1145,10 @@ class ContentPreview extends React.PureComponent<Props, State> {
         });
     };
 
-    handleAnnotationSelect = ({ file_version: { id: annotationFileVersionId }, id, target }: Annotation) => {
+    handleAnnotationSelect = ({ file_version, id, target }: Annotation) => {
         const { location = {} } = target;
         const { file, selectedVersion } = this.state;
+        const annotationFileVersionId = getProp(file_version, 'id');
         const currentFileVersionId = getProp(file, 'file_version.id');
         const currentPreviewFileVersionId = getProp(selectedVersion, 'id', currentFileVersionId);
         const unit = startAtTypes[location.type];

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1154,7 +1154,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
         const unit = startAtTypes[location.type];
         const viewer = this.getViewer();
 
-        if (unit && annotationFileVersionId !== currentPreviewFileVersionId) {
+        if (unit && annotationFileVersionId && annotationFileVersionId !== currentPreviewFileVersionId) {
             this.setState({
                 startAt: {
                     unit,

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -1163,6 +1163,7 @@ describe('elements/content-preview/ContentPreview', () => {
             ${'123'}                | ${'124'}          | ${'page'}    | ${1}
             ${'124'}                | ${'124'}          | ${'page'}    | ${0}
             ${'123'}                | ${'124'}          | ${''}        | ${0}
+            ${undefined}            | ${'124'}          | ${'page'}    | ${0}
         `(
             'should call onVersionChange $onVersionChangeCount times and setState $setStateCount times',
             ({ annotationFileVersionId, selectedVersionId, locationType, setStateCount }) => {

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -613,7 +613,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
 
         emitAnnotatorActiveChangeEvent(nextActiveAnnotationId);
 
-        if (annotationFileVersionId !== selectedFileVersionId) {
+        if (annotationFileVersionId && annotationFileVersionId !== selectedFileVersionId) {
             history.push(getAnnotationsPath(annotationFileVersionId, nextActiveAnnotationId));
         }
 

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -596,10 +596,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     };
 
     handleAnnotationSelect = (annotation: Annotation): void => {
-        const {
-            file_version: { id: annotationFileVersionId },
-            id: nextActiveAnnotationId,
-        } = annotation;
+        const { file_version, id: nextActiveAnnotationId } = annotation;
         const {
             emitAnnotatorActiveChangeEvent,
             file,
@@ -609,6 +606,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             location,
             onAnnotationSelect,
         } = this.props;
+        const annotationFileVersionId = getProp(file_version, 'id');
         const currentFileVersionId = getProp(file, 'file_version.id');
         const match = getAnnotationsMatchPath(location);
         const selectedFileVersionId = getProp(match, 'params.fileVersionId', currentFileVersionId);

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -734,6 +734,19 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             expect(history.push).toHaveBeenCalledWith('/activity/annotations/235/124');
             expect(onAnnotationSelect).toHaveBeenCalledWith(annotation);
         });
+
+        test('should not call history.push if no file version id on the annotation', () => {
+            const wrapper = getAnnotationWrapper();
+            const instance = wrapper.instance();
+            const annotation = { file_version: null, id: '124' };
+            getAnnotationsMatchPath.mockReturnValue({ params: { fileVersionId: undefined } });
+
+            instance.handleAnnotationSelect(annotation);
+
+            expect(emitAnnotatorActiveChangeEvent).toHaveBeenCalledWith('124');
+            expect(history.push).not.toHaveBeenCalled();
+            expect(onAnnotationSelect).toHaveBeenCalledWith(annotation);
+        });
     });
 
     describe('handleAnnotationDelete()', () => {

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -1,5 +1,6 @@
 // @flow
 import classNames from 'classnames';
+import getProp from 'lodash/get';
 import noop from 'lodash/noop';
 import * as React from 'react';
 import ActivityError from '../common/activity-error';
@@ -50,10 +51,14 @@ const AnnotationActivity = ({
     const createdAtTimestamp = new Date(created_at).getTime();
     const createdByUser = created_by || PLACEHOLDER_USER;
     const canDelete = permissions.can_delete;
+    const isFileVersionUnavailable = file_version === null;
     const isMenuVisible = canDelete && !isPending;
     const message = (description && description.message) || '';
     const linkMessage = isCurrentVersion ? messages.annotationActivityPageItem : messages.annotationActivityVersionLink;
-    const linkValue = isCurrentVersion ? target.location.value : file_version.version_number;
+    const linkValue = isCurrentVersion ? target.location.value : getProp(file_version, 'version_number');
+    const activityLinkMessage = isFileVersionUnavailable
+        ? messages.annotationActivityVersionUnavailable
+        : { ...linkMessage, values: { number: linkValue } };
 
     return (
         <div className="bcs-AnnotationActivity">
@@ -83,10 +88,8 @@ const AnnotationActivity = ({
                     <ActivityMessage id={id} tagged_message={message} getUserProfileUrl={getUserProfileUrl} />
                     <AnnotationActivityLink
                         id={id}
-                        message={{
-                            ...linkMessage,
-                            values: { number: linkValue },
-                        }}
+                        isDisabled={isFileVersionUnavailable}
+                        message={activityLinkMessage}
                         onClick={handleOnSelect}
                     />
                 </Media.Body>

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.scss
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.scss
@@ -46,5 +46,9 @@
     .bcs-AnnotationActivity-link {
         color: $bdl-box-blue;
         font-weight: bold;
+
+        &[aria-disabled='true'] {
+            color: $bdl-gray-62;
+        }
     }
 }

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityLink.tsx
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityLink.tsx
@@ -6,11 +6,17 @@ import { ButtonType } from '../../../../components/button';
 
 export interface AnnotationActivityLinkProps {
     id: string;
+    isDisabled: boolean;
     message: MessageDescriptor;
     onClick: (id: string) => void;
 }
 
-const AnnotationActivityLink = ({ id, message, onClick = noop }: AnnotationActivityLinkProps): JSX.Element => {
+const AnnotationActivityLink = ({
+    id,
+    isDisabled = false,
+    message,
+    onClick = noop,
+}: AnnotationActivityLinkProps): JSX.Element => {
     const handleClick = (event: React.SyntheticEvent) => {
         event.preventDefault();
         event.stopPropagation();
@@ -22,7 +28,12 @@ const AnnotationActivityLink = ({ id, message, onClick = noop }: AnnotationActiv
         onClick(id);
     };
     return (
-        <PlainButton className="bcs-AnnotationActivity-link" onClick={handleClick} type={ButtonType.BUTTON}>
+        <PlainButton
+            className="bcs-AnnotationActivity-link"
+            isDisabled={isDisabled}
+            onClick={handleClick}
+            type={ButtonType.BUTTON}
+        >
             <FormattedMessage {...message} />
         </PlainButton>
     );

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
@@ -74,6 +74,16 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
         });
     });
 
+    test('should render version unavailable if file version is null', () => {
+        const wrapper = getWrapper({ item: { ...mockAnnotation, file_version: null } });
+        const activityLink = wrapper.find(AnnotationActivityLink);
+
+        expect(activityLink.prop('message')).toEqual({
+            ...messages.annotationActivityVersionUnavailable,
+        });
+        expect(activityLink.prop('isDisabled')).toBe(true);
+    });
+
     test('should render commenter as a link', () => {
         const wrapper = getWrapper();
         expect(wrapper.find('UserLink').prop('name')).toEqual(mockActivity.item.created_by.name);

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/__snapshots__/AnnotationActivityLink.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/__snapshots__/AnnotationActivityLink.test.js.snap
@@ -3,6 +3,7 @@
 exports[`elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityLink should correctly render annotation activity link 1`] = `
 <PlainButton
   className="bcs-AnnotationActivity-link"
+  isDisabled={false}
   onClick={[Function]}
   type="button"
 >

--- a/src/elements/content-sidebar/activity-feed/annotations/messages.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/messages.js
@@ -26,6 +26,12 @@ const messages = defineMessages({
         defaultMessage: 'Version {number}',
         description: 'Annotation activity item link shown on annotation activity for previous file version',
     },
+    annotationActivityVersionUnavailable: {
+        id: 'be.contentSidebar.activityFeed.annotationActivityVersionUnavailable',
+        defaultMessage: 'Version Unavailable',
+        description:
+            'Annotation activity item link shown on annotation activity for previous file version that is unavailable',
+    },
 });
 
 export default messages;


### PR DESCRIPTION
When a file version is unavailable, disable the activity link button and show a grayed out message `Version Unavailable`

![Screen Shot 2020-06-23 at 3 16 29 PM](https://user-images.githubusercontent.com/17791289/85472122-465ccd00-b566-11ea-9763-f52a33279ae4.png)
