### PR TITLE
fix(sidebar): Only render restrictions label when items exist

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -714,8 +714,6 @@ boxui.classification.missing = Not classified
 boxui.classification.modifiedBy = {modifiedBy} on {modifiedAt}
 # Label displayed above details about when a classification was last modified.
 boxui.classification.modifiedByLabel = Classification Updated By
-# Label displayed above the security restrictions on the file due to the classification label and associated policies.
-boxui.classification.restrictionsLabel = Restrictions
 # Text to display for users who have not accepted an invitation to collaborate yet
 boxui.collaboratorAvatars.collaboration.pendingCollabText = Pending
 # Label for collaborator avatars
@@ -1144,6 +1142,8 @@ boxui.securityControls.mobileDownloadOwnersEditors = Download restricted on mobi
 boxui.securityControls.modalDescription = Classification labels defined by your administrator can be used to label content and apply security policies.
 # Title for modal to display classification and security controls details
 boxui.securityControls.modalTitle = View Classification for '{itemName}'
+# Label displayed above the security restrictions on the file due to the classification label and associated policies.
+boxui.securityControls.securityControlsLabel = Restrictions
 # Bullet point that summarizes collaborators shared link restriction applied to classification
 boxui.securityControls.sharingCollabAndCompanyOnly = Shared links cannot be made publicly accessible.
 # Bullet point that summarizes shared link restriction applied to classification

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -96,17 +96,16 @@ const Classification = ({
             )}
 
             {isSecurityControlsEnabled && (
-                <Label text={<FormattedMessage {...messages.restrictionsLabel} />}>
-                    <SecurityControls
-                        classificationColor={color}
-                        classificationName={name}
-                        controls={controls}
-                        controlsFormat={controlsFormat}
-                        definition={definition}
-                        itemName={itemName}
-                        maxAppCount={maxAppCount}
-                    />
-                </Label>
+                <SecurityControls
+                    classificationColor={color}
+                    classificationName={name}
+                    controls={controls}
+                    controlsFormat={controlsFormat}
+                    definition={definition}
+                    itemName={itemName}
+                    maxAppCount={maxAppCount}
+                    shouldRenderLabel
+                />
             )}
             {isControlsIndicatorEnabled && <LoadingIndicator />}
         </article>

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -83,29 +83,21 @@ exports[`features/classification/Classification should render a classified badge
       fubar
     </p>
   </Label>
-  <Label
-    text={
-      <FormattedMessage
-        defaultMessage="Restrictions"
-        id="boxui.classification.restrictionsLabel"
-      />
-    }
-  >
-    <SecurityControls
-      classificationName="Confidential"
-      controls={
-        Object {
-          "sharedLink": Object {
-            "accessLevel": "collabOnly",
-          },
-        }
+  <SecurityControls
+    classificationName="Confidential"
+    controls={
+      Object {
+        "sharedLink": Object {
+          "accessLevel": "collabOnly",
+        },
       }
-      controlsFormat="short"
-      definition="fubar"
-      itemName=""
-      maxAppCount={3}
-    />
-  </Label>
+    }
+    controlsFormat="short"
+    definition="fubar"
+    itemName=""
+    maxAppCount={3}
+    shouldRenderLabel={true}
+  />
 </article>
 `;
 

--- a/src/features/classification/messages.js
+++ b/src/features/classification/messages.js
@@ -36,12 +36,6 @@ const messages = defineMessages({
         description: 'Sentence stating which user or service modified a classification and on what date.',
         id: 'boxui.classification.modifiedBy',
     },
-    restrictionsLabel: {
-        defaultMessage: 'Restrictions',
-        description:
-            'Label displayed above the security restrictions on the file due to the classification label and associated policies.',
-        id: 'boxui.classification.restrictionsLabel',
-    },
     // Classification Colors
     classificationYellow: {
         defaultMessage: 'Yellow',

--- a/src/features/classification/security-controls/SecurityControls.js
+++ b/src/features/classification/security-controls/SecurityControls.js
@@ -6,6 +6,7 @@ import { DEFAULT_MAX_APP_COUNT, SECURITY_CONTROLS_FORMAT } from '../constants';
 import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from './utils';
 import messages from './messages';
 import PlainButton from '../../../components/plain-button';
+import Label from '../../../components/label/Label';
 import SecurityControlsItem from './SecurityControlsItem';
 import SecurityControlsModal from './SecurityControlsModal';
 import type { Controls, ControlsFormat } from '../flowTypes';
@@ -22,6 +23,7 @@ type Props = {
     definition?: string,
     itemName?: string,
     maxAppCount?: number,
+    shouldRenderLabel?: boolean,
 };
 
 type State = {
@@ -36,6 +38,7 @@ class SecurityControls extends React.Component<Props, State> {
         controls: {},
         controlsFormat: SHORT,
         maxAppCount: DEFAULT_MAX_APP_COUNT,
+        shouldRenderLabel: false,
     };
 
     state = {
@@ -55,6 +58,7 @@ class SecurityControls extends React.Component<Props, State> {
             definition,
             itemName,
             maxAppCount,
+            shouldRenderLabel,
         } = this.props;
 
         let items = [];
@@ -79,13 +83,21 @@ class SecurityControls extends React.Component<Props, State> {
         const shouldShowSecurityControlsModal =
             controlsFormat === SHORT_WITH_BTN && !!itemName && !!classificationName && !!definition;
 
+        let itemsList = (
+            <ul className="bdl-SecurityControls">
+                {items.map(({ message, tooltipMessage }) => (
+                    <SecurityControlsItem key={message.id} message={message} tooltipMessage={tooltipMessage} />
+                ))}
+            </ul>
+        );
+
+        if (shouldRenderLabel) {
+            itemsList = <Label text={<FormattedMessage {...messages.securityControlsLabel} />}>{itemsList}</Label>;
+        }
+
         return (
             <>
-                <ul className="bdl-SecurityControls">
-                    {items.map(({ message, tooltipMessage }) => (
-                        <SecurityControlsItem key={message.id} message={message} tooltipMessage={tooltipMessage} />
-                    ))}
-                </ul>
+                {itemsList}
                 {shouldShowSecurityControlsModal && (
                     <>
                         <PlainButton className="lnk" onClick={this.openModal} type="button">

--- a/src/features/classification/security-controls/__tests__/SecurityControls.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControls.test.js
@@ -59,6 +59,14 @@ describe('features/classification/security-controls/SecurityControls', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should render label for security controls when shouldRenderLabel prop is set', () => {
+        wrapper.setProps({ controlsFormat: SHORT });
+        expect(wrapper.find('Label').length).toBe(0);
+
+        wrapper.setProps({ controlsFormat: SHORT, shouldRenderLabel: true });
+        expect(wrapper.find('Label').length).toBe(1);
+    });
+
     test('should restrict displayed app names to maxAppCount', () => {
         controls.app.apps = [
             { displayText: 'App 1' },

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -2,6 +2,12 @@
 import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
+    securityControlsLabel: {
+        defaultMessage: 'Restrictions',
+        description:
+            'Label displayed above the security restrictions on the file due to the classification label and associated policies.',
+        id: 'boxui.securityControls.securityControlsLabel',
+    },
     shortSharing: {
         defaultMessage: 'Sharing restriction applies',
         description: 'Short summary displayed for classification when a sharing restriction is applied to it',


### PR DESCRIPTION
The changes to the Classifications component caused a `Restrictions` label to render even if no restrictions existed. Moved label rendering to the SecurityControls component and use a prop to selectively render it.