### PR TITLE
fix(content-picker): update create folder dialog styling

### DIFF
--- a/src/elements/common/create-folder-dialog/CreateFolderDialog.js
+++ b/src/elements/common/create-folder-dialog/CreateFolderDialog.js
@@ -18,6 +18,7 @@ import {
     ERROR_CODE_ITEM_NAME_TOO_LONG,
     ERROR_CODE_ITEM_NAME_IN_USE,
 } from '../../../constants';
+import './CreateFolderDialog.scss';
 
 type Props = {
     appElement: HTMLElement,
@@ -106,7 +107,9 @@ const CreateFolderDialog = ({
                     </div>
                 ) : null}
                 <FormattedMessage tagName="div" {...messages.createDialogText} />
-                <input ref={ref} onKeyDown={onKeyDown} required type="text" />
+                <div className="be-modal-input">
+                    <input ref={ref} onKeyDown={onKeyDown} required type="text" />
+                </div>
             </label>
             <div className="be-modal-btns">
                 <PrimaryButton data-testid="be-btn-create-folder" isLoading={isLoading} onClick={create} type="button">

--- a/src/elements/common/create-folder-dialog/CreateFolderDialog.scss
+++ b/src/elements/common/create-folder-dialog/CreateFolderDialog.scss
@@ -1,0 +1,3 @@
+.be-modal-input input {
+    width: 100% !important;
+}


### PR DESCRIPTION
fixes #2205
updates create folder text input to span the width of the modal

**Before**
<img width="1680" alt="Screen Shot 2020-06-30 at 2 29 35 PM" src="https://user-images.githubusercontent.com/6053208/86180574-48cca300-bae1-11ea-8665-5d6bd361e56d.png">

**After**
<img width="1680" alt="Screen Shot 2020-06-30 at 2 28 51 PM" src="https://user-images.githubusercontent.com/6053208/86180590-5124de00-bae1-11ea-8ce1-ba478c6a2ac1.png">
