### PR TITLE
refactor(annotations): Separate mouse event handlers for links

### DIFF
--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityLink.tsx
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityLink.tsx
@@ -17,28 +17,33 @@ const AnnotationActivityLink = ({
     message,
     onClick = noop,
 }: AnnotationActivityLinkProps): JSX.Element => {
+    const handleClick = (event: React.SyntheticEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        onClick(id);
+    };
+
     const handleMouseDown = (event: React.MouseEvent<HTMLButtonElement>) => {
         if (isDisabled) {
             return;
         }
 
-        event.preventDefault();
-        event.stopPropagation();
         // Prevents document event handlers from executing because box-annotations relies on
         // detecting mouse events on the document outside of annotation targets to determine when to
         // deselect annotations. This link also may represent that annotation target in the sidebar.
         event.nativeEvent.stopImmediatePropagation();
 
-        // Stopping propagation on the mousedown event prevents focus from reaching the button.
+        // Stopping propagation on the mousedown event prevents focus from reaching the button, so forward it.
         event.currentTarget.focus();
-
-        onClick(id);
     };
+
     return (
         <PlainButton
             className="bcs-AnnotationActivity-link"
             data-resin-target="annotationLink"
             isDisabled={isDisabled}
+            onClick={handleClick}
             onMouseDown={handleMouseDown}
             type={ButtonType.BUTTON}
         >

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivityLink.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivityLink.test.js
@@ -18,16 +18,29 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityLi
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should fire onMousedown when link is followed', () => {
+    test('should fire onClick when the button is clicked', () => {
         const onClickFn = jest.fn();
         const wrapper = getWrapper({ onClick: onClickFn });
+        const onClick = wrapper.find('PlainButton').prop('onClick');
+        const event = {
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+        };
+
+        onClick(event);
+
+        expect(onClickFn).toHaveBeenCalledWith('123');
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(event.stopPropagation).toHaveBeenCalled();
+    });
+
+    test('should stop propagation of the native mousedown event', () => {
+        const wrapper = getWrapper();
         const onMouseDown = wrapper.find('PlainButton').prop('onMouseDown');
         const event = {
             currentTarget: {
                 focus: jest.fn(),
             },
-            preventDefault: jest.fn(),
-            stopPropagation: jest.fn(),
             nativeEvent: {
                 stopImmediatePropagation: jest.fn(),
             },
@@ -35,23 +48,17 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityLi
 
         onMouseDown(event);
 
-        expect(onClickFn).toHaveBeenCalledWith('123');
         expect(event.currentTarget.focus).toHaveBeenCalled();
-        expect(event.preventDefault).toHaveBeenCalled();
-        expect(event.stopPropagation).toHaveBeenCalled();
         expect(event.nativeEvent.stopImmediatePropagation).toHaveBeenCalled();
     });
 
-    test('should mpt fire onMousedown when link is followed if isDisabled is true', () => {
-        const onClickFn = jest.fn();
-        const wrapper = getWrapper({ isDisabled: true, onClick: onClickFn });
+    test('should not stop propagation of the native mousedown event if isDisabled is true', () => {
+        const wrapper = getWrapper({ isDisabled: true });
         const onMouseDown = wrapper.find('PlainButton').prop('onMouseDown');
         const event = {
             currentTarget: {
                 focus: jest.fn(),
             },
-            preventDefault: jest.fn(),
-            stopPropagation: jest.fn(),
             nativeEvent: {
                 stopImmediatePropagation: jest.fn(),
             },
@@ -59,10 +66,7 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityLi
 
         onMouseDown(event);
 
-        expect(onClickFn).not.toHaveBeenCalledWith('123');
         expect(event.currentTarget.focus).not.toHaveBeenCalled();
-        expect(event.preventDefault).not.toHaveBeenCalled();
-        expect(event.stopPropagation).not.toHaveBeenCalled();
         expect(event.nativeEvent.stopImmediatePropagation).not.toHaveBeenCalled();
     });
 });

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/__snapshots__/AnnotationActivityLink.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/__snapshots__/AnnotationActivityLink.test.js.snap
@@ -5,6 +5,7 @@ exports[`elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityLin
   className="bcs-AnnotationActivity-link"
   data-resin-target="annotationLink"
   isDisabled={false}
+  onClick={[Function]}
   onMouseDown={[Function]}
   type="button"
 >


### PR DESCRIPTION
Sorry for the multiple PRs, but I wanted to avoid `onMouseDown` managing the invocation of the `onClick` callback.