### PR TITLE
fix(content-picker): Fix shared-access width issue

### DIFF
--- a/src/elements/content-picker/ItemList.js
+++ b/src/elements/content-picker/ItemList.js
@@ -157,7 +157,7 @@ const ItemList = ({
                                 <Column
                                     dataKey={FIELD_SHARED_LINK}
                                     cellRenderer={shareAccessCell}
-                                    width={220}
+                                    width={260}
                                     flexShrink={0}
                                 />
                             )}


### PR DESCRIPTION
Before:
ja-JP
<img width="1384" alt="Screen Shot 2020-08-26 at 10 37 18 PM" src="https://user-images.githubusercontent.com/8661684/91478997-abc68600-e855-11ea-916b-8dca4d50c09a.png">


After:
ja-JP
![Screen Shot 2020-08-27 at 10 59 23 AM](https://user-images.githubusercontent.com/8661684/91478910-8b96c700-e855-11ea-872c-83acde72b9a1.png)

fr-FR
![Screen Shot 2020-08-27 at 10 57 49 AM](https://user-images.githubusercontent.com/8661684/91478930-93566b80-e855-11ea-886a-fc30be8fb34d.png)

en-US
![Screen Shot 2020-08-27 at 10 59 58 AM](https://user-images.githubusercontent.com/8661684/91478950-9c473d00-e855-11ea-836f-d2e343f33a84.png)
