### PR TITLE
fix(unified-share-modal): adding aria-label attribute to email button

### DIFF
--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -253,6 +253,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                     {!hideEmailButton && (
                         <Tooltip position="top-left" text={<FormattedMessage {...messages.sendSharedLink} />}>
                             <Button
+                                aria-label={intl.formatMessage(messages.sendSharedLink)}
                                 className="email-shared-link-btn"
                                 isDisabled={submitting}
                                 onClick={onEmailSharedLinkClick}


### PR DESCRIPTION
The email button in the unified shared modal needs an aria-label for accessibility purposes