### PR TITLE
fix(content-sharing): limit collab and link permissions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -346,6 +346,10 @@ export const SKILLS_STATUS_INVOKED = 'skills_invoked_status';
 
 /* ------------------ File Extensions ---------------------- */
 export const FILE_EXTENSION_BOX_NOTE = 'boxnote';
+export const FILE_EXTENSION_GOOGLE_DOC = 'gdoc';
+export const FILE_EXTENSION_GOOGLE_SHEET = 'gsheet';
+export const FILE_EXTENSION_GOOGLE_SLIDE = 'gslides';
+export const FILE_EXTENSION_GOOGLE_SLIDE_LEGACY = 'gslide';
 
 /* ------------------ X-Rep-Hints ---------------------- */
 // available dimensions for JPG: "32x32", "94x94", "160x160", "320x320", "1024x1024", "2048x2048"

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -25,7 +25,7 @@ import {
 import useContactsByEmail from './hooks/useContactsByEmail';
 import { FIELD_ENTERPRISE, FIELD_HOSTNAME, TYPE_FILE, TYPE_FOLDER } from '../../constants';
 import { CONTENT_SHARING_ERRORS, CONTENT_SHARING_ITEM_FIELDS, CONTENT_SHARING_VIEWS } from './constants';
-import { INVITEE_PERMISSIONS_FOLDER, INVITEE_PERMISSIONS_SFC } from '../../features/unified-share-modal/constants';
+import { INVITEE_PERMISSIONS_FOLDER, INVITEE_PERMISSIONS_FILE } from '../../features/unified-share-modal/constants';
 import contentSharingMessages from './messages';
 import type { ErrorResponseData } from '../../common/types/api';
 import type { ItemType, StringMap } from '../../common/types/core';
@@ -249,7 +249,7 @@ function SharingModal({
                         getContactsByEmail={getContactsByEmail}
                         initialDataReceived
                         inviteePermissions={
-                            itemType === TYPE_FOLDER ? INVITEE_PERMISSIONS_FOLDER : INVITEE_PERMISSIONS_SFC
+                            itemType === TYPE_FOLDER ? INVITEE_PERMISSIONS_FOLDER : INVITEE_PERMISSIONS_FILE
                         }
                         isOpen={isVisible}
                         item={item}

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -25,7 +25,7 @@ import {
 import useContactsByEmail from './hooks/useContactsByEmail';
 import { FIELD_ENTERPRISE, FIELD_HOSTNAME, TYPE_FILE, TYPE_FOLDER } from '../../constants';
 import { CONTENT_SHARING_ERRORS, CONTENT_SHARING_ITEM_FIELDS, CONTENT_SHARING_VIEWS } from './constants';
-import { INVITEE_PERMISSIONS } from '../../features/unified-share-modal/constants';
+import { INVITEE_PERMISSIONS_FOLDER, INVITEE_PERMISSIONS_SFC } from '../../features/unified-share-modal/constants';
 import contentSharingMessages from './messages';
 import type { ErrorResponseData } from '../../common/types/api';
 import type { ItemType, StringMap } from '../../common/types/core';
@@ -190,7 +190,7 @@ function SharingModal({
     }
 
     const { ownerEmail, ownerID, permissions } = item;
-    const { accessLevel = '', expirationTimestamp, serverURL } = sharedLink;
+    const { accessLevel = '', expirationTimestamp, isDownloadAvailable = false, serverURL } = sharedLink;
     return (
         <Internationalize language={language} messages={messages}>
             <>
@@ -202,6 +202,7 @@ function SharingModal({
                     collaboratorsList={collaboratorsList}
                     currentUserID={currentUserID}
                     getContacts={getContacts}
+                    isDownloadAvailable={isDownloadAvailable}
                     itemID={itemID}
                     itemType={itemType}
                     onSubmitSettings={onSubmitSettings}
@@ -247,7 +248,9 @@ function SharingModal({
                         getCollaboratorContacts={getContacts}
                         getContactsByEmail={getContactsByEmail}
                         initialDataReceived
-                        inviteePermissions={INVITEE_PERMISSIONS}
+                        inviteePermissions={
+                            itemType === TYPE_FOLDER ? INVITEE_PERMISSIONS_FOLDER : INVITEE_PERMISSIONS_SFC
+                        }
                         isOpen={isVisible}
                         item={item}
                         onAddLink={onAddLink}

--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -41,6 +41,7 @@ type SharingNotificationProps = {
     collaboratorsList: collaboratorsListType | null,
     currentUserID: string | null,
     getContacts: GetContactsFnType | null,
+    isDownloadAvailable: boolean,
     itemID: string,
     itemType: ItemType,
     ownerEmail: ?string,
@@ -71,6 +72,7 @@ function SharingNotification({
     collaboratorsList,
     currentUserID,
     getContacts,
+    isDownloadAvailable,
     itemID,
     itemType,
     ownerEmail,
@@ -196,7 +198,8 @@ function SharingNotification({
         transformAccess: newAccessLevel => USM_TO_API_ACCESS_LEVEL_MAP[newAccessLevel],
         transformPermissions: newSharedLinkPermissionLevel =>
             convertSharedLinkPermissions(newSharedLinkPermissionLevel),
-        transformSettings: (settings, access) => convertSharedLinkSettings(settings, access, serverURL),
+        transformSettings: (settings, access) =>
+            convertSharedLinkSettings(settings, access, isDownloadAvailable, serverURL),
     });
 
     setChangeSharedLinkAccessLevel(() => changeSharedLinkAccessLevel);

--- a/src/elements/content-sharing/__tests__/SharingModal.test.js
+++ b/src/elements/content-sharing/__tests__/SharingModal.test.js
@@ -26,7 +26,7 @@ import {
     CAN_VIEW_DOWNLOAD,
     CAN_VIEW_ONLY,
     PEOPLE_IN_ITEM,
-    INVITEE_PERMISSIONS_SFC,
+    INVITEE_PERMISSIONS_FILE,
     INVITEE_PERMISSIONS_FOLDER,
 } from '../../../features/unified-share-modal/constants';
 import {
@@ -173,7 +173,7 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(convertItemResponse).toHaveBeenCalledWith(MOCK_ITEM_API_RESPONSE);
             expect(usm.prop('item')).toEqual(MOCK_ITEM);
             expect(usm.prop('sharedLink')).toEqual(MOCK_NORMALIZED_SHARED_LINK_DATA_FOR_USM);
-            expect(usm.prop('inviteePermissions')).toEqual(INVITEE_PERMISSIONS_SFC);
+            expect(usm.prop('inviteePermissions')).toEqual(INVITEE_PERMISSIONS_FILE);
             expect(wrapper.exists(SharingNotification)).toBe(true);
         });
 

--- a/src/elements/content-sharing/__tests__/SharingModal.test.js
+++ b/src/elements/content-sharing/__tests__/SharingModal.test.js
@@ -26,6 +26,8 @@ import {
     CAN_VIEW_DOWNLOAD,
     CAN_VIEW_ONLY,
     PEOPLE_IN_ITEM,
+    INVITEE_PERMISSIONS_SFC,
+    INVITEE_PERMISSIONS_FOLDER,
 } from '../../../features/unified-share-modal/constants';
 import {
     convertCollabsRequest,
@@ -171,6 +173,7 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(convertItemResponse).toHaveBeenCalledWith(MOCK_ITEM_API_RESPONSE);
             expect(usm.prop('item')).toEqual(MOCK_ITEM);
             expect(usm.prop('sharedLink')).toEqual(MOCK_NORMALIZED_SHARED_LINK_DATA_FOR_USM);
+            expect(usm.prop('inviteePermissions')).toEqual(INVITEE_PERMISSIONS_SFC);
             expect(wrapper.exists(SharingNotification)).toBe(true);
         });
 
@@ -187,6 +190,7 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(convertItemResponse).toHaveBeenCalledWith(MOCK_ITEM_API_RESPONSE);
             expect(usm.prop('item')).toEqual(MOCK_ITEM);
             expect(usm.prop('sharedLink')).toEqual(MOCK_NORMALIZED_SHARED_LINK_DATA_FOR_USM);
+            expect(usm.prop('inviteePermissions')).toEqual(INVITEE_PERMISSIONS_FOLDER);
             expect(wrapper.exists(SharingNotification)).toBe(true);
         });
 

--- a/src/elements/content-sharing/__tests__/SharingNotification.test.js
+++ b/src/elements/content-sharing/__tests__/SharingNotification.test.js
@@ -65,6 +65,7 @@ describe('elements/content-sharing/SharingNotification', () => {
                 collaboratorsList={null}
                 currentUserID={MOCK_OWNER_ID}
                 getContacts={null}
+                isDownloadAvailable
                 itemID={MOCK_ITEM_ID}
                 itemType={TYPE_FOLDER}
                 ownerEmail={MOCK_OWNER_EMAIL}

--- a/src/elements/content-sharing/types.js
+++ b/src/elements/content-sharing/types.js
@@ -29,7 +29,12 @@ export type ContentSharingUserDataType = {
 };
 
 // This type is used when an item does not have a shared link.
-type SharedLinkNotCreatedType = { accessLevel?: string, canInvite: boolean, expirationTimestamp?: ?number };
+type SharedLinkNotCreatedType = {
+    accessLevel?: string,
+    canInvite: boolean,
+    expirationTimestamp?: ?number,
+    isDownloadAvailable?: boolean,
+};
 
 // This is the full shared link type, which extends the internal USM shared link with
 // data necessary for instantiating the Shared Link Settings modal.

--- a/src/features/unified-share-modal/constants.js
+++ b/src/features/unified-share-modal/constants.js
@@ -71,7 +71,7 @@ const INVITEE_PERMISSIONS_FOLDER = [
     },
 ];
 
-const INVITEE_PERMISSIONS_SFC = [
+const INVITEE_PERMISSIONS_FILE = [
     {
         default: true, // default in the WebApp
         text: EDITOR,
@@ -98,7 +98,7 @@ export {
     DISABLED_REASON_MALICIOUS_CONTENT,
     EDITOR,
     INVITEE_PERMISSIONS_FOLDER,
-    INVITEE_PERMISSIONS_SFC,
+    INVITEE_PERMISSIONS_FILE,
     OWNER,
     PEOPLE_IN_ITEM,
     PREVIEWER,

--- a/src/features/unified-share-modal/constants.js
+++ b/src/features/unified-share-modal/constants.js
@@ -33,7 +33,7 @@ const ALLOWED_ACCESS_LEVELS = {
 const DISABLED_REASON_ACCESS_POLICY: 'access_policy' = 'access_policy';
 const DISABLED_REASON_MALICIOUS_CONTENT: 'malicious_content' = 'malicious_content';
 
-const INVITEE_PERMISSIONS = [
+const INVITEE_PERMISSIONS_FOLDER = [
     {
         default: false,
         text: CO_OWNER,
@@ -71,6 +71,19 @@ const INVITEE_PERMISSIONS = [
     },
 ];
 
+const INVITEE_PERMISSIONS_SFC = [
+    {
+        default: true, // default in the WebApp
+        text: EDITOR,
+        value: EDITOR,
+    },
+    {
+        default: false,
+        text: VIEWER,
+        value: VIEWER,
+    },
+];
+
 export {
     ALLOWED_ACCESS_LEVELS,
     ANYONE_IN_COMPANY,
@@ -84,7 +97,8 @@ export {
     DISABLED_REASON_ACCESS_POLICY,
     DISABLED_REASON_MALICIOUS_CONTENT,
     EDITOR,
-    INVITEE_PERMISSIONS,
+    INVITEE_PERMISSIONS_FOLDER,
+    INVITEE_PERMISSIONS_SFC,
     OWNER,
     PEOPLE_IN_ITEM,
     PREVIEWER,

--- a/src/features/unified-share-modal/utils/__tests__/convertData.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/convertData.test.js
@@ -297,6 +297,8 @@ describe('convertItemResponse()', () => {
 
             const { download_url: isDirectLinkAvailable, password } = sharedLinkFeatures;
 
+            const isDownloadAvailable = can_download && extension !== ITEM_EXTENSION_GDOC;
+
             const convertedResponse = {
                 item: {
                     canUserSeeClassification: false,
@@ -320,7 +322,7 @@ describe('convertItemResponse()', () => {
                           accessLevelsDisabledReason: {},
                           allowedAccessLevels: ALLOWED_ACCESS_LEVELS,
                           canChangeAccessLevel: can_set_share_access,
-                          canChangeDownload: can_set_share_access && can_download && extension !== ITEM_EXTENSION_GDOC,
+                          canChangeDownload: can_set_share_access && isDownloadAvailable,
                           canChangeExpiration: can_set_share_access,
                           canChangePassword: can_set_share_access && password,
                           canChangeVanityName: false,
@@ -328,10 +330,10 @@ describe('convertItemResponse()', () => {
                           directLink: download_url,
                           expirationTimestamp: MOCK_TIMESTAMP_MILLISECONDS,
                           isDirectLinkAvailable,
-                          isDownloadAllowed: can_download && extension !== ITEM_EXTENSION_GDOC,
-                          isDownloadAvailable: can_download && extension !== ITEM_EXTENSION_GDOC,
-                          isDownloadEnabled: can_download && extension !== ITEM_EXTENSION_GDOC,
-                          isDownloadSettingAvailable: can_download && extension !== ITEM_EXTENSION_GDOC,
+                          isDownloadAllowed: isDownloadAvailable,
+                          isDownloadAvailable,
+                          isDownloadEnabled: isDownloadAvailable,
+                          isDownloadSettingAvailable: isDownloadAvailable,
                           isEditAllowed: true,
                           isNewSharedLink: false,
                           isPasswordAvailable: password,

--- a/src/features/unified-share-modal/utils/__tests__/convertData.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/convertData.test.js
@@ -5,12 +5,14 @@ import {
     convertCollabsRequest,
     convertCollabsResponse,
     convertGroupContactsResponse,
+    convertIsDownloadSettingAvailable,
     convertItemResponse,
     convertSharedLinkPermissions,
     convertSharedLinkSettings,
     convertUserContactsResponse,
     convertUserContactsByEmailResponse,
     convertUserResponse,
+    convertEffectiveSharedLinkPermission,
 } from '../convertData';
 import {
     TYPE_FILE,
@@ -77,6 +79,7 @@ import {
 } from '../__mocks__/USMMocks';
 
 jest.mock('../../../../utils/file', () => ({
+    ...jest.requireActual('../../../../utils/file'),
     getTypedFileId: () => 'f_190457309',
     getTypedFolderId: () => 'd_190457309',
 }));
@@ -120,7 +123,8 @@ describe('convertItemResponse()', () => {
     const ITEM_DESCRIPTION = 'Why we <3 Box UI Elements';
     const ITEM_SHARED_LINK_URL = 'https://cloud.box.com/s/boxuielementsarethebest';
     const ITEM_SHARED_DOWNLOAD_URL = 'https://cloud.box.com/shared/static/boxuielementsarethebest';
-    const ITEM_EXTENSION = '.png';
+    const ITEM_EXTENSION = 'png';
+    const ITEM_EXTENSION_GDOC = 'gdoc';
 
     const ITEM_SHARED_LINK = {
         access: 'company',
@@ -205,71 +209,72 @@ describe('convertItemResponse()', () => {
     };
 
     test.each`
-        itemType       | extension         | sharedLink          | sharedLinkFeatures          | permissions                     | typedID            | description
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and all shared link features'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and the vanity URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and the download URL feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and the password feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and the password feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and the password feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${null}             | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and the password feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and the password feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and the password feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and the password feature'}
-        ${TYPE_FILE}   | ${ITEM_EXTENSION} | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and all shared link features'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and the vanity URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and the download URL feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${null}             | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and the password feature'}
-        ${TYPE_FOLDER} | ${null}           | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and the password feature'}
+        itemType       | extension              | sharedLink          | sharedLinkFeatures          | permissions                     | typedID            | description
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and all shared link features'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and the vanity URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and the download URL feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with no shared link, full permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with no shared link, download permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with no shared link, invite collabs permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${null}             | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with no shared link, set share access permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FILE_ID}   | ${'files with a shared link, full permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FILE_ID}   | ${'files with a shared link, download permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FILE_ID}   | ${'files with a shared link, invite collabs permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION}      | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'files with a shared link, set share access permissions, and the password feature'}
+        ${TYPE_FILE}   | ${ITEM_EXTENSION_GDOC} | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FILE_ID}   | ${'g suite files with a shared link, set share access permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${ALL_SHARED_LINK_FEATURES} | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and all shared link features'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${VANITY_NAME_ONLY}         | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and the vanity URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${DOWNLOAD_URL_ONLY}        | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and the download URL feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with no shared link, full permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with no shared link, download permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with no shared link, invite collabs permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${null}             | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with no shared link, set share access permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${FULL_PERMISSIONS}             | ${TYPED_FOLDER_ID} | ${'folders with a shared link, full permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${DOWNLOAD_PERMISSIONS}         | ${TYPED_FOLDER_ID} | ${'folders with a shared link, download permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${INVITE_COLLAB_PERMISSIONS}    | ${TYPED_FOLDER_ID} | ${'folders with a shared link, invite collabs permissions, and the password feature'}
+        ${TYPE_FOLDER} | ${null}                | ${ITEM_SHARED_LINK} | ${PASSWORD_ONLY}            | ${SET_SHARE_ACCESS_PERMISSIONS} | ${TYPED_FOLDER_ID} | ${'folders with a shared link, set share access permissions, and the password feature'}
     `(
         'should convert $description',
         ({ itemType, extension, sharedLink, sharedLinkFeatures, permissions, typedID }) => {
@@ -315,7 +320,7 @@ describe('convertItemResponse()', () => {
                           accessLevelsDisabledReason: {},
                           allowedAccessLevels: ALLOWED_ACCESS_LEVELS,
                           canChangeAccessLevel: can_set_share_access,
-                          canChangeDownload: can_set_share_access && can_download,
+                          canChangeDownload: can_set_share_access && can_download && extension !== ITEM_EXTENSION_GDOC,
                           canChangeExpiration: can_set_share_access,
                           canChangePassword: can_set_share_access && password,
                           canChangeVanityName: false,
@@ -323,16 +328,19 @@ describe('convertItemResponse()', () => {
                           directLink: download_url,
                           expirationTimestamp: MOCK_TIMESTAMP_MILLISECONDS,
                           isDirectLinkAvailable,
-                          isDownloadAllowed: can_download,
-                          isDownloadAvailable: can_download,
-                          isDownloadEnabled: can_download,
-                          isDownloadSettingAvailable: can_download,
+                          isDownloadAllowed: can_download && extension !== ITEM_EXTENSION_GDOC,
+                          isDownloadAvailable: can_download && extension !== ITEM_EXTENSION_GDOC,
+                          isDownloadEnabled: can_download && extension !== ITEM_EXTENSION_GDOC,
+                          isDownloadSettingAvailable: can_download && extension !== ITEM_EXTENSION_GDOC,
                           isEditAllowed: true,
                           isNewSharedLink: false,
                           isPasswordAvailable: password,
                           isPasswordEnabled: is_password_enabled,
                           isPreviewAllowed: can_preview,
-                          permissionLevel: API_TO_USM_PERMISSION_LEVEL_MAP[effective_permission],
+                          permissionLevel:
+                              extension !== ITEM_EXTENSION_GDOC
+                                  ? API_TO_USM_PERMISSION_LEVEL_MAP[effective_permission]
+                                  : CAN_VIEW_ONLY,
                           url,
                           vanityName: vanity_name || '',
                       }
@@ -499,7 +507,7 @@ describe('convertSharedLinkSettings', () => {
         'should convert a shared link settings USM object $description when the accessLevel is ANYONE_IN_COMPANY',
         ({ newSettings, permissions, unsharedAt, serverURL, vanityUrl }) => {
             // "password" should not exist in the converted object
-            expect(convertSharedLinkSettings(newSettings, ANYONE_IN_COMPANY, serverURL)).toEqual({
+            expect(convertSharedLinkSettings(newSettings, ANYONE_IN_COMPANY, true, serverURL)).toEqual({
                 permissions,
                 unshared_at: unsharedAt,
                 vanity_url: vanityUrl,
@@ -518,7 +526,7 @@ describe('convertSharedLinkSettings', () => {
         'should convert a shared link settings USM object $description when the accessLevel is PEOPLE_IN_ITEM',
         ({ newSettings, unsharedAt, serverURL, vanityUrl }) => {
             // "password" and "permissions" should not exist in the converted object
-            expect(convertSharedLinkSettings(newSettings, PEOPLE_IN_ITEM, serverURL)).toEqual({
+            expect(convertSharedLinkSettings(newSettings, PEOPLE_IN_ITEM, true, serverURL)).toEqual({
                 unshared_at: unsharedAt,
                 vanity_url: vanityUrl,
             });
@@ -537,9 +545,32 @@ describe('convertSharedLinkSettings', () => {
         'should convert a shared link settings USM object $description when the accessLevel is ANYONE_WITH_LINK',
         ({ newSettings, password, permissions, unsharedAt, serverURL, vanityUrl }) => {
             // All fields should exist in the converted object
-            expect(convertSharedLinkSettings(newSettings, ANYONE_WITH_LINK, serverURL)).toEqual({
+            expect(convertSharedLinkSettings(newSettings, ANYONE_WITH_LINK, true, serverURL)).toEqual({
                 password,
                 permissions,
+                unshared_at: unsharedAt,
+                vanity_url: vanityUrl,
+            });
+        },
+    );
+
+    test.each`
+        newSettings                         | permissions                           | unsharedAt                   | vanityUrl          | password         | serverURL          | description
+        ${MOCK_SETTINGS_WITH_ALL_FEATURES}  | ${MOCK_SETTINGS_DOWNLOAD_PERMISSIONS} | ${MOCK_TIMESTAMP_ISO_STRING} | ${MOCK_VANITY_URL} | ${MOCK_PASSWORD} | ${MOCK_SERVER_URL} | ${'with all features'}
+        ${MOCK_SETTINGS_WITHOUT_DOWNLOAD}   | ${MOCK_SETTINGS_PREVIEW_PERMISSIONS}  | ${MOCK_TIMESTAMP_ISO_STRING} | ${MOCK_VANITY_URL} | ${MOCK_PASSWORD} | ${MOCK_SERVER_URL} | ${'without disallowed direct downloads'}
+        ${MOCK_SETTINGS_WITHOUT_EXPIRATION} | ${MOCK_SETTINGS_DOWNLOAD_PERMISSIONS} | ${null}                      | ${MOCK_VANITY_URL} | ${MOCK_PASSWORD} | ${MOCK_SERVER_URL} | ${'without an expiration date'}
+        ${MOCK_SETTINGS_WITHOUT_PASSWORD}   | ${MOCK_SETTINGS_DOWNLOAD_PERMISSIONS} | ${MOCK_TIMESTAMP_ISO_STRING} | ${MOCK_VANITY_URL} | ${null}          | ${MOCK_SERVER_URL} | ${'without a password'}
+        ${MOCK_SETTINGS_WITHOUT_VANITY_URL} | ${MOCK_SETTINGS_DOWNLOAD_PERMISSIONS} | ${MOCK_TIMESTAMP_ISO_STRING} | ${''}              | ${MOCK_PASSWORD} | ${MOCK_SERVER_URL} | ${'without a vanity name'}
+        ${MOCK_SETTINGS_WITH_ALL_FEATURES}  | ${MOCK_SETTINGS_DOWNLOAD_PERMISSIONS} | ${MOCK_TIMESTAMP_ISO_STRING} | ${''}              | ${MOCK_PASSWORD} | ${null}            | ${'without a server URL'}
+    `(
+        'should convert a shared link settings USM object $description when isDownloadEnabled is false',
+        ({ newSettings, password, permissions, unsharedAt, serverURL, vanityUrl }) => {
+            // can_download should never be in permissions
+            expect(convertSharedLinkSettings(newSettings, ANYONE_WITH_LINK, false, serverURL)).toEqual({
+                password,
+                permissions: {
+                    can_preview: !permissions.can_download,
+                },
                 unshared_at: unsharedAt,
                 vanity_url: vanityUrl,
             });
@@ -755,5 +786,37 @@ describe('convertCollabsRequest()', () => {
         ${{ emails: '', groups: '', permission: 'Editor' }} | ${{ groups: [], users: [] }}                            | ${'no users or groups'}
     `('should convert a request with $description', ({ requestFromUSM, convertedResponse }) => {
         expect(convertCollabsRequest(requestFromUSM)).toEqual(convertedResponse);
+    });
+});
+
+describe('convertEffectiveSharedLinkPermission()', () => {
+    const ITEM_EXTENSION = 'png';
+    const ITEM_EXTENSION_GDOC = 'gdoc';
+
+    test.each`
+        extension              | permissionFromApi          | expectedPermission   | description
+        ${ITEM_EXTENSION}      | ${PERMISSION_CAN_DOWNLOAD} | ${CAN_VIEW_DOWNLOAD} | ${'file with download permission'}
+        ${ITEM_EXTENSION}      | ${PERMISSION_CAN_PREVIEW}  | ${CAN_VIEW_ONLY}     | ${'file with preview permission'}
+        ${ITEM_EXTENSION_GDOC} | ${PERMISSION_CAN_DOWNLOAD} | ${CAN_VIEW_ONLY}     | ${'g suite file with download permission'}
+        ${ITEM_EXTENSION_GDOC} | ${PERMISSION_CAN_PREVIEW}  | ${CAN_VIEW_ONLY}     | ${'g suite file with preview permission'}
+    `('should convert the permission for a $description', ({ extension, permissionFromApi, expectedPermission }) => {
+        expect(convertEffectiveSharedLinkPermission(permissionFromApi, extension)).toBe(expectedPermission);
+    });
+});
+
+describe('convertIsDownloadSettingAvailable()', () => {
+    const ITEM_EXTENSION = 'png';
+    const ITEM_EXTENSION_GDOC = 'gdoc';
+
+    test.each`
+        extension              | settingFromApi | expectedSetting | description
+        ${ITEM_EXTENSION}      | ${true}        | ${true}         | ${'file with download available'}
+        ${ITEM_EXTENSION}      | ${false}       | ${false}        | ${'file without download available'}
+        ${ITEM_EXTENSION}      | ${undefined}   | ${undefined}    | ${'file with undefined download available'}
+        ${ITEM_EXTENSION_GDOC} | ${true}        | ${false}        | ${'g suite file with download available'}
+        ${ITEM_EXTENSION_GDOC} | ${false}       | ${false}        | ${'g suite file without download available'}
+        ${ITEM_EXTENSION_GDOC} | ${undefined}   | ${undefined}    | ${'g suite file with undefined download available'}
+    `('should convert the setting for a $description', ({ extension, settingFromApi, expectedSetting }) => {
+        expect(convertIsDownloadSettingAvailable(settingFromApi, extension)).toBe(expectedSetting);
     });
 });

--- a/src/utils/__tests__/file.test.js
+++ b/src/utils/__tests__/file.test.js
@@ -1,4 +1,10 @@
-import { isBoxNote, getTypedFileId, getTypedFolderId, getFileExtension } from '../file';
+import {
+    FILE_EXTENSION_GOOGLE_DOC,
+    FILE_EXTENSION_GOOGLE_SHEET,
+    FILE_EXTENSION_GOOGLE_SLIDE,
+    FILE_EXTENSION_GOOGLE_SLIDE_LEGACY,
+} from '../../constants';
+import { isBoxNote, getTypedFileId, getTypedFolderId, getFileExtension, isGSuiteExtension } from '../file';
 
 describe('util/file', () => {
     describe('isBoxNote()', () => {
@@ -40,6 +46,20 @@ describe('util/file', () => {
             ['invalidfilenamepdf', ''],
         ])('should return extension of file correctly', (filename, extension) => {
             expect(getFileExtension(filename)).toBe(extension);
+        });
+    });
+
+    describe('isGSuiteExtension()', () => {
+        test.each`
+            extension                             | expectedResult
+            ${FILE_EXTENSION_GOOGLE_DOC}          | ${true}
+            ${FILE_EXTENSION_GOOGLE_SHEET}        | ${true}
+            ${FILE_EXTENSION_GOOGLE_SLIDE}        | ${true}
+            ${FILE_EXTENSION_GOOGLE_SLIDE_LEGACY} | ${true}
+            ${'docx'}                             | ${false}
+            ${'png'}                              | ${false}
+        `('should return the correct value for a $extension', ({ extension, expectedResult }) => {
+            expect(isGSuiteExtension(extension)).toBe(expectedResult);
         });
     });
 });

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -5,7 +5,15 @@
  */
 
 import getProp from 'lodash/get';
-import { TYPED_ID_FILE_PREFIX, TYPED_ID_FOLDER_PREFIX, FILE_EXTENSION_BOX_NOTE } from '../constants';
+import {
+    TYPED_ID_FILE_PREFIX,
+    TYPED_ID_FOLDER_PREFIX,
+    FILE_EXTENSION_BOX_NOTE,
+    FILE_EXTENSION_GOOGLE_DOC,
+    FILE_EXTENSION_GOOGLE_SHEET,
+    FILE_EXTENSION_GOOGLE_SLIDE,
+    FILE_EXTENSION_GOOGLE_SLIDE_LEGACY,
+} from '../constants';
 import type { BoxItem } from '../common/types/core';
 
 const FILE_EXT_REGEX = /\.([0-9a-z]+)$/i; // Case insensitive regex to extract file extension without "."
@@ -37,6 +45,20 @@ export function getTypedFolderId(id: string): string {
  */
 export function isBoxNote(file: BoxItem): boolean {
     return file.extension === FILE_EXTENSION_BOX_NOTE;
+}
+
+/**
+ * Determines whether a file extension is associated with a G Suite file.
+ * @param {string} extension
+ * @return boolean true if the extension is a valid G Suite extension
+ */
+export function isGSuiteExtension(extension: string): boolean {
+    return (
+        extension === FILE_EXTENSION_GOOGLE_DOC ||
+        extension === FILE_EXTENSION_GOOGLE_SHEET ||
+        extension === FILE_EXTENSION_GOOGLE_SLIDE ||
+        extension === FILE_EXTENSION_GOOGLE_SLIDE_LEGACY
+    );
 }
 
 /**


### PR DESCRIPTION
SFC collabs should only be shown viewer and editor permissions, and G Suite files should never have the can download shared link permission available