### PR TITLE
build(ie11): Exclude core-js module from babel loader

### DIFF
--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -89,7 +89,9 @@ function getConfig(isReactExternalized) {
                     test: /\.(js|mjs|ts|tsx)$/,
                     loader: 'babel-loader',
                     // For webpack dev build perf we want to exlcude node_modules unless we want to support legacy browsers like IE11
-                    exclude: shouldIncludeAllSupportedBrowsers ? /@babel(?:\/|\\{1,2})runtime|pikaday/ : /node_modules/,
+                    exclude: shouldIncludeAllSupportedBrowsers
+                        ? /@babel(?:\/|\\{1,2})runtime|pikaday|core-js/
+                        : /node_modules/,
                 },
                 {
                     test: /\.s?css$/,


### PR DESCRIPTION
This PR addresses following issue:
https://github.com/zloirock/core-js/issues/514

Before:
Here is the exception you see in IE11 with the current combination of webpack 4.x, babel-core 7.x and core-js 3.x
![image](https://user-images.githubusercontent.com/8661684/92269912-f1a8cd00-ee99-11ea-8117-c0e62c0a53c3.png)

After
No exception and the react-styleguidist page loads and works as expected.