### PR TITLE
fix(open-with): fix onError and onExecute callback options

### DIFF
--- a/src/elements/wrappers/ContentOpenWith.js
+++ b/src/elements/wrappers/ContentOpenWith.js
@@ -37,11 +37,11 @@ class ContentOpenWith extends ES6Wrapper {
                 fileId={this.id}
                 language={this.language}
                 messages={this.messages}
+                onError={this.onError}
+                onExecute={this.onExecute}
                 onInteraction={this.onInteraction}
                 token={this.token}
                 {...this.options}
-                onError={this.onError}
-                onExecute={this.onExecute}
             />,
             this.container,
         );


### PR DESCRIPTION
BREAKING CHANGE: if a user passes in onError & onExecute options, those will now replace the equivalent methods on the ES6 wrapper. This is the expected behavior according to the docs, but I'm marking this as a breaking change since its an options update.

The Developer Docs already lists these callbacks as options in https://developer.box.com/guides/embed/ui-elements/open-with/#options