### PR TITLE
fix(upload): add support for detecting and handling package files

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -660,6 +660,8 @@ be.uploadsManagerUploadInProgress = Uploading
 be.uploadsManagerUploadPrompt = Drop files on this page to upload them into this folder.
 # Error message shown when one or more child folders failed to upload
 be.uploadsOneOrMoreChildFoldersFailedToUploadMessage = One or more child folders failed to upload.
+# Error message to display when a macOS package failed to upload
+be.uploadsPackageUploadErrorMessage = Package file uploads not currently supported. Please retry by saving as a single file.
 # Error message shown when pending app folder size exceeds the limit
 be.uploadsPendingFolderSizeLimitErrorMessage = Pending app folder size limit exceeded
 # Error message shown when pending folder upload contains invalid characters

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -661,7 +661,7 @@ be.uploadsManagerUploadPrompt = Drop files on this page to upload them into this
 # Error message shown when one or more child folders failed to upload
 be.uploadsOneOrMoreChildFoldersFailedToUploadMessage = One or more child folders failed to upload.
 # Error message to display when a macOS package failed to upload
-be.uploadsPackageUploadErrorMessage = Package file uploads not currently supported. Please retry by saving as a single file.
+be.uploadsPackageUploadErrorMessage = Package file uploads are not currently supported. Please retry by saving as a single file.
 # Error message shown when pending app folder size exceeds the limit
 be.uploadsPendingFolderSizeLimitErrorMessage = Pending app folder size limit exceeded
 # Error message shown when pending folder upload contains invalid characters

--- a/src/constants.js
+++ b/src/constants.js
@@ -228,6 +228,8 @@ export const ERROR_CODE_UPLOAD_CHILD_FOLDER_FAILED = 'child_folder_failed_upload
 export const ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED = 'storage_limit_exceeded';
 export const ERROR_CODE_UPLOAD_FILE_SIZE_LIMIT_EXCEEDED = 'file_size_limit_exceeded';
 export const ERROR_CODE_UPLOAD_PENDING_APP_FOLDER_SIZE_LIMIT = 'pending_app_folder_size_limit';
+export const ERROR_CODE_UPLOAD_BAD_DIGEST = 'bad_digest';
+export const ERROR_CODE_UPLOAD_FAILED_PACKAGE = 'failed_package_upload';
 export const ERROR_CODE_FETCH_ACTIVITY = 'fetch_activity_error';
 export const ERROR_CODE_FETCH_ANNOTATION = 'fetch_annotation_error';
 export const ERROR_CODE_FETCH_ANNOTATIONS = 'fetch_annotations_error';
@@ -379,10 +381,11 @@ export const HTTP_OPTIONS: 'OPTIONS' = 'OPTIONS';
 export const HTTP_HEAD: 'HEAD' = 'HEAD';
 
 /* ------------------ HTTP Codes  ---------------------- */
+export const HTTP_STATUS_CODE_BAD_REQUEST: 400 = 400;
+export const HTTP_STATUS_CODE_UNAUTHORIZED: 401 = 401;
 export const HTTP_STATUS_CODE_FORBIDDEN: 403 = 403;
 export const HTTP_STATUS_CODE_NOT_FOUND: 404 = 404;
 export const HTTP_STATUS_CODE_CONFLICT: 409 = 409;
-export const HTTP_STATUS_CODE_UNAUTHORIZED: 401 = 401;
 export const HTTP_STATUS_CODE_RATE_LIMIT: 429 = 429;
 export const HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR: 500 = 500;
 export const HTTP_STATUS_CODE_NOT_IMPLEMENTED: 501 = 501;

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -715,7 +715,7 @@ const messages = defineMessages({
     uploadsPackageUploadErrorMessage: {
         id: 'be.uploadsPackageUploadErrorMessage',
         description: 'Error message to display when a macOS package failed to upload',
-        defaultMessage: 'Package file uploads not currently supported. Please retry by saving as a single file.',
+        defaultMessage: 'Package file uploads are not currently supported. Please retry by saving as a single file.',
     },
     uploadsDefaultErrorMessage: {
         id: 'be.uploadsDefaultErrorMessage',

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -712,6 +712,11 @@ const messages = defineMessages({
         description: 'Error message shown when one or more child folders failed to upload',
         defaultMessage: 'One or more child folders failed to upload.',
     },
+    uploadsPackageUploadErrorMessage: {
+        id: 'be.uploadsPackageUploadErrorMessage',
+        description: 'Error message to display when a macOS package failed to upload',
+        defaultMessage: 'Package file uploads not currently supported. Please retry by saving as a single file.',
+    },
     uploadsDefaultErrorMessage: {
         id: 'be.uploadsDefaultErrorMessage',
         description: 'Default error message shown when upload fails',

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -391,7 +391,6 @@ class ContentUploader extends Component<Props, State> {
         const folderItems = [];
         const fileItems = [];
         const packageItems = [];
-
         Array.from(dataTransferItems).forEach(item => {
             const isDirectory = isDataTransferItemAFolder(item);
             if (Browser.isSafari() && isDataTransferItemAPackage(item)) {
@@ -404,7 +403,7 @@ class ContentUploader extends Component<Props, State> {
         });
 
         this.addFileDataTransferItemsToUploadQueue(fileItems, itemUpdateCallback);
-        if (packageItems.length) this.addPackageDataTransferItemsToUploadQueue(packageItems, itemUpdateCallback);
+        this.addPackageDataTransferItemsToUploadQueue(packageItems, itemUpdateCallback);
         this.addFolderDataTransferItemsToUploadQueue(folderItems, itemUpdateCallback);
     };
 
@@ -442,19 +441,14 @@ class ContentUploader extends Component<Props, State> {
         dataTransferItems: Array<DataTransferItem | UploadDataTransferItemWithAPIOptions>,
         itemUpdateCallback: Function,
     ): void => {
-        dataTransferItems.forEach(async item => {
-            try {
-                const file = await getPackageFileFromDataTransferItem(item);
+        dataTransferItems.forEach(item => {
+            const file = getPackageFileFromDataTransferItem(item);
 
-                if (!file) {
-                    return;
-                }
-
-                this.addFilesToUploadQueue([file], itemUpdateCallback);
-            } catch (ex) {
-                // no-op ; discard errors for handling in the upload queue
-                // this will occur if the item cannot be converted into its file representation
+            if (!file) {
+                return;
             }
+
+            this.addFilesToUploadQueue([file], itemUpdateCallback);
         });
     };
 

--- a/src/elements/content-uploader/ContentUploader.js
+++ b/src/elements/content-uploader/ContentUploader.js
@@ -12,6 +12,8 @@ import noop from 'lodash/noop';
 import uniqueid from 'lodash/uniqueId';
 import cloneDeep from 'lodash/cloneDeep';
 import { getTypedFileId, getTypedFolderId } from '../../utils/file';
+import Browser from '../../utils/Browser';
+
 import makeResponsive from '../common/makeResponsive';
 import Internationalize from '../common/Internationalize';
 import FolderUpload from '../../api/uploads/FolderUpload';
@@ -392,7 +394,7 @@ class ContentUploader extends Component<Props, State> {
 
         Array.from(dataTransferItems).forEach(item => {
             const isDirectory = isDataTransferItemAFolder(item);
-            if (isDataTransferItemAPackage(item)) {
+            if (Browser.isSafari() && isDataTransferItemAPackage(item)) {
                 packageItems.push(item);
             } else if (isDirectory && isFolderUploadEnabled) {
                 folderItems.push(item);

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import * as UploaderUtils from '../../../utils/uploads';
+import Browser from '../../../utils/Browser';
 import { ContentUploaderComponent, CHUNKED_UPLOAD_MIN_SIZE_BYTES } from '../ContentUploader';
 import Footer from '../Footer';
 import {
@@ -16,6 +17,8 @@ import {
 } from '../../../constants';
 
 const EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD = 5;
+
+jest.mock('../../../utils/Browser');
 
 describe('elements/content-uploader/ContentUploader', () => {
     const getWrapper = (props = {}) => shallow(<ContentUploaderComponent {...props} />);
@@ -122,6 +125,7 @@ describe('elements/content-uploader/ContentUploader', () => {
 
         test('should handle accepting package "files" separate from folders', () => {
             const mockFile = { name: 'hi' };
+            Browser.isSafari = jest.fn(() => true);
             const entry = {
                 isDirectory: true,
                 kind: 'file',

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -119,6 +119,40 @@ describe('elements/content-uploader/ContentUploader', () => {
             const expected = { yoyo: true, yoyo_0_10000: true };
             expect(wrapper.state().itemIds).toEqual(expected);
         });
+
+        test.only('should handle accepting package "files" separate from folders', () => {
+            const mockFile = { name: 'hi' };
+            const entry = {
+                isDirectory: true,
+                kind: 'file',
+                file: fn => {
+                    fn(mockFile);
+                },
+            };
+            const wrapper = getWrapper({
+                rootFolderId: 0,
+                isFolderUploadEnabled: true,
+                hasUploads: true,
+                useUploadsManager: true,
+            });
+
+            global.Date.now = jest.fn(() => 10000);
+
+            wrapper.setProps({
+                files: [mockFile],
+                dataTransferItems: [
+                    {
+                        kind: 'file',
+                        type: 'application/zip',
+                        getAsFile: jest.fn(() => mockFile),
+                        webkitGetAsEntry: () => entry,
+                        name: 'hi',
+                    },
+                ],
+            });
+            const expected = { hi: true, hi_0_10000: true };
+            expect(wrapper.state().itemIds).toEqual(expected);
+        });
     });
 
     describe('removeFileFromUploadQueue()', () => {

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -120,7 +120,7 @@ describe('elements/content-uploader/ContentUploader', () => {
             expect(wrapper.state().itemIds).toEqual(expected);
         });
 
-        test.only('should handle accepting package "files" separate from folders', () => {
+        test('should handle accepting package "files" separate from folders', () => {
             const mockFile = { name: 'hi' };
             const entry = {
                 isDirectory: true,

--- a/src/elements/content-uploader/progressCellRenderer.js
+++ b/src/elements/content-uploader/progressCellRenderer.js
@@ -5,8 +5,10 @@
 
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import Browser from '../../utils/Browser';
 import messages from '../common/messages';
 import ItemProgress from './ItemProgress';
+
 import {
     ERROR_CODE_UPLOAD_FILE_SIZE_LIMIT_EXCEEDED,
     ERROR_CODE_ITEM_NAME_IN_USE,
@@ -14,9 +16,11 @@ import {
     ERROR_CODE_UPLOAD_PENDING_APP_FOLDER_SIZE_LIMIT,
     ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED,
     ERROR_CODE_UPLOAD_CHILD_FOLDER_FAILED,
-    STATUS_ERROR,
+    ERROR_CODE_UPLOAD_BAD_DIGEST,
+    ERROR_CODE_UPLOAD_FAILED_PACKAGE,
     STATUS_IN_PROGRESS,
     STATUS_STAGED,
+    STATUS_ERROR,
 } from '../../constants';
 import type { UploadItem } from '../../common/types/upload';
 
@@ -47,13 +51,15 @@ const getErrorMessage = (errorCode: ?string, itemName: ?string) => {
             return <FormattedMessage {...messages.uploadsStorageLimitErrorMessage} />;
         case ERROR_CODE_UPLOAD_PENDING_APP_FOLDER_SIZE_LIMIT:
             return <FormattedMessage {...messages.uploadsPendingFolderSizeLimitErrorMessage} />;
+        case ERROR_CODE_UPLOAD_FAILED_PACKAGE:
+            return <FormattedMessage {...messages.uploadsPackageUploadErrorMessage} />;
         default:
             return <FormattedMessage {...messages.uploadsDefaultErrorMessage} />;
     }
 };
 
 export default () => ({ rowData }: Props) => {
-    const { status, error = {}, name, isFolder } = rowData;
+    const { status, error = {}, name, isFolder, file } = rowData;
     const { code } = error;
 
     if (isFolder && status !== STATUS_ERROR) {
@@ -65,6 +71,9 @@ export default () => ({ rowData }: Props) => {
         case STATUS_STAGED:
             return <ItemProgress {...rowData} />;
         case STATUS_ERROR:
+            if (Browser.isSafari() && code === ERROR_CODE_UPLOAD_BAD_DIGEST && file.name.indexOf('.zip') !== -1) {
+                return getErrorMessage(ERROR_CODE_UPLOAD_FAILED_PACKAGE, file.name);
+            }
             return getErrorMessage(code, name);
         default:
             return null;

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -37,6 +37,15 @@ class Browser {
     }
 
     /**
+     * Returns whether browser is Safari.
+     *
+     * @return {boolena} Whether browser is IE
+     */
+    static isSafari() {
+        return /AppleWebKit/i.test(Browser.getUserAgent());
+    }
+
+    /**
      * Checks the browser for Dash support using H264 high.
      * Dash requires MediaSource extensions to exist and be applicable
      * to the H264 container (since we use H264 and not webm)

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -42,7 +42,8 @@ class Browser {
      * @return {boolena} Whether browser is IE
      */
     static isSafari() {
-        return /AppleWebKit/i.test(Browser.getUserAgent());
+        const userAgent = Browser.getUserAgent();
+        return /AppleWebKit/i.test(userAgent) && !/Chrome\//i.test(userAgent);
     }
 
     /**

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -39,7 +39,7 @@ class Browser {
     /**
      * Returns whether browser is Safari.
      *
-     * @return {boolena} Whether browser is IE
+     * @return {boolean} Whether browser is Safari
      */
     static isSafari() {
         const userAgent = Browser.getUserAgent();

--- a/src/utils/__tests__/Browser.test.js
+++ b/src/utils/__tests__/Browser.test.js
@@ -43,6 +43,13 @@ describe('util/Browser/isSafari()', () => {
         browser.getUserAgent = jest.fn().mockReturnValueOnce('Trident');
         expect(browser.isSafari()).toBeFalsy();
     });
+
+    test('should not incorrectly identify Blink as WebKit', () => {
+        browser.getUserAgent = jest
+            .fn()
+            .mockReturnValueOnce('AppleWebKit/7.8 (KHTML, like Gecko) Chrome/1.2.3.4 Safari/5.6');
+        expect(browser.isSafari()).toBeFalsy();
+    });
 });
 
 describe('util/Browser/getUserAgent()', () => {

--- a/src/utils/__tests__/Browser.test.js
+++ b/src/utils/__tests__/Browser.test.js
@@ -35,20 +35,14 @@ describe('util/Browser/isIE()', () => {
 });
 
 describe('util/Browser/isSafari()', () => {
-    test('should return true if Safari', () => {
-        browser.getUserAgent = jest.fn().mockReturnValueOnce('AppleWebKit/4.0');
-        expect(browser.isSafari()).toBeTruthy();
-    });
-    test('should return false if not Safari', () => {
-        browser.getUserAgent = jest.fn().mockReturnValueOnce('Trident');
-        expect(browser.isSafari()).toBeFalsy();
-    });
-
-    test('should not incorrectly identify Blink as WebKit', () => {
-        browser.getUserAgent = jest
-            .fn()
-            .mockReturnValueOnce('AppleWebKit/7.8 (KHTML, like Gecko) Chrome/1.2.3.4 Safari/5.6');
-        expect(browser.isSafari()).toBeFalsy();
+    test.each`
+        result   | userAgent
+        ${true}  | ${'AppleWebKit/4.0'}
+        ${false} | ${'Trident'}
+        ${false} | ${'AppleWebKit/7.8 (KHTML, like Gecko) Chrome/1.2.3.4 Safari/5.6'}
+    `('should return $result when user agent is $userAgent', ({ result, userAgent }) => {
+        browser.getUserAgent = jest.fn().mockReturnValueOnce(userAgent);
+        expect(browser.isSafari()).toBe(result);
     });
 });
 

--- a/src/utils/__tests__/Browser.test.js
+++ b/src/utils/__tests__/Browser.test.js
@@ -34,6 +34,17 @@ describe('util/Browser/isIE()', () => {
     });
 });
 
+describe('util/Browser/isSafari()', () => {
+    test('should return true if Safari', () => {
+        browser.getUserAgent = jest.fn().mockReturnValueOnce('AppleWebKit/4.0');
+        expect(browser.isSafari()).toBeTruthy();
+    });
+    test('should return false if not Safari', () => {
+        browser.getUserAgent = jest.fn().mockReturnValueOnce('Trident');
+        expect(browser.isSafari()).toBeFalsy();
+    });
+});
+
 describe('util/Browser/getUserAgent()', () => {
     test('should return the user agent', () => {
         expect(browser.getUserAgent()).toBeUndefined();

--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -3,7 +3,9 @@ import {
     getFileLastModifiedAsISONoMSIfPossible,
     tryParseJson,
     isDataTransferItemAFolder,
+    isDataTransferItemAPackage,
     getFileFromDataTransferItem,
+    getPackageFileFromDataTransferItem,
     doesFileContainAPIOptions,
     doesDataTransferItemContainAPIOptions,
     getFile,
@@ -181,6 +183,82 @@ describe('util/uploads', () => {
                 file: mockFile,
                 options,
             });
+        });
+    });
+
+    describe('getPackageFileFromDataTransferItem()', () => {
+        test('should return file of UploadFileWithAPIOptions type when itemData is UploadDataTransferItemWithAPIOptions type', async () => {
+            const mockPackageItem = {
+                getAsFile: jest.fn(() => mockFile),
+                webkitGetAsEntry: () => entry,
+            };
+            const itemData = {
+                item: mockPackageItem,
+                options,
+            };
+
+            expect(await getPackageFileFromDataTransferItem(itemData)).toEqual({
+                file: mockFile,
+                options,
+            });
+        });
+    });
+
+    describe('isDataTransferItemAPackage()', () => {
+        test('should be false if data transfer item thinks it is a folder', () => {
+            const folderEntry = {
+                isDirectory: true,
+            };
+
+            const folderItem = {
+                kind: '',
+                webkitGetAsEntry: () => folderEntry,
+            };
+
+            const itemData = {
+                item: folderItem,
+                options,
+            };
+
+            expect(isDataTransferItemAPackage(itemData)).toBeFalsy();
+        });
+
+        test('should be false if data transfer item thinks it is a file', () => {
+            const fileEntry = {
+                isDirectory: false,
+                isFile: true,
+            };
+
+            const folderItem = {
+                kind: 'file',
+                webkitGetAsEntry: () => fileEntry,
+            };
+
+            const itemData = {
+                item: folderItem,
+                options,
+            };
+
+            expect(isDataTransferItemAPackage(itemData)).toBeFalsy();
+        });
+
+        test('should be true if data transfer item has both identifies a directory but has kind = file', () => {
+            const packageEntry = {
+                isDirectory: true,
+                isFile: false,
+            };
+
+            const folderItem = {
+                kind: 'file',
+                webkitGetAsEntry: () => packageEntry,
+            };
+
+            const itemData = {
+                item: folderItem,
+                options,
+            };
+
+            expect(isDataTransferItemAPackage(itemData)).toBeTruthy();
         });
     });
 

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -212,10 +212,7 @@ function isDataTransferItemAPackage(itemData: UploadDataTransferItemWithAPIOptio
     const item = getDataTransferItem(itemData);
     const isDirectory = isDataTransferItemAFolder(item);
 
-    if (isDirectory && item.kind === 'file') {
-        return true;
-    }
-    return false;
+    return isDirectory && item.kind === 'file';
 }
 
 /**
@@ -265,11 +262,11 @@ async function getFileFromDataTransferItem(
  * @see https://en.wikipedia.org/wiki/Package_(macOS)
  *
  * @param {UploadDataTransferItemWithAPIOptions | DataTransferItem} itemData
- * @returns {Promise<?UploadFile | ?UploadFileWithAPIOptions | null>}
+ * @returns {?UploadFile | ?UploadFileWithAPIOptions | null}
  */
-async function getPackageFileFromDataTransferItem(
+function getPackageFileFromDataTransferItem(
     itemData: UploadDataTransferItemWithAPIOptions | DataTransferItem,
-): Promise<?UploadFile | ?UploadFileWithAPIOptions | null> {
+): ?UploadFile | ?UploadFileWithAPIOptions | null {
     const item = getDataTransferItem(itemData);
     const entry = getEntryFromDataTransferItem(((item: any): DataTransferItem));
     if (!entry) {
@@ -279,13 +276,13 @@ async function getPackageFileFromDataTransferItem(
     const itemFile = item.getAsFile();
 
     if (doesDataTransferItemContainAPIOptions(itemData)) {
-        return Promise.resolve({
+        return {
             file: ((itemFile: any): UploadFile),
             options: getDataTransferItemAPIOptions(itemData),
-        });
+        };
     }
 
-    return Promise.resolve(itemFile);
+    return itemFile;
 }
 
 /**


### PR DESCRIPTION
This change allows the upload manager to properly identify it has received a [package file](https://en.wikipedia.org/wiki/Package_(macOS)), and attempt to upload it. 

In Safari, this will fail predictably, so we allow detection of the error type, and show a specific error message detailing the issue with a workaround.