### PR TITLE
Adding aria label for accessibility purposes on "Send Shared Link" 

### DIFF
--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -257,6 +257,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                                 isDisabled={submitting}
                                 onClick={onEmailSharedLinkClick}
                                 type="button"
+                                aria-label={intl.formatMessage(messages.sendSharedLink)}
                                 {...sendSharedLinkButtonProps}
                             >
                                 <IconMail />


### PR DESCRIPTION
The email button on the Universal Share Modal needs an aria-label for accessibility purposes