### PR TITLE
feat(content-sharing): Close modal after certain actions

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -76,6 +76,8 @@ be.contentSharing.notFoundError = Could not find shared link for this item.
 be.contentSharing.sendInvitesError = Could not send invites.
 # Message that appears when collaborators were added to the shared link in the ContentSharing Element.
 be.contentSharing.sendInvitesSuccess = Successfully invited collaborators.
+# Message that appears when the shared link in the ContentSharing Element was removed.
+be.contentSharing.sharedLinkRemovalSuccess = The shared link for this item was removed.
 # Message that appears when the shared link settings in the ContentSharing Element were successfully updated.
 be.contentSharing.sharedLinkSettingsUpdateSuccess = The shared link for this item was successfully updated.
 # Message that appears when the shared link in the ContentSharing Element cannot be updated.

--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -7,7 +7,6 @@
  * @author Box
  */
 import * as React from 'react';
-import noop from 'lodash/noop';
 import API from '../../api';
 import SharingModal from './SharingModal';
 import { CLIENT_NAME_CONTENT_SHARING } from '../../constants';
@@ -62,7 +61,6 @@ function ContentSharing({
     messages,
     token,
 }: ContentSharingProps) {
-    const [isOpen, setIsOpen] = React.useState<boolean>(true);
     const [api, setAPI] = React.useState<API>(createAPI(apiHost, itemID, itemType, token));
     const [launchButton, setLaunchButton] = React.useState<React.Element<any> | null>(null);
     const [sharingModalInstance, setSharingModalInstance] = React.useState<React.Element<typeof SharingModal> | null>(
@@ -87,12 +85,10 @@ function ContentSharing({
     React.useEffect(() => {
         setSharingModalInstance(null);
         setLaunchButton(null);
-        setIsOpen(true);
     }, [api]);
 
     React.useEffect(() => {
         const createSharingModalInstance = () => {
-            setIsOpen(true);
             return (
                 <SharingModal
                     api={api}
@@ -101,7 +97,6 @@ function ContentSharing({
                     itemType={itemType}
                     language={language}
                     messages={messages}
-                    onRequestClose={displayInModal ? () => setIsOpen(false) : noop} // this function only applies to the modal view
                 />
             );
         };
@@ -118,26 +113,10 @@ function ContentSharing({
         }
 
         // If there is no custom button, instantiate SharingModal
-        if (!customButton && !sharingModalInstance && isOpen) {
+        if (!customButton && !sharingModalInstance) {
             setSharingModalInstance(createSharingModalInstance());
         }
-
-        // If the modal is closed, remove the SharingModal instance
-        if (!isOpen) {
-            setSharingModalInstance(null);
-        }
-    }, [
-        api,
-        sharingModalInstance,
-        customButton,
-        displayInModal,
-        isOpen,
-        itemID,
-        itemType,
-        language,
-        launchButton,
-        messages,
-    ]);
+    }, [api, sharingModalInstance, customButton, displayInModal, itemID, itemType, language, launchButton, messages]);
 
     return (
         <>

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -6,6 +6,7 @@
  * @author Box
  */
 import * as React from 'react';
+import noop from 'lodash/noop';
 import { FormattedMessage } from 'react-intl';
 import type { $AxiosError } from 'axios';
 import API from '../../api';
@@ -39,18 +40,9 @@ type SharingModalProps = {
     itemType: ItemType,
     language: string,
     messages?: StringMap,
-    onRequestClose?: () => void,
 };
 
-function SharingModal({
-    api,
-    displayInModal,
-    itemID,
-    itemType,
-    language,
-    messages,
-    onRequestClose,
-}: SharingModalProps) {
+function SharingModal({ api, displayInModal, itemID, itemType, language, messages }: SharingModalProps) {
     const [item, setItem] = React.useState<itemFlowType | null>(null);
     const [sharedLink, setSharedLink] = React.useState<ContentSharingSharedLinkType | null>(null);
     const [currentUserID, setCurrentUserID] = React.useState<string | null>(null);
@@ -71,6 +63,7 @@ function SharingModal({
     const [getContacts, setGetContacts] = React.useState<null | GetContactsFnType>(null);
     const [sendInvites, setSendInvites] = React.useState<null | SendInvitesFnType>(null);
     const [isLoading, setIsLoading] = React.useState<boolean>(true);
+    const [isOpen, setIsOpen] = React.useState<boolean>(true);
 
     // Handle successful GET requests to /files or /folders
     const handleGetItemSuccess = React.useCallback((itemData: ContentSharingItemAPIResponse) => {
@@ -171,7 +164,7 @@ function SharingModal({
                 <SharingNotification
                     accessLevel={accessLevel}
                     api={api}
-                    closeComponent={onRequestClose}
+                    closeComponent={displayInModal ? () => setIsOpen(false) : noop}
                     closeSettings={() => setCurrentView(CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL)}
                     collaboratorsList={collaboratorsList}
                     currentUserID={currentUserID}
@@ -196,7 +189,7 @@ function SharingModal({
                     setSendInvites={setSendInvites}
                     setSharedLink={setSharedLink}
                 />
-                {currentView === CONTENT_SHARING_VIEWS.SHARED_LINK_SETTINGS && (
+                {isOpen && currentView === CONTENT_SHARING_VIEWS.SHARED_LINK_SETTINGS && (
                     <SharedLinkSettingsModal
                         isDirectLinkUnavailableDueToDownloadSettings={false}
                         isDirectLinkUnavailableDueToAccessPolicy={false}
@@ -209,7 +202,7 @@ function SharingModal({
                         {...sharedLink}
                     />
                 )}
-                {currentView === CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL && (
+                {isOpen && currentView === CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL && (
                     <UnifiedShareModal
                         canInvite={sharedLink.canInvite}
                         changeSharedLinkAccessLevel={changeSharedLinkAccessLevel}
@@ -223,7 +216,7 @@ function SharingModal({
                         isOpen
                         item={item}
                         onAddLink={onAddLink}
-                        onRequestClose={onRequestClose}
+                        onRequestClose={displayInModal ? () => setIsOpen(false) : noop}
                         onRemoveLink={onRemoveLink}
                         onSettingsClick={() => setCurrentView(CONTENT_SHARING_VIEWS.SHARED_LINK_SETTINGS)}
                         sendInvites={sendInvites}

--- a/src/elements/content-sharing/__tests__/ContentSharing.test.js
+++ b/src/elements/content-sharing/__tests__/ContentSharing.test.js
@@ -75,25 +75,6 @@ describe('elements/content-sharing/ContentSharing', () => {
         expect(wrapper.exists(Button)).toBe(true);
     });
 
-    test('should remove SharingModal when isOpen is set to false', () => {
-        let wrapper;
-        act(() => {
-            wrapper = getWrapper({ customButton, displayInModal: true });
-        });
-        wrapper.update();
-        const launchButton = wrapper.find(Button);
-        act(() => {
-            launchButton.invoke('onClick')();
-        });
-        wrapper.update();
-        act(() => {
-            wrapper.find(SharingModal).invoke('onRequestClose')();
-        });
-        wrapper.update();
-        expect(wrapper.exists(SharingModal)).toBe(false);
-        expect(wrapper.exists(Button)).toBe(true);
-    });
-
     test.each([true, false])(
         'should instantiate SharingModal automatically when no button exists and displayInModal is %s',
         ({ displayInModal }) => {

--- a/src/elements/content-sharing/__tests__/useSharedLink.test.js
+++ b/src/elements/content-sharing/__tests__/useSharedLink.test.js
@@ -16,7 +16,8 @@ import { ANYONE_IN_COMPANY, CAN_VIEW_DOWNLOAD, PEOPLE_IN_ITEM } from '../../../f
 import { CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS } from '../constants';
 import type { BoxItemPermission } from '../../../common/types/core';
 
-const handleError = jest.fn();
+const handleRemoveSharedLinkError = jest.fn();
+const handleUpdateSharedLinkError = jest.fn();
 const handleRemoveSharedLinkSuccess = jest.fn().mockReturnValue(MOCK_ITEM_API_RESPONSE);
 const handleUpdateSharedLinkSuccess = jest.fn().mockReturnValue(MOCK_ITEM_API_RESPONSE);
 
@@ -136,7 +137,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                             api={mockAPI}
                             itemType={itemType}
                             permissions={MOCK_ITEM_PERMISSIONS}
-                            options={{ handleError, handleUpdateSharedLinkSuccess }}
+                            options={{ handleUpdateSharedLinkError, handleUpdateSharedLinkSuccess }}
                         />,
                     );
                 });
@@ -151,7 +152,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                     MOCK_ITEM_DATA,
                     shareAccess,
                     expect.anything(Function),
-                    handleError,
+                    handleUpdateSharedLinkError,
                     CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS,
                 );
                 expect(handleUpdateSharedLinkSuccess).toHaveBeenCalled();
@@ -169,7 +170,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                             api={mockAPI}
                             itemType={itemType}
                             permissions={MOCK_ITEM_PERMISSIONS}
-                            options={{ handleError, handleRemoveSharedLinkSuccess }}
+                            options={{ handleRemoveSharedLinkError, handleRemoveSharedLinkSuccess }}
                         />,
                     );
                 });
@@ -184,7 +185,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                     MOCK_ITEM_DATA,
                     ACCESS_NONE,
                     expect.anything(Function),
-                    handleError,
+                    handleRemoveSharedLinkError,
                     CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS,
                 );
                 expect(handleRemoveSharedLinkSuccess).toHaveBeenCalled();
@@ -208,7 +209,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                             api={mockAPI}
                             itemType={itemType}
                             permissions={permissions}
-                            options={{ handleError, handleUpdateSharedLinkSuccess }}
+                            options={{ handleUpdateSharedLinkError, handleUpdateSharedLinkSuccess }}
                         />,
                     );
                 });
@@ -223,7 +224,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                     { id: MOCK_ITEM_ID, permissions },
                     sharedLinkData,
                     expect.anything(Function),
-                    handleError,
+                    handleUpdateSharedLinkError,
                     CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS,
                 );
                 expect(handleUpdateSharedLinkSuccess).toHaveBeenCalled();
@@ -243,7 +244,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                         api={mockAPI}
                         itemType={TYPE_FILE}
                         permissions={MOCK_ITEM_PERMISSIONS}
-                        options={{ handleError, transformAccess }}
+                        options={{ handleUpdateSharedLinkError, transformAccess }}
                     />,
                 );
             });
@@ -263,7 +264,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                         api={mockAPI}
                         itemType={TYPE_FILE}
                         permissions={MOCK_ITEM_PERMISSIONS}
-                        options={{ handleError, transformPermissions }}
+                        options={{ handleUpdateSharedLinkError, transformPermissions }}
                     />,
                 );
             });
@@ -283,7 +284,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                         api={mockAPI}
                         itemType={TYPE_FILE}
                         permissions={MOCK_ITEM_PERMISSIONS}
-                        options={{ handleError, transformSettings }}
+                        options={{ handleUpdateSharedLinkError, transformSettings }}
                     />,
                 );
             });
@@ -315,25 +316,29 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
         });
 
         test.each`
-            itemType       | buttonIndex | invokedFunctionArg                 | description
-            ${TYPE_FILE}   | ${0}        | ${ANYONE_IN_COMPANY}               | ${'changeSharedLinkAccessLevel'}
-            ${TYPE_FILE}   | ${1}        | ${PERMISSION_CAN_DOWNLOAD}         | ${'changeSharedLinkPermissionLevel'}
-            ${TYPE_FILE}   | ${2}        | ${undefined}                       | ${'onAddLink'}
-            ${TYPE_FILE}   | ${3}        | ${undefined}                       | ${'onRemoveLink'}
-            ${TYPE_FILE}   | ${4}        | ${MOCK_SETTINGS_WITH_ALL_FEATURES} | ${'onSubmitSettings'}
-            ${TYPE_FOLDER} | ${0}        | ${ANYONE_IN_COMPANY}               | ${'changeSharedLinkAccessLevel'}
-            ${TYPE_FOLDER} | ${1}        | ${PERMISSION_CAN_DOWNLOAD}         | ${'changeSharedLinkPermissionLevel'}
-            ${TYPE_FOLDER} | ${2}        | ${undefined}                       | ${'onAddLink'}
-            ${TYPE_FOLDER} | ${3}        | ${undefined}                       | ${'onRemoveLink'}
-            ${TYPE_FOLDER} | ${4}        | ${MOCK_SETTINGS_WITH_ALL_FEATURES} | ${'onSubmitSettings'}
+            itemType       | buttonIndex | invokedFunctionArg                 | errorFn                        | description
+            ${TYPE_FILE}   | ${0}        | ${ANYONE_IN_COMPANY}               | ${handleUpdateSharedLinkError} | ${'changeSharedLinkAccessLevel'}
+            ${TYPE_FILE}   | ${1}        | ${PERMISSION_CAN_DOWNLOAD}         | ${handleUpdateSharedLinkError} | ${'changeSharedLinkPermissionLevel'}
+            ${TYPE_FILE}   | ${2}        | ${undefined}                       | ${handleUpdateSharedLinkError} | ${'onAddLink'}
+            ${TYPE_FILE}   | ${3}        | ${undefined}                       | ${handleRemoveSharedLinkError} | ${'onRemoveLink'}
+            ${TYPE_FILE}   | ${4}        | ${MOCK_SETTINGS_WITH_ALL_FEATURES} | ${handleUpdateSharedLinkError} | ${'onSubmitSettings'}
+            ${TYPE_FOLDER} | ${0}        | ${ANYONE_IN_COMPANY}               | ${handleUpdateSharedLinkError} | ${'changeSharedLinkAccessLevel'}
+            ${TYPE_FOLDER} | ${1}        | ${PERMISSION_CAN_DOWNLOAD}         | ${handleUpdateSharedLinkError} | ${'changeSharedLinkPermissionLevel'}
+            ${TYPE_FOLDER} | ${2}        | ${undefined}                       | ${handleUpdateSharedLinkError} | ${'onAddLink'}
+            ${TYPE_FOLDER} | ${3}        | ${undefined}                       | ${handleRemoveSharedLinkError} | ${'onRemoveLink'}
+            ${TYPE_FOLDER} | ${4}        | ${MOCK_SETTINGS_WITH_ALL_FEATURES} | ${handleUpdateSharedLinkError} | ${'onSubmitSettings'}
         `(
-            'should set $description() and call handleError() when invoked',
-            ({ itemType, buttonIndex, invokedFunctionArg }) => {
+            'should set $description() and call handleUpdateSharedLinkError() when invoked',
+            ({ itemType, buttonIndex, invokedFunctionArg, errorFn }) => {
                 let fakeComponent;
 
                 act(() => {
                     fakeComponent = mount(
-                        <FakeComponent api={mockAPI} itemType={itemType} options={{ handleError }} />,
+                        <FakeComponent
+                            api={mockAPI}
+                            itemType={itemType}
+                            options={{ handleUpdateSharedLinkError, handleRemoveSharedLinkError }}
+                        />,
                     );
                 });
                 fakeComponent.update();
@@ -341,7 +346,7 @@ describe('elements/content-sharing/hooks/useSharedLink', () => {
                 const btn = fakeComponent.find('button').at(buttonIndex);
                 expect(btn.prop('onClick')).toBeDefined();
                 btn.invoke('onClick')(invokedFunctionArg);
-                expect(handleError).toHaveBeenCalled();
+                expect(errorFn).toHaveBeenCalled();
             },
         );
     });

--- a/src/elements/content-sharing/hooks/useSharedLink.js
+++ b/src/elements/content-sharing/hooks/useSharedLink.js
@@ -51,8 +51,9 @@ function useSharedLink(
     const currentAccessLevel = React.useRef(accessLevel);
 
     const {
-        handleError = noop,
+        handleRemoveSharedLinkError = noop,
         handleRemoveSharedLinkSuccess = arg => arg,
+        handleUpdateSharedLinkError = noop,
         handleUpdateSharedLinkSuccess = arg => arg,
         setIsLoading = noop,
         transformAccess = arg => arg,
@@ -81,9 +82,10 @@ function useSharedLink(
             access,
             requestOptions = CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS,
             successFn = handleUpdateSharedLinkSuccess,
+            errorFn = handleUpdateSharedLinkError,
         }) => {
             setIsLoading(true);
-            return itemAPIInstance.share(itemData, access, successFn, handleError, requestOptions);
+            return itemAPIInstance.share(itemData, access, successFn, errorFn, requestOptions);
         };
 
         /**
@@ -110,7 +112,11 @@ function useSharedLink(
 
         // Shared link removal function
         const updatedOnRemoveLinkFn: SharedLinkUpdateLevelFnType = () => () =>
-            connectToItemShare({ access: ACCESS_NONE, successFn: handleRemoveSharedLinkSuccess });
+            connectToItemShare({
+                access: ACCESS_NONE,
+                successFn: handleRemoveSharedLinkSuccess,
+                errorFn: handleRemoveSharedLinkError,
+            });
         setOnRemoveLink(updatedOnRemoveLinkFn);
 
         // Shared link access level change function
@@ -131,7 +137,7 @@ function useSharedLink(
                 itemData,
                 newSharedLinkData,
                 handleUpdateSharedLinkSuccess,
-                handleError,
+                handleUpdateSharedLinkError,
                 CONTENT_SHARING_SHARED_LINK_UPDATE_PARAMS,
             );
         };
@@ -157,7 +163,6 @@ function useSharedLink(
         itemID,
         itemType,
         handleUpdateSharedLinkSuccess,
-        handleError,
         handleRemoveSharedLinkSuccess,
         transformAccess,
         accessLevel,
@@ -166,6 +171,8 @@ function useSharedLink(
         currentAccessLevel,
         api,
         setIsLoading,
+        handleRemoveSharedLinkError,
+        handleUpdateSharedLinkError,
     ]);
 
     return {

--- a/src/elements/content-sharing/messages.js
+++ b/src/elements/content-sharing/messages.js
@@ -32,6 +32,11 @@ const messages = defineMessages({
             'Message that appears when the shared link settings in the ContentSharing Element were successfully updated.',
         id: 'be.contentSharing.sharedLinkSettingsUpdateSuccess',
     },
+    sharedLinkRemovalSuccess: {
+        defaultMessage: 'The shared link for this item was removed.',
+        description: 'Message that appears when the shared link in the ContentSharing Element was removed.',
+        id: 'be.contentSharing.sharedLinkRemovalSuccess',
+    },
     collaboratorsLoadingError: {
         defaultMessage: 'Could not retrieve collaborators for this item.',
         description: 'Message that appears when collaborators cannot be retrieved in the ContentSharing Element.',

--- a/src/elements/content-sharing/types.js
+++ b/src/elements/content-sharing/types.js
@@ -78,8 +78,10 @@ export type ContentSharingItemAPIResponse = {
 
 export type ContentSharingHooksOptions = {
     handleError?: Function,
+    handleRemoveSharedLinkError?: Function,
     handleRemoveSharedLinkSuccess?: Function,
     handleSuccess?: Function,
+    handleUpdateSharedLinkError?: Function,
     handleUpdateSharedLinkSuccess?: Function,
     setIsLoading?: Function,
     transformAccess?: Function,
@@ -117,6 +119,7 @@ export type SendInvitesFnType = () => InviteCollaboratorsRequest => Promise<null
 
 export type ConnectToItemShareFnType = ({
     access?: string,
+    errorFn?: Function,
     requestOptions?: RequestOptions,
     successFn?: Function,
 }) => Function;


### PR DESCRIPTION
Close the USM in ContentSharing after certain actions, mirroring the behavior of the WebApp.

After sending an invitation:
![content-sharing-close-after-removing](https://user-images.githubusercontent.com/2956895/89445246-bb93f400-d707-11ea-9235-b9521bc77abe.gif)

After removing a shared link:
![content-sharing-close-after-inviting](https://user-images.githubusercontent.com/2956895/89445242-ba62c700-d707-11ea-9ee3-2a1ecc102591.gif)
