### PR TITLE
fix(content-sharing): Enable reinstantiation via a custom button

### DIFF
--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -67,12 +67,14 @@ function ContentSharing({
 }: ContentSharingProps) {
     const [api, setAPI] = React.useState<API>(createAPI(apiHost, itemID, itemType, token));
     const [launchButton, setLaunchButton] = React.useState<React.Element<any> | null>(null);
+    const [isOpen, setIsOpen] = React.useState<boolean>(true);
     const [sharingModalInstance, setSharingModalInstance] = React.useState<React.Element<typeof SharingModal> | null>(
         customButton ? null : (
             <SharingModal
                 api={api}
                 config={config}
                 displayInModal={false}
+                isOpen={isOpen}
                 itemID={itemID}
                 itemType={itemType}
                 language={language}
@@ -92,11 +94,19 @@ function ContentSharing({
         setLaunchButton(null);
     }, [api]);
 
+    // Reset instance if modal has been closed
+    React.useEffect(() => {
+        if (!isOpen) {
+            setSharingModalInstance(null);
+        }
+    }, [isOpen]);
+
     React.useEffect(() => {
         const createSharingModalInstance = () => {
             return (
                 <SharingModal
                     api={api}
+                    closeModal={() => setIsOpen(false)}
                     config={config}
                     displayInModal={displayInModal}
                     itemID={itemID}
@@ -112,6 +122,7 @@ function ContentSharing({
             setLaunchButton(
                 React.cloneElement(customButton, {
                     onClick: () => {
+                        setIsOpen(true);
                         return setSharingModalInstance(createSharingModalInstance());
                     },
                 }),

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -39,6 +39,7 @@ import type {
 
 type SharingModalProps = {
     api: API,
+    closeModal?: () => void,
     config?: USMConfig,
     displayInModal: boolean,
     itemID: string,
@@ -47,7 +48,16 @@ type SharingModalProps = {
     messages?: StringMap,
 };
 
-function SharingModal({ api, config, displayInModal, itemID, itemType, language, messages }: SharingModalProps) {
+function SharingModal({
+    api,
+    closeModal,
+    config,
+    displayInModal,
+    itemID,
+    itemType,
+    language,
+    messages,
+}: SharingModalProps) {
     const [item, setItem] = React.useState<itemFlowType | null>(null);
     const [sharedLink, setSharedLink] = React.useState<ContentSharingSharedLinkType | null>(null);
     const [currentUserID, setCurrentUserID] = React.useState<string | null>(null);
@@ -68,7 +78,6 @@ function SharingModal({ api, config, displayInModal, itemID, itemType, language,
     const [getContacts, setGetContacts] = React.useState<null | GetContactsFnType>(null);
     const [sendInvites, setSendInvites] = React.useState<null | SendInvitesFnType>(null);
     const [isLoading, setIsLoading] = React.useState<boolean>(true);
-    const [isOpen, setIsOpen] = React.useState<boolean>(true);
 
     // Handle successful GET requests to /files or /folders
     const handleGetItemSuccess = React.useCallback((itemData: ContentSharingItemAPIResponse) => {
@@ -169,7 +178,7 @@ function SharingModal({ api, config, displayInModal, itemID, itemType, language,
                 <SharingNotification
                     accessLevel={accessLevel}
                     api={api}
-                    closeComponent={displayInModal ? () => setIsOpen(false) : noop}
+                    closeComponent={displayInModal && closeModal ? closeModal : noop}
                     closeSettings={() => setCurrentView(CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL)}
                     collaboratorsList={collaboratorsList}
                     currentUserID={currentUserID}
@@ -194,7 +203,7 @@ function SharingModal({ api, config, displayInModal, itemID, itemType, language,
                     setSendInvites={setSendInvites}
                     setSharedLink={setSharedLink}
                 />
-                {isOpen && currentView === CONTENT_SHARING_VIEWS.SHARED_LINK_SETTINGS && (
+                {currentView === CONTENT_SHARING_VIEWS.SHARED_LINK_SETTINGS && (
                     <SharedLinkSettingsModal
                         isDirectLinkUnavailableDueToDownloadSettings={false}
                         isDirectLinkUnavailableDueToAccessPolicy={false}
@@ -207,7 +216,7 @@ function SharingModal({ api, config, displayInModal, itemID, itemType, language,
                         {...sharedLink}
                     />
                 )}
-                {isOpen && currentView === CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL && (
+                {currentView === CONTENT_SHARING_VIEWS.UNIFIED_SHARE_MODAL && (
                     <UnifiedShareModal
                         canInvite={sharedLink.canInvite}
                         config={config}
@@ -222,7 +231,7 @@ function SharingModal({ api, config, displayInModal, itemID, itemType, language,
                         isOpen
                         item={item}
                         onAddLink={onAddLink}
-                        onRequestClose={displayInModal ? () => setIsOpen(false) : noop}
+                        onRequestClose={displayInModal && closeModal ? closeModal : noop}
                         onRemoveLink={onRemoveLink}
                         onSettingsClick={() => setCurrentView(CONTENT_SHARING_VIEWS.SHARED_LINK_SETTINGS)}
                         sendInvites={sendInvites}

--- a/src/elements/content-sharing/__tests__/ContentSharing.test.js
+++ b/src/elements/content-sharing/__tests__/ContentSharing.test.js
@@ -75,6 +75,41 @@ describe('elements/content-sharing/ContentSharing', () => {
         expect(wrapper.exists(Button)).toBe(true);
     });
 
+    test('should reinstantiate SharingModal', () => {
+        const clickLaunchButton = (launchButton, wrapper) => {
+            act(() => {
+                launchButton.invoke('onClick')();
+            });
+            wrapper.update();
+        };
+
+        const closeModal = wrapper => {
+            act(() => {
+                wrapper.find(SharingModal).invoke('closeModal')();
+            });
+            wrapper.update();
+        };
+
+        let wrapper;
+        act(() => {
+            wrapper = getWrapper({ customButton, displayInModal: true });
+        });
+        wrapper.update();
+
+        const launchButton = wrapper.find(Button);
+        clickLaunchButton(launchButton, wrapper); // open modal
+        expect(wrapper.exists(SharingModal)).toBe(true);
+
+        closeModal(wrapper); // close modal
+        expect(wrapper.exists(SharingModal)).toBe(false);
+
+        clickLaunchButton(launchButton, wrapper); // open modal again
+        expect(wrapper.exists(SharingModal)).toBe(true);
+
+        closeModal(wrapper); // close modal again
+        expect(wrapper.exists(SharingModal)).toBe(false);
+    });
+
     test.each([true, false])(
         'should instantiate SharingModal automatically when no button exists and displayInModal is %s',
         ({ displayInModal }) => {


### PR DESCRIPTION
This PR fixes a bug in which the Content Sharing Element could only be opened once via a custom button. The top-level component (`ContentSharing`) now unmounts the secondary component (`SharingModal`) when the X button is closed and then reinstantiates it when the custom button is clicked again.