### PR TITLE
feat(classification): Render classification modified info when provided

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -714,6 +714,8 @@ boxui.classification.missing = Not classified
 boxui.classification.modifiedBy = {modifiedBy} on {modifiedAt}
 # Label displayed above details about when a classification was last modified.
 boxui.classification.modifiedByLabel = Classification Updated By
+# Label displayed above the security restrictions on the file due to the classification label and associated policies.
+boxui.classification.restrictionsLabel = Restrictions
 # Text to display for users who have not accepted an invitation to collaborate yet
 boxui.collaboratorAvatars.collaboration.pendingCollabText = Pending
 # Label for collaborator avatars

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -710,6 +710,10 @@ boxui.classification.definition = Definition
 boxui.classification.edit = Edit
 # Default message for classification in the sidebar when there is none
 boxui.classification.missing = Not classified
+# Sentence stating which user or service modified a classification and on what date.
+boxui.classification.modifiedBy = {modifiedBy} on {modifiedAt}
+# Label displayed above details about when a classification was last modified.
+boxui.classification.modifiedByLabel = Classification Updated By
 # Text to display for users who have not accepted an invitation to collaborate yet
 boxui.collaboratorAvatars.collaboration.pendingCollabText = Pending
 # Label for collaborator avatars

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 
+import { isValidDate } from '../../utils/datetime';
 import Label from '../../components/label/Label';
 import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
 import ClassifiedBadge from './ClassifiedBadge';
@@ -13,12 +14,6 @@ import type { Controls, ControlsFormat } from './flowTypes';
 
 const STYLE_INLINE: 'inline' = 'inline';
 const STYLE_TOOLTIP: 'tooltip' = 'tooltip';
-
-const formattedDateOptions = {
-    month: 'long',
-    year: 'numeric',
-    day: 'numeric',
-};
 type Props = {
     className?: string,
     color?: string,
@@ -61,10 +56,12 @@ const Classification = ({
     const isControlsIndicatorEnabled = isClassified && isLoadingControls && messageStyle === STYLE_INLINE;
     const isSecurityControlsEnabled =
         isClassified && !isLoadingControls && hasSecurityControls && messageStyle === STYLE_INLINE;
-    const isModifiedMessageVisible = isClassified && hasModifiedAt && hasModifiedBy && messageStyle === STYLE_INLINE;
+    const modifiedDate = new Date(modifiedAt || 0);
+    const isModifiedMessageVisible =
+        isClassified && hasModifiedAt && isValidDate(modifiedDate) && hasModifiedBy && messageStyle === STYLE_INLINE;
 
     const formattedModifiedAt = isModifiedMessageVisible && (
-        <FormattedDate value={new Date(modifiedAt)} {...formattedDateOptions} />
+        <FormattedDate value={modifiedDate} month="long" year="numeric" day="numeric" />
     );
 
     return (
@@ -89,7 +86,7 @@ const Classification = ({
             )}
             {isModifiedMessageVisible && (
                 <Label text={<FormattedMessage {...messages.modifiedByLabel} />}>
-                    <p className="bdl-Classification-modifiedBy">
+                    <p className="bdl-Classification-modifiedBy" data-testid="classification-modifiedby">
                         <FormattedMessage
                             {...messages.modifiedBy}
                             values={{ modifiedAt: formattedModifiedAt, modifiedBy }}

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import type { InjectIntlProvidedProps } from 'react-intl';
 
 import Label from '../../components/label/Label';
 import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
@@ -24,18 +25,23 @@ type Props = {
     itemName?: string,
     maxAppCount?: number,
     messageStyle?: typeof STYLE_INLINE | typeof STYLE_TOOLTIP,
+    modifiedAt?: string,
+    modifiedBy?: string,
     name?: string,
     onClick?: (event: SyntheticEvent<HTMLButtonElement>) => void,
-};
+} & InjectIntlProvidedProps;
 
 const Classification = ({
     definition,
     className = '',
     controls,
     controlsFormat,
+    intl,
     isLoadingControls,
     maxAppCount,
     messageStyle,
+    modifiedAt,
+    modifiedBy,
     name,
     itemName = '',
     color,
@@ -43,6 +49,8 @@ const Classification = ({
 }: Props) => {
     const isClassified = !!name;
     const hasDefinition = !!definition;
+    const hasModifiedAt = !!modifiedAt;
+    const hasModifiedBy = !!modifiedBy;
     const hasSecurityControls = !!controls;
     const isTooltipMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_TOOLTIP;
     const isInlineMessageEnabled = isClassified && hasDefinition && messageStyle === STYLE_INLINE;
@@ -50,6 +58,18 @@ const Classification = ({
     const isControlsIndicatorEnabled = isClassified && isLoadingControls && messageStyle === STYLE_INLINE;
     const isSecurityControlsEnabled =
         isClassified && !isLoadingControls && hasSecurityControls && messageStyle === STYLE_INLINE;
+    const isModifiedMessageVisible = isClassified && hasModifiedAt && hasModifiedBy;
+
+    let formattedModifiedAt;
+
+    if (isModifiedMessageVisible) {
+        const d = new Date(modifiedAt);
+        formattedModifiedAt = intl.formatDate(d, {
+            month: 'long',
+            year: 'numeric',
+            day: 'numeric',
+        });
+    }
 
     return (
         <article className={`bdl-Classification ${className}`}>
@@ -82,10 +102,21 @@ const Classification = ({
                     maxAppCount={maxAppCount}
                 />
             )}
+            {isModifiedMessageVisible && (
+                <Label text={<FormattedMessage {...messages.modifiedByLabel} />}>
+                    <p className="bdl-Classification-modifiedBy">
+                        <FormattedMessage
+                            {...messages.modifiedBy}
+                            values={{ modifiedAt: formattedModifiedAt, modifiedBy }}
+                        />
+                    </p>
+                </Label>
+            )}
             {isControlsIndicatorEnabled && <LoadingIndicator />}
         </article>
     );
 };
 
 export { STYLE_INLINE, STYLE_TOOLTIP };
-export default Classification;
+export { Classification as ClassificationCore };
+export default injectIntl(Classification);

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
-import { injectIntl, FormattedMessage } from 'react-intl';
-import type { InjectIntlProvidedProps } from 'react-intl';
+import { FormattedDate, FormattedMessage } from 'react-intl';
 
 import Label from '../../components/label/Label';
 import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
@@ -15,6 +14,11 @@ import type { Controls, ControlsFormat } from './flowTypes';
 const STYLE_INLINE: 'inline' = 'inline';
 const STYLE_TOOLTIP: 'tooltip' = 'tooltip';
 
+const formattedDateOptions = {
+    month: 'long',
+    year: 'numeric',
+    day: 'numeric',
+};
 type Props = {
     className?: string,
     color?: string,
@@ -29,14 +33,13 @@ type Props = {
     modifiedBy?: string,
     name?: string,
     onClick?: (event: SyntheticEvent<HTMLButtonElement>) => void,
-} & InjectIntlProvidedProps;
+};
 
 const Classification = ({
     definition,
     className = '',
     controls,
     controlsFormat,
-    intl,
     isLoadingControls,
     maxAppCount,
     messageStyle,
@@ -58,18 +61,11 @@ const Classification = ({
     const isControlsIndicatorEnabled = isClassified && isLoadingControls && messageStyle === STYLE_INLINE;
     const isSecurityControlsEnabled =
         isClassified && !isLoadingControls && hasSecurityControls && messageStyle === STYLE_INLINE;
-    const isModifiedMessageVisible = isClassified && hasModifiedAt && hasModifiedBy;
+    const isModifiedMessageVisible = isClassified && hasModifiedAt && hasModifiedBy && messageStyle === STYLE_INLINE;
 
-    let formattedModifiedAt;
-
-    if (isModifiedMessageVisible) {
-        const d = new Date(modifiedAt);
-        formattedModifiedAt = intl.formatDate(d, {
-            month: 'long',
-            year: 'numeric',
-            day: 'numeric',
-        });
-    }
+    const formattedModifiedAt = isModifiedMessageVisible && (
+        <FormattedDate value={new Date(modifiedAt)} {...formattedDateOptions} />
+    );
 
     return (
         <article className={`bdl-Classification ${className}`}>
@@ -91,17 +87,6 @@ const Classification = ({
                     <FormattedMessage {...messages.missing} />
                 </span>
             )}
-            {isSecurityControlsEnabled && (
-                <SecurityControls
-                    classificationColor={color}
-                    classificationName={name}
-                    controls={controls}
-                    controlsFormat={controlsFormat}
-                    definition={definition}
-                    itemName={itemName}
-                    maxAppCount={maxAppCount}
-                />
-            )}
             {isModifiedMessageVisible && (
                 <Label text={<FormattedMessage {...messages.modifiedByLabel} />}>
                     <p className="bdl-Classification-modifiedBy">
@@ -112,11 +97,24 @@ const Classification = ({
                     </p>
                 </Label>
             )}
+
+            {isSecurityControlsEnabled && (
+                <Label text={<FormattedMessage {...messages.restrictionsLabel} />}>
+                    <SecurityControls
+                        classificationColor={color}
+                        classificationName={name}
+                        controls={controls}
+                        controlsFormat={controlsFormat}
+                        definition={definition}
+                        itemName={itemName}
+                        maxAppCount={maxAppCount}
+                    />
+                </Label>
+            )}
             {isControlsIndicatorEnabled && <LoadingIndicator />}
         </article>
     );
 };
 
 export { STYLE_INLINE, STYLE_TOOLTIP };
-export { Classification as ClassificationCore };
-export default injectIntl(Classification);
+export default Classification;

--- a/src/features/classification/__tests__/Classification.test.js
+++ b/src/features/classification/__tests__/Classification.test.js
@@ -63,7 +63,7 @@ describe('features/classification/Classification', () => {
             definition: 'fubar',
             messageStyle: 'inline',
         });
-        expect(wrapper.find('.bdl-Classification-modifiedBy').length).toBe(0);
+        expect(wrapper.exists('[data-testid="classification-modifiedby"]')).toBe(false);
     });
 
     test('should not render classification last modified information when message is tooltip', () => {
@@ -74,7 +74,7 @@ describe('features/classification/Classification', () => {
             modifiedAt: '2020-07-16T00:51:10.000Z',
             modifiedBy: 'A User',
         });
-        expect(wrapper.find('.bdl-Classification-modifiedBy').length).toBe(0);
+        expect(wrapper.exists('[data-testid="classification-modifiedby"]')).toBe(false);
     });
 
     test('should render classification last modified information when provided and message style is inline', () => {
@@ -85,8 +85,7 @@ describe('features/classification/Classification', () => {
             modifiedAt: '2020-07-16T00:51:10.000Z',
             modifiedBy: 'A User',
         });
-        expect(wrapper.find('.bdl-Classification-modifiedBy').length).toBe(1);
-        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.exists('[data-testid="classification-modifiedby"]')).toBe(true);
     });
 
     test('should render a classified badge with security controls when provided and message style is inline', () => {

--- a/src/features/classification/__tests__/Classification.test.js
+++ b/src/features/classification/__tests__/Classification.test.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import { createIntl } from 'react-intl';
 
-import Classification from '../Classification';
+import { ClassificationCore as Classification } from '../Classification';
 import ClassifiedBadge from '../ClassifiedBadge';
 import SecurityControls from '../security-controls';
 import LoadingIndicator from '../../../components/loading-indicator/LoadingIndicator';
+
+const intl = createIntl({ locale: 'en' });
 
 describe('features/classification/Classification', () => {
     const getWrapper = (props = {}) => shallow(<Classification {...props} />);
@@ -53,6 +56,18 @@ describe('features/classification/Classification', () => {
             definition: 'fubar',
             messageStyle: 'tooltip',
             onClick: () => {},
+        });
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render classification last modified information when provided and message style is inline', () => {
+        const wrapper = getWrapper({
+            name: 'Confidential',
+            definition: 'fubar',
+            intl,
+            messageStyle: 'inline',
+            modifiedAt: '2020-07-16T00:51:10.000Z',
+            modifiedBy: 'A User',
         });
         expect(wrapper).toMatchSnapshot();
     });

--- a/src/features/classification/__tests__/Classification.test.js
+++ b/src/features/classification/__tests__/Classification.test.js
@@ -1,12 +1,9 @@
 import React from 'react';
-import { createIntl } from 'react-intl';
 
-import { ClassificationCore as Classification } from '../Classification';
+import Classification from '../Classification';
 import ClassifiedBadge from '../ClassifiedBadge';
 import SecurityControls from '../security-controls';
 import LoadingIndicator from '../../../components/loading-indicator/LoadingIndicator';
-
-const intl = createIntl({ locale: 'en' });
 
 describe('features/classification/Classification', () => {
     const getWrapper = (props = {}) => shallow(<Classification {...props} />);
@@ -60,15 +57,35 @@ describe('features/classification/Classification', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should not render classification last modified information when modified props are not provided', () => {
+        const wrapper = getWrapper({
+            name: 'Confidential',
+            definition: 'fubar',
+            messageStyle: 'inline',
+        });
+        expect(wrapper.find('.bdl-Classification-modifiedBy').length).toBe(0);
+    });
+
+    test('should not render classification last modified information when message is tooltip', () => {
+        const wrapper = getWrapper({
+            name: 'Confidential',
+            definition: 'fubar',
+            messageStyle: 'tooltip',
+            modifiedAt: '2020-07-16T00:51:10.000Z',
+            modifiedBy: 'A User',
+        });
+        expect(wrapper.find('.bdl-Classification-modifiedBy').length).toBe(0);
+    });
+
     test('should render classification last modified information when provided and message style is inline', () => {
         const wrapper = getWrapper({
             name: 'Confidential',
             definition: 'fubar',
-            intl,
             messageStyle: 'inline',
             modifiedAt: '2020-07-16T00:51:10.000Z',
             modifiedBy: 'A User',
         });
+        expect(wrapper.find('.bdl-Classification-modifiedBy').length).toBe(1);
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -100,6 +100,54 @@ exports[`features/classification/Classification should render a classified badge
 </article>
 `;
 
+exports[`features/classification/Classification should render classification last modified information when provided and message style is inline 1`] = `
+<article
+  className="bdl-Classification "
+>
+  <ClassifiedBadge
+    color="#ffeb7f"
+    name="Confidential"
+  />
+  <Label
+    text={
+      <FormattedMessage
+        defaultMessage="Definition"
+        id="boxui.classification.definition"
+      />
+    }
+  >
+    <p
+      className="bdl-Classification-definition"
+    >
+      fubar
+    </p>
+  </Label>
+  <Label
+    text={
+      <FormattedMessage
+        defaultMessage="Classification Updated By"
+        id="boxui.classification.modifiedByLabel"
+      />
+    }
+  >
+    <p
+      className="bdl-Classification-modifiedBy"
+    >
+      <FormattedMessage
+        defaultMessage="{modifiedBy} on {modifiedAt}"
+        id="boxui.classification.modifiedBy"
+        values={
+          Object {
+            "modifiedAt": 2020-07-16T00:51:10.000Z,
+            "modifiedBy": "A User",
+          }
+        }
+      />
+    </p>
+  </Label>
+</article>
+`;
+
 exports[`features/classification/Classification should render not classified message 1`] = `
 <article
   className="bdl-Classification "

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -109,59 +109,6 @@ exports[`features/classification/Classification should render a classified badge
 </article>
 `;
 
-exports[`features/classification/Classification should render classification last modified information when provided and message style is inline 1`] = `
-<article
-  className="bdl-Classification "
->
-  <ClassifiedBadge
-    color="#ffeb7f"
-    name="Confidential"
-  />
-  <Label
-    text={
-      <FormattedMessage
-        defaultMessage="Definition"
-        id="boxui.classification.definition"
-      />
-    }
-  >
-    <p
-      className="bdl-Classification-definition"
-    >
-      fubar
-    </p>
-  </Label>
-  <Label
-    text={
-      <FormattedMessage
-        defaultMessage="Classification Updated By"
-        id="boxui.classification.modifiedByLabel"
-      />
-    }
-  >
-    <p
-      className="bdl-Classification-modifiedBy"
-    >
-      <FormattedMessage
-        defaultMessage="{modifiedBy} on {modifiedAt}"
-        id="boxui.classification.modifiedBy"
-        values={
-          Object {
-            "modifiedAt": <FormattedDate
-              day="numeric"
-              month="long"
-              value={2020-07-16T00:51:10.000Z}
-              year="numeric"
-            />,
-            "modifiedBy": "A User",
-          }
-        }
-      />
-    </p>
-  </Label>
-</article>
-`;
-
 exports[`features/classification/Classification should render not classified message 1`] = `
 <article
   className="bdl-Classification "

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -83,20 +83,29 @@ exports[`features/classification/Classification should render a classified badge
       fubar
     </p>
   </Label>
-  <SecurityControls
-    classificationName="Confidential"
-    controls={
-      Object {
-        "sharedLink": Object {
-          "accessLevel": "collabOnly",
-        },
-      }
+  <Label
+    text={
+      <FormattedMessage
+        defaultMessage="Restrictions"
+        id="boxui.classification.restrictionsLabel"
+      />
     }
-    controlsFormat="short"
-    definition="fubar"
-    itemName=""
-    maxAppCount={3}
-  />
+  >
+    <SecurityControls
+      classificationName="Confidential"
+      controls={
+        Object {
+          "sharedLink": Object {
+            "accessLevel": "collabOnly",
+          },
+        }
+      }
+      controlsFormat="short"
+      definition="fubar"
+      itemName=""
+      maxAppCount={3}
+    />
+  </Label>
 </article>
 `;
 
@@ -138,7 +147,12 @@ exports[`features/classification/Classification should render classification las
         id="boxui.classification.modifiedBy"
         values={
           Object {
-            "modifiedAt": 2020-07-16T00:51:10.000Z,
+            "modifiedAt": <FormattedDate
+              day="numeric"
+              month="long"
+              value={2020-07-16T00:51:10.000Z}
+              year="numeric"
+            />,
             "modifiedBy": "A User",
           }
         }

--- a/src/features/classification/messages.js
+++ b/src/features/classification/messages.js
@@ -26,6 +26,16 @@ const messages = defineMessages({
         description: 'Default message for classification in the sidebar when there is none',
         id: 'boxui.classification.missing',
     },
+    modifiedByLabel: {
+        defaultMessage: 'Classification Updated By',
+        description: 'Label displayed above details about when a classification was last modified.',
+        id: 'boxui.classification.modifiedByLabel',
+    },
+    modifiedBy: {
+        defaultMessage: '{modifiedBy} on {modifiedAt}',
+        description: 'Sentence stating which user or service modified a classification and on what date.',
+        id: 'boxui.classification.modifiedBy',
+    },
     // Classification Colors
     classificationYellow: {
         defaultMessage: 'Yellow',

--- a/src/features/classification/messages.js
+++ b/src/features/classification/messages.js
@@ -36,6 +36,12 @@ const messages = defineMessages({
         description: 'Sentence stating which user or service modified a classification and on what date.',
         id: 'boxui.classification.modifiedBy',
     },
+    restrictionsLabel: {
+        defaultMessage: 'Restrictions',
+        description:
+            'Label displayed above the security restrictions on the file due to the classification label and associated policies.',
+        id: 'boxui.classification.restrictionsLabel',
+    },
     // Classification Colors
     classificationYellow: {
         defaultMessage: 'Yellow',


### PR DESCRIPTION
Adds information on when a classification was last updated when it is provided in the props. Also adds a Restrictions label to Security Controls per Product.

![Screen Shot 2020-07-22 at 12 11 14 PM](https://user-images.githubusercontent.com/5079185/88223280-0bf55700-cc1c-11ea-8a7c-bb728dbd0ce3.png)
