### PR TITLE
fix(localstore): handle error with access restriction to local storage

### DIFF
--- a/src/utils/LocalStore.js
+++ b/src/utils/LocalStore.js
@@ -24,8 +24,12 @@ class LocalStore {
      */
     constructor() {
         this.memoryStore = new Cache();
-        this.localStorage = window.localStorage;
-        this.isLocalStorageAvailable = this.canUseLocalStorage();
+        try {
+            this.localStorage = window.localStorage;
+            this.isLocalStorageAvailable = this.canUseLocalStorage();
+        } catch (e) {
+            this.isLocalStorageAvailable = false;
+        }
     }
 
     /**


### PR DESCRIPTION
This addresses this issue - 

https://stackoverflow.com/questions/30481516/iframe-in-chrome-error-failed-to-read-localstorage-from-window-access-deni