### PR TITLE
feat(content-sharing): Add loading states to ContentSharing

### DIFF
--- a/src/api/Item.js
+++ b/src/api/Item.js
@@ -318,7 +318,7 @@ class Item extends Base {
      */
     async share(
         item: BoxItem,
-        access: string,
+        access: ?string, // if "access" is undefined, the backend will set the default access level for the shared link
         successCallback: Function,
         errorCallback: ElementsErrorCallback = noop,
         options: RequestOptions = {},

--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -7,18 +7,34 @@
  * @author Box
  */
 import * as React from 'react';
+import noop from 'lodash/noop';
 import API from '../../api';
 import SharingModal from './SharingModal';
 import { CLIENT_NAME_CONTENT_SHARING } from '../../constants';
 import type { ItemType } from '../../common/types/core';
 
 type ContentSharingProps = {
+    /** apiHost - API hostname. Defaults to https://api.box.com */
     apiHost: string,
+    /**
+     * customButton - Clickable element for opening the SharingModal component.
+     * This property should always be used in conjunction with displayInModal.
+     */
     customButton?: React.Element<any>,
+    /**
+     * displayInModal - Whether the SharingModal component should be displayed in a modal.
+     * If false, the SharingModal component will appear as a form within the surrounding page.
+     * This property can be used with or without a customButton. If used without a customButton,
+     * the modal will appear on page load. See ContentSharing.stories.js for examples.
+     */
     displayInModal: boolean,
+    /** itemID - Box file or folder ID */
     itemID: string,
+    /** itemType - "file" or "folder" */
     itemType: ItemType,
+    /** language - Language used for the element */
     language: string,
+    /** token - Valid access token */
     token: string,
 };
 
@@ -70,7 +86,7 @@ function ContentSharing({
                     itemID={itemID}
                     itemType={itemType}
                     language={language}
-                    onRequestClose={() => setIsOpen(false)}
+                    onRequestClose={displayInModal ? () => setIsOpen(false) : noop} // this function only applies to the modal view
                 />
             );
         };
@@ -99,8 +115,8 @@ function ContentSharing({
 
     return (
         <>
-            {sharingModalInstance}
             {launchButton}
+            {sharingModalInstance}
         </>
     );
 }

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -11,6 +11,7 @@ import type { $AxiosError } from 'axios';
 import API from '../../api';
 import Internationalize from '../common/Internationalize';
 import ErrorMask from '../../components/error-mask/ErrorMask';
+import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
 import UnifiedShareModal from '../../features/unified-share-modal';
 import SharedLinkSettingsModal from '../../features/shared-link-settings-modal';
 import SharingNotification from './SharingNotification';
@@ -61,6 +62,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
     const [currentView, setCurrentView] = React.useState<string>(CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL);
     const [getContacts, setGetContacts] = React.useState<null | GetContactsFnType>(null);
     const [sendInvites, setSendInvites] = React.useState<null | SendInvitesFnType>(null);
+    const [isLoading, setIsLoading] = React.useState<boolean>(true);
 
     // Handle successful GET requests to /files or /folders
     const handleGetItemSuccess = React.useCallback((itemData: ContentSharingItemAPIResponse) => {
@@ -68,6 +70,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
         setComponentErrorMessage(null);
         setItem(itemFromAPI);
         setSharedLink(sharedLinkFromAPI);
+        setIsLoading(false);
     }, []);
 
     // Handle component-level errors
@@ -97,6 +100,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
         setOnAddLink(null);
         setOnRemoveLink(null);
         setSharedLink(null);
+        setIsLoading(true);
     }, []);
 
     // Get initial data for the item
@@ -125,6 +129,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
             setCurrentUserID(id);
             setSharedLink(prevSharedLink => ({ ...prevSharedLink, ...userEnterpriseData }));
             setComponentErrorMessage(null);
+            setIsLoading(false);
         };
 
         const getUserData = () => {
@@ -147,7 +152,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
     // Ensure that all necessary data has been received before rendering child components
     // "serverURL" is added to sharedLink after the call to the Users API
     if (!item || !sharedLink || !currentUserID || !sharedLink.serverURL) {
-        return null;
+        return <LoadingIndicator />;
     }
 
     const { ownerEmail, ownerID, permissions } = item;
@@ -174,6 +179,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
                     setChangeSharedLinkPermissionLevel={setChangeSharedLinkPermissionLevel}
                     setGetContacts={setGetContacts}
                     setCollaboratorsList={setCollaboratorsList}
+                    setIsLoading={setIsLoading}
                     setItem={setItem}
                     setOnAddLink={setOnAddLink}
                     setOnRemoveLink={setOnRemoveLink}
@@ -190,6 +196,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
                         item={item}
                         onRequestClose={() => setCurrentView(CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL)}
                         onSubmit={onSubmitSettings}
+                        submitting={isLoading}
                         {...sharedLink}
                     />
                 )}
@@ -212,6 +219,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
                         onSettingsClick={() => setCurrentView(CONTENT_SHARING_VIEWS.SHARED_LINK_SETTINGS)}
                         sendInvites={sendInvites}
                         sharedLink={sharedLink}
+                        submitting={isLoading}
                     />
                 )}
             </>

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -163,12 +163,13 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, onReque
                 <SharingNotification
                     accessLevel={accessLevel}
                     api={api}
+                    closeComponent={onRequestClose}
+                    closeSettings={() => setCurrentView(CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL)}
                     collaboratorsList={collaboratorsList}
                     currentUserID={currentUserID}
                     getContacts={getContacts}
                     itemID={itemID}
                     itemType={itemType}
-                    onRequestClose={() => setCurrentView(CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL)}
                     onSubmitSettings={onSubmitSettings}
                     ownerEmail={ownerEmail}
                     ownerID={ownerID}

--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -50,6 +50,7 @@ type SharingNotificationProps = {
     ) => void,
     setCollaboratorsList: (collaboratorsList: collaboratorsListType | null) => void,
     setGetContacts: (getContacts: () => GetContactsFnType | null) => void,
+    setIsLoading: boolean => void,
     setItem: ((item: itemFlowType | null) => itemFlowType) => void,
     setOnAddLink: (addLink: () => SharedLinkUpdateLevelFnType | null) => void,
     setOnRemoveLink: (removeLink: () => SharedLinkUpdateLevelFnType | null) => void,
@@ -76,6 +77,7 @@ function SharingNotification({
     setChangeSharedLinkPermissionLevel,
     setGetContacts,
     setCollaboratorsList,
+    setIsLoading,
     setItem,
     setOnAddLink,
     setOnRemoveLink,
@@ -148,17 +150,24 @@ function SharingNotification({
         onRemoveLink,
         onSubmitSettings,
     } = useSharedLink(api, itemID, itemType, permissions, accessLevel, {
-        handleError: () => createNotification(TYPE_ERROR, contentSharingMessages.sharedLinkUpdateError),
+        handleError: () => {
+            createNotification(TYPE_ERROR, contentSharingMessages.sharedLinkUpdateError);
+            setIsLoading(false);
+            onRequestClose();
+        },
         handleUpdateSharedLinkSuccess: itemData => {
             createNotification(TYPE_INFO, contentSharingMessages.sharedLinkSettingsUpdateSuccess);
             handleUpdateSharedLinkSuccess(itemData);
+            setIsLoading(false);
             onRequestClose();
         },
         handleRemoveSharedLinkSuccess: itemData => {
             createNotification(TYPE_INFO, contentSharingMessages.sharedLinkSettingsUpdateSuccess);
             handleRemoveSharedLinkSuccess(itemData);
+            setIsLoading(false);
             onRequestClose();
         },
+        setIsLoading,
         transformAccess: newAccessLevel => USM_TO_API_ACCESS_LEVEL_MAP[newAccessLevel],
         transformPermissions: newSharedLinkPermissionLevel =>
             convertSharedLinkPermissions(newSharedLinkPermissionLevel),
@@ -190,8 +199,15 @@ function SharingNotification({
 
     // Set the sendInvites function
     const sendInvitesFn = useInvites(api, itemID, itemType, {
-        handleSuccess: () => createNotification(TYPE_INFO, contentSharingMessages.sendInvitesSuccess),
-        handleError: () => createNotification(TYPE_ERROR, contentSharingMessages.sendInvitesError),
+        handleSuccess: () => {
+            createNotification(TYPE_INFO, contentSharingMessages.sendInvitesSuccess);
+            setIsLoading(false);
+        },
+        handleError: () => {
+            createNotification(TYPE_ERROR, contentSharingMessages.sendInvitesError);
+            setIsLoading(false);
+        },
+        setIsLoading,
         transformRequest: data => convertCollabsRequest(data),
     });
     if (sendInvitesFn && !sendInvites) {

--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -33,8 +33,8 @@ import type {
 type SharingNotificationProps = {
     accessLevel: string,
     api: API,
-    closeComponent: Function,
-    closeSettings: Function,
+    closeComponent: () => void,
+    closeSettings: () => string,
     collaboratorsList: collaboratorsListType | null,
     currentUserID: string | null,
     getContacts: GetContactsFnType | null,

--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import noop from 'lodash/noop';
 import { FormattedMessage } from 'react-intl';
 import type { MessageDescriptor } from 'react-intl';
 import API from '../../api';
@@ -33,8 +34,8 @@ import type {
 type SharingNotificationProps = {
     accessLevel: string,
     api: API,
-    closeComponent: () => void,
-    closeSettings: () => string,
+    closeComponent?: () => void,
+    closeSettings: () => void,
     collaboratorsList: collaboratorsListType | null,
     currentUserID: string | null,
     getContacts: GetContactsFnType | null,
@@ -63,7 +64,7 @@ type SharingNotificationProps = {
 function SharingNotification({
     accessLevel,
     api,
-    closeComponent,
+    closeComponent = noop,
     closeSettings,
     collaboratorsList,
     currentUserID,

--- a/src/elements/content-sharing/__tests__/SharingModal.test.js
+++ b/src/elements/content-sharing/__tests__/SharingModal.test.js
@@ -486,7 +486,7 @@ describe('elements/content-sharing/SharingModal', () => {
             wrapper.update();
             expect(share).toHaveBeenCalledWith(
                 { id: MOCK_ITEM_ID, permissions: {} },
-                ACCESS_COLLAB,
+                undefined,
                 expect.anything(),
                 expect.anything(),
                 CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS,
@@ -497,9 +497,10 @@ describe('elements/content-sharing/SharingModal', () => {
         });
 
         test('should call share() from onRemoveLink() and remove the existing shared link', async () => {
+            const onRequestCloseSpy = jest.fn();
             let wrapper;
             await act(async () => {
-                wrapper = getWrapper({ api, itemType: TYPE_FILE });
+                wrapper = getWrapper({ api, itemType: TYPE_FILE, onRequestClose: onRequestCloseSpy });
             });
             wrapper.update();
 
@@ -521,6 +522,7 @@ describe('elements/content-sharing/SharingModal', () => {
                 CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS,
             );
             expect(wrapper.find(UnifiedShareModal).prop('sharedLink')).toEqual(MOCK_NULL_SHARED_LINK);
+            expect(onRequestCloseSpy).toHaveBeenCalled();
         });
 
         test.each`

--- a/src/elements/content-sharing/__tests__/SharingModal.test.js
+++ b/src/elements/content-sharing/__tests__/SharingModal.test.js
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { FormattedMessage } from 'react-intl';
 import ErrorMask from '../../../components/error-mask/ErrorMask';
+import LoadingIndicator from '../../../components/loading-indicator/LoadingIndicator';
 import SharingModal from '../SharingModal';
 import Notification, { TYPE_ERROR, TYPE_INFO } from '../../../components/notification/Notification';
 import SharedLinkSettingsModal from '../../../features/shared-link-settings-modal';
@@ -195,18 +196,44 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(wrapper.exists(SharedLinkSettingsModal)).toBe(false);
             expect(wrapper.exists(UnifiedShareModal)).toBe(true);
         });
+
+        test('should show the LoadingIndicator while data is being retrieved', async () => {
+            const api = createAPIMock({ getFile }, null, { getUser });
+
+            let wrapper;
+            await act(async () => {
+                wrapper = getWrapper({ api, itemType: TYPE_FILE });
+            });
+
+            expect(wrapper.exists(LoadingIndicator)).toBe(true);
+
+            wrapper.update();
+            expect(wrapper.exists(LoadingIndicator)).toBe(false);
+            expect(wrapper.exists(UnifiedShareModal)).toBe(true);
+        });
     });
 
     describe('with failed GET requests to the Item and/or Users API', () => {
-        test('should show the ErrorMask and skip the call to getUser() if the call to getFile() fails', async () => {
-            const getFile = jest.fn().mockImplementation((id, successFn, failureFn) => {
+        let api;
+        let getFile;
+        let getFolderFields;
+        let getUser;
+        beforeEach(() => {
+            getFile = jest.fn().mockImplementation((id, successFn, failureFn) => {
                 return Promise.reject(new Error({ status: '400' })).catch(response => {
                     failureFn(response);
                 });
             });
-            const getUser = jest.fn();
-            const api = createAPIMock({ getFile }, null, { getUser });
+            getFolderFields = jest.fn().mockImplementation((id, successFn, failureFn) => {
+                return Promise.reject(new Error({ status: '400' })).catch(response => {
+                    failureFn(response);
+                });
+            });
+            getUser = jest.fn();
+            api = createAPIMock({ getFile }, { getFolderFields }, { getUser });
+        });
 
+        test('should show the ErrorMask and skip the call to getUser() if the call to getFile() fails', async () => {
             let wrapper;
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FILE });
@@ -221,14 +248,6 @@ describe('elements/content-sharing/SharingModal', () => {
         });
 
         test('should show the ErrorMask and skip the call to getUser() if the call to getFolderFields() fails', async () => {
-            const getFolderFields = jest.fn().mockImplementation((id, successFn, failureFn) => {
-                return Promise.reject(new Error({ status: '400' })).catch(response => {
-                    failureFn(response);
-                });
-            });
-            const getUser = jest.fn();
-            const api = createAPIMock(null, { getFolderFields }, { getUser });
-
             let wrapper;
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FOLDER });
@@ -241,6 +260,18 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(wrapper.exists(UnifiedShareModal)).toBe(false);
             expect(wrapper.exists(SharingNotification)).toBe(false);
         });
+
+        test('should show the LoadingIndicator while data is being retrieved', async () => {
+            let wrapper;
+            await act(async () => {
+                wrapper = getWrapper({ api, itemType: TYPE_FOLDER });
+            });
+            expect(wrapper.exists(LoadingIndicator)).toBe(true);
+
+            wrapper.update();
+            expect(wrapper.exists(LoadingIndicator)).toBe(false);
+            expect(wrapper.exists(ErrorMask)).toBe(true);
+        });
     });
 
     describe('with successful item API calls, but an unsuccessful users API call', () => {
@@ -248,7 +279,7 @@ describe('elements/content-sharing/SharingModal', () => {
         let getFile;
         let getFolderFields;
         let getUser;
-        beforeAll(() => {
+        beforeEach(() => {
             getFile = jest.fn().mockImplementation(createSuccessMock(MOCK_ITEM_API_RESPONSE));
             getFolderFields = jest.fn().mockImplementation(createSuccessMock(MOCK_ITEM_API_RESPONSE));
             getUser = jest.fn().mockImplementation((id, successFn, failureFn) => {
@@ -287,6 +318,19 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(wrapper.exists(ErrorMask)).toBe(true);
             expect(wrapper.exists(UnifiedShareModal)).toBe(false);
             expect(wrapper.exists(SharingNotification)).toBe(false);
+        });
+
+        test('should show the LoadingIndicator while data is being retrieved', async () => {
+            let wrapper;
+            await act(async () => {
+                wrapper = getWrapper({ api, itemType: TYPE_FOLDER });
+            });
+
+            expect(wrapper.exists(LoadingIndicator)).toBe(true);
+
+            wrapper.update();
+            expect(wrapper.exists(LoadingIndicator)).toBe(false);
+            expect(wrapper.exists(ErrorMask)).toBe(true);
         });
     });
 

--- a/src/elements/content-sharing/__tests__/useSharedLink.test.js
+++ b/src/elements/content-sharing/__tests__/useSharedLink.test.js
@@ -5,7 +5,7 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import API from '../../../api';
 import useSharedLink from '../hooks/useSharedLink';
-import { ACCESS_COLLAB, ACCESS_NONE, PERMISSION_CAN_DOWNLOAD, TYPE_FILE, TYPE_FOLDER } from '../../../constants';
+import { ACCESS_NONE, PERMISSION_CAN_DOWNLOAD, TYPE_FILE, TYPE_FOLDER } from '../../../constants';
 import {
     MOCK_ITEM_API_RESPONSE,
     MOCK_ITEM_ID,
@@ -122,9 +122,9 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
         test.each`
             itemType       | buttonIndex | invokedFunctionArg   | shareAccess          | description
             ${TYPE_FILE}   | ${0}        | ${ANYONE_IN_COMPANY} | ${ANYONE_IN_COMPANY} | ${'changeSharedLinkAccessLevel'}
-            ${TYPE_FILE}   | ${2}        | ${undefined}         | ${ACCESS_COLLAB}     | ${'onAddLink'}
+            ${TYPE_FILE}   | ${2}        | ${undefined}         | ${undefined}         | ${'onAddLink'}
             ${TYPE_FOLDER} | ${0}        | ${ANYONE_IN_COMPANY} | ${ANYONE_IN_COMPANY} | ${'changeSharedLinkAccessLevel'}
-            ${TYPE_FOLDER} | ${2}        | ${undefined}         | ${ACCESS_COLLAB}     | ${'onAddLink'}
+            ${TYPE_FOLDER} | ${2}        | ${undefined}         | ${undefined}         | ${'onAddLink'}
         `(
             'should set $description() and call success functions when invoked for a $itemType',
             ({ itemType, buttonIndex, invokedFunctionArg, shareAccess }) => {

--- a/src/elements/content-sharing/hooks/useInvites.js
+++ b/src/elements/content-sharing/hooks/useInvites.js
@@ -17,7 +17,13 @@ import type { ItemType } from '../../../common/types/core';
  */
 function useInvites(api: API, itemID: string, itemType: ItemType, options: UseInvitesOptions) {
     const [sendInvites, setSendInvites] = React.useState<null | SendInvitesFnType>(null);
-    const { handleSuccess = noop, handleError = noop, transformRequest, transformResponse = arg => arg } = options;
+    const {
+        handleSuccess = noop,
+        handleError = noop,
+        setIsLoading = noop,
+        transformRequest,
+        transformResponse = arg => arg,
+    } = options;
 
     React.useEffect(() => {
         if (sendInvites) return;
@@ -26,8 +32,9 @@ function useInvites(api: API, itemID: string, itemType: ItemType, options: UseIn
             id: itemID,
             type: itemType,
         };
-        const sendCollabRequest = collab =>
-            api.getCollaborationsAPI(false).addCollaboration(
+        const sendCollabRequest = collab => {
+            setIsLoading(true);
+            return api.getCollaborationsAPI(false).addCollaboration(
                 itemData,
                 collab,
                 response => {
@@ -36,6 +43,7 @@ function useInvites(api: API, itemID: string, itemType: ItemType, options: UseIn
                 },
                 handleError,
             );
+        };
 
         const createPostCollaborationFn: SendInvitesFnType = () => async (
             collabRequest: InviteCollaboratorsRequest,
@@ -52,7 +60,17 @@ function useInvites(api: API, itemID: string, itemType: ItemType, options: UseIn
         if (!sendInvites) {
             setSendInvites(createPostCollaborationFn);
         }
-    }, [api, handleError, handleSuccess, itemID, itemType, sendInvites, transformRequest, transformResponse]);
+    }, [
+        api,
+        handleError,
+        handleSuccess,
+        itemID,
+        itemType,
+        sendInvites,
+        setIsLoading,
+        transformRequest,
+        transformResponse,
+    ]);
 
     return sendInvites;
 }

--- a/src/elements/content-sharing/types.js
+++ b/src/elements/content-sharing/types.js
@@ -78,6 +78,7 @@ export type ContentSharingHooksOptions = {
     handleRemoveSharedLinkSuccess?: Function,
     handleSuccess?: Function,
     handleUpdateSharedLinkSuccess?: Function,
+    setIsLoading?: Function,
     transformAccess?: Function,
     transformItem?: Function,
     transformPermissions?: Function,

--- a/src/elements/content-sharing/types.js
+++ b/src/elements/content-sharing/types.js
@@ -12,6 +12,7 @@ import type {
     item,
     sharedLinkType as USMSharedLinkType,
 } from '../../features/unified-share-modal/flowTypes';
+import type { RequestOptions } from '../../common/types/api';
 
 // "SLS" denotes values that are used in the Shared Link Settings modal
 type ContentSharingEnterpriseDataType = {
@@ -111,3 +112,9 @@ export type SharedLinkUpdateSettingsFnType = () => ($Shape<APISharedLink>) => Pr
 export type GetContactsFnType = () => (filterTerm: string) => Promise<Array<contactType> | UserCollection> | null;
 
 export type SendInvitesFnType = () => InviteCollaboratorsRequest => Promise<null | Array<Function>>;
+
+export type ConnectToItemShareFnType = ({
+    access?: string,
+    requestOptions?: RequestOptions,
+    successFn?: Function,
+}) => Function;

--- a/src/features/unified-share-modal/utils/convertData.js
+++ b/src/features/unified-share-modal/utils/convertData.js
@@ -199,6 +199,11 @@ export const convertSharedLinkPermissions = (newSharedLinkPermissionLevel: strin
 
 /**
  * Convert a shared link settings object from the USM into the format that the API expects.
+ * This function compares the provided access level to both API and internal USM access level constants, to accommodate two potential flows:
+ * - Changing the settings for a shared link right after the shared link has been created. The access level is saved directly from the data
+ *   returned by the API, so it is in API format.
+ * - Changing the settings for a shared link in any other scenario. The access level is saved from the initial calls to the Item API and
+ *   convertItemResponse, so it is in internal USM format.
  *
  * @param {SharedLinkSettingsOptions} newSettings
  * @param {accessLevel} string
@@ -221,9 +226,13 @@ export const convertSharedLinkSettings = (
     const convertedSettings: $Shape<SharedLink> = {
         unshared_at: expirationTimestamp && isExpirationEnabled ? new Date(expirationTimestamp).toISOString() : null,
         vanity_url: serverURL && vanityName ? `${serverURL}${vanityName}` : '',
-        // Download permissions can only be set on "company" or "open" shared links.
-        // A Flow limitation prevents the usage of an && statement in an object spread: https://github.com/facebook/flow/issues/5946
-        ...(accessLevel !== PEOPLE_IN_ITEM ? { permissions: { can_download, can_preview: !can_download } } : {}),
+        /**
+         * Download permissions can only be set on "company" or "open" shared links.
+         * A Flow limitation prevents the usage of an && statement in an object spread: https://github.com/facebook/flow/issues/5946
+         */
+        ...(accessLevel !== PEOPLE_IN_ITEM && accessLevel !== ACCESS_COLLAB
+            ? { permissions: { can_download, can_preview: !can_download } }
+            : {}),
     };
 
     /**
@@ -239,7 +248,7 @@ export const convertSharedLinkSettings = (
      *   returns password = '' and isPasswordEnabled = true. In these cases, the password should *not*
      *   be converted to null, because that would remove the existing password.
      */
-    if (accessLevel === ANYONE_WITH_LINK) {
+    if (accessLevel === ANYONE_WITH_LINK || accessLevel === ACCESS_OPEN) {
         if (isPasswordEnabled && !!password) {
             convertedSettings.password = password;
         } else if (!isPasswordEnabled) {

--- a/src/features/unified-share-modal/utils/convertData.js
+++ b/src/features/unified-share-modal/utils/convertData.js
@@ -226,14 +226,12 @@ export const convertSharedLinkSettings = (
     const convertedSettings: $Shape<SharedLink> = {
         unshared_at: expirationTimestamp && isExpirationEnabled ? new Date(expirationTimestamp).toISOString() : null,
         vanity_url: serverURL && vanityName ? `${serverURL}${vanityName}` : '',
-        /**
-         * Download permissions can only be set on "company" or "open" shared links.
-         * A Flow limitation prevents the usage of an && statement in an object spread: https://github.com/facebook/flow/issues/5946
-         */
-        ...(accessLevel !== PEOPLE_IN_ITEM && accessLevel !== ACCESS_COLLAB
-            ? { permissions: { can_download, can_preview: !can_download } }
-            : {}),
     };
+
+    // Download permissions can only be set on "company" or "open" shared links.
+    if (![ACCESS_COLLAB, PEOPLE_IN_ITEM].includes(accessLevel)) {
+        convertedSettings.permissions = { can_download, can_preview: !can_download };
+    }
 
     /**
      * This block covers the following cases:
@@ -248,7 +246,7 @@ export const convertSharedLinkSettings = (
      *   returns password = '' and isPasswordEnabled = true. In these cases, the password should *not*
      *   be converted to null, because that would remove the existing password.
      */
-    if (accessLevel === ANYONE_WITH_LINK || accessLevel === ACCESS_OPEN) {
+    if ([ANYONE_WITH_LINK, ACCESS_OPEN].includes(accessLevel)) {
         if (isPasswordEnabled && !!password) {
             convertedSettings.password = password;
         } else if (!isPasswordEnabled) {


### PR DESCRIPTION
Show loading animations in the ContentSharing Element.

![content-sharing-animations copy](https://user-images.githubusercontent.com/2956895/89087211-5b3c3580-d348-11ea-9870-e38fe71e7043.gif)

