### PR TITLE
fix(content-sharing): add regenerator-runtime to content sharing element

### DIFF
--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -6,6 +6,7 @@
  * button click (when a custom button is provided).
  * @author Box
  */
+import 'regenerator-runtime/runtime';
 import * as React from 'react';
 import API from '../../api';
 import SharingModal from './SharingModal';


### PR DESCRIPTION
Needed for when the element is used via the ES6 wrapper