### PR TITLE
feat(preview): Add currentFileVersionId in preview options

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -761,6 +761,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
 
         if (selectedVersion) {
             setProp(fileOpts, [fileId, 'fileVersionId'], selectedVersion.id);
+            setProp(fileOpts, [fileId, 'currentFileVersionId'], getProp(file, 'file_version.id'));
         }
 
         if (activeAnnotationId) {

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -304,7 +304,7 @@ describe('elements/content-preview/ContentPreview', () => {
         test('should call preview show with file version params if provided', async () => {
             const wrapper = getWrapper(props);
             wrapper.setState({
-                file,
+                file: { ...file, file_version: { id: '67890' } },
                 selectedVersion: {
                     id: '12345',
                 },
@@ -323,6 +323,7 @@ describe('elements/content-preview/ContentPreview', () => {
                     fileOptions: {
                         [file.id]: {
                             fileVersionId: '12345',
+                            currentFileVersionId: '67890',
                         },
                     },
                 }),


### PR DESCRIPTION
The prerequisite of https://github.com/box/box-annotations/pull/542