### PR TITLE
fix(thumbnail-card): use different flow typing for textRef

### DIFF
--- a/src/components/thumbnail-card/ThumbnailCardDetails.js
+++ b/src/components/thumbnail-card/ThumbnailCardDetails.js
@@ -16,7 +16,8 @@ type TitleProps = {
 };
 
 const Title = ({ title }: TitleProps) => {
-    const textRef = React.useRef<?HTMLElement>(null);
+    const textRef: { current: null | HTMLElement } = React.useRef(null);
+
     const isTextOverflowed = useIsContentOverflowed(textRef);
 
     if (isTextOverflowed) {

--- a/src/components/thumbnail-card/ThumbnailCardDetails.js
+++ b/src/components/thumbnail-card/ThumbnailCardDetails.js
@@ -16,7 +16,7 @@ type TitleProps = {
 };
 
 const Title = ({ title }: TitleProps) => {
-    const textRef: { current: null | HTMLElement } = React.useRef(null);
+    const textRef: { current: null | typeof undefined | HTMLElement } = React.useRef(null);
 
     const isTextOverflowed = useIsContentOverflowed(textRef);
 


### PR DESCRIPTION
Changes in this PR:
- define the type of textRef as an object that has current which may be null or HTMLElement