### PR TITLE
fix(content-uploader): allow cancellation of folder uploads

### DIFF
--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -1021,7 +1021,8 @@ class ContentUploader extends Component<Props, State> {
     onClick = (item: UploadItem) => {
         const { chunked, isResumableUploadsEnabled, onClickCancel, onClickResume, onClickRetry } = this.props;
         const { status, file } = item;
-        const isChunkedUpload = chunked && file.size > CHUNKED_UPLOAD_MIN_SIZE_BYTES && isMultiputSupported();
+        const isChunkedUpload =
+            chunked && !item.isFolder && file.size > CHUNKED_UPLOAD_MIN_SIZE_BYTES && isMultiputSupported();
         const isResumable = isResumableUploadsEnabled && isChunkedUpload && item.api.sessionId;
 
         switch (status) {

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -223,7 +223,7 @@ describe('elements/content-uploader/ContentUploader', () => {
 
             instance.onClick(item);
 
-            expect(instance.removeFileFromUploadQueue).toBeCalled();
+            expect(instance.removeFileFromUploadQueue).toBeCalledWith(item);
             expect(onClickCancel.mock.calls.length).toBe(1);
         });
 

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -213,6 +213,20 @@ describe('elements/content-uploader/ContentUploader', () => {
     });
 
     describe('onClick()', () => {
+        test('should cancel folder upload in progress', () => {
+            const item = { api: {}, isFolder: true, status: STATUS_IN_PROGRESS };
+            const onClickCancel = jest.fn();
+            const wrapper = getWrapper({ onClickCancel });
+            const instance = wrapper.instance();
+
+            instance.removeFileFromUploadQueue = jest.fn();
+
+            instance.onClick(item);
+
+            expect(instance.removeFileFromUploadQueue).toBeCalled();
+            expect(onClickCancel.mock.calls.length).toBe(1);
+        });
+
         test.each([
             [
                 'should set bytesUploadedOnLastResume when status is error and item is resumable',

--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -277,7 +277,7 @@ describe('util/uploads', () => {
         Date.now = jest.fn(() => now);
 
         test('should return item id correctly when item does not contain API options', () => {
-            expect(getDataTransferItemId(mockItem, rootFolderId)).toBe(`hi_0_${now}`);
+            expect(getDataTransferItemId(mockItem, rootFolderId)).toBe(`hi`);
         });
 
         test('should return item id correctly when item does contain API options', () => {

--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -277,7 +277,7 @@ describe('util/uploads', () => {
         Date.now = jest.fn(() => now);
 
         test('should return item id correctly when item does not contain API options', () => {
-            expect(getDataTransferItemId(mockItem, rootFolderId)).toBe(`hi`);
+            expect(getDataTransferItemId(mockItem, rootFolderId)).toBe('hi');
         });
 
         test('should return item id correctly when item does contain API options', () => {

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -268,6 +268,9 @@ function getFileId(file: UploadFileWithAPIOptions | UploadFile, rootFolderId: st
 
 /**
  * Generates item id based on item properties
+ *
+ * When item options including folderId or uploadInitTimestamp are missing, item name is returned as item id.
+ * Otherwise, item properties are used as item id.
  * E.g., folder1_0_123124124
  *
  * @param {DataTransferItem | UploadDataTransferItemWithAPIOptions} itemData
@@ -280,6 +283,10 @@ function getDataTransferItemId(
 ): string {
     const item = getDataTransferItem(itemData);
     const { name } = getEntryFromDataTransferItem(item);
+    if (!doesDataTransferItemContainAPIOptions(itemData)) {
+        return name;
+    }
+
     const { folderId = rootFolderId, uploadInitTimestamp = Date.now() } = getDataTransferItemAPIOptions(itemData);
 
     return `${name}_${folderId}_${uploadInitTimestamp}`;


### PR DESCRIPTION
Added a check for if an item is a folder before attempting to get the file size to prevent errors when attempting to cancel a single folder upload or multiple folder uploads. 

Additionally, changed the ID assigned when there are not API Options for a DataTransferItem to be identical to that for a File (where only the name is used as the ID when there are not API Options available), so that behavior for folders being uploaded is identical to that of files.