### PR TITLE
chore(content-explorer): Add test ids for e2e testing

### DIFF
--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.js
@@ -573,5 +573,10 @@ describe('elements/content-explorer/ContentExplorer', () => {
             expect(uploadDialogElement.length).toBe(1);
             expect(uploadDialogElement.prop('contentUploaderProps')).toEqual(contentUploaderProps);
         });
+
+        test('should render test id for e2e testing', () => {
+            const wrapper = getWrapper();
+            expect(wrapper.find('[data-testid="content-explorer"]')).toHaveLength(1);
+        });
     });
 });

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -404,6 +404,7 @@ class ContentExplorer extends Component {
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
             <div
                 className={classNames('content-explorer', className)}
+                data-testid="content-explorer"
                 onClick={this.handleContentExplorerClick}
                 ref={ref => {
                     this.domNode = ref;

--- a/src/features/content-explorer/content-explorer/__tests__/__snapshots__/ContentExplorer.test.js.snap
+++ b/src/features/content-explorer/content-explorer/__tests__/__snapshots__/ContentExplorer.test.js.snap
@@ -3,6 +3,7 @@
 exports[`features/content-explorer/content-explorer/ContentExplorer render() customInput should be contain a custom input if the prop is passed 1`] = `
 <div
   className="content-explorer"
+  data-testid="content-explorer"
   onClick={[Function]}
 >
   <ContentExplorerHeaderActions

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import getProp from 'lodash/get';
 
 import Column from 'react-virtualized/dist/commonjs/Table/Column';
 import Table from 'react-virtualized/dist/commonjs/Table';
@@ -143,6 +144,7 @@ const ItemList = ({
         const { index, key, style, className: rowClassName, columns } = rendererParams;
         const item = items[index];
         const itemRowClassname = classNames(rowClassName, getRowClassNames(index, item));
+        const testId = getProp(rendererParams, 'rowData.id', '');
 
         if (item.isLoading) {
             return (
@@ -164,10 +166,11 @@ const ItemList = ({
             );
         }
 
-        return defaultTableRowRenderer({
+        const defaultRow = defaultTableRowRenderer({
             ...rendererParams,
             className: itemRowClassname,
         });
+        return React.cloneElement(defaultRow, { 'data-testid': `item-row-${testId}` });
     };
 
     let TableComponent = Table;

--- a/src/features/content-explorer/item-list/__tests__/ItemList.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemList.test.js
@@ -111,6 +111,18 @@ describe('features/content-explorer/item-list/ItemList', () => {
             });
         });
 
+        test('should render items with test ids for e2e testing', () => {
+            const items = [
+                { id: 'item1', name: 'item1' },
+                { id: 'item2', name: 'item2' },
+            ];
+            const expectedTestId = ['item-row-item1', 'item-row-item2'];
+            const wrapper = renderComponent({ items });
+
+            const testIds = wrapper.find('[role="row"][data-testid*="item-row-"]').map(row => row.prop('data-testid'));
+            expect(testIds).toEqual(expectedTestId);
+        });
+
         test('should render component with default item buttons', () => {
             const items = [
                 { id: '1', name: 'item1' },


### PR DESCRIPTION
Adding test ids to key elements in `ContentExplorer` in order to allow matching them in a more robust fashion while running e2e tests.

Updates include:

- Adding test id on main `ContentExplorer` element to allow scoping element searches (e.g., using `.within()` with Cypress(.
- Adding test id to each row item. Items are currently hard to match since the actual inputs are hidden and the clickable element (parent row) is a few levels above and does not have any identifying attributes apart from CSS classes.