### PR TITLE
feat(content-sharing): Display avatars

### DIFF
--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -16,6 +16,7 @@ import {
     convertUserContactsResponse,
     USM_TO_API_ACCESS_LEVEL_MAP,
 } from '../../features/unified-share-modal/utils/convertData';
+import useAvatars from './hooks/useAvatars';
 import useCollaborators from './hooks/useCollaborators';
 import useContacts from './hooks/useContacts';
 import useInvites from './hooks/useInvites';
@@ -206,8 +207,12 @@ function SharingNotification({
     const collaboratorsListFromAPI: Collaborations | null = useCollaborators(api, itemID, itemType, {
         handleError: () => createNotification(TYPE_ERROR, contentSharingMessages.collaboratorsLoadingError),
     });
-    if (collaboratorsListFromAPI && !collaboratorsList) {
-        setCollaboratorsList(convertCollabsResponse(collaboratorsListFromAPI, ownerEmail, currentUserID === ownerID));
+    const avatarsFromAPI = useAvatars(api, itemID, collaboratorsListFromAPI);
+
+    if (collaboratorsListFromAPI && avatarsFromAPI && !collaboratorsList) {
+        setCollaboratorsList(
+            convertCollabsResponse(collaboratorsListFromAPI, avatarsFromAPI, ownerEmail, currentUserID === ownerID),
+        );
     }
 
     // Set the getContacts function

--- a/src/elements/content-sharing/__tests__/SharingModal.test.js
+++ b/src/elements/content-sharing/__tests__/SharingModal.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { FormattedMessage } from 'react-intl';
@@ -74,7 +74,7 @@ const createAPIMock = (fileAPI, folderAPI, usersAPI, collaborationsAPI, groupsAP
     getFolderCollaborationsAPI: jest.fn().mockReturnValue({
         getCollaborations: jest.fn(),
     }),
-    getUsersAPI: jest.fn().mockReturnValue(usersAPI),
+    getUsersAPI: jest.fn().mockReturnValue({ getAvatarUrlWithAccessToken: jest.fn(), ...usersAPI }),
     getCollaborationsAPI: jest.fn().mockReturnValue(collaborationsAPI),
     getGroupsAPI: jest.fn().mockReturnValue(groupsAPI),
 });

--- a/src/elements/content-sharing/__tests__/SharingNotification.test.js
+++ b/src/elements/content-sharing/__tests__/SharingNotification.test.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { FormattedMessage } from 'react-intl';
 import SharingNotification from '../SharingNotification';
 import { TYPE_FILE, TYPE_FOLDER } from '../../../constants';
 import {
+    MOCK_AVATAR_URL_MAP,
     MOCK_COLLABS_API_RESPONSE,
     MOCK_COLLABS_CONVERTED_RESPONSE,
     MOCK_ITEM_ID,
@@ -31,6 +32,9 @@ describe('elements/content-sharing/SharingNotification', () => {
     const setCollaboratorsListStub = jest.fn();
     const setOnSubmitSettingsStub = jest.fn();
     const setSendInvitesStub = jest.fn();
+    const getAvatarUrlWithAccessTokenStub = jest.fn(
+        userID => `https://api.box.com/2.0/users/${userID}/avatar?access_token=foo&pic_type=large`,
+    );
     const createAPIInstance = getCollabStub => ({
         getCollaborationsAPI: jest.fn().mockReturnValue({
             addCollaboration: jest.fn(),
@@ -48,6 +52,9 @@ describe('elements/content-sharing/SharingNotification', () => {
         }),
         getFolderCollaborationsAPI: jest.fn().mockReturnValue({
             getCollaborations: getCollabStub,
+        }),
+        getUsersAPI: jest.fn().mockReturnValue({
+            getAvatarUrlWithAccessToken: getAvatarUrlWithAccessTokenStub,
         }),
     });
 
@@ -126,8 +133,14 @@ describe('elements/content-sharing/SharingNotification', () => {
             });
             wrapper.update();
             expect(getCollaborations).toHaveBeenCalledWith(MOCK_ITEM_ID, expect.anything(), expect.anything());
-            expect(convertCollabsResponse).toHaveBeenCalledWith(MOCK_COLLABS_API_RESPONSE, MOCK_OWNER_EMAIL, true);
+            expect(convertCollabsResponse).toHaveBeenCalledWith(
+                MOCK_COLLABS_API_RESPONSE,
+                MOCK_AVATAR_URL_MAP,
+                MOCK_OWNER_EMAIL,
+                true,
+            );
             expect(setCollaboratorsListStub).toHaveBeenCalledWith(MOCK_COLLABS_CONVERTED_RESPONSE);
+            expect(getAvatarUrlWithAccessTokenStub).toHaveBeenCalled();
             expect(wrapper.exists(Notification)).toBe(false);
         });
     });

--- a/src/elements/content-sharing/__tests__/useAvatars.test.js
+++ b/src/elements/content-sharing/__tests__/useAvatars.test.js
@@ -1,0 +1,101 @@
+// @flow
+
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import useAvatars from '../hooks/useAvatars';
+import {
+    MOCK_AVATAR_URL_MAP,
+    MOCK_AVATAR_URL_MAP_FOR_INCOMPLETE_ENTRIES,
+    MOCK_COLLABS_API_RESPONSE,
+    MOCK_COLLABS_API_RESPONSE_WITH_INCOMPLETE_ENTRIES,
+    MOCK_ITEM_ID,
+    MOCK_USER_IDS,
+} from '../../../features/unified-share-modal/utils/__mocks__/USMMocks';
+import { Collaborations } from '../../../common/types/core';
+
+const getAvatarUrlWithAccessToken = jest.fn(
+    userID => `https://api.box.com/2.0/users/${userID}/avatar?access_token=foo&pic_type=large`,
+);
+const mockAPI = {
+    getUsersAPI: jest.fn().mockReturnValue({
+        getAvatarUrlWithAccessToken,
+    }),
+};
+
+function FakeComponent({ collaboratorsList }: { collaboratorsList: Collaborations }) {
+    const [avatarURLMap, setAvatarURLMap] = React.useState(null);
+
+    const retrievedAvatarURLMap = useAvatars(mockAPI, MOCK_ITEM_ID, collaboratorsList);
+
+    if (retrievedAvatarURLMap && !avatarURLMap) {
+        setAvatarURLMap(JSON.stringify(retrievedAvatarURLMap));
+    }
+
+    return avatarURLMap && <div>{avatarURLMap}</div>;
+}
+
+describe('elements/content-sharing/hooks/useCollaborators', () => {
+    test.each`
+        collaboratorsList                                    | avatarURLMap                                                  | description
+        ${MOCK_COLLABS_API_RESPONSE_WITH_INCOMPLETE_ENTRIES} | ${JSON.stringify(MOCK_AVATAR_URL_MAP_FOR_INCOMPLETE_ENTRIES)} | ${'contains some incomplete entries'}
+        ${MOCK_COLLABS_API_RESPONSE}                         | ${JSON.stringify(MOCK_AVATAR_URL_MAP)}                        | ${'contains complete entries only'}
+    `(
+        'should return the expected avatar URL map when collaborators list $description',
+        async ({ collaboratorsList, avatarURLMap }) => {
+            let fakeComponent;
+
+            await act(async () => {
+                fakeComponent = mount(<FakeComponent collaboratorsList={collaboratorsList} />);
+            });
+            fakeComponent.update();
+
+            expect(getAvatarUrlWithAccessToken).toHaveBeenCalled();
+            expect(fakeComponent.find('div').text()).toBe(avatarURLMap);
+        },
+    );
+
+    test('should call getAvatarUrlWithAccessToken() with each user ID', async () => {
+        let fakeComponent;
+
+        await act(async () => {
+            fakeComponent = mount(<FakeComponent collaboratorsList={MOCK_COLLABS_API_RESPONSE} />);
+        });
+        fakeComponent.update();
+
+        MOCK_USER_IDS.forEach(userID => expect(getAvatarUrlWithAccessToken).toHaveBeenCalledWith(userID, MOCK_ITEM_ID));
+    });
+
+    test.each`
+        collaboratorsList | description
+        ${null}           | ${'is null'}
+        ${undefined}      | ${'is undefined'}
+        ${{}}             | ${'is an empty object'}
+        ${{ foo: 'bar' }} | ${'does not have entries'}
+    `('should not generate avatar URLs when when collaborators list $description', ({ collaboratorsList }) => {
+        let fakeComponent;
+
+        act(() => {
+            fakeComponent = mount(<FakeComponent collaboratorsList={collaboratorsList} />);
+        });
+        fakeComponent.update();
+
+        expect(getAvatarUrlWithAccessToken).not.toHaveBeenCalled();
+    });
+
+    test.each`
+        collaboratorsList                     | description
+        ${{ entries: [] }}                    | ${'has an empty entries array'}
+        ${{ entries: [null, undefined, ''] }} | ${'contains incomplete entries only'}
+    `('should return an empty object when when collaborators list $description', async ({ collaboratorsList }) => {
+        let fakeComponent;
+
+        await act(async () => {
+            fakeComponent = mount(<FakeComponent collaboratorsList={collaboratorsList} />);
+        });
+        fakeComponent.update();
+
+        expect(getAvatarUrlWithAccessToken).not.toHaveBeenCalled();
+        expect(fakeComponent.find('div').text()).toBe('{}');
+    });
+});

--- a/src/elements/content-sharing/__tests__/useAvatars.test.js
+++ b/src/elements/content-sharing/__tests__/useAvatars.test.js
@@ -72,7 +72,7 @@ describe('elements/content-sharing/hooks/useCollaborators', () => {
         ${undefined}      | ${'is undefined'}
         ${{}}             | ${'is an empty object'}
         ${{ foo: 'bar' }} | ${'does not have entries'}
-    `('should not generate avatar URLs when when collaborators list $description', ({ collaboratorsList }) => {
+    `('should not generate avatar URLs when collaborators list $description', ({ collaboratorsList }) => {
         let fakeComponent;
 
         act(() => {
@@ -87,7 +87,7 @@ describe('elements/content-sharing/hooks/useCollaborators', () => {
         collaboratorsList                     | description
         ${{ entries: [] }}                    | ${'has an empty entries array'}
         ${{ entries: [null, undefined, ''] }} | ${'contains incomplete entries only'}
-    `('should return an empty object when when collaborators list $description', async ({ collaboratorsList }) => {
+    `('should return an empty object when collaborators list $description', async ({ collaboratorsList }) => {
         let fakeComponent;
 
         await act(async () => {

--- a/src/elements/content-sharing/__tests__/useCollaborators.test.js
+++ b/src/elements/content-sharing/__tests__/useCollaborators.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import API from '../../../api';

--- a/src/elements/content-sharing/__tests__/useContacts.test.js
+++ b/src/elements/content-sharing/__tests__/useContacts.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import API from '../../../api';

--- a/src/elements/content-sharing/__tests__/useInvites.test.js
+++ b/src/elements/content-sharing/__tests__/useInvites.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import API from '../../../api';

--- a/src/elements/content-sharing/__tests__/useSharedLink.test.js
+++ b/src/elements/content-sharing/__tests__/useSharedLink.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import API from '../../../api';

--- a/src/elements/content-sharing/hooks/useAvatars.js
+++ b/src/elements/content-sharing/hooks/useAvatars.js
@@ -1,0 +1,48 @@
+// @flow
+
+import * as React from 'react';
+import noop from 'lodash/noop';
+import API from '../../../api';
+import type { ContentSharingHooksOptions, GetAvatarsFnType } from '../types';
+
+/**
+ * Generate the getAvatars() function, which is used for retrieving potential collaborators in the USM.
+ *
+ * @param {API} api
+ * @param {collaboratorsList}
+ * @returns {GetAvatarsFnType | null}
+ */
+function useAvatars(
+    api: API,
+    itemID,
+    collaboratorsList,
+    options: ContentSharingHooksOptions = {},
+): GetAvatarsFnType | null {
+    const [avatars, setAvatars] = React.useState<null | GetAvatarsFnType>(null);
+    const { handleSuccess = noop, handleError = noop } = options;
+
+    React.useEffect(() => {
+        if (avatars || !collaboratorsList || !collaboratorsList.entries) return;
+        const usersAPI = api.getUsersAPI(false);
+
+        (async () => {
+            const idToAvatarMap = {};
+            await Promise.all(
+                collaboratorsList.entries.map(async collab => {
+                    if (!collab || !collab.accessible_by) return null;
+                    const {
+                        accessible_by: { id: userID },
+                    } = collab;
+                    const url = await usersAPI.getAvatarUrlWithAccessToken(userID, itemID);
+                    idToAvatarMap[userID] = url;
+                    return null;
+                }),
+            );
+            setAvatars(idToAvatarMap);
+        })();
+    }, [api, avatars, collaboratorsList, handleError, handleSuccess, itemID]);
+
+    return avatars;
+}
+
+export default useAvatars;

--- a/src/elements/content-sharing/hooks/useAvatars.js
+++ b/src/elements/content-sharing/hooks/useAvatars.js
@@ -1,48 +1,44 @@
 // @flow
 
 import * as React from 'react';
-import noop from 'lodash/noop';
 import API from '../../../api';
-import type { ContentSharingHooksOptions, GetAvatarsFnType } from '../types';
+import type { Collaboration, Collaborations } from '../../../common/types/core';
+import type { AvatarURLMap } from '../types';
 
 /**
- * Generate the getAvatars() function, which is used for retrieving potential collaborators in the USM.
+ * Generate a map of avatar URLs, which are used to display collaborators in the USM.
  *
  * @param {API} api
- * @param {collaboratorsList}
- * @returns {GetAvatarsFnType | null}
+ * @param {string} itemID
+ * @param {Collaborations | null} collaboratorsList
+ * @returns {AvatarURLMap | null}
  */
-function useAvatars(
-    api: API,
-    itemID,
-    collaboratorsList,
-    options: ContentSharingHooksOptions = {},
-): GetAvatarsFnType | null {
-    const [avatars, setAvatars] = React.useState<null | GetAvatarsFnType>(null);
-    const { handleSuccess = noop, handleError = noop } = options;
+function useAvatars(api: API, itemID: string, collaboratorsList: Collaborations | null): AvatarURLMap | null {
+    const [avatarURLMap, setAvatarURLMap] = React.useState<AvatarURLMap | null>(null);
 
     React.useEffect(() => {
-        if (avatars || !collaboratorsList || !collaboratorsList.entries) return;
+        if (avatarURLMap || !collaboratorsList || !collaboratorsList.entries) return;
+
         const usersAPI = api.getUsersAPI(false);
 
         (async () => {
-            const idToAvatarMap = {};
+            const retrievedAvatarURLMap: AvatarURLMap = {};
+            const entries = collaboratorsList ? collaboratorsList.entries : []; // needed for Flow
             await Promise.all(
-                collaboratorsList.entries.map(async collab => {
-                    if (!collab || !collab.accessible_by) return null;
+                entries.map(async (collab: Collaboration) => {
+                    if (!collab || !collab.accessible_by) return;
                     const {
                         accessible_by: { id: userID },
                     } = collab;
-                    const url = await usersAPI.getAvatarUrlWithAccessToken(userID, itemID);
-                    idToAvatarMap[userID] = url;
-                    return null;
+                    const url = await usersAPI.getAvatarUrlWithAccessToken(userID.toString(), itemID);
+                    retrievedAvatarURLMap[userID] = url;
                 }),
             );
-            setAvatars(idToAvatarMap);
+            setAvatarURLMap(retrievedAvatarURLMap);
         })();
-    }, [api, avatars, collaboratorsList, handleError, handleSuccess, itemID]);
+    }, [api, avatarURLMap, collaboratorsList, itemID]);
 
-    return avatars;
+    return avatarURLMap;
 }
 
 export default useAvatars;

--- a/src/elements/content-sharing/types.js
+++ b/src/elements/content-sharing/types.js
@@ -129,3 +129,5 @@ export type ConnectToItemShareFnType = ({
     requestOptions?: RequestOptions,
     successFn?: Function,
 }) => Function;
+
+export type AvatarURLMap = { [number | string]: ?string };

--- a/src/features/unified-share-modal/utils/__mocks__/USMMocks.js
+++ b/src/features/unified-share-modal/utils/__mocks__/USMMocks.js
@@ -138,8 +138,21 @@ const MOCK_USER_IDS = ['1415', '1617', '1819', '2021', '2223'];
 const MOCK_COLLAB_IDS_CONVERTED = [123, 456, 789, 1011, 1213];
 const MOCK_USER_IDS_CONVERTED = [1415, 1617, 1819, 2021, 2223];
 
+const MOCK_AVATAR_URL_MAP = {
+    [MOCK_USER_IDS[0]]: `https://api.box.com/2.0/users/${MOCK_USER_IDS[0]}/avatar?access_token=foo&pic_type=large`,
+    [MOCK_USER_IDS[1]]: `https://api.box.com/2.0/users/${MOCK_USER_IDS[1]}/avatar?access_token=foo&pic_type=large`,
+    [MOCK_USER_IDS[2]]: `https://api.box.com/2.0/users/${MOCK_USER_IDS[2]}/avatar?access_token=foo&pic_type=large`,
+    [MOCK_USER_IDS[3]]: `https://api.box.com/2.0/users/${MOCK_USER_IDS[3]}/avatar?access_token=foo&pic_type=large`,
+    [MOCK_USER_IDS[4]]: `https://api.box.com/2.0/users/${MOCK_USER_IDS[4]}/avatar?access_token=foo&pic_type=large`,
+};
+
+const MOCK_AVATAR_URL_MAP_FOR_INCOMPLETE_ENTRIES = {
+    [MOCK_USER_IDS[3]]: `https://api.box.com/2.0/users/${MOCK_USER_IDS[3]}/avatar?access_token=foo&pic_type=large`,
+    [MOCK_USER_IDS[4]]: `https://api.box.com/2.0/users/${MOCK_USER_IDS[4]}/avatar?access_token=foo&pic_type=large`,
+};
+
 const MOCK_COLLABS_API_RESPONSE = {
-    total_count: 4,
+    total_count: 5,
     entries: [
         {
             type: 'collaboration',
@@ -198,6 +211,77 @@ const MOCK_COLLABS_API_RESPONSE = {
             acknowledged_at: '2019-11-20T14:33:52-08:00',
             item: COLLAB_ITEM,
         },
+        {
+            type: 'collaboration',
+            id: MOCK_COLLAB_IDS[3],
+            created_by: MOCK_OWNER,
+            created_at: '2019-11-20T14:33:52-08:00',
+            modified_at: '2019-11-20T14:33:52-08:00',
+            expires_at: null,
+            status: 'accepted',
+            accessible_by: {
+                type: 'user',
+                id: MOCK_USER_IDS[3],
+                name: 'Content Uploader',
+                login: 'contentuploader@box.com',
+            },
+            invite_email: null,
+            role: 'editor',
+            acknowledged_at: '2019-11-20T14:33:52-08:00',
+            item: COLLAB_ITEM,
+        },
+        {
+            type: 'collaboration',
+            id: MOCK_COLLAB_IDS[4],
+            created_by: MOCK_OWNER,
+            created_at: '2019-11-20T14:33:52-08:00',
+            modified_at: '2019-11-20T14:33:52-08:00',
+            expires_at: null,
+            status: 'accepted',
+            accessible_by: {
+                type: 'user',
+                id: MOCK_USER_IDS[4],
+                name: 'BoxWorks Demo',
+                login: 'demo@boxworks.com',
+            },
+            invite_email: null,
+            role: 'viewer',
+            acknowledged_at: '2019-11-20T14:33:52-08:00',
+            item: COLLAB_ITEM,
+        },
+    ],
+};
+
+const MOCK_COLLABS_API_RESPONSE_WITH_INCOMPLETE_ENTRIES = {
+    total_count: 5,
+    entries: [
+        {
+            type: 'collaboration',
+            id: MOCK_COLLAB_IDS[0],
+            created_by: MOCK_OWNER,
+            created_at: '2019-08-07T13:37:32-07:00',
+            modified_at: '2019-08-07T13:37:32-07:00',
+            expires_at: null,
+            status: 'accepted',
+            invite_email: null,
+            role: 'editor',
+            acknowledged_at: '2019-08-07T13:37:32-07:00',
+            item: COLLAB_ITEM,
+        },
+        {
+            type: 'collaboration',
+            id: MOCK_COLLAB_IDS[1],
+            created_by: MOCK_OWNER,
+            created_at: '2019-08-07T13:37:32-07:00',
+            modified_at: '2019-08-07T13:37:32-07:00',
+            expires_at: null,
+            status: 'accepted',
+            invite_email: null,
+            role: 'editor',
+            acknowledged_at: '2019-08-07T13:37:32-07:00',
+            item: COLLAB_ITEM,
+        },
+        null,
         {
             type: 'collaboration',
             id: MOCK_COLLAB_IDS[3],
@@ -616,9 +700,12 @@ const MOCK_DISABLED_REASONS = {
 };
 
 export {
+    MOCK_AVATAR_URL_MAP,
+    MOCK_AVATAR_URL_MAP_FOR_INCOMPLETE_ENTRIES,
     MOCK_COLLAB_IDS,
     MOCK_COLLAB_IDS_CONVERTED,
     MOCK_COLLABS_API_RESPONSE,
+    MOCK_COLLABS_API_RESPONSE_WITH_INCOMPLETE_ENTRIES,
     MOCK_COLLABS_CONVERTED_GROUPS,
     MOCK_COLLABS_CONVERTED_RESPONSE,
     MOCK_COLLABS_CONVERTED_REQUEST,

--- a/src/features/unified-share-modal/utils/__tests__/convertData.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/convertData.test.js
@@ -38,6 +38,7 @@ import {
     bdlYellow50,
 } from '../../../../styles/variables';
 import {
+    MOCK_AVATAR_URL_MAP,
     MOCK_COLLABS_API_RESPONSE,
     MOCK_COLLABS_CONVERTED_REQUEST,
     MOCK_COLLAB_IDS_CONVERTED,
@@ -528,19 +529,21 @@ describe('convertSharedLinkSettings', () => {
 
 describe('convertCollabsResponse', () => {
     test.each`
-        isCurrentUserOwner | description
-        ${true}            | ${'the owner'}
-        ${false}           | ${'not the owner'}
+        isCurrentUserOwner | avatarURLMap | ownerDescription   | avatarURLMapDescription
+        ${true}            | ${{}}        | ${'the owner'}     | ${'empty'}
+        ${false}           | ${{}}        | ${'not the owner'} | ${'empty'}
+        ${true}            | ${null}      | ${'the owner'}     | ${'null'}
+        ${false}           | ${null}      | ${'not the owner'} | ${'null'}
     `(
-        'should correctly convert a Collaborations API response when the current user is $description',
-        ({ isCurrentUserOwner }) => {
+        'should correctly convert a Collaborations API response when the current user is $ownerDescription and the avatar URL map is $avatarURLMapDescription',
+        ({ isCurrentUserOwner, avatarURLMap }) => {
             const convertedResponse = {
                 collaborators: [
                     {
                         collabID: MOCK_COLLAB_IDS_CONVERTED[0],
                         email: 'contentexplorer@box.com',
                         hasCustomAvatar: false,
-                        imageURL: null,
+                        imageURL: undefined,
                         isExternalCollab: false,
                         name: 'Content Explorer',
                         translatedRole: 'Editor',
@@ -551,7 +554,7 @@ describe('convertCollabsResponse', () => {
                         collabID: MOCK_COLLAB_IDS_CONVERTED[1],
                         email: 'contentpreview@box.com',
                         hasCustomAvatar: false,
-                        imageURL: null,
+                        imageURL: undefined,
                         isExternalCollab: false,
                         name: 'Content Preview',
                         translatedRole: 'Editor',
@@ -565,7 +568,7 @@ describe('convertCollabsResponse', () => {
                             executeAt: '2020-07-09T14:53:12-08:00',
                         },
                         hasCustomAvatar: false,
-                        imageURL: null,
+                        imageURL: undefined,
                         isExternalCollab: false,
                         name: 'Content Picker',
                         translatedRole: 'Editor',
@@ -576,7 +579,7 @@ describe('convertCollabsResponse', () => {
                         collabID: MOCK_COLLAB_IDS_CONVERTED[3],
                         email: 'contentuploader@box.com',
                         hasCustomAvatar: false,
-                        imageURL: null,
+                        imageURL: undefined,
                         isExternalCollab: false,
                         name: 'Content Uploader',
                         translatedRole: 'Editor',
@@ -587,7 +590,7 @@ describe('convertCollabsResponse', () => {
                         collabID: MOCK_COLLAB_IDS_CONVERTED[4],
                         email: 'demo@boxworks.com',
                         hasCustomAvatar: false,
-                        imageURL: null,
+                        imageURL: undefined,
                         isExternalCollab: !!isCurrentUserOwner,
                         name: 'BoxWorks Demo',
                         translatedRole: 'Viewer',
@@ -596,17 +599,95 @@ describe('convertCollabsResponse', () => {
                     },
                 ],
             };
-            expect(convertCollabsResponse(MOCK_COLLABS_API_RESPONSE, MOCK_OWNER_EMAIL, isCurrentUserOwner)).toEqual(
-                convertedResponse,
-            );
+            expect(
+                convertCollabsResponse(MOCK_COLLABS_API_RESPONSE, avatarURLMap, MOCK_OWNER_EMAIL, isCurrentUserOwner),
+            ).toEqual(convertedResponse);
         },
     );
 
-    test('should return an object with an empty array if there are no collaborations', () => {
-        expect(convertCollabsResponse({ total_count: 0, entries: [] }, MOCK_OWNER_EMAIL, true)).toEqual({
-            collaborators: [],
-        });
+    test('should correctly convert a Collaborations API response with avatar URLs', () => {
+        const convertedResponse = {
+            collaborators: [
+                {
+                    collabID: MOCK_COLLAB_IDS_CONVERTED[0],
+                    email: 'contentexplorer@box.com',
+                    hasCustomAvatar: true,
+                    imageURL: MOCK_AVATAR_URL_MAP[MOCK_USER_IDS_CONVERTED[0]],
+                    isExternalCollab: false,
+                    name: 'Content Explorer',
+                    translatedRole: 'Editor',
+                    type: 'user',
+                    userID: MOCK_USER_IDS_CONVERTED[0],
+                },
+                {
+                    collabID: MOCK_COLLAB_IDS_CONVERTED[1],
+                    email: 'contentpreview@box.com',
+                    hasCustomAvatar: true,
+                    imageURL: MOCK_AVATAR_URL_MAP[MOCK_USER_IDS_CONVERTED[1]],
+                    isExternalCollab: false,
+                    name: 'Content Preview',
+                    translatedRole: 'Editor',
+                    type: 'user',
+                    userID: MOCK_USER_IDS_CONVERTED[1],
+                },
+                {
+                    collabID: MOCK_COLLAB_IDS_CONVERTED[2],
+                    email: 'contentpicker@box.com',
+                    expiration: {
+                        executeAt: '2020-07-09T14:53:12-08:00',
+                    },
+                    hasCustomAvatar: true,
+                    imageURL: MOCK_AVATAR_URL_MAP[MOCK_USER_IDS_CONVERTED[2]],
+                    isExternalCollab: false,
+                    name: 'Content Picker',
+                    translatedRole: 'Editor',
+                    type: 'user',
+                    userID: MOCK_USER_IDS_CONVERTED[2],
+                },
+                {
+                    collabID: MOCK_COLLAB_IDS_CONVERTED[3],
+                    email: 'contentuploader@box.com',
+                    hasCustomAvatar: true,
+                    imageURL: MOCK_AVATAR_URL_MAP[MOCK_USER_IDS_CONVERTED[3]],
+                    isExternalCollab: false,
+                    name: 'Content Uploader',
+                    translatedRole: 'Editor',
+                    type: 'user',
+                    userID: MOCK_USER_IDS_CONVERTED[3],
+                },
+                {
+                    collabID: MOCK_COLLAB_IDS_CONVERTED[4],
+                    email: 'demo@boxworks.com',
+                    hasCustomAvatar: true,
+                    imageURL: MOCK_AVATAR_URL_MAP[MOCK_USER_IDS_CONVERTED[4]],
+                    isExternalCollab: true,
+                    name: 'BoxWorks Demo',
+                    translatedRole: 'Viewer',
+                    type: 'user',
+                    userID: MOCK_USER_IDS_CONVERTED[4],
+                },
+            ],
+        };
+        expect(convertCollabsResponse(MOCK_COLLABS_API_RESPONSE, MOCK_AVATAR_URL_MAP, MOCK_OWNER_EMAIL, true)).toEqual(
+            convertedResponse,
+        );
     });
+
+    test.each`
+        avatarURLMap           | description
+        ${null}                | ${'null'}
+        ${{}}                  | ${'empty'}
+        ${MOCK_AVATAR_URL_MAP} | ${'not empty'}
+    `(
+        'should return an object with an empty array if there are no collaborations and the avatar URL map is $description',
+        ({ avatarURLMap }) => {
+            expect(
+                convertCollabsResponse({ total_count: 0, entries: [] }, avatarURLMap, MOCK_OWNER_EMAIL, true),
+            ).toEqual({
+                collaborators: [],
+            });
+        },
+    );
 });
 
 describe('convertUserContactsResponse()', () => {

--- a/src/features/unified-share-modal/utils/convertData.js
+++ b/src/features/unified-share-modal/utils/convertData.js
@@ -345,6 +345,7 @@ export const convertSharedLinkSettings = (
  */
 export const convertCollabsResponse = (
     collabsAPIData: Collaborations,
+    avatarsAPIData,
     ownerEmail: ?string,
     isCurrentUserOwner: boolean,
 ): collaboratorsListType => {
@@ -364,11 +365,12 @@ export const convertCollabsResponse = (
                 expires_at: executeAt,
                 role,
             } = collab;
+            const avatarURL = avatarsAPIData[userID];
             const convertedCollab: collaboratorType = {
                 collabID: parseInt(collabID, 10),
                 email,
-                hasCustomAvatar: false, // to do: connect to Avatar API
-                imageURL: null, // to do: connect to Avatar API
+                hasCustomAvatar: !!avatarURL, // to do: connect to Avatar API
+                imageURL: avatarURL, // to do: connect to Avatar API
                 isExternalCollab: checkIsExternalUser(isCurrentUserOwner, ownerEmailDomain, email),
                 name,
                 translatedRole: `${role[0].toUpperCase()}${role.slice(1)}`, // capitalize the user's role

--- a/src/features/unified-share-modal/utils/convertData.js
+++ b/src/features/unified-share-modal/utils/convertData.js
@@ -43,6 +43,7 @@ import {
     CLASSIFICATION_COLOR_ID_7,
 } from '../../classification/constants';
 import type {
+    AvatarURLMap,
     ContentSharingCollaborationsRequest,
     ContentSharingItemAPIResponse,
     ContentSharingItemDataType,
@@ -339,13 +340,14 @@ export const convertSharedLinkSettings = (
  * Convert a response from the Item Collaborations API into the object that the USM expects.
  *
  * @param {Collaborations} collabsAPIData
+ * @param {AvatarURLMap | null} avatarURLMap
  * @param {string | null | undefined} ownerEmail
  * @param {boolean} isCurrentUserOwner
  * @returns {collaboratorsListType} Object containing an array of collaborators
  */
 export const convertCollabsResponse = (
     collabsAPIData: Collaborations,
-    avatarsAPIData,
+    avatarURLMap: ?AvatarURLMap,
     ownerEmail: ?string,
     isCurrentUserOwner: boolean,
 ): collaboratorsListType => {
@@ -365,12 +367,12 @@ export const convertCollabsResponse = (
                 expires_at: executeAt,
                 role,
             } = collab;
-            const avatarURL = avatarsAPIData[userID];
+            const avatarURL = avatarURLMap ? avatarURLMap[userID] : undefined;
             const convertedCollab: collaboratorType = {
                 collabID: parseInt(collabID, 10),
                 email,
-                hasCustomAvatar: !!avatarURL, // to do: connect to Avatar API
-                imageURL: avatarURL, // to do: connect to Avatar API
+                hasCustomAvatar: !!avatarURL,
+                imageURL: avatarURL,
                 isExternalCollab: checkIsExternalUser(isCurrentUserOwner, ownerEmailDomain, email),
                 name,
                 translatedRole: `${role[0].toUpperCase()}${role.slice(1)}`, // capitalize the user's role


### PR DESCRIPTION
Retrieve avatar URLs in the ContentSharing Element.

<img width="482" alt="content-sharing-avatars" src="https://user-images.githubusercontent.com/2956895/91212844-9fabbe80-e6c5-11ea-9ddf-ffaf26176a57.png">
