### PR TITLE
fix(annotations): Avoid error when adding initial annotation on a file

### DIFF
--- a/src/elements/content-sidebar/__tests__/withSidebarAnnotations.test.js
+++ b/src/elements/content-sidebar/__tests__/withSidebarAnnotations.test.js
@@ -212,27 +212,32 @@ describe('elements/content-sidebar/withSidebarAnnotations', () => {
         );
 
         test.each`
-            isAnnotationsPath | isOpen   | current             | expectedCount
-            ${false}          | ${false} | ${null}             | ${0}
-            ${true}           | ${false} | ${null}             | ${0}
-            ${false}          | ${true}  | ${null}             | ${0}
-            ${false}          | ${false} | ${sidebarPanelsRef} | ${0}
-            ${true}           | ${true}  | ${null}             | ${0}
-            ${false}          | ${true}  | ${sidebarPanelsRef} | ${0}
-            ${true}           | ${true}  | ${sidebarPanelsRef} | ${1}
+            pathname                            | isOpen   | current             | expectedCount
+            ${'/'}                              | ${false} | ${null}             | ${0}
+            ${'/details'}                       | ${true}  | ${null}             | ${0}
+            ${'/activity'}                      | ${false} | ${null}             | ${0}
+            ${'/activity'}                      | ${true}  | ${null}             | ${0}
+            ${'/activity'}                      | ${false} | ${sidebarPanelsRef} | ${0}
+            ${'/activity'}                      | ${true}  | ${sidebarPanelsRef} | ${1}
+            ${'/activity/versions/12345'}       | ${true}  | ${sidebarPanelsRef} | ${1}
+            ${'/activity/versions/12345/67890'} | ${true}  | ${sidebarPanelsRef} | ${1}
+            ${'/details'}                       | ${true}  | ${sidebarPanelsRef} | ${0}
+            ${'/'}                              | ${true}  | ${sidebarPanelsRef} | ${0}
         `(
-            'should refresh the sidebarPanels ref accordingly if isAnnotationsPath=$isAnnotationsPath, isOpen=$isOpen, current=$current',
-            ({ isAnnotationsPath, isOpen, current, expectedCount }) => {
+            'should refresh the sidebarPanels ref accordingly if pathname=$pathname, isOpen=$isOpen, current=$current',
+            ({ current, expectedCount, isOpen, pathname }) => {
                 const annotatorStateMock = {
                     meta: {
                         requestId: '123',
                     },
                 };
-
-                const wrapper = getWrapper({ annotatorState: annotatorStateMock, currentUser, isOpen });
+                const wrapper = getWrapper({
+                    annotatorState: annotatorStateMock,
+                    currentUser,
+                    isOpen,
+                    location: { pathname },
+                });
                 const instance = wrapper.instance();
-
-                annotatorContextProps.getAnnotationsMatchPath.mockReturnValueOnce(isAnnotationsPath);
                 instance.sidebarPanels = {
                     current,
                 };

--- a/src/elements/content-sidebar/withSidebarAnnotations.js
+++ b/src/elements/content-sidebar/withSidebarAnnotations.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import getProp from 'lodash/get';
 import noop from 'lodash/noop';
-import type { ContextRouter } from 'react-router-dom';
+import { matchPath, type ContextRouter } from 'react-router-dom';
 import { getBadUserError } from '../../utils/error';
 import type { WithAnnotatorContextProps } from '../common/annotator-context';
 import type { BoxItem, User } from '../../common/types/core';
@@ -98,7 +98,6 @@ export default function withSidebarAnnotations(
                 currentUser,
                 file,
                 fileId,
-                getAnnotationsMatchPath,
                 isOpen,
                 location,
             } = this.props;
@@ -113,7 +112,8 @@ export default function withSidebarAnnotations(
             }
 
             const feedAPI = api.getFeedAPI(false);
-            const isAnnotationsPath = !!getAnnotationsMatchPath(location);
+            const pathname = getProp(location, 'pathname', '');
+            const isActivity = matchPath(pathname, '/activity');
             const isPending = action === 'create_start';
             const { items: hasItems } = feedAPI.getCachedItems(fileId) || {};
             const { current } = this.sidebarPanels;
@@ -124,8 +124,8 @@ export default function withSidebarAnnotations(
                 feedAPI.addAnnotation(file, currentUser, annotation, requestId, isPending);
             }
 
-            if (isAnnotationsPath && isOpen && current) {
-                // If the sidebar is currently open, then force the sidebar to refresh with the updated data
+            // If the activity sidebar is currently open, then force it to refresh with the updated data
+            if (current && isActivity && isOpen) {
                 current.refresh(false);
             }
         }


### PR DESCRIPTION
The previous implementation relied on an oddity in the event handling between the Annotations SDK, Preview SDK, and withAnnotations component. The withAnnotations component received/receives events in the following order, with the new behavior being the desired sequence:

```
old: create_pending (add to feed) -> active_change (navigate) -> create_success (refresh sidebar)
new: create_pending (add to feed) -> create_success (refresh sidebar) -> active_change (navigate)