### PR TITLE
fix(content-sharing): Small styling issues with standalone element

### DIFF
--- a/src/features/shared-link-settings-modal/AllowDownloadSection.scss
+++ b/src/features/shared-link-settings-modal/AllowDownloadSection.scss
@@ -7,6 +7,8 @@
         .text-input-container {
             input {
                 width: 100%;
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
             }
         }
     }

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables';
+@import '../../styles/mixins/buttons';
 @import '../../styles/mixins/overlay';
 
 // Menus are rendered at the root of the DOM, so this style is not nested
@@ -279,15 +280,10 @@
     }
 
     .manage-all-btn {
-        $manageAllBtnMargin: -5px 0 10px 0;
+        @include bdl-Button-margins(-5px 0 10px 0);
 
         float: right;
-        margin: $manageAllBtnMargin;
         color: $bdl-box-blue;
-
-        &:hover {
-            margin: $manageAllBtnMargin;
-        }
     }
 }
 

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -140,7 +140,7 @@
         }
     }
 
-    .bdl-PillSelector {
+    .bdl-PillSelectorDropdown .bdl-PillSelector {
         margin-top: 10px;
         border: 1px solid $bdl-gray-20;
 
@@ -217,6 +217,8 @@
             input {
                 width: 100%;
                 margin-top: 0;
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
             }
         }
 
@@ -277,9 +279,15 @@
     }
 
     .manage-all-btn {
+        $manageAllBtnMargin: -5px 0 10px 0;
+
         float: right;
-        margin: -5px 0 10px 0;
+        margin: $manageAllBtnMargin;
         color: $bdl-box-blue;
+
+        &:hover {
+            margin: $manageAllBtnMargin;
+        }
     }
 }
 

--- a/src/styles/mixins/_buttons.scss
+++ b/src/styles/mixins/_buttons.scss
@@ -1,0 +1,8 @@
+@mixin bdl-Button-margins($margin) {
+    margin: $margin;
+
+    &:hover,
+    &:active {
+        margin: $margin;
+    }
+}


### PR DESCRIPTION
Fixes:
- "Dancing" manage all button on collaborators page when hovered
- Rounded corners on right side of text portion of text w/ copy button components
- Collaborator avatars too close to invite textbox

Standalone -
![Screen Shot 2020-10-02 at 1 46 29 PM](https://user-images.githubusercontent.com/21277746/94969231-320a6380-04b7-11eb-8569-e1bcad3388ce.png)
![Screen Shot 2020-10-02 at 1 46 18 PM](https://user-images.githubusercontent.com/21277746/94969236-33d42700-04b7-11eb-850c-8c74b832915e.png)
![Screen Shot 2020-10-02 at 1 53 50 PM](https://user-images.githubusercontent.com/21277746/94969239-36368100-04b7-11eb-8cb2-0dc9c6216082.png)


EUA -
![Screen Shot 2020-10-02 at 1 53 22 PM](https://user-images.githubusercontent.com/21277746/94969264-40587f80-04b7-11eb-85aa-d8f40babaedf.png)
![Screen Shot 2020-10-02 at 1 53 05 PM](https://user-images.githubusercontent.com/21277746/94969274-43ec0680-04b7-11eb-8e63-68058cbf6fc5.png)
![Screen Shot 2020-10-02 at 1 53 38 PM](https://user-images.githubusercontent.com/21277746/94969282-45b5ca00-04b7-11eb-8390-a576e33f72b9.png)
