### PR TITLE
fix(thumbnail-card): suppress flow issue

### DIFF
--- a/src/components/thumbnail-card/ThumbnailCardDetails.js
+++ b/src/components/thumbnail-card/ThumbnailCardDetails.js
@@ -16,23 +16,16 @@ type TitleProps = {
 };
 
 const Title = ({ title }: TitleProps) => {
+    // $FlowFixMe
     const textRef: { current: null | HTMLElement } = React.useRef(null);
-
     const isTextOverflowed = useIsContentOverflowed(textRef);
 
-    if (isTextOverflowed) {
-        return (
-            <Tooltip text={title}>
-                <div ref={textRef} className="thumbnail-card-title">
-                    {title}
-                </div>
-            </Tooltip>
-        );
-    }
     return (
-        <div ref={textRef} className="thumbnail-card-title">
-            {title}
-        </div>
+        <Tooltip isDisabled={!isTextOverflowed} text={title}>
+            <div ref={textRef} className="thumbnail-card-title">
+                {title}
+            </div>
+        </Tooltip>
     );
 };
 


### PR DESCRIPTION
Changes in this PR:
- after many attempts at solutions, we are going to suppress the Flow error that is coming from this component
- we think that the issue may be with Flow because it doesn't make sense that the <div> needs the textRef to be a HTMLDivElement when HTMLElement is a parent of HTMLDivElement
- cleaned up the implementation by reducing the number of lines