### PR TITLE
fix(content-sharing): Refresh component from ES6 wrapper

### DIFF
--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -10,7 +10,7 @@ import 'regenerator-runtime/runtime';
 import * as React from 'react';
 import API from '../../api';
 import SharingModal from './SharingModal';
-import { CLIENT_NAME_CONTENT_SHARING } from '../../constants';
+import { CLIENT_NAME_CONTENT_SHARING, DEFAULT_HOSTNAME_API } from '../../constants';
 import type { ItemType, StringMap } from '../../common/types/core';
 import type { USMConfig } from '../../features/unified-share-modal/flowTypes';
 
@@ -21,6 +21,7 @@ import '../common/modal.scss';
 type ContentSharingProps = {
     /** apiHost - API hostname. Defaults to https://api.box.com */
     apiHost: string,
+    /** config - Configuration object that shows/hides features in the USM */
     config?: USMConfig,
     /**
      * customButton - Clickable element for opening the SharingModal component.
@@ -44,6 +45,8 @@ type ContentSharingProps = {
     messages?: StringMap,
     /** token - Valid access token */
     token: string,
+    /** uuid - Unique identifier, used for refreshing element visibility when called from the ES6 wrapper */
+    uuid?: number,
 };
 
 const createAPI = (apiHost, itemID, itemType, token) =>
@@ -55,7 +58,7 @@ const createAPI = (apiHost, itemID, itemType, token) =>
     });
 
 function ContentSharing({
-    apiHost,
+    apiHost = DEFAULT_HOSTNAME_API,
     config,
     customButton,
     displayInModal,
@@ -64,6 +67,7 @@ function ContentSharing({
     language,
     messages,
     token,
+    uuid,
 }: ContentSharingProps) {
     const [api, setAPI] = React.useState<API | null>(createAPI(apiHost, itemID, itemType, token));
     const [launchButton, setLaunchButton] = React.useState<React.Element<any> | null>(null);
@@ -81,7 +85,7 @@ function ContentSharing({
     // Reset state if the API has changed
     React.useEffect(() => {
         setIsVisible(!customButton);
-    }, [api, customButton]);
+    }, [api, customButton, uuid]);
 
     React.useEffect(() => {
         if (customButton && !launchButton) {

--- a/src/elements/content-sharing/__tests__/ContentSharing.test.js
+++ b/src/elements/content-sharing/__tests__/ContentSharing.test.js
@@ -125,6 +125,41 @@ describe('elements/content-sharing/ContentSharing', () => {
         expect(wrapper.find(SharingModal).prop('isVisible')).toBe(false);
     });
 
+    test('should reset isVisible when given a new uuid', () => {
+        const setIsVisible = (wrapper, isVisible) => {
+            act(() => {
+                wrapper.find(SharingModal).invoke('setIsVisible')(isVisible);
+            });
+            wrapper.update();
+        };
+
+        let wrapper;
+        act(() => {
+            wrapper = getWrapper({
+                apiHost: DEFAULT_HOSTNAME_API,
+                displayInModal: true,
+                itemID: MOCK_ITEM_ID,
+                itemType: TYPE_FOLDER,
+                token: MOCK_TOKEN,
+                uuid: 'unique-id-0',
+            });
+        });
+        wrapper.update();
+
+        expect(wrapper.exists(SharingModal)).toBe(true);
+        expect(wrapper.find(SharingModal).prop('isVisible')).toBe(true);
+
+        setIsVisible(wrapper, false); // close modal
+        expect(wrapper.find(SharingModal).prop('isVisible')).toBe(false);
+
+        act(() => {
+            wrapper.setProps({ uuid: 'unique-id-1' });
+        });
+        wrapper.update();
+
+        expect(wrapper.find(SharingModal).prop('isVisible')).toBe(true);
+    });
+
     test.each([true, false])(
         'should instantiate SharingModal automatically when no button exists and displayInModal is %s',
         ({ displayInModal }) => {

--- a/src/elements/wrappers/ContentSharing.js
+++ b/src/elements/wrappers/ContentSharing.js
@@ -4,7 +4,8 @@
  * @author Box
  */
 
-import React from 'react';
+import * as React from 'react';
+import uniqueId from 'lodash/uniqueId';
 import { render } from 'react-dom';
 import ES6Wrapper from './ES6Wrapper';
 import ContentSharingReactComponent from '../content-sharing';
@@ -23,6 +24,7 @@ class ContentSharing extends ES6Wrapper {
                 language={this.language}
                 messages={this.messages}
                 token={this.token}
+                uuid={uniqueId('contentSharing_')}
                 {...this.options}
             />,
             this.container,


### PR DESCRIPTION
Enable the ContentSharing ES6 wrapper to refresh (and thus reopen) the ContentSharing React component by passing a new `uuid` property whenever the wrapper calls `ReactDOM.render()`.