### PR TITLE
refactor(metadata-view): update metadata queries API interaction

### DIFF
--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -55,7 +55,8 @@ type MetadataFieldValue = string | number | Array<any>;
 type MetadataFields = { [string]: MetadataFieldValue };
 
 type MetadataQueryInstanceTypeField = {
-    name: string,
+    displayName: string,
+    key: string,
     options?: MetadataTemplateFieldOption,
     type: string,
     value: ?MetadataFieldValue,

--- a/src/common/types/metadataQueries.js
+++ b/src/common/types/metadataQueries.js
@@ -6,17 +6,8 @@ type MetadataQueryResponseEntryEnterprise = {
     [string]: MetadataInstanceV2,
 };
 
-type MetadataQueryResponseEntryMetadata = {
-    [string]: MetadataQueryResponseEntryEnterprise,
-};
-
-type MetadataQueryResponseEntry = {
-    item: BoxItem,
-    metadata: MetadataQueryResponseEntryMetadata,
-};
-
 type MetadataQueryResponseData = {
-    entries: Array<MetadataQueryResponseEntry>,
+    entries: Array<BoxItem>,
     next_marker?: string,
 };
 
@@ -38,20 +29,9 @@ type MetadataQuery = {
     use_index?: string,
 };
 
-type MetadataColumnConfig = {
-    canEdit?: boolean,
-    name: string,
-};
-
-type MetadataColumnsToShow = Array<MetadataColumnConfig | string>;
-
 export type {
-    MetadataColumnConfig,
-    MetadataColumnsToShow,
     MetadataQuery,
     MetadataQueryOrderByClause,
     MetadataQueryResponseData,
-    MetadataQueryResponseEntry,
     MetadataQueryResponseEntryEnterprise,
-    MetadataQueryResponseEntryMetadata,
 };

--- a/src/elements/content-explorer/Content.js
+++ b/src/elements/content-explorer/Content.js
@@ -12,7 +12,6 @@ import ItemList from './ItemList';
 import MetadataBasedItemList from '../../features/metadata-based-view';
 import { VIEW_ERROR, VIEW_METADATA, VIEW_MODE_LIST, VIEW_MODE_GRID, VIEW_SELECTED } from '../../constants';
 import type { ViewMode } from '../common/flowTypes';
-import type { MetadataColumnsToShow } from '../../common/types/metadataQueries';
 import type { View, Collection } from '../../common/types/core';
 import './Content.scss';
 
@@ -23,9 +22,9 @@ import './Content.scss';
  * @param {Object} currentCollection the current collection
  * @return {boolean} empty or not
  */
-function isEmpty(view: View, currentCollection: Collection, metadataColumnsToShow: MetadataColumnsToShow): boolean {
+function isEmpty(view: View, currentCollection: Collection): boolean {
     const { items = [] }: Collection = currentCollection;
-    return view === VIEW_ERROR || items.length === 0 || (view === VIEW_METADATA && metadataColumnsToShow.length === 0);
+    return view === VIEW_ERROR || items.length === 0;
 }
 
 type Props = {
@@ -40,7 +39,6 @@ type Props = {
     isMedium: boolean,
     isSmall: boolean,
     isTouch: boolean,
-    metadataColumnsToShow?: MetadataColumnsToShow,
     onItemClick: Function,
     onItemDelete: Function,
     onItemDownload: Function,
@@ -66,10 +64,9 @@ const Content = ({
     tableRef,
     view,
     viewMode = VIEW_MODE_LIST,
-    metadataColumnsToShow = [],
     ...rest
 }: Props) => {
-    const isViewEmpty = isEmpty(view, currentCollection, metadataColumnsToShow);
+    const isViewEmpty = isEmpty(view, currentCollection);
     const isMetadataBasedView = view === VIEW_METADATA;
     const isListView = !isMetadataBasedView && viewMode === VIEW_MODE_LIST; // Folder view or Recents view
     const isGridView = !isMetadataBasedView && viewMode === VIEW_MODE_GRID; // Folder view or Recents view
@@ -82,11 +79,7 @@ const Content = ({
 
             {isViewEmpty && <EmptyState view={view} isLoading={currentCollection.percentLoaded !== 100} />}
             {!isViewEmpty && isMetadataBasedView && (
-                <MetadataBasedItemList
-                    currentCollection={currentCollection}
-                    metadataColumnsToShow={metadataColumnsToShow}
-                    {...rest}
-                />
+                <MetadataBasedItemList currentCollection={currentCollection} {...rest} />
             )}
             {!isViewEmpty && isListView && (
                 <ItemList

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -63,7 +63,7 @@ import {
     TYPED_ID_FOLDER_PREFIX,
 } from '../../constants';
 import type { ViewMode } from '../common/flowTypes';
-import type { MetadataQuery, MetadataColumnsToShow } from '../../common/types/metadataQueries';
+import type { MetadataQuery } from '../../common/types/metadataQueries';
 import type { MetadataFieldValue } from '../../common/types/metadata';
 import type {
     View,
@@ -115,7 +115,6 @@ type Props = {
     logoUrl?: string,
     measureRef?: Function,
     messages?: StringMap,
-    metadataColumnsToShow: MetadataColumnsToShow,
     metadataQuery: MetadataQuery,
     onCreate: Function,
     onDelete: Function,
@@ -1522,7 +1521,7 @@ class ContentExplorer extends Component<Props, State> {
             if (item.id === clonedItem.id) {
                 const fields = getProp(clonedItem, 'metadata.enterprise.fields', []);
                 fields.forEach(itemField => {
-                    if (itemField.name === field) {
+                    if (itemField.key === field) {
                         itemField.value = newValue; // set updated metadata value to correct item in currentCollection
                     }
                 });
@@ -1569,7 +1568,6 @@ class ContentExplorer extends Component<Props, State> {
             logoUrl,
             measureRef,
             messages,
-            metadataColumnsToShow,
             onDownload,
             onPreview,
             onUpload,
@@ -1670,7 +1668,6 @@ class ContentExplorer extends Component<Props, State> {
                             isMedium={isMedium}
                             isSmall={isSmall}
                             isTouch={isTouch}
-                            metadataColumnsToShow={metadataColumnsToShow}
                             onItemClick={this.onItemClick}
                             onItemDelete={this.delete}
                             onItemDownload={this.download}

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.js
@@ -488,7 +488,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
         test('should correctly update the current collection and set the state', () => {
             const boxItem = { id: 2 };
             const field = 'amount';
-            const newVaue = 111.22;
+            const newValue = 111.22;
             const collectionItem1 = {
                 id: 1,
                 metadata: {
@@ -496,11 +496,13 @@ describe('elements/content-explorer/ContentExplorer', () => {
                         fields: [
                             {
                                 name: 'name',
+                                key: 'name',
                                 value: 'abc',
                                 type: 'string',
                             },
                             {
                                 name: 'amount',
+                                key: 'amount',
                                 value: 100.34,
                                 type: 'float',
                             },
@@ -515,11 +517,13 @@ describe('elements/content-explorer/ContentExplorer', () => {
                         fields: [
                             {
                                 name: 'name',
+                                key: 'name',
                                 value: 'pqr',
                                 type: 'string',
                             },
                             {
                                 name: 'amount',
+                                key: 'amount',
                                 value: 354.23,
                                 type: 'float',
                             },
@@ -536,7 +540,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
             const wrapper = getWrapper();
 
             // update the metadata
-            clonedCollectionItem2.metadata.enterprise.fields.find(item => item.name === field).value = newVaue;
+            clonedCollectionItem2.metadata.enterprise.fields.find(item => item.key === field).value = newValue;
 
             const updatedItems = [collectionItem1, clonedCollectionItem2];
 
@@ -544,7 +548,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
             const instance = wrapper.instance();
             instance.setState = jest.fn();
 
-            instance.updateMetadataSuccessCallback(boxItem, field, newVaue);
+            instance.updateMetadataSuccessCallback(boxItem, field, newValue);
             expect(instance.setState).toHaveBeenCalledWith({
                 currentCollection: {
                     items: updatedItems,

--- a/src/features/metadata-based-view/MetadataBasedItemList.js
+++ b/src/features/metadata-based-view/MetadataBasedItemList.js
@@ -20,7 +20,6 @@ import messages from '../../elements/common/messages';
 
 import './MetadataBasedItemList.scss';
 
-import type { MetadataColumnConfig, MetadataColumnsToShow } from '../../common/types/metadataQueries';
 import type { MetadataFieldValue } from '../../common/types/metadata';
 import type { StringAnyMap, Collection, BoxItem } from '../../common/types/core';
 
@@ -53,7 +52,6 @@ type State = {
 
 type Props = {
     currentCollection: Collection,
-    metadataColumnsToShow: MetadataColumnsToShow,
     onItemClick: BoxItem => void,
     onMetadataUpdate: (BoxItem, string, ?MetadataFieldValue, ?MetadataFieldValue) => void,
 };
@@ -116,8 +114,13 @@ class MetadataBasedItemList extends React.Component<Props, State> {
         }
     }
 
+    getFieldsToShow() {
+        const fields = getProp(this.props, 'currentCollection.items[0].metadata.enterprise.fields', []);
+        return fields.map(({ key, displayName }) => ({ key, displayName }));
+    }
+
     getColumnWidth(width: number): ColumnWidthCallback {
-        const { metadataColumnsToShow }: Props = this.props;
+        const metadataFieldsToShow = this.getFieldsToShow();
 
         return ({ index }: { index: number }): number => {
             if (index === FILE_ICON_COLUMN_INDEX) {
@@ -130,7 +133,7 @@ class MetadataBasedItemList extends React.Component<Props, State> {
 
             const availableWidth = width - FILE_NAME_COLUMN_WIDTH - FILE_ICON_COLUMN_WIDTH; // total width minus width of sticky columns
             // Maintain min column width, else occupy the rest of the space equally
-            return Math.max(availableWidth / metadataColumnsToShow.length, MIN_METADATA_COLUMN_WIDTH);
+            return Math.max(availableWidth / metadataFieldsToShow.length, MIN_METADATA_COLUMN_WIDTH);
         };
     }
 
@@ -143,10 +146,6 @@ class MetadataBasedItemList extends React.Component<Props, State> {
         const permissions = { can_preview: true, can_upload: true };
         return { ...item, permissions };
     };
-
-    getMetadataColumnName(column: MetadataColumnConfig | string): string {
-        return typeof column === 'string' ? column : getProp(column, 'name');
-    }
 
     handleItemClick(item: BoxItem): void {
         const { onItemClick }: Props = this.props;
@@ -220,8 +219,8 @@ class MetadataBasedItemList extends React.Component<Props, State> {
     getGridCellData(columnIndex: number, rowIndex: number): GridCellData | void {
         const {
             currentCollection: { items = [] },
-            metadataColumnsToShow,
         }: Props = this.props;
+        const metadataFieldsToShow = this.getFieldsToShow();
 
         const {
             editedColumnIndex,
@@ -234,8 +233,8 @@ class MetadataBasedItemList extends React.Component<Props, State> {
         const isCellBeingEdited = columnIndex === editedColumnIndex && rowIndex === editedRowIndex;
         const isCellHovered = columnIndex === hoveredColumnIndex && rowIndex === hoveredRowIndex;
 
-        const metadataColumn = metadataColumnsToShow[columnIndex - FIXED_COLUMNS_NUMBER];
-        const isCellEditable = !isCellBeingEdited && isCellHovered && !!getProp(metadataColumn, 'canEdit', false);
+        const metadataColumn = metadataFieldsToShow[columnIndex - FIXED_COLUMNS_NUMBER];
+        const isCellEditable = !isCellBeingEdited && isCellHovered;
         const item = items[rowIndex - 1];
         const { id, name } = item;
         const fields = getProp(item, 'metadata.enterprise.fields', []);
@@ -253,8 +252,8 @@ class MetadataBasedItemList extends React.Component<Props, State> {
                 );
                 break;
             default: {
-                const mdFieldName = this.getMetadataColumnName(metadataColumn);
-                const field = find(fields, ['name', mdFieldName]);
+                const { key } = metadataColumn;
+                const field = find(fields, ['key', key]);
                 if (!field) {
                     return cellData;
                 }
@@ -273,11 +272,11 @@ class MetadataBasedItemList extends React.Component<Props, State> {
                             <div className="bdl-MetadataBasedItemList-cell--edit">
                                 <MetadataField
                                     canEdit
-                                    dataKey={`${id}${mdFieldName}`}
+                                    dataKey={`${id}${key}`}
                                     dataValue={valueBeingEdited}
                                     displayName=""
                                     type={type}
-                                    onChange={(key, changedValue) => {
+                                    onChange={(changeKey, changedValue) => {
                                         this.setState({
                                             valueBeingEdited: changedValue,
                                         });
@@ -296,9 +295,7 @@ class MetadataBasedItemList extends React.Component<Props, State> {
                                 {value !== valueBeingEdited && (
                                     <IconWithTooltip
                                         className="bdl-MetadataBasedItemList-cell--saveIcon"
-                                        onClick={() =>
-                                            this.handleSave(item, mdFieldName, type, value, valueBeingEdited)
-                                        }
+                                        onClick={() => this.handleSave(item, key, type, value, valueBeingEdited)}
                                         tooltipText={<FormattedMessage {...messages.save} />}
                                         type={SAVE_ICON_TYPE}
                                         isUpdating={isUpdating}
@@ -314,14 +311,14 @@ class MetadataBasedItemList extends React.Component<Props, State> {
         return cellData;
     }
 
-    getGridHeaderData(columnIndex: number): string | Element<typeof FormattedMessage> {
-        const { metadataColumnsToShow } = this.props;
+    getGridHeaderData(columnIndex: number): string | Element<typeof FormattedMessage> | void {
+        const metadataFieldsToShow = this.getFieldsToShow();
 
+        if (columnIndex === 0) return undefined;
         if (columnIndex === FILE_NAME_COLUMN_INDEX) {
             return <FormattedMessage {...messages.name} />; // "Name" column header
         }
-
-        return this.getMetadataColumnName(metadataColumnsToShow[columnIndex - FIXED_COLUMNS_NUMBER]); // column header
+        return metadataFieldsToShow[columnIndex - FIXED_COLUMNS_NUMBER].displayName;
     }
 
     cellRenderer = ({ columnIndex, rowIndex, key, style }: CellRendererArgs): Element<'div'> => {
@@ -366,15 +363,16 @@ class MetadataBasedItemList extends React.Component<Props, State> {
     }
 
     calculateContentWidth(): number {
-        const { metadataColumnsToShow }: Props = this.props;
+        const metadataFieldsToShow = this.getFieldsToShow();
         // total width = sum of widths of sticky & non-sticky columns
         return (
-            FILE_ICON_COLUMN_WIDTH + FILE_NAME_COLUMN_WIDTH + metadataColumnsToShow.length * MIN_METADATA_COLUMN_WIDTH
+            FILE_ICON_COLUMN_WIDTH + FILE_NAME_COLUMN_WIDTH + metadataFieldsToShow.length * MIN_METADATA_COLUMN_WIDTH
         );
     }
 
     render() {
-        const { currentCollection, metadataColumnsToShow }: Props = this.props;
+        const { currentCollection }: Props = this.props;
+        const metadataFieldsToShow = this.getFieldsToShow();
         const rowCount = currentCollection.items ? currentCollection.items.length : 0;
 
         return (
@@ -392,7 +390,7 @@ class MetadataBasedItemList extends React.Component<Props, State> {
                                 cellRenderer={this.cellRenderer}
                                 classNameBottomRightGrid={classesBottomRightGrid}
                                 classNameTopRightGrid={classesTopRightGrid}
-                                columnCount={metadataColumnsToShow.length + FIXED_COLUMNS_NUMBER}
+                                columnCount={metadataFieldsToShow.length + FIXED_COLUMNS_NUMBER}
                                 columnWidth={this.getColumnWidth(width)}
                                 fixedColumnCount={FIXED_COLUMNS_NUMBER}
                                 fixedRowCount={FIXED_ROW_NUMBER}

--- a/src/features/metadata-based-view/MetadataBasedItemList.scss
+++ b/src/features/metadata-based-view/MetadataBasedItemList.scss
@@ -89,6 +89,7 @@ $bdl-MetadataBasedItemList-insetShadowRight: 3px 0 3px -2px $bdl-gray-10 inset;
     color: $bdl-gray;
 
     & .btn-plain {
+        text-align: left;
         outline: none;
     }
 }

--- a/src/features/metadata-based-view/MetadataQueryAPIHelper.js
+++ b/src/features/metadata-based-view/MetadataQueryAPIHelper.js
@@ -16,12 +16,7 @@ import {
     METADATA_FIELD_TYPE_MULTISELECT,
 } from '../../common/constants';
 
-import type {
-    MetadataQuery as MetadataQueryType,
-    MetadataQueryResponseData,
-    MetadataQueryResponseEntry,
-    MetadataQueryResponseEntryMetadata,
-} from '../../common/types/metadataQueries';
+import type { MetadataQuery as MetadataQueryType, MetadataQueryResponseData } from '../../common/types/metadataQueries';
 import type {
     MetadataTemplateSchemaResponse,
     MetadataTemplate,
@@ -72,7 +67,7 @@ export default class MetadataQueryAPIHelper {
         },
     ];
 
-    flattenMetadata = (metadata: MetadataQueryResponseEntryMetadata): MetadataType => {
+    flattenMetadata = (metadata?: MetadataType): MetadataType => {
         const templateFields = getProp(this.metadataTemplate, 'fields', []);
         const instance = getProp(metadata, `${this.templateScope}.${this.templateKey}`);
 
@@ -85,10 +80,12 @@ export default class MetadataQueryAPIHelper {
             .map(key => {
                 const templateField = find(templateFields, ['key', key]);
                 const type = getProp(templateField, 'type'); // get data type
+                const displayName = getProp(templateField, 'displayName'); // get displayName
                 const field: MetadataQueryInstanceTypeField = {
-                    name: key,
+                    key,
                     value: instance[key],
                     type,
+                    displayName,
                 };
 
                 if (includes(SELECT_TYPES, type)) {
@@ -107,8 +104,8 @@ export default class MetadataQueryAPIHelper {
         };
     };
 
-    flattenResponseEntry = ({ item, metadata }: MetadataQueryResponseEntry): BoxItem => {
-        const { id, name, size } = item;
+    flattenResponseEntry = (metadataEntry: BoxItem): BoxItem => {
+        const { id, name, size, metadata } = metadataEntry;
 
         return {
             id,
@@ -121,7 +118,7 @@ export default class MetadataQueryAPIHelper {
     filterMetdataQueryResponse = (response: MetadataQueryResponseData): MetadataQueryResponseData => {
         const { entries = [], next_marker } = response;
         return {
-            entries: entries.filter(entry => getProp(entry, 'item.type') === ITEM_TYPE_FILE), // return only file items
+            entries: entries.filter(entry => getProp(entry, 'type') === ITEM_TYPE_FILE), // return only file items
             next_marker,
         };
     };

--- a/src/features/metadata-based-view/__tests__/MetadataBasedItemList.test.js
+++ b/src/features/metadata-based-view/__tests__/MetadataBasedItemList.test.js
@@ -35,12 +35,14 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
                         id: '11',
                         fields: [
                             {
-                                name: 'type',
+                                key: 'type',
+                                displayName: 'Type',
                                 type: 'string',
                                 value: 'bill',
                             },
                             {
-                                name: 'amount',
+                                key: 'amount',
+                                displayName: 'Amount',
                                 type: 'float',
                                 value: 100.12,
                             },
@@ -57,12 +59,14 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
                         id: '22',
                         fields: [
                             {
-                                name: 'type',
+                                key: 'type',
+                                displayName: 'Type',
                                 type: 'string',
                                 value: 'receipt',
                             },
                             {
-                                name: 'amount',
+                                key: 'amount',
+                                displayName: 'Amount',
                                 type: 'float',
                                 value: 200.88,
                             },
@@ -75,7 +79,6 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
         ],
         nextMarker: 'abc',
     };
-    const metadataColumnsToShow = ['type', { name: 'amount', canEdit: true }];
 
     const pdfNameButton = (
         <PlainButton onClick={onClick} type="button">
@@ -92,7 +95,6 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
 
     const defaultProps = {
         currentCollection,
-        metadataColumnsToShow,
         intl,
         onItemClick,
         onMetadataUpdate,
@@ -120,7 +122,6 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
         test('should call setState() when component gets updated with different props', () => {
             const updatedProps = {
                 currentCollection: [],
-                metadataColumnsToShow,
                 intl,
                 onItemClick,
             };
@@ -216,8 +217,8 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
             columnIndex | headerData
             ${0}        | ${undefined}
             ${1}        | ${'Name'}
-            ${2}        | ${'type'}
-            ${3}        | ${'amount'}
+            ${2}        | ${'Type'}
+            ${3}        | ${'Amount'}
         `('headerData for column $columnIndex', ({ columnIndex, headerData }) => {
             const data = instance.getGridHeaderData(columnIndex);
             if (columnIndex === 1) {
@@ -226,18 +227,6 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
             } else {
                 expect(data).toBe(headerData);
             }
-        });
-    });
-
-    describe('getMetadataColumnName()', () => {
-        test('should return the column name when either column or column config object is passed', () => {
-            const column = 'amount';
-            const columnConfig = {
-                name: 'amount',
-                canEdit: true,
-            };
-            expect(instance.getMetadataColumnName(column)).toBe('amount');
-            expect(instance.getMetadataColumnName(columnConfig)).toBe('amount');
         });
     });
 
@@ -358,12 +347,21 @@ describe('features/metadata-based-view/MetadataBasedItemList', () => {
 
     describe('calculateContentWidth()', () => {
         test('should return total width of the content', () => {
-            const width =
-                FILE_ICON_COLUMN_WIDTH +
-                FILE_NAME_COLUMN_WIDTH +
-                metadataColumnsToShow.length * MIN_METADATA_COLUMN_WIDTH;
+            const { fields } = currentCollection.items[0].metadata.enterprise;
+            const width = FILE_ICON_COLUMN_WIDTH + FILE_NAME_COLUMN_WIDTH + fields.length * MIN_METADATA_COLUMN_WIDTH;
 
             expect(instance.calculateContentWidth()).toBe(width);
+        });
+    });
+
+    describe('getFieldsToShow()', () => {
+        test('should return a list of metadata fields to display', () => {
+            const response = instance.getFieldsToShow();
+            const fields = [
+                { key: 'type', displayName: 'Type' },
+                { key: 'amount', displayName: 'Amount' },
+            ];
+            expect(response).toEqual(fields);
         });
     });
 

--- a/src/features/metadata-based-view/__tests__/MetadataQueryAPIHelper.test.js
+++ b/src/features/metadata-based-view/__tests__/MetadataQueryAPIHelper.test.js
@@ -60,12 +60,10 @@ describe('features/metadata-based-view/MetadataQueryAPIHelper', () => {
     const metadataQueryResponse = {
         entries: [
             {
-                item: {
-                    type: 'file',
-                    id: '1234',
-                    name: 'filename1.pdf',
-                    size: 10000,
-                },
+                type: 'file',
+                id: '1234',
+                name: 'filename1.pdf',
+                size: 10000,
                 metadata: {
                     [templateScope]: {
                         [templateKey]: {
@@ -83,12 +81,10 @@ describe('features/metadata-based-view/MetadataQueryAPIHelper', () => {
                 },
             },
             {
-                item: {
-                    type: 'file',
-                    id: '9876',
-                    name: 'filename2.mp4',
-                    size: 50000,
-                },
+                type: 'file',
+                id: '9876',
+                name: 'filename2.mp4',
+                size: 50000,
                 metadata: {
                     [templateScope]: {
                         [templateKey]: {
@@ -113,17 +109,20 @@ describe('features/metadata-based-view/MetadataQueryAPIHelper', () => {
             enterprise: {
                 fields: [
                     {
-                        name: 'type',
+                        displayName: 'type',
+                        key: 'type',
                         value: 'bill',
                         type: 'string',
                     },
                     {
-                        name: 'year',
+                        displayName: 'year',
+                        key: 'year',
                         value: 2017,
                         type: 'float',
                     },
                     {
-                        name: 'approved',
+                        displayName: 'approved',
+                        key: 'approved',
                         value: 'yes',
                         type: 'enum',
                         options,
@@ -136,17 +135,20 @@ describe('features/metadata-based-view/MetadataQueryAPIHelper', () => {
             enterprise: {
                 fields: [
                     {
-                        name: 'type',
+                        displayName: 'type',
+                        key: 'type',
                         value: 'receipt',
                         type: 'string',
                     },
                     {
-                        name: 'year',
+                        displayName: 'year',
+                        key: 'year',
                         value: 2018,
                         type: 'float',
                     },
                     {
-                        name: 'approved',
+                        displayName: 'approved',
+                        key: 'approved',
                         value: 'no',
                         type: 'enum',
                         options,
@@ -250,11 +252,11 @@ describe('features/metadata-based-view/MetadataQueryAPIHelper', () => {
     describe('filterMetdataQueryResponse()', () => {
         test('should return query response with entries of type file only', () => {
             const entries = [
-                { item: { type: 'file' }, metadata: {} },
-                { item: { type: 'folder' }, metadata: {} },
-                { item: { type: 'file' }, metadata: {} },
-                { item: { type: 'folder' }, metadata: {} },
-                { item: { type: 'file' }, metadata: {} },
+                { type: 'file', metadata: {} },
+                { type: 'folder', metadata: {} },
+                { type: 'file', metadata: {} },
+                { type: 'folder', metadata: {} },
+                { type: 'file', metadata: {} },
             ];
             const next_marker = 'marker_123456789';
             const mdQueryResponse = {
@@ -263,7 +265,7 @@ describe('features/metadata-based-view/MetadataQueryAPIHelper', () => {
             };
 
             const filteredResponse = metadataQueryAPIHelper.filterMetdataQueryResponse(mdQueryResponse);
-            const isEveryEntryOfTypeFile = filteredResponse.entries.every(entry => entry.item.type === ITEM_TYPE_FILE);
+            const isEveryEntryOfTypeFile = filteredResponse.entries.every(entry => entry.type === ITEM_TYPE_FILE);
             expect(isEveryEntryOfTypeFile).toBe(true);
         });
     });

--- a/src/features/metadata-based-view/__tests__/__snapshots__/MetadataBasedItemList.test.js.snap
+++ b/src/features/metadata-based-view/__tests__/__snapshots__/MetadataBasedItemList.test.js.snap
@@ -11,12 +11,14 @@ exports[`features/metadata-based-view/MetadataBasedItemList render() should rend
             "enterprise": Object {
               "fields": Array [
                 Object {
-                  "name": "type",
+                  "displayName": "Type",
+                  "key": "type",
                   "type": "string",
                   "value": "bill",
                 },
                 Object {
-                  "name": "amount",
+                  "displayName": "Amount",
+                  "key": "amount",
                   "type": "float",
                   "value": 100.12,
                 },
@@ -33,12 +35,14 @@ exports[`features/metadata-based-view/MetadataBasedItemList render() should rend
             "enterprise": Object {
               "fields": Array [
                 Object {
-                  "name": "type",
+                  "displayName": "Type",
+                  "key": "type",
                   "type": "string",
                   "value": "receipt",
                 },
                 Object {
-                  "name": "amount",
+                  "displayName": "Amount",
+                  "key": "amount",
                   "type": "float",
                   "value": 200.88,
                 },
@@ -57,15 +61,6 @@ exports[`features/metadata-based-view/MetadataBasedItemList render() should rend
     Object {
       "formatMessage": [MockFunction],
     }
-  }
-  metadataColumnsToShow={
-    Array [
-      "type",
-      Object {
-        "canEdit": true,
-        "name": "amount",
-      },
-    ]
   }
   onItemClick={[MockFunction]}
   onMetadataUpdate={[MockFunction]}


### PR DESCRIPTION
This PR handles the change in the `/metadata_queries` API request response change. The new syntax is mentioned here: https://developer.box.com/guides/metadata/quick-start/create-query/

Earlier, developers would pass an array of fields/columns to `<ContentExplorer />` as a prop `metadataColumnsToShow`. Now they can include that piece of info as part of the query syntax (`fields` clause).

<img width="1324" alt="Screen Shot 2020-08-04 at 10 48 49 AM" src="https://user-images.githubusercontent.com/8661684/89327060-24b03480-d640-11ea-9dd0-e13fe4f03162.png">
