### PR TITLE
feat(content-sharing): Add config for email button

### DIFF
--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -11,7 +11,7 @@ import API from '../../api';
 import SharingModal from './SharingModal';
 import { CLIENT_NAME_CONTENT_SHARING } from '../../constants';
 import type { ItemType, StringMap } from '../../common/types/core';
-import type { SharingConfig } from '../../features/unified-share-modal/flowTypes';
+import type { USMConfig } from '../../features/unified-share-modal/flowTypes';
 
 import '../common/base.scss';
 import '../common/fonts.scss';
@@ -20,7 +20,7 @@ import '../common/modal.scss';
 type ContentSharingProps = {
     /** apiHost - API hostname. Defaults to https://api.box.com */
     apiHost: string,
-    config?: SharingConfig,
+    config?: USMConfig,
     /**
      * customButton - Clickable element for opening the SharingModal component.
      * This property should always be used in conjunction with displayInModal.

--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -11,6 +11,7 @@ import API from '../../api';
 import SharingModal from './SharingModal';
 import { CLIENT_NAME_CONTENT_SHARING } from '../../constants';
 import type { ItemType, StringMap } from '../../common/types/core';
+import type { SharingConfig } from '../../features/unified-share-modal/flowTypes';
 
 import '../common/base.scss';
 import '../common/fonts.scss';
@@ -19,6 +20,7 @@ import '../common/modal.scss';
 type ContentSharingProps = {
     /** apiHost - API hostname. Defaults to https://api.box.com */
     apiHost: string,
+    config?: SharingConfig,
     /**
      * customButton - Clickable element for opening the SharingModal component.
      * This property should always be used in conjunction with displayInModal.
@@ -53,6 +55,7 @@ const createAPI = (apiHost, itemID, itemType, token) =>
 
 function ContentSharing({
     apiHost,
+    config,
     customButton,
     displayInModal,
     itemID,
@@ -67,6 +70,7 @@ function ContentSharing({
         customButton ? null : (
             <SharingModal
                 api={api}
+                config={config}
                 displayInModal={false}
                 itemID={itemID}
                 itemType={itemType}
@@ -92,6 +96,7 @@ function ContentSharing({
             return (
                 <SharingModal
                     api={api}
+                    config={config}
                     displayInModal={displayInModal}
                     itemID={itemID}
                     itemType={itemType}
@@ -116,7 +121,18 @@ function ContentSharing({
         if (!customButton && !sharingModalInstance) {
             setSharingModalInstance(createSharingModalInstance());
         }
-    }, [api, sharingModalInstance, customButton, displayInModal, itemID, itemType, language, launchButton, messages]);
+    }, [
+        api,
+        config,
+        sharingModalInstance,
+        customButton,
+        displayInModal,
+        itemID,
+        itemType,
+        language,
+        launchButton,
+        messages,
+    ]);
 
     return (
         <>

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -26,7 +26,7 @@ import type { ItemType, StringMap } from '../../common/types/core';
 import type {
     collaboratorsListType,
     item as itemFlowType,
-    SharingConfig,
+    USMConfig,
 } from '../../features/unified-share-modal/flowTypes';
 import type {
     ContentSharingItemAPIResponse,
@@ -39,7 +39,7 @@ import type {
 
 type SharingModalProps = {
     api: API,
-    config?: SharingConfig,
+    config?: USMConfig,
     displayInModal: boolean,
     itemID: string,
     itemType: ItemType,

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -23,7 +23,11 @@ import { INVITEE_PERMISSIONS } from '../../features/unified-share-modal/constant
 import contentSharingMessages from './messages';
 import type { ErrorResponseData } from '../../common/types/api';
 import type { ItemType, StringMap } from '../../common/types/core';
-import type { collaboratorsListType, item as itemFlowType } from '../../features/unified-share-modal/flowTypes';
+import type {
+    collaboratorsListType,
+    item as itemFlowType,
+    SharingConfig,
+} from '../../features/unified-share-modal/flowTypes';
 import type {
     ContentSharingItemAPIResponse,
     ContentSharingSharedLinkType,
@@ -35,6 +39,7 @@ import type {
 
 type SharingModalProps = {
     api: API,
+    config?: SharingConfig,
     displayInModal: boolean,
     itemID: string,
     itemType: ItemType,
@@ -42,7 +47,7 @@ type SharingModalProps = {
     messages?: StringMap,
 };
 
-function SharingModal({ api, displayInModal, itemID, itemType, language, messages }: SharingModalProps) {
+function SharingModal({ api, config, displayInModal, itemID, itemType, language, messages }: SharingModalProps) {
     const [item, setItem] = React.useState<itemFlowType | null>(null);
     const [sharedLink, setSharedLink] = React.useState<ContentSharingSharedLinkType | null>(null);
     const [currentUserID, setCurrentUserID] = React.useState<string | null>(null);
@@ -205,6 +210,7 @@ function SharingModal({ api, displayInModal, itemID, itemType, language, message
                 {isOpen && currentView === CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL && (
                     <UnifiedShareModal
                         canInvite={sharedLink.canInvite}
+                        config={config}
                         changeSharedLinkAccessLevel={changeSharedLinkAccessLevel}
                         changeSharedLinkPermissionLevel={changeSharedLinkPermissionLevel}
                         collaboratorsList={collaboratorsList}

--- a/src/elements/content-sharing/stories/ContentSharing.stories.js
+++ b/src/elements/content-sharing/stories/ContentSharing.stories.js
@@ -21,7 +21,7 @@ export const withModal = () => {
             <IntlProvider locale="en">
                 <ContentSharing
                     apiHost={apiHost}
-                    config={{ allowEmails: false }}
+                    config={{ showEmailSharedLinkForm: false }}
                     displayInModal
                     itemID={itemID}
                     itemType={itemType}
@@ -49,7 +49,7 @@ export const withModalAndCustomButton = () => {
             <IntlProvider locale="en">
                 <ContentSharing
                     apiHost={apiHost}
-                    config={{ allowEmails: false }}
+                    config={{ showEmailSharedLinkForm: false }}
                     customButton={customButton}
                     displayInModal
                     itemID={itemID}

--- a/src/elements/content-sharing/stories/ContentSharing.stories.js
+++ b/src/elements/content-sharing/stories/ContentSharing.stories.js
@@ -21,6 +21,7 @@ export const withModal = () => {
             <IntlProvider locale="en">
                 <ContentSharing
                     apiHost={apiHost}
+                    config={{ allowEmails: false }}
                     displayInModal
                     itemID={itemID}
                     itemType={itemType}
@@ -48,6 +49,7 @@ export const withModalAndCustomButton = () => {
             <IntlProvider locale="en">
                 <ContentSharing
                     apiHost={apiHost}
+                    config={{ allowEmails: false }}
                     customButton={customButton}
                     displayInModal
                     itemID={itemID}

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -27,8 +27,8 @@ import type {
     permissionLevelType,
     sharedLinkType,
     sharedLinkTrackingType,
-    SharingConfig,
     tooltipComponentIdentifierType,
+    USMConfig,
 } from './flowTypes';
 import { PEOPLE_IN_ITEM, ANYONE_WITH_LINK, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from './constants';
 
@@ -40,7 +40,7 @@ type Props = {
     changeSharedLinkPermissionLevel: (
         newPermissionLevel: permissionLevelType,
     ) => Promise<{ permissionLevel: permissionLevelType }>,
-    config?: SharingConfig,
+    config?: USMConfig,
     intl: any,
     item: itemtype,
     itemType: ItemType,
@@ -208,9 +208,9 @@ class SharedLinkSection extends React.Component<Props, State> {
 
         /**
          * The email button should be rendered by default.
-         * Only hide the button if there is a config prop that declares allowEmails to be false.
+         * Only hide the button if there is a config prop that declares showEmailSharedLinkForm to be false.
          */
-        const hideEmailButton = config && config.allowEmails === false;
+        const hideEmailButton = config && config.showEmailSharedLinkForm === false;
 
         const isEditableBoxNote = isBoxNote(convertToBoxItem(item)) && isEditAllowed;
         let allowedPermissionLevels = [CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -27,6 +27,7 @@ import type {
     permissionLevelType,
     sharedLinkType,
     sharedLinkTrackingType,
+    SharingConfig,
     tooltipComponentIdentifierType,
 } from './flowTypes';
 import { PEOPLE_IN_ITEM, ANYONE_WITH_LINK, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from './constants';
@@ -39,6 +40,7 @@ type Props = {
     changeSharedLinkPermissionLevel: (
         newPermissionLevel: permissionLevelType,
     ) => Promise<{ permissionLevel: permissionLevelType }>,
+    config?: SharingConfig,
     intl: any,
     item: itemtype,
     itemType: ItemType,
@@ -164,6 +166,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             autofocusSharedLink,
             changeSharedLinkAccessLevel,
             changeSharedLinkPermissionLevel,
+            config,
             item,
             itemType,
             intl,
@@ -203,6 +206,12 @@ class SharedLinkSection extends React.Component<Props, State> {
 
         const shouldTriggerCopyOnLoad = !!triggerCopyOnLoad && !!isCopySuccessful;
 
+        /**
+         * The email button should be rendered by default.
+         * Only hide the button if there is a config prop that declares allowEmails to be false.
+         */
+        const hideEmailButton = config && config.allowEmails === false;
+
         const isEditableBoxNote = isBoxNote(convertToBoxItem(item)) && isEditAllowed;
         let allowedPermissionLevels = [CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];
 
@@ -241,17 +250,19 @@ class SharedLinkSection extends React.Component<Props, State> {
                             value={url}
                         />
                     </Tooltip>
-                    <Tooltip position="top-left" text={<FormattedMessage {...messages.sendSharedLink} />}>
-                        <Button
-                            className="email-shared-link-btn"
-                            isDisabled={submitting}
-                            onClick={onEmailSharedLinkClick}
-                            type="button"
-                            {...sendSharedLinkButtonProps}
-                        >
-                            <IconMail />
-                        </Button>
-                    </Tooltip>
+                    {!hideEmailButton && (
+                        <Tooltip position="top-left" text={<FormattedMessage {...messages.sendSharedLink} />}>
+                            <Button
+                                className="email-shared-link-btn"
+                                isDisabled={submitting}
+                                onClick={onEmailSharedLinkClick}
+                                type="button"
+                                {...sendSharedLinkButtonProps}
+                            >
+                                <IconMail />
+                            </Button>
+                        </Tooltip>
+                    )}
                 </div>
 
                 <div className="shared-link-access-row">

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -483,6 +483,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             changeSharedLinkAccessLevel,
             createSharedLinkOnLoad,
             changeSharedLinkPermissionLevel,
+            config,
             displayInModal,
             focusSharedLinkOnLoad,
             getSharedLinkContacts,
@@ -526,6 +527,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             addSharedLink={onAddLink}
                             autofocusSharedLink={this.shouldAutoFocusSharedLink()}
                             autoCreateSharedLink={createSharedLinkOnLoad}
+                            config={config}
                             triggerCopyOnLoad={createSharedLinkOnLoad && focusSharedLinkOnLoad}
                             changeSharedLinkAccessLevel={changeSharedLinkAccessLevel}
                             changeSharedLinkPermissionLevel={changeSharedLinkPermissionLevel}

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -203,6 +203,18 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
         expect(tooltip).toMatchSnapshot();
     });
 
+    test.each`
+        config                    | emailButtonExists | description
+        ${undefined}              | ${true}           | ${'should render email shared link button when config is undefined'}
+        ${{ foo: 'bar' }}         | ${true}           | ${'should render email shared link button when config does not contain allowEmail'}
+        ${{ allowEmails: true }}  | ${true}           | ${'should render email shared link button when config.allowEmail is true'}
+        ${{ allowEmails: false }} | ${false}          | ${'should not render email shared link button when config.allowEmail is false'}
+    `('$description', ({ config, emailButtonExists }) => {
+        const sharedLink = { url: 'https://example.com/shared-link' };
+        const wrapper = getWrapper({ config, sharedLink });
+        expect(wrapper.exists('.email-shared-link-btn')).toBe(emailButtonExists);
+    });
+
     describe('componentDidMount()', () => {
         test('should attempt shared link creation when component is mounted with initial, empty shared link data', () => {
             const sharedLink = { url: '', isNewSharedLink: false };

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -204,11 +204,11 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
     });
 
     test.each`
-        config                    | emailButtonExists | description
-        ${undefined}              | ${true}           | ${'should render email shared link button when config is undefined'}
-        ${{ foo: 'bar' }}         | ${true}           | ${'should render email shared link button when config does not contain allowEmail'}
-        ${{ allowEmails: true }}  | ${true}           | ${'should render email shared link button when config.allowEmail is true'}
-        ${{ allowEmails: false }} | ${false}          | ${'should not render email shared link button when config.allowEmail is false'}
+        config                                | emailButtonExists | description
+        ${undefined}                          | ${true}           | ${'should render email shared link button when config is undefined'}
+        ${{ foo: 'bar' }}                     | ${true}           | ${'should render email shared link button when config does not contain showEmailSharedLinkForm'}
+        ${{ showEmailSharedLinkForm: true }}  | ${true}           | ${'should render email shared link button when config.showEmailSharedLinkForm is true'}
+        ${{ showEmailSharedLinkForm: false }} | ${false}          | ${'should not render email shared link button when config.showEmailSharedLinkForm is false'}
     `('$description', ({ config, emailButtonExists }) => {
         const sharedLink = { url: 'https://example.com/shared-link' };
         const wrapper = getWrapper({ config, sharedLink });

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -264,9 +264,9 @@ type EmailFormTypes = {
     sendSharedLinkError: React.Node,
 };
 
-export type SharingConfig = {
-    /** Whether the send email button in the USM should be rendered */
-    allowEmails: boolean,
+export type USMConfig = {
+    /** Whether the "Email Shared Link" button and form should be rendered in the USM/USF */
+    showEmailSharedLinkForm: boolean,
 };
 
 // Prop types shared by both the Unified Share Modal and the Unified Share Form
@@ -279,7 +279,7 @@ type BaseUnifiedShareProps = CollaboratorAvatarsTypes &
         /** Flag to determine whether to enable invite collaborators section */
         canInvite: boolean,
         /** Configuration object for hiding parts of the USM */
-        config?: SharingConfig,
+        config?: USMConfig,
         /** Whether the full USM should be rendered */
         displayInModal?: boolean,
         /** Whether the form should focus the shared link after the URL is resolved */

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
-import type { BoxItemPermission, ItemType } from '../../common/types/core';
 import * as constants from './constants';
+import type { BoxItemPermission, ItemType } from '../../common/types/core';
 
 // DRY: Invert the constants so that we can construct the appropriate enum types
 const accessLevelValues = {
@@ -264,6 +264,11 @@ type EmailFormTypes = {
     sendSharedLinkError: React.Node,
 };
 
+export type SharingConfig = {
+    /** Whether the send email button in the USM should be rendered */
+    allowEmails: boolean,
+};
+
 // Prop types shared by both the Unified Share Modal and the Unified Share Form
 type BaseUnifiedShareProps = CollaboratorAvatarsTypes &
     EmailFormTypes &
@@ -273,6 +278,8 @@ type BaseUnifiedShareProps = CollaboratorAvatarsTypes &
         allShareRestrictionWarning?: React.Node,
         /** Flag to determine whether to enable invite collaborators section */
         canInvite: boolean,
+        /** Configuration object for hiding parts of the USM */
+        config?: SharingConfig,
         /** Whether the full USM should be rendered */
         displayInModal?: boolean,
         /** Whether the form should focus the shared link after the URL is resolved */


### PR DESCRIPTION
Add a configuration object that hides the email button in the USM.

An example of the ContentSharing UI Element without the email button:
<img width="492" alt="content-sharing-email-button-hidden" src="https://user-images.githubusercontent.com/2956895/89593198-63421c80-d803-11ea-8e68-d890c3303bd1.png">

The default USM:
<img width="487" alt="regular-usm" src="https://user-images.githubusercontent.com/2956895/89592967-cbdcc980-d802-11ea-9eef-93082fcdfd4f.png">
