### PR TITLE
feat(i18n): add a zoneinfo call to get time zones

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
         "@babel/preset-typescript": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "@box/cldr-data": "^34.2.0",
+        "@box/cldr-data": "^34.4.1",
         "@box/frontend": "8.0.0",
         "@box/languages": "^1.0.0",
         "@commitlint/cli": "^8.3.5",
@@ -319,7 +319,7 @@
         "yargs": "^15.1.0"
     },
     "peerDependencies": {
-        "@box/cldr-data": "^34.2.0",
+        "@box/cldr-data": "^34.4.1",
         "@hapi/address": ">=2.0.0 <2.1.2",
         "axios": "^0.18.1",
         "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
         "@babel/preset-typescript": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "@box/cldr-data": "^34.4.1",
+        "@box/cldr-data": "^34.5.0",
         "@box/frontend": "8.0.0",
         "@box/languages": "^1.0.0",
         "@commitlint/cli": "^8.3.5",
@@ -319,7 +319,7 @@
         "yargs": "^15.1.0"
     },
     "peerDependencies": {
-        "@box/cldr-data": "^34.4.1",
+        "@box/cldr-data": "^34.5.0",
         "@hapi/address": ">=2.0.0 <2.1.2",
         "axios": "^0.18.1",
         "classnames": "^2.2.5",

--- a/src/utils/__tests__/timezones.test.ts
+++ b/src/utils/__tests__/timezones.test.ts
@@ -1,0 +1,159 @@
+/**
+ * load locale data manually that is not the current locale so that
+ * we can use it for unit testing
+ */
+
+import germanLocaleData from '@box/cldr-data/locale-data/de-DE';
+import russianLocaleData from '@box/cldr-data/locale-data/ru-RU';
+import japaneseLocaleData from '@box/cldr-data/locale-data/ja-JP';
+import timezones, { findTimeZone, TimeZone, TimeZoneEntries } from '../timezones';
+
+const germanZoneData = germanLocaleData.timezones;
+const russianZoneData = russianLocaleData.timezones;
+const japaneseZoneData = japaneseLocaleData.timezones;
+
+describe('util/timezones', () => {
+    test('should work in English', () => {
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+        }); // default is English
+        expect(zones['1']).toStrictEqual({
+            name: 'Africa/Abidjan',
+            displayName: 'GMT+00:00 Africa/Abidjan GMT',
+            id: 1,
+        });
+        expect(zones['139']).toStrictEqual({
+            name: 'America/Los_Angeles',
+            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            enabled: true,
+            id: 139,
+        });
+    });
+
+    test('should work in German', () => {
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+            tzData: germanZoneData,
+        });
+        expect(zones['295']).toStrictEqual({
+            name: 'Asia/Yekaterinburg',
+            displayName: 'GMT+05:00 Jekaterinburg +05',
+            enabled: true,
+            id: 295,
+        });
+        expect(zones['301']).toStrictEqual({
+            name: 'Atlantic/Faeroe',
+            displayName: 'GMT+00:00 Färöer UTC',
+            id: 301,
+        });
+    });
+
+    test('should work in Japanese', () => {
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+            tzData: japaneseZoneData,
+        });
+        expect(zones['321']).toStrictEqual({
+            name: 'Australia/Melbourne',
+            displayName: 'GMT+10:00 メルボルン AEST',
+            id: 321,
+        });
+        expect(zones['390']).toStrictEqual({
+            name: 'Europe/Amsterdam',
+            displayName: 'GMT+01:00 アムステルダム CET',
+            enabled: true,
+            id: 390,
+        });
+    });
+
+    test('should work in Russian', () => {
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+            tzData: russianZoneData,
+        });
+        expect(zones['295']).toStrictEqual({
+            name: 'Asia/Yekaterinburg',
+            displayName: 'GMT+05:00 Екатеринбург +05',
+            enabled: true,
+            id: 295,
+        });
+        expect(zones['402']).toStrictEqual({
+            name: 'Europe/Dublin',
+            displayName: 'GMT+01:00 Дублин IST/GMT',
+            id: 402,
+        });
+    });
+
+    test('should get all zones', () => {
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+        });
+        expect(Object.keys(zones).length).toBe(551);
+        expect(zones['1']).toStrictEqual({
+            name: 'Africa/Abidjan',
+            displayName: 'GMT+00:00 Africa/Abidjan GMT',
+            id: 1,
+        });
+        expect(zones['139']).toStrictEqual({
+            name: 'America/Los_Angeles',
+            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            enabled: true,
+            id: 139,
+        });
+    });
+
+    test('should get only enabled zones', () => {
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'enabled',
+        });
+        expect(Object.keys(zones).length).toBe(85);
+        expect(zones['1']).toBeUndefined();
+        expect(zones['139']).toStrictEqual({
+            name: 'America/Los_Angeles',
+            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            enabled: true,
+            id: 139,
+        });
+    });
+
+    test('findzone should work in English', () => {
+        const zone: TimeZone = findTimeZone(139);
+        expect(zone).toStrictEqual({
+            name: 'America/Los_Angeles',
+            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            enabled: true,
+            id: 139,
+        });
+    });
+
+    test('findzone should work in English with a string param', () => {
+        const zone: TimeZone = findTimeZone('139');
+        expect(zone).toStrictEqual({
+            name: 'America/Los_Angeles',
+            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            enabled: true,
+            id: 139,
+        });
+    });
+
+    test('findzone should work with disabled zones in English', () => {
+        const zone: TimeZone = findTimeZone(1);
+        expect(zone).toStrictEqual({
+            name: 'Africa/Abidjan',
+            displayName: 'GMT+00:00 Africa/Abidjan GMT',
+            id: 1,
+        });
+    });
+
+    test('findzone should work in Japanese', () => {
+        const zone: TimeZone = findTimeZone(139, {
+            tzData: japaneseZoneData,
+        });
+        expect(zone).toStrictEqual({
+            name: 'America/Los_Angeles',
+            displayName: 'GMT-08:00 ロサンゼルス PST',
+            enabled: true,
+            id: 139,
+        });
+    });
+});

--- a/src/utils/__tests__/timezones.test.ts
+++ b/src/utils/__tests__/timezones.test.ts
@@ -12,97 +12,254 @@ const germanZoneData = germanLocaleData.timezones;
 const russianZoneData = russianLocaleData.timezones;
 const japaneseZoneData = japaneseLocaleData.timezones;
 
+const RealDate = Date;
+
+function mockDate(isoDate: string) {
+    const unixtime = new Date(isoDate).getTime();
+    global.Date.now = jest.fn(() => {
+        return unixtime;
+    });
+}
+
 describe('util/timezones', () => {
+    afterEach(() => {
+        global.Date.now = RealDate.now;
+    });
+
     test('should work in English', () => {
+        mockDate('2020-06-01T00:00:00z');
+
         const zones: TimeZoneEntries = timezones({
             includeZones: 'all',
         }); // default is English
+
+        // no DST
         expect(zones['1']).toStrictEqual({
             name: 'Africa/Abidjan',
+            nameLocalized: 'Africa/Abidjan',
             displayName: 'GMT+00:00 Africa/Abidjan GMT',
+            abbreviationStandard: 'GMT',
             id: 1,
         });
+        // has DST
         expect(zones['139']).toStrictEqual({
             name: 'America/Los_Angeles',
-            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            nameLocalized: 'America/Los_Angeles',
+            displayName: 'GMT-07:00 America/Los_Angeles PDT',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
             enabled: true,
             id: 139,
         });
     });
 
+    test('should be sensitive to the current date in English', () => {
+        mockDate('2020-01-01T00:00:00z');
+
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+        }); // default is English
+        // no DST
+        expect(zones['1']).toStrictEqual({
+            name: 'Africa/Abidjan',
+            nameLocalized: 'Africa/Abidjan',
+            displayName: 'GMT+00:00 Africa/Abidjan GMT',
+            abbreviationStandard: 'GMT',
+            id: 1,
+        });
+        // has DST
+        expect(zones['139']).toStrictEqual({
+            name: 'America/Los_Angeles',
+            nameLocalized: 'America/Los_Angeles',
+            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
+            enabled: true,
+            id: 139,
+        });
+    });
+
+    test('should work in the southern hemisphere standard time', () => {
+        mockDate('2020-06-01T00:00:00z');
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+        });
+        expect(zones['321']).toStrictEqual({
+            name: 'Australia/Melbourne',
+            nameLocalized: 'Australia/Melbourne',
+            displayName: 'GMT+10:00 Australia/Melbourne AEST',
+            abbreviationStandard: 'AEST',
+            abbreviationDaylight: 'AEDT',
+            id: 321,
+        });
+    });
+
+    test('should work in the southern hemisphere daylight time', () => {
+        mockDate('2020-01-01T00:00:00z');
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+        });
+        expect(zones['321']).toStrictEqual({
+            name: 'Australia/Melbourne',
+            nameLocalized: 'Australia/Melbourne',
+            displayName: 'GMT+11:00 Australia/Melbourne AEDT',
+            abbreviationStandard: 'AEST',
+            abbreviationDaylight: 'AEDT',
+            id: 321,
+        });
+    });
+
+    test('should be able to format partial hour offsets standard', () => {
+        mockDate('2020-01-01T00:00:00z');
+
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+        }); // default is English
+        // northern hemisphere
+        expect(zones['184']).toStrictEqual({
+            name: 'America/St_Johns',
+            nameLocalized: 'America/St_Johns',
+            displayName: 'GMT-03:30 America/St_Johns NST',
+            abbreviationStandard: 'NST',
+            abbreviationDaylight: 'NDT',
+            enabled: true,
+            id: 184,
+        });
+        // southern hemisphere
+        expect(zones['487']).toStrictEqual({
+            name: 'Pacific/Chatham',
+            nameLocalized: 'Pacific/Chatham',
+            displayName: 'GMT+13:45 Pacific/Chatham +1245/+1345',
+            abbreviationStandard: '+1245/+1345',
+            abbreviationDaylight: '+1245/+1345',
+            id: 487,
+        });
+    });
+
+    test('should be able to format partial hour offsets daylight', () => {
+        mockDate('2020-06-01T00:00:00z');
+
+        const zones: TimeZoneEntries = timezones({
+            includeZones: 'all',
+        }); // default is English
+        // northern hemisphere
+        expect(zones['184']).toStrictEqual({
+            name: 'America/St_Johns',
+            nameLocalized: 'America/St_Johns',
+            displayName: 'GMT-02:30 America/St_Johns NDT',
+            abbreviationStandard: 'NST',
+            abbreviationDaylight: 'NDT',
+            enabled: true,
+            id: 184,
+        });
+        // southern hemisphere
+        expect(zones['487']).toStrictEqual({
+            name: 'Pacific/Chatham',
+            nameLocalized: 'Pacific/Chatham',
+            displayName: 'GMT+12:45 Pacific/Chatham +1245/+1345',
+            abbreviationStandard: '+1245/+1345',
+            abbreviationDaylight: '+1245/+1345',
+            id: 487,
+        });
+    });
+
     test('should work in German', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zones: TimeZoneEntries = timezones({
             includeZones: 'all',
             tzData: germanZoneData,
         });
         expect(zones['295']).toStrictEqual({
             name: 'Asia/Yekaterinburg',
+            nameLocalized: 'Jekaterinburg',
             displayName: 'GMT+05:00 Jekaterinburg +05',
+            abbreviationStandard: '+05',
             enabled: true,
             id: 295,
         });
         expect(zones['301']).toStrictEqual({
             name: 'Atlantic/Faeroe',
+            nameLocalized: 'Färöer',
             displayName: 'GMT+00:00 Färöer UTC',
+            abbreviationStandard: 'UTC',
             id: 301,
         });
     });
 
     test('should work in Japanese', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zones: TimeZoneEntries = timezones({
             includeZones: 'all',
             tzData: japaneseZoneData,
         });
         expect(zones['321']).toStrictEqual({
             name: 'Australia/Melbourne',
+            nameLocalized: 'メルボルン',
             displayName: 'GMT+10:00 メルボルン AEST',
+            abbreviationStandard: 'AEST',
+            abbreviationDaylight: 'AEDT',
             id: 321,
         });
         expect(zones['390']).toStrictEqual({
             name: 'Europe/Amsterdam',
-            displayName: 'GMT+01:00 アムステルダム CET',
+            nameLocalized: 'アムステルダム',
+            displayName: 'GMT+02:00 アムステルダム CEST',
+            abbreviationStandard: 'CET',
+            abbreviationDaylight: 'CEST',
             enabled: true,
             id: 390,
         });
     });
 
     test('should work in Russian', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zones: TimeZoneEntries = timezones({
             includeZones: 'all',
             tzData: russianZoneData,
         });
         expect(zones['295']).toStrictEqual({
             name: 'Asia/Yekaterinburg',
+            nameLocalized: 'Екатеринбург',
             displayName: 'GMT+05:00 Екатеринбург +05',
+            abbreviationStandard: '+05',
             enabled: true,
             id: 295,
         });
         expect(zones['402']).toStrictEqual({
             name: 'Europe/Dublin',
+            nameLocalized: 'Дублин',
             displayName: 'GMT+01:00 Дублин IST/GMT',
+            abbreviationStandard: 'IST/GMT',
             id: 402,
         });
     });
 
     test('should get all zones', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zones: TimeZoneEntries = timezones({
             includeZones: 'all',
         });
         expect(Object.keys(zones).length).toBe(551);
         expect(zones['1']).toStrictEqual({
             name: 'Africa/Abidjan',
+            nameLocalized: 'Africa/Abidjan',
             displayName: 'GMT+00:00 Africa/Abidjan GMT',
+            abbreviationStandard: 'GMT',
             id: 1,
         });
         expect(zones['139']).toStrictEqual({
             name: 'America/Los_Angeles',
-            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            nameLocalized: 'America/Los_Angeles',
+            displayName: 'GMT-07:00 America/Los_Angeles PDT',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
             enabled: true,
             id: 139,
         });
     });
 
     test('should get only enabled zones', () => {
+        mockDate('2020-01-01T00:00:00z');
         const zones: TimeZoneEntries = timezones({
             includeZones: 'enabled',
         });
@@ -110,48 +267,82 @@ describe('util/timezones', () => {
         expect(zones['1']).toBeUndefined();
         expect(zones['139']).toStrictEqual({
             name: 'America/Los_Angeles',
+            nameLocalized: 'America/Los_Angeles',
             displayName: 'GMT-08:00 America/Los_Angeles PST',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
             enabled: true,
             id: 139,
         });
     });
 
     test('findzone should work in English', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zone: TimeZone = findTimeZone(139);
         expect(zone).toStrictEqual({
             name: 'America/Los_Angeles',
-            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            nameLocalized: 'America/Los_Angeles',
+            displayName: 'GMT-07:00 America/Los_Angeles PDT',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
             enabled: true,
             id: 139,
         });
     });
 
     test('findzone should work in English with a string param', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zone: TimeZone = findTimeZone('139');
         expect(zone).toStrictEqual({
             name: 'America/Los_Angeles',
-            displayName: 'GMT-08:00 America/Los_Angeles PST',
+            nameLocalized: 'America/Los_Angeles',
+            displayName: 'GMT-07:00 America/Los_Angeles PDT',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
             enabled: true,
             id: 139,
         });
     });
 
     test('findzone should work with disabled zones in English', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zone: TimeZone = findTimeZone(1);
         expect(zone).toStrictEqual({
             name: 'Africa/Abidjan',
+            nameLocalized: 'Africa/Abidjan',
             displayName: 'GMT+00:00 Africa/Abidjan GMT',
+            abbreviationStandard: 'GMT',
             id: 1,
         });
     });
 
     test('findzone should work in Japanese', () => {
+        mockDate('2020-06-01T00:00:00z');
         const zone: TimeZone = findTimeZone(139, {
             tzData: japaneseZoneData,
         });
         expect(zone).toStrictEqual({
             name: 'America/Los_Angeles',
+            nameLocalized: 'ロサンゼルス',
+            displayName: 'GMT-07:00 ロサンゼルス PDT',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
+            enabled: true,
+            id: 139,
+        });
+    });
+
+    test('findzone should be sensitive to the date in Japanese', () => {
+        mockDate('2020-01-01T00:00:00z');
+        const zone: TimeZone = findTimeZone(139, {
+            tzData: japaneseZoneData,
+        });
+        expect(zone).toStrictEqual({
+            name: 'America/Los_Angeles',
+            nameLocalized: 'ロサンゼルス',
             displayName: 'GMT-08:00 ロサンゼルス PST',
+            abbreviationStandard: 'PST',
+            abbreviationDaylight: 'PDT',
             enabled: true,
             id: 139,
         });

--- a/src/utils/timezones.ts
+++ b/src/utils/timezones.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Function to provide a localized list of time zones that Box supports
+ * @author Box
+ */
+
+import data, { TimeZone, TimeZoneList } from 'box-locale-data';
+
+export { TimeZone };
+
+const { timezones: boxzones } = data;
+
+export interface TimeZoneOptions {
+    tzData?: TimeZoneList;
+    includeZones?: 'all' | 'enabled';
+}
+
+export interface TimeZoneEntries {
+    [id: string]: TimeZone;
+}
+
+function timezones(options: TimeZoneOptions = {}): TimeZoneEntries {
+    const zones: TimeZoneEntries = {};
+
+    const { includeZones = 'enabled' }: { includeZones?: string } = options;
+
+    // used the passed in info first. If it is not there, fall back to
+    // the one we loaded above from the 'box-locale-data' alias
+    let { tzData }: { tzData?: TimeZoneList } = options;
+    if (!tzData) {
+        tzData = boxzones;
+    }
+
+    tzData.forEach(zone => {
+        if (includeZones === 'all' || zone.enabled) {
+            zones[String(zone.id)] = zone;
+        }
+    });
+
+    return zones;
+}
+
+export function findTimeZone(id: string | number, options: TimeZoneOptions = {}): TimeZone {
+    const stringId = String(id);
+    return timezones({
+        ...options,
+        includeZones: 'all',
+    })[stringId];
+}
+
+export default timezones;

--- a/src/utils/timezones.ts
+++ b/src/utils/timezones.ts
@@ -18,6 +18,93 @@ export interface TimeZoneEntries {
     [id: string]: TimeZone;
 }
 
+/**
+ * Test whether or not the current platform and JS engine supports the Intl object
+ * and resolving time zones. If it doesn't, we just return a static list of time
+ * zones. If it does, we make a dynamic list where each time zone is given with the
+ * offset for the current day, taking into account whether that is in DST or not.
+ */
+const supportsIntl: boolean = (function support() {
+    if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat === 'undefined') {
+        return false;
+    }
+
+    const tz: string = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/Los_Angeles',
+    }).resolvedOptions().timeZone;
+
+    return typeof tz !== 'undefined';
+})();
+
+/**
+ * Convert the offset in minutes to an hour:minute string.
+ */
+function getOffsetStr(offsetInMinutes: number): string {
+    const offsetHours = Math.floor(Math.abs(offsetInMinutes) / 60);
+    const offsetMinutes = Math.floor(Math.abs(offsetInMinutes) % (offsetHours * 60));
+
+    return `${offsetInMinutes < 1 ? '+' : '-'}${offsetHours < 10 ? `0${offsetHours}` : offsetHours}:${
+        offsetMinutes < 10 ? `0${offsetMinutes}` : offsetMinutes
+    }`;
+}
+
+/**
+ * Return the offset from UTC in minutes.
+ */
+function offset(date: Date, timeZone: string): number {
+    // use Japanese with toLocaleString because they have a nice arrangement of date parts from largest to smallest.
+    // If toLocaleString on this engine does not support locale or options parameters, then this call will throw
+    // and we will catch that
+    const arr: number[] = date
+        .toLocaleString('ja', { timeZone })
+        .split(/[/\s:]/)
+        .map(part => {
+            return Number(part);
+        });
+    arr[1] -= 1; // months are zero-based in JS for some reason, so subtract one to get the right month number
+    const t1 = Date.UTC.apply(null, arr as [number, number, number, number, number, number]);
+    const t2 = new Date(date).setMilliseconds(0);
+    return (t2 - t1) / 60000;
+}
+
+/**
+ * Calculate the display name of the zone for the given date. If the zone is in DST on that date or not,
+ * then return the string appropriately. If the zone does not use DST or if the platform cannot calculate it,
+ * then just return the static displayName string from @box/cldr-data
+ */
+function getCurrentDisplayName(date: Date, zone: TimeZone): string {
+    const { name, displayName } = zone;
+    if (supportsIntl && zone.abbreviationDaylight) {
+        try {
+            const jan1 = new Date(date.getFullYear(), 0, 1, 0, 0, 0);
+            const jun1 = new Date(date.getFullYear(), 5, 1, 0, 0, 0);
+            const jan1offset = offset(jan1, name);
+            const jun1offset = offset(jun1, name);
+            if (jan1offset === jun1offset) {
+                // no DST in this zone in this year, so just return the already calculated display name
+                return displayName;
+            }
+
+            const current = offset(new Date(Date.now()), name);
+            let zonename = `GMT${getOffsetStr(current)} ${zone.nameLocalized} `;
+            if (jan1offset < jun1offset) {
+                // southern hemisphere
+                zonename += current === jan1offset ? zone.abbreviationDaylight : zone.abbreviationStandard;
+            } else {
+                // northern hemisphere
+                zonename += current === jun1offset ? zone.abbreviationDaylight : zone.abbreviationStandard;
+            }
+            return zonename;
+        } catch (e) {
+            // sometimes the current platform does not support all of the zones or toLocaleString does not support
+            // locale and option parameters, so we have to catch for those cases
+            return displayName;
+        }
+    } else {
+        return displayName;
+    }
+}
+
 function timezones(options: TimeZoneOptions = {}): TimeZoneEntries {
     const zones: TimeZoneEntries = {};
 
@@ -30,9 +117,13 @@ function timezones(options: TimeZoneOptions = {}): TimeZoneEntries {
         tzData = boxzones;
     }
 
+    const today = new Date(Date.now());
     tzData.forEach(zone => {
         if (includeZones === 'all' || zone.enabled) {
-            zones[String(zone.id)] = zone;
+            zones[String(zone.id)] = {
+                ...zone,
+                displayName: getCurrentDisplayName(today, zone),
+            };
         }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3104,7 +3104,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@box/cldr-data@^34.4.1":
+"@box/cldr-data@^34.5.0":
   version "34.5.0"
   resolved "https://registry.yarnpkg.com/@box/cldr-data/-/cldr-data-34.5.0.tgz#58281a039a48d7b605e814eb10b0308b11356909"
   integrity sha1-WCgaA5pI17YF6BTrELAwixE1aQk=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,9 +3105,9 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@box/cldr-data@^34.4.1":
-  version "34.4.1"
-  resolved "https://registry.yarnpkg.com/@box/cldr-data/-/cldr-data-34.4.1.tgz#6ca1959e8758f7937a0fd36808f222743a9f18bd"
-  integrity sha1-bKGVnodY95N6D9NoCPIidDqfGL0=
+  version "34.5.0"
+  resolved "https://registry.yarnpkg.com/@box/cldr-data/-/cldr-data-34.5.0.tgz#58281a039a48d7b605e814eb10b0308b11356909"
+  integrity sha1-WCgaA5pI17YF6BTrELAwixE1aQk=
 
 "@box/frontend@8.0.0":
   version "8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3104,10 +3104,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@box/cldr-data@^34.2.0":
-  version "34.2.0"
-  resolved "https://registry.yarnpkg.com/@box/cldr-data/-/cldr-data-34.2.0.tgz#d2a50e778d28988faaf5e56194b17b46c6b98ae5"
-  integrity sha1-0qUOd40omI+q9eVhlLF7Rsa5iuU=
+"@box/cldr-data@^34.4.1":
+  version "34.4.1"
+  resolved "https://registry.yarnpkg.com/@box/cldr-data/-/cldr-data-34.4.1.tgz#6ca1959e8758f7937a0fd36808f222743a9f18bd"
+  integrity sha1-bKGVnodY95N6D9NoCPIidDqfGL0=
 
 "@box/frontend@8.0.0":
   version "8.0.0"


### PR DESCRIPTION
- Return the list of time zones that Box recognizes
    - returned as a JS object with values like this:
      ```javascript
      // the Box id, same as below
      "139": {
            // the IANA name of the zone
            name: 'America/Los_Angeles',

            // the above name, localized
            nameLocalized: 'America/Los_Angeles',
 
            // the display name of the zone translated to the
            // current or given locale
            displayName: 'GMT-08:00 America/Los_Angeles PST',

            // the abbreviation used in standard time
            abbreviationStandard: 'PST',

            // the abbreviation used in daylight time
            abbreviationDaylight: 'PDT',

            // whether or not this is an enabled standard Box zone
            enabled: true,

            // The numeric Box backend id of this entry
            id: 139
      }
      ```
- Added findTimeZone to get a particular zone for a given box id
- By default, it only returns the enabled zones now. If you want
all zones anyways, you can give the option "includeZones": "all"
in the options parameter