### PR TITLE
fix(content-sharing): Update disabled reasons field name

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -98,8 +98,8 @@ export const FIELD_RESTORED_FROM = 'restored_from';
 export const FIELD_CREATED_AT = 'created_at';
 export const FIELD_INTERACTED_AT: 'interacted_at' = 'interacted_at';
 export const FIELD_SHARED_LINK = 'shared_link';
-export const FIELD_SHARED_LINK_ACCESS_LEVELS_DISABLED_REASONS: 'shared_link_access_levels_disabled_reasons' =
-    'shared_link_access_levels_disabled_reasons';
+export const FIELD_SHARED_LINK_ACCESS_LEVELS_DISABLED_REASONS: 'allowed_shared_link_access_levels_disabled_reasons' =
+    'allowed_shared_link_access_levels_disabled_reasons';
 export const FIELD_SHARED_LINK_FEATURES: 'shared_link_features' = 'shared_link_features';
 export const FIELD_ALLOWED_INVITEE_ROLES: 'allowed_invitee_roles' = 'allowed_invitee_roles';
 export const FIELD_ALLOWED_SHARED_LINK_ACCESS_LEVELS = 'allowed_shared_link_access_levels';

--- a/src/elements/content-sharing/types.js
+++ b/src/elements/content-sharing/types.js
@@ -59,6 +59,7 @@ export type ContentSharingItemDataType = {
 export type ContentSharingItemAPIResponse = {
     allowed_invitee_roles: Array<string>,
     allowed_shared_link_access_levels?: Array<string>,
+    allowed_shared_link_access_levels_disabled_reasons?: accessLevelsDisabledReasonType,
     classification: ?BoxItemClassification,
     description: string,
     etag: string,
@@ -71,7 +72,6 @@ export type ContentSharingItemAPIResponse = {
     },
     permissions: BoxItemPermission,
     shared_link?: APISharedLink,
-    shared_link_access_levels_disabled_reasons?: accessLevelsDisabledReasonType,
     shared_link_features: {
         download_url: boolean,
         password: boolean,

--- a/src/features/unified-share-modal/utils/__tests__/convertData.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/convertData.test.js
@@ -404,6 +404,7 @@ describe('convertItemResponse()', () => {
     `('should return $description', ({ disabledReasonsFromAPI, convertedDisabledReasons }) => {
         const responseFromAPI = {
             allowed_invitee_roles: ['editor', 'viewer'],
+            allowed_shared_link_access_levels_disabled_reasons: disabledReasonsFromAPI,
             description: ITEM_DESCRIPTION,
             etag: '1',
             id: ITEM_ID,
@@ -412,7 +413,6 @@ describe('convertItemResponse()', () => {
             permissions: FULL_PERMISSIONS,
             shared_link: ITEM_SHARED_LINK,
             shared_link_features: ALL_SHARED_LINK_FEATURES,
-            shared_link_access_levels_disabled_reasons: disabledReasonsFromAPI,
             type: TYPE_FOLDER,
         };
         const {

--- a/src/features/unified-share-modal/utils/convertData.js
+++ b/src/features/unified-share-modal/utils/convertData.js
@@ -129,6 +129,7 @@ export const convertItemResponse = (itemAPIData: ContentSharingItemAPIResponse):
     const {
         allowed_invitee_roles,
         allowed_shared_link_access_levels,
+        allowed_shared_link_access_levels_disabled_reasons,
         classification,
         id,
         description,
@@ -137,7 +138,6 @@ export const convertItemResponse = (itemAPIData: ContentSharingItemAPIResponse):
         owned_by: { id: ownerID, login: ownerEmail },
         permissions,
         shared_link,
-        shared_link_access_levels_disabled_reasons,
         shared_link_features: { download_url: isDirectLinkAvailable, password: isPasswordAvailable },
         type,
     } = itemAPIData;
@@ -191,7 +191,7 @@ export const convertItemResponse = (itemAPIData: ContentSharingItemAPIResponse):
 
         sharedLink = {
             accessLevel,
-            accessLevelsDisabledReason: shared_link_access_levels_disabled_reasons || {},
+            accessLevelsDisabledReason: allowed_shared_link_access_levels_disabled_reasons || {},
             allowedAccessLevels: convertAllowedAccessLevels(allowed_shared_link_access_levels) || ALLOWED_ACCESS_LEVELS, // show all access levels by default
             canChangeAccessLevel,
             canChangeDownload,


### PR DESCRIPTION
This PR updates the disabled reasons field name **allowed_shared_link_access_levels_disabled_reasons**, in accordance with the API.