### PR TITLE
fix(style): move generic BDL overlay styles to shared mixin directory

### DIFF
--- a/src/components/datalist-item/DatalistItem.scss
+++ b/src/components/datalist-item/DatalistItem.scss
@@ -1,12 +1,6 @@
 @import '../../styles/variables';
+@import '../../styles/mixins/overlay';
 
 .datalist-item {
-    margin: 0 ($bdl-grid-unit * 2);
-    padding: $bdl-grid-unit ($bdl-grid-unit * 9) $bdl-grid-unit ($bdl-grid-unit * 2);
-    border-radius: $bdl-border-radius-size * 2;
-
-    &.is-active {
-        background-color: fade-out($bdl-gray, .95);
-        cursor: pointer;
-    }
+    @include bdl-Overlay-listItemContainer;
 }

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.scss
@@ -1,6 +1,6 @@
 @import '../../styles/variables';
+@import '../../styles/mixins/overlay';
 @import 'PillSelector';
-@import 'mixins';
 
 .bdl-PillSelector {
     &.show-error {
@@ -10,7 +10,7 @@
 
 .bdl-PillSelectorDropdown {
     .overlay {
-        @include bdl-PillSelectorDropdown-container;
+        @include bdl-Overlay-container;
     }
 
     .suggested {

--- a/src/components/pill-selector-dropdown/_mixins.scss
+++ b/src/components/pill-selector-dropdown/_mixins.scss
@@ -1,9 +1,0 @@
-@import '../../styles/variables';
-
-@mixin bdl-PillSelectorDropdown-container {
-    margin-top: $bdl-grid-unit;
-    background-color: $white;
-    border: 1px solid $bdl-gray-10;
-    border-radius: $bdl-border-radius-size;
-    box-shadow: 0 $bdl-grid-unit ($bdl-grid-unit * 3) 0 rgba($black, .1);
-}

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -1,5 +1,5 @@
 @import '../../styles/variables';
-@import '../../components/pill-selector-dropdown/mixins';
+@import '../../styles/mixins/overlay';
 
 // Menus are rendered at the root of the DOM, so this style is not nested
 .usm-menu-description {
@@ -109,7 +109,7 @@
             height: 280px;
             overflow-y: scroll;
 
-            @include bdl-PillSelectorDropdown-container;
+            @include bdl-Overlay-container;
         }
 
         .overlay {

--- a/src/styles/mixins/_overlay.scss
+++ b/src/styles/mixins/_overlay.scss
@@ -1,0 +1,50 @@
+@import '../variables';
+
+/**
+ * Mixin to make standard the style for selected items in flyout lists
+ * Example:
+ * - data list components
+ */
+@mixin bdl-Overlay-listItemContainer {
+    margin: 0 ($bdl-grid-unit * 2);
+    padding: $bdl-grid-unit ($bdl-grid-unit * 9) $bdl-grid-unit ($bdl-grid-unit * 2);
+    border-radius: $bdl-border-radius-size * 2;
+    cursor: pointer;
+
+    &.is-active {
+        background-color: fade-out($bdl-gray, .95);
+
+        &:focus {
+            box-shadow: inset 0 0 1px 1px $bdl-box-blue-50, 0 0 2px 0 $bdl-box-blue-50;
+        }
+    }
+}
+
+/**
+ * Mixin to make standard the container treatment for any overlapping containers (Overlays)
+ * Component Examples:
+ * - Flyout
+ * - Overlay
+ * - Pill Selector Dropdown
+ * Feature Examples:
+ * - Header Flyout
+ */
+@mixin bdl-Overlay-container {
+    margin-top: $bdl-grid-unit;
+    background-color: $white;
+    border: 1px solid $bdl-gray-10;
+    border-radius: $bdl-border-radius-size;
+
+    @include bdl-Overlay-containerShadow;
+}
+
+/**
+ * Mixin to make standard the shadow treatment for any overlapping containers
+ * Example:
+ * - custom flyouts with different border designs
+ * - tooltips
+ * - FTUX tooltip guides
+ */
+@mixin bdl-Overlay-containerShadow {
+    box-shadow: 0 $bdl-grid-unit ($bdl-grid-unit * 3) 0 rgba($black, .1);
+}


### PR DESCRIPTION
Move the styles used for the new BDL-style overlays to a common area, to be used for other components with overlay behavior.

This change should be a visual no-op; the same styles should be used on the components where originally applied.