### PR TITLE
fix(content-sharing): style issues when using element via ES6 wrapper

### DIFF
--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -165,7 +165,7 @@ function SharingModal({ api, config, displayInModal, itemID, itemType, language,
     const { accessLevel = '', serverURL } = sharedLink;
     return (
         <Internationalize language={language} messages={messages}>
-            <div className="be">
+            <>
                 <SharingNotification
                     accessLevel={accessLevel}
                     api={api}
@@ -230,7 +230,7 @@ function SharingModal({ api, config, displayInModal, itemID, itemType, language,
                         submitting={isLoading}
                     />
                 )}
-            </div>
+            </>
         </Internationalize>
     );
 }

--- a/src/features/collaborator-avatars/CollaboratorList.js
+++ b/src/features/collaborator-avatars/CollaboratorList.js
@@ -62,7 +62,7 @@ class CollaboratorList extends React.Component<Props> {
                 <div className="manage-all-btn-container">
                     {this.createCollaboratorPageLink(manageAllBtn, manageLinkProps)}
                 </div>
-                <ul className="collaborator-list">
+                <ul className="be collaborator-list">
                     {collaborators.slice(0, maxListSizeToRender).map((collaborator, index) => {
                         const { collabID, type } = collaborator;
                         return (

--- a/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorList.test.js.snap
+++ b/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorList.test.js.snap
@@ -25,7 +25,7 @@ exports[`features/collaborator-avatars/CollaboratorList render() should render d
     </Link>
   </div>
   <ul
-    className="collaborator-list"
+    className="be collaborator-list"
   >
     <CollaboratorListItem
       collaborator={
@@ -130,7 +130,7 @@ exports[`features/collaborator-avatars/CollaboratorList render() should render e
     </Link>
   </div>
   <ul
-    className="collaborator-list"
+    className="be collaborator-list"
   >
     <CollaboratorListItem
       collaborator={

--- a/src/features/shared-link-settings-modal/AllowDownloadSection.js
+++ b/src/features/shared-link-settings-modal/AllowDownloadSection.js
@@ -10,6 +10,8 @@ import Tooltip from '../../components/tooltip';
 
 import messages from './messages';
 
+import './AllowDownloadSection.scss';
+
 const AllowDownloadSection = ({
     canChangeDownload,
     classification,
@@ -67,6 +69,7 @@ const AllowDownloadSection = ({
                     position="middle-left"
                 >
                     <Fieldset
+                        className="be"
                         disabled={isDirectLinkUnavailable}
                         title={<FormattedMessage {...messages.allowDownloadTitle} />}
                     >

--- a/src/features/shared-link-settings-modal/AllowDownloadSection.scss
+++ b/src/features/shared-link-settings-modal/AllowDownloadSection.scss
@@ -2,4 +2,12 @@
     &.bdl-is-disabled {
         opacity: .5;
     }
+
+    .direct-link-input {
+        .text-input-container {
+            input {
+                width: 100%;
+            }
+        }
+    }
 }

--- a/src/features/shared-link-settings-modal/ExpirationSection.js
+++ b/src/features/shared-link-settings-modal/ExpirationSection.js
@@ -46,7 +46,7 @@ const ExpirationSection = ({
     return (
         <div>
             <hr />
-            <Fieldset className="expiration-section" title={<FormattedMessage {...messages.expirationTitle} />}>
+            <Fieldset className="be expiration-section" title={<FormattedMessage {...messages.expirationTitle} />}>
                 <Checkbox
                     isChecked={isExpirationEnabled}
                     isDisabled={!canChangeExpiration}

--- a/src/features/shared-link-settings-modal/PasswordSection.js
+++ b/src/features/shared-link-settings-modal/PasswordSection.js
@@ -45,7 +45,7 @@ const PasswordSection = ({
     return (
         <div>
             <hr />
-            <Fieldset className="password-section" title={<FormattedMessage {...messages.passwordTitle} />}>
+            <Fieldset className="be password-section" title={<FormattedMessage {...messages.passwordTitle} />}>
                 <Checkbox
                     isChecked={isPasswordEnabled}
                     isDisabled={!canChangePassword}

--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
@@ -392,7 +392,7 @@ class SharedLinkSettingsModal extends Component {
         const disableSaveBtn = !(canChangeDownload || canChangeExpiration || canChangePassword || canChangeVanityName);
         return (
             <Modal
-                className="shared-link-settings-modal"
+                className="be-modal shared-link-settings-modal"
                 isOpen={isOpen}
                 onRequestClose={submitting ? undefined : onRequestClose}
                 title={this.renderModalTitle()}

--- a/src/features/shared-link-settings-modal/VanityNameSection.js
+++ b/src/features/shared-link-settings-modal/VanityNameSection.js
@@ -52,7 +52,7 @@ const VanityNameSection = ({
     return (
         <div>
             <hr />
-            <Fieldset className="vanity-name-section" title={<FormattedMessage {...messages.customURLLabel} />}>
+            <Fieldset className="be vanity-name-section" title={<FormattedMessage {...messages.customURLLabel} />}>
                 <Checkbox
                     label={<FormattedMessage {...messages.vanityURLEnableText} />}
                     isChecked={isVanityEnabled}

--- a/src/features/unified-share-modal/InviteePermissionsMenu.js
+++ b/src/features/unified-share-modal/InviteePermissionsMenu.js
@@ -118,7 +118,7 @@ class InviteePermissionsMenu extends Component<Props> {
         // TODO: `DropdownMenu` doesn't currently handle a scenario where the menu is taller than
         // the available vertical space. cannot use the constraint props here in short windows.
         return (
-            <div className="invitee-menu-wrap">
+            <div className="be invitee-menu-wrap">
                 <DropdownMenu>
                     {plainButtonWrap}
                     {this.renderMenu()}

--- a/src/features/unified-share-modal/RemoveLinkConfirmModal.js
+++ b/src/features/unified-share-modal/RemoveLinkConfirmModal.js
@@ -42,6 +42,7 @@ class RemoveLinkConfirmModal extends Component<Props> {
 
         return (
             <Modal
+                className="be-modal"
                 focusElementSelector=".btn-primary"
                 isOpen={isOpen}
                 onRequestClose={submitting ? undefined : onRequestClose}

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -459,7 +459,7 @@ class SharedLinkSection extends React.Component<Props, State> {
         const isSharedLinkEnabled = !!sharedLink.url;
 
         return (
-            <div>
+            <div className="be">
                 <hr className="bdl-SharedLinkSection-separator" />
                 {/* eslint-disable-next-line jsx-a11y/label-has-for */}
                 <label>

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -516,7 +516,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             allShareRestrictionWarning;
 
         return (
-            <div className={displayInModal ? '' : 'bdl-UnifiedShareForm'}>
+            <div className={displayInModal ? '' : 'be bdl-UnifiedShareForm'}>
                 <LoadingIndicatorWrapper isLoading={isFetching} hideContent>
                     {showShareRestrictionWarning && allShareRestrictionWarning}
 

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -158,7 +158,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
             <>
                 {displayInModal ? (
                     <Modal
-                        className="unified-share-modal"
+                        className="be-modal unified-share-modal"
                         isOpen={isConfirmModalOpen ? false : isOpen}
                         onRequestClose={submitting ? undefined : onRequestClose}
                         title={
@@ -173,7 +173,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
                         {this.renderUSF()}
                     </Modal>
                 ) : (
-                    this.renderUSF()
+                    <div className="unified-share-form-container">{this.renderUSF()}</div>
                 )}
                 {isConfirmModalOpen && (
                     <RemoveLinkConfirmModal

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -173,7 +173,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
                         {this.renderUSF()}
                     </Modal>
                 ) : (
-                    <div className="unified-share-form-container">{this.renderUSF()}</div>
+                    <div className="bdl-UnifiedShareForm-container">{this.renderUSF()}</div>
                 )}
                 {isConfirmModalOpen && (
                     <RemoveLinkConfirmModal

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -78,6 +78,12 @@
     /*** Invite collaborators section ***/
     .invite-collaborator-container {
         position: relative;
+
+        .text-area-container {
+            textarea {
+                width: 100%;
+            }
+        }
     }
 
     .invitee-menu-wrap {
@@ -209,6 +215,7 @@
             flex: 1;
 
             input {
+                width: 100%;
                 margin-top: 0;
             }
         }
@@ -274,6 +281,10 @@
         margin: -5px 0 10px 0;
         color: $bdl-box-blue;
     }
+}
+
+.unified-share-form-container {
+    width: 400px;
 }
 
 .bdl-UnifiedShareForm {

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -283,7 +283,7 @@
     }
 }
 
-.unified-share-form-container {
+.bdl-UnifiedShareForm-container {
     width: 400px;
 }
 

--- a/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 1`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -127,7 +127,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 2`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -234,7 +234,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 3`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -359,7 +359,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 4`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -466,7 +466,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 5`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -591,7 +591,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 6`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -698,7 +698,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 7`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -823,7 +823,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 8`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -930,7 +930,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 9`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -1055,7 +1055,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 10`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -1162,7 +1162,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 11`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -1287,7 +1287,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 12`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -1394,7 +1394,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 13`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}
@@ -1501,7 +1501,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
 
 exports[`features/unified-share-modal/InviteePermissionsMenu render() it should render correct menu 14`] = `
 <div
-  className="invitee-menu-wrap"
+  className="be invitee-menu-wrap"
 >
   <DropdownMenu
     constrainToScrollParent={false}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`features/unified-share-modal/SharedLinkSection should account for shared link expirations being set 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -164,7 +166,9 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render a default component when there is a shared link but user lacks permission to toggle off 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -310,7 +314,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render default component with no sharedLink 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -361,7 +367,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render default component with shared link 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -496,7 +504,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render default components with proper tooltip state while submitting request 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -599,7 +609,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled r
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render proper dropdown override when viewing an editable box note 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -755,7 +767,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render proper list of permission options based on the the download setting availability 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -891,7 +905,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render proper list of permission options based on the the download setting availability 2`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />
@@ -1052,7 +1068,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render settings l
 `;
 
 exports[`features/unified-share-modal/SharedLinkSection should render without SharedLinkPermissionMenu if access level is "people in item" 1`] = `
-<div>
+<div
+  className="be"
+>
   <hr
     className="bdl-SharedLinkSection-separator"
   />

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
@@ -3,7 +3,7 @@
 exports[`features/unified-share-modal/UnifiedShareModal render() should not render a default component FTUX when prop is false 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -96,7 +96,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
 exports[`features/unified-share-modal/UnifiedShareModal render() should not render a default component FTUX when state is false 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -189,7 +189,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a component with autofocus set for shared link when focusSharedLinkOnLoad is enabled and there is a shared link 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -285,7 +285,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component FTUX based on enabled prop and state 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -378,7 +378,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component in initial loading state 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -470,7 +470,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component when showing invite section expanded 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -562,7 +562,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component when the user cannot invite collaborators due to item type of weblink 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -655,7 +655,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component when the user cannot invite collaborators due to permissions 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -748,7 +748,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with collaboration restriction warning specified and invite section is NOT expanded 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
@@ -841,7 +841,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with collaboration restriction warning specified and invite section is expanded 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
@@ -934,7 +934,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with collaborator list if showCollaboratorList state is set 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -1035,7 +1035,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with confirm modal open 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     isOpen={false}
     style={
@@ -1133,7 +1133,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with correct Focus element and props when focusSharedLinkOnLoad is enabled 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -1229,7 +1229,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with default props 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".toggle-simple"
     style={
       Object {
@@ -1321,7 +1321,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with invitee permissions listed 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
@@ -1412,7 +1412,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with send invite error specified 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {
@@ -1510,7 +1510,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
 exports[`features/unified-share-modal/UnifiedShareModal render() should render a default component with upgrade CTA when showUpgradeOptions is enabled 1`] = `
 <Fragment>
   <Modal
-    className="unified-share-modal"
+    className="be-modal unified-share-modal"
     focusElementSelector=".bdl-PillSelector-input"
     style={
       Object {

--- a/test/sharing-no-react.html
+++ b/test/sharing-no-react.html
@@ -20,9 +20,10 @@
         <link rel="stylesheet" type="text/css" href="../dev/en-US/sharing.css" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.9.0/umd/react.development.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.9.0/umd/react-dom.development.js"></script>
-        <script src="../dev/en-US/sharing.no.react.js"></script>
     </head>
     <body>
+        <script src="../dev/en-US/sharing.no.react.js"></script>
+
         <div>
             <form class="inputs">
                 <label>

--- a/test/sharing.html
+++ b/test/sharing.html
@@ -18,9 +18,10 @@
         </style>
 
         <link rel="stylesheet" type="text/css" href="../dev/en-US/sharing.css" />
-        <script src="../dev/en-US/sharing.js"></script>
     </head>
     <body>
+        <script src="../dev/en-US/sharing.js"></script>
+
         <div>
             <form class="inputs">
                 <label>


### PR DESCRIPTION
Box styling was missing or being overridden when using the element on a standalone page