### PR TITLE
feat(usm): Adding UI for business justifications

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1432,6 +1432,8 @@ boxui.unifiedShare.collaboration.userCollabText = User
 boxui.unifiedShare.collaboratorListTitle = People in ‘{itemName}’
 # This string is displayed as tooltip on hovering over expire icon for collab
 boxui.unifiedShare.collaborators.expirationTooltipClickableText = Access expires on {date}. Click for details.
+# Text to show when the number of contact email addresses displayed on a tooltip exceeds the maximum amount that can be displayed
+boxui.unifiedShare.contactEmailsTooltipText = {emails}, and {remainingEmailsCount} more
 # Error message when more than the maximum number of contacts is entered
 boxui.unifiedShare.contactsExceedLimitError = Oops! The maximum number of collaborators that can be added at once is {maxContacts} collaborators. Please try again by splitting your invitations into batches.
 # Text shown in share modal when there is at least one external collaborators
@@ -1478,6 +1480,12 @@ boxui.unifiedShare.inviteDisabledTooltip = You do not have permission to invite 
 boxui.unifiedShare.inviteDisabledWeblinkTooltip = Collaborators cannot be added to bookmarks.
 # Label of the field where a user designates who to invite to collaborate on an item
 boxui.unifiedShare.inviteFieldLabel = Invite People
+# The error message that is displayed when a user tries to send invitations to external collaborators, but a business justification is required before proceeding
+boxui.unifiedShare.justificationRequiredError = Select a justification or remove people to continue
+# The label displayed at the top of the select field that allows selecting a business justification reason
+boxui.unifiedShare.justificationSelectLabel = Business Justification
+# The placeholder text of the select field that allows selecting a business justification reason
+boxui.unifiedShare.justificationSelectPlaceholder = Select Justification
 # Call to action text for allowing the user to create a new shared link
 boxui.unifiedShare.linkShareOff = Create shared link
 # Call to action text for allowing the user to remove an existing shared link

--- a/src/components/pill-selector-dropdown/RoundPill.js
+++ b/src/components/pill-selector-dropdown/RoundPill.js
@@ -123,6 +123,7 @@ class RoundPill extends React.PureComponent<Props, State> {
                 {showAvatar ? (
                     <LabelPill.Icon
                         Component={Avatar}
+                        className="bdl-RoundPill-avatar"
                         avatarUrl={avatarUrl}
                         id={id}
                         isExternal={isExternal}

--- a/src/components/pill-selector-dropdown/RoundPill.scss
+++ b/src/components/pill-selector-dropdown/RoundPill.scss
@@ -30,6 +30,13 @@
     }
 }
 
+.bdl-RoundPill-avatar,
+.bdl-RoundPill-closeBtn {
+    path {
+        fill: $bdl-gray-50;
+    }
+}
+
 .bdl-RoundPill-text {
     flex-grow: 1;
     flex-shrink: 1;
@@ -52,12 +59,18 @@
 }
 
 .bdl-RoundPill--warning {
+    background-color: $bdl-yellorange-10;
+    border: 1px solid $bdl-yellorange-50;
+
     .bdl-Avatar-externalBadge {
         border-color: $bdl-yellorange-10;
     }
 }
 
 .bdl-RoundPill--error {
+    background-color: $bdl-watermelon-red-10;
+    border: 1px solid $bdl-watermelon-red-50;
+
     .bdl-Avatar-externalBadge {
         border-color: $bdl-watermelon-red-10;
     }

--- a/src/components/pill-selector-dropdown/RoundPill.scss
+++ b/src/components/pill-selector-dropdown/RoundPill.scss
@@ -80,6 +80,26 @@
     .bdl-Avatar-externalBadge {
         border-color: $bdl-gray-20;
     }
+
+    &.bdl-RoundPill--warning {
+        background-color: $bdl-yellorange-20;
+        border-color: $bdl-yellorange;
+        box-shadow: none;
+
+        .bdl-Avatar-externalBadge {
+            border-color: $bdl-yellorange-20;
+        }
+    }
+
+    &.bdl-RoundPill--error {
+        background-color: $bdl-watermelon-red-20;
+        border-color: $bdl-watermelon-red;
+        box-shadow: none;
+
+        .bdl-Avatar-externalBadge {
+            border-color: $bdl-watermelon-red-20;
+        }
+    }
 }
 
 .bdl-RoundPill--disabled {

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/RoundPill.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/RoundPill.test.js.snap
@@ -7,6 +7,7 @@ exports[`components/RoundPill-selector-dropdown/RoundPill should render avatar i
 >
   <LabelPillIcon
     Component={[Function]}
+    className="bdl-RoundPill-avatar"
     name="box"
     shouldShowExternal={true}
     size="small"

--- a/src/features/unified-share-modal/ContactRestrictionNotice.js
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.js
@@ -1,0 +1,139 @@
+// @flow
+
+import * as React from 'react';
+import noop from 'lodash/noop';
+import getProp from 'lodash/get';
+import uniqueId from 'lodash/uniqueId';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import type { InjectIntlProvidedProps } from 'react-intl';
+
+import FormattedCompMessage from '../../components/i18n/FormattedCompMessage';
+import Param from '../../components/i18n/Param';
+import Label from '../../components/label';
+import PlainButton from '../../components/plain-button';
+import InlineNotice from '../../components/inline-notice';
+import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
+import SingleSelectField from '../../components/select-field/SingleSelectField';
+
+import ContactsEmailsTooltip from './ContactsEmailsTooltip';
+import messages from './messages';
+
+import type { SelectOptionProp } from '../../components/select-field/props';
+import type { contactType as Contact } from './flowTypes';
+
+import './ContactRestrictionNotice.scss';
+
+type Props = {
+    error?: React.Node,
+    isLoading?: boolean,
+    justificationReasons: Array<SelectOptionProp>,
+    onRemoveRestrictedExternalContacts: () => void,
+    onSelectJustificationReason: (justificationReasonOption: SelectOptionProp) => void,
+    restrictedExternalEmails: Array<string>,
+    selectedContacts: Array<Contact>,
+    selectedJustificationReason: ?SelectOptionProp,
+} & InjectIntlProvidedProps;
+
+const ContactRestrictionNotice = ({
+    error,
+    intl,
+    isLoading,
+    justificationReasons,
+    onRemoveRestrictedExternalContacts,
+    onSelectJustificationReason,
+    restrictedExternalEmails,
+    selectedContacts,
+    selectedJustificationReason,
+}: Props) => {
+    const compMessageId = uniqueId('compMessage');
+    const restrictedExternalContacts = selectedContacts.filter(({ value }) => restrictedExternalEmails.includes(value));
+    const restrictedExternalContactCount = restrictedExternalContacts.length;
+
+    if (!restrictedExternalContactCount) {
+        return null;
+    }
+
+    const RemoveButton = ({ children }: { children: React.Node }) => (
+        <PlainButton
+            className="bdl-ContactRestrictionNotice-removeBtn"
+            data-resin-target="removeBtn"
+            onClick={onRemoveRestrictedExternalContacts}
+        >
+            {children}
+        </PlainButton>
+    );
+
+    // TODO:
+    // Switch to react-intl v3+ api once migration is complete. FormattedCompMessage is now
+    // deprecated and has some issues with components nested within <Plural/>, hence why we
+    // use two messages and use unique keys as a workaround.
+
+    const noticeDescriptionSingular = (
+        <FormattedCompMessage
+            key={compMessageId}
+            description="Notice to display when sharing a file with external collaborators requires a business justification to be provided."
+            id="boxui.unifiedShare.businessJustificationRequiredSingular"
+        >
+            This classified content requires business justification to collaborate with{' '}
+            <ContactsEmailsTooltip contacts={restrictedExternalContacts}>1 person</ContactsEmailsTooltip>. Select a
+            business justification below or <RemoveButton>remove them</RemoveButton> to continue.
+        </FormattedCompMessage>
+    );
+
+    const noticeDescriptionPlural = (
+        <FormattedCompMessage
+            key={compMessageId}
+            description="Notice to display when sharing a file with external collaborators requires a business justification to be provided."
+            id="boxui.unifiedShare.businessJustificationRequiredPlural"
+        >
+            This classified content requires business justification to collaborate with{' '}
+            <ContactsEmailsTooltip contacts={restrictedExternalContacts}>
+                <Param
+                    value={restrictedExternalContactCount}
+                    description="Number of external collborators currently selected"
+                />{' '}
+                people
+            </ContactsEmailsTooltip>
+            . Select a business justification below or <RemoveButton>remove them</RemoveButton> to continue.
+        </FormattedCompMessage>
+    );
+
+    const selectedValue = getProp(selectedJustificationReason, 'value', null);
+    const noticeDescription =
+        restrictedExternalContactCount === 1 ? noticeDescriptionSingular : noticeDescriptionPlural;
+
+    return (
+        <InlineNotice
+            className="bdl-ContactRestrictionNotice"
+            data-resin-component="contactRestrictionNotice"
+            type="error"
+        >
+            <p className="bdl-ContactRestrictionNotice-description">{noticeDescription}</p>
+            <Label text={<FormattedMessage {...messages.justificationSelectLabel} />}>
+                {isLoading ? (
+                    <LoadingIndicator className="bdl-ContactRestrictionNotice-loadingIndicator" />
+                ) : (
+                    <SingleSelectField
+                        data-resin-target="justificationReasonsSelect"
+                        error={error}
+                        options={justificationReasons}
+                        onChange={onSelectJustificationReason}
+                        placeholder={intl.formatMessage(messages.justificationSelectPlaceholder)}
+                        selectedValue={selectedValue}
+                    />
+                )}
+            </Label>
+        </InlineNotice>
+    );
+};
+
+ContactRestrictionNotice.displayName = 'ContactRestrictionNotice';
+
+ContactRestrictionNotice.defaultProps = {
+    justificationReasons: [],
+    onRemoveRestrictedExternalContacts: noop,
+    onSelectJustificationReason: noop,
+};
+
+export { ContactRestrictionNotice as ContactRestrictionNoticeComponent };
+export default injectIntl(ContactRestrictionNotice);

--- a/src/features/unified-share-modal/ContactRestrictionNotice.js
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.js
@@ -74,9 +74,14 @@ const ContactRestrictionNotice = ({
             description="Notice to display when sharing a file with external collaborators requires a business justification to be provided."
             id="boxui.unifiedShare.businessJustificationRequiredSingular"
         >
-            This classified content requires business justification to collaborate with{' '}
-            <ContactsEmailsTooltip contacts={restrictedExternalContacts}>1 person</ContactsEmailsTooltip>. Select a
-            business justification below or <RemoveButton>remove them</RemoveButton> to continue.
+            This classified content requires a business justification to collaborate with{' '}
+            <span className="bdl-ContactRestrictionNotice-contactEmail">
+                <Param
+                    value={restrictedExternalContacts[0].value}
+                    description="The email address of the external user"
+                />
+            </span>
+            . Select a business justification below or <RemoveButton>remove the user</RemoveButton> to continue.
         </FormattedCompMessage>
     );
 
@@ -86,7 +91,7 @@ const ContactRestrictionNotice = ({
             description="Notice to display when sharing a file with external collaborators requires a business justification to be provided."
             id="boxui.unifiedShare.businessJustificationRequiredPlural"
         >
-            This classified content requires business justification to collaborate with{' '}
+            This classified content requires a business justification to collaborate with{' '}
             <ContactsEmailsTooltip contacts={restrictedExternalContacts}>
                 <Param
                     value={restrictedExternalContactCount}

--- a/src/features/unified-share-modal/ContactRestrictionNotice.scss
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.scss
@@ -1,0 +1,24 @@
+@import '../../styles/variables';
+
+.bdl-ContactRestrictionNotice {
+    .bdl-SelectButton {
+        margin-top: 10px;
+    }
+
+    .bdl-SelectFieldDropdown {
+        z-index: $overlay-z-index;
+        max-width: 100%;
+    }
+}
+
+.bdl-ContactRestrictionNotice-description {
+    margin-bottom: 10px;
+}
+
+.bdl-ContactRestrictionNotice-loadingIndicator {
+    margin: 14px auto 10px auto;
+}
+
+.bdl-ContactRestrictionNotice-removeBtn {
+    text-decoration: underline;
+}

--- a/src/features/unified-share-modal/ContactRestrictionNotice.scss
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.scss
@@ -2,7 +2,7 @@
 
 .bdl-ContactRestrictionNotice {
     .bdl-SelectButton {
-        margin-top: 10px;
+        margin-top: $bdl-grid-unit * 2;
     }
 
     .bdl-SelectFieldDropdown {
@@ -11,14 +11,19 @@
     }
 }
 
+.bdl-ContactRestrictionNotice-contactEmail {
+    text-decoration: underline;
+}
+
 .bdl-ContactRestrictionNotice-description {
-    margin-bottom: 10px;
+    margin-bottom: $bdl-grid-unit * 2;
 }
 
 .bdl-ContactRestrictionNotice-loadingIndicator {
-    margin: 14px auto 10px auto;
+    margin: 14px auto $bdl-grid-unit * 2 auto;
 }
 
 .bdl-ContactRestrictionNotice-removeBtn {
+    color: $bdl-gray;
     text-decoration: underline;
 }

--- a/src/features/unified-share-modal/ContactsEmailsTooltip.js
+++ b/src/features/unified-share-modal/ContactsEmailsTooltip.js
@@ -43,7 +43,7 @@ ContactsEmailsTooltip.displayName = 'ContactsEmailsTooltip';
 
 ContactsEmailsTooltip.defaultProps = {
     contacts: [],
-    maxContacts: 10,
+    maxContacts: 15,
 };
 
 export default ContactsEmailsTooltip;

--- a/src/features/unified-share-modal/ContactsEmailsTooltip.js
+++ b/src/features/unified-share-modal/ContactsEmailsTooltip.js
@@ -1,0 +1,49 @@
+// @flow
+
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+import take from 'lodash/take';
+
+import Tooltip from '../../components/tooltip';
+import messages from './messages';
+
+import type { contactType as Contact } from './flowTypes';
+
+import './ContactsEmailsTooltip.scss';
+
+type Props = {
+    children: React.Node,
+    contacts: Array<Contact>,
+    maxContacts: number,
+};
+
+const ContactsEmailsTooltip = ({ children, contacts, maxContacts }: Props) => {
+    const contactsToDisplay = take(contacts, maxContacts);
+    const remainingContactCount = contacts.length - contactsToDisplay.length;
+    const emailsToDisplay = contactsToDisplay.map(({ email }) => email).join(', ');
+    const isDisabled = !emailsToDisplay.length;
+
+    const tooltipText = remainingContactCount ? (
+        <FormattedMessage
+            {...messages.contactEmailsTooltipText}
+            values={{ emails: emailsToDisplay, remainingEmailsCount: remainingContactCount }}
+        />
+    ) : (
+        emailsToDisplay
+    );
+
+    return (
+        <Tooltip className="bdl-ContactsEmailsTooltip" text={tooltipText} isDisabled={isDisabled}>
+            <span className="bdl-ContactsEmailsTooltip-target">{children}</span>
+        </Tooltip>
+    );
+};
+
+ContactsEmailsTooltip.displayName = 'ContactsEmailsTooltip';
+
+ContactsEmailsTooltip.defaultProps = {
+    contacts: [],
+    maxContacts: 10,
+};
+
+export default ContactsEmailsTooltip;

--- a/src/features/unified-share-modal/ContactsEmailsTooltip.scss
+++ b/src/features/unified-share-modal/ContactsEmailsTooltip.scss
@@ -1,0 +1,8 @@
+.bdl-ContactsEmailsTooltip {
+    max-width: 480px;
+    text-align: center;
+}
+
+.bdl-ContactsEmailsTooltip-target {
+    text-decoration: underline;
+}

--- a/src/features/unified-share-modal/__tests__/ContactRestrictionNotice.test.js
+++ b/src/features/unified-share-modal/__tests__/ContactRestrictionNotice.test.js
@@ -1,0 +1,168 @@
+// @flow
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ContactRestrictionNoticeComponent as ContactRestrictionNotice } from '../ContactRestrictionNotice';
+
+describe('features/unified-share-modal/ContactRestrictionNotice', () => {
+    let wrapper;
+    let selectedContacts;
+    let restrictedExternalEmails;
+
+    const singularMessageId = 'boxui.unifiedShare.businessJustificationRequiredSingular';
+    const pluralMessageId = 'boxui.unifiedShare.businessJustificationRequiredPlural';
+
+    const getWrapper = (props = {}) => {
+        return shallow(
+            <ContactRestrictionNotice
+                error=""
+                isLoading={false}
+                intl={{ formatMessage: jest.fn() }}
+                justificationReasons={[]}
+                onRemoveRestrictedExternalContacts={jest.fn()}
+                onSelectJustificationReason={jest.fn()}
+                restrictedExternalEmails={restrictedExternalEmails}
+                selectedContacts={selectedContacts}
+                selectedJustificationReason={null}
+                {...props}
+            />,
+        );
+    };
+
+    beforeEach(() => {
+        selectedContacts = [
+            {
+                email: 'x@example.com',
+                id: '12345',
+                text: 'X User',
+                type: 'group',
+                value: 'x@example.com',
+            },
+            {
+                email: 'y@example.com',
+                id: '23456',
+                text: 'Y User',
+                type: 'user',
+                value: 'y@example.com',
+            },
+            {
+                email: 'z@example.com',
+                id: '34567',
+                text: 'Z User',
+                type: 'user',
+                value: 'z@example.com',
+            },
+        ];
+        restrictedExternalEmails = ['x@example.com', 'y@example.com'];
+
+        wrapper = getWrapper();
+    });
+
+    describe('render', () => {
+        test('should render default ContactRestrictionNotice component', () => {
+            expect(wrapper.is('InlineNotice')).toBe(true);
+            expect(wrapper.find(`FormattedCompMessage[id="${pluralMessageId}"]`)).toHaveLength(1);
+            expect(wrapper.find('[data-resin-target="justificationReasonsSelect"]')).toHaveLength(1);
+        });
+
+        test('should render nothing when there are no restricted external contacts', () => {
+            wrapper.setProps({ restrictedExternalEmails: [], selectedContacts });
+            expect(wrapper.isEmptyRender()).toBe(true);
+
+            wrapper.setProps({ restrictedExternalEmails, selectedContacts: [] });
+            expect(wrapper.isEmptyRender()).toBe(true);
+        });
+
+        test('should render singular message when only one restricted external contact exists', () => {
+            restrictedExternalEmails = ['x@example.com'];
+
+            wrapper.setProps({ restrictedExternalEmails });
+            const message = wrapper.find(`FormattedCompMessage[id="${singularMessageId}"]`);
+            expect(message).toHaveLength(1);
+        });
+
+        test('should render plural message when more than one restricted external contact exist', () => {
+            restrictedExternalEmails = ['x@example.com', 'y@example.com', 'z@example.com'];
+
+            wrapper.setProps({ restrictedExternalEmails });
+            const message = wrapper.find(`FormattedCompMessage[id="${pluralMessageId}"]`);
+            expect(message).toHaveLength(1);
+        });
+
+        test('should pass contacts information to tooltip within message', () => {
+            const expectedContacts = selectedContacts.filter(({ value }) => restrictedExternalEmails.includes(value));
+            const message = wrapper.find(`FormattedCompMessage[id="${pluralMessageId}"]`);
+
+            expect(message.find('ContactsEmailsTooltip').props().contacts).toEqual(expectedContacts);
+            expect(
+                message
+                    .find('ContactsEmailsTooltip')
+                    .find('Param')
+                    .props().value,
+            ).toBe(expectedContacts.length);
+        });
+
+        test('should render a loading indicator instead of the justification reasons select when isLoading is true', () => {
+            wrapper.setProps({ isLoading: true });
+
+            expect(wrapper.find('[data-resin-target="justificationReasonsSelect"]')).toHaveLength(0);
+            expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
+        });
+
+        test('should pass error to justification reasons select when provided', () => {
+            const error = 'error';
+            wrapper.setProps({ error, isLoading: false });
+
+            expect(wrapper.find('[data-resin-target="justificationReasonsSelect"]').props().error).toBe(error);
+        });
+
+        test('should render justification reasons select when isLoading is false', () => {
+            const selectedJustificationReason = {
+                displayText: 'displayText1',
+                value: 'value1',
+            };
+            const justificationReasons = [
+                selectedJustificationReason,
+                {
+                    displayText: 'displayText2',
+                    value: 'value2',
+                },
+            ];
+            wrapper.setProps({ isLoading: false, justificationReasons, selectedJustificationReason });
+
+            const justificationReasonsSelect = wrapper.find('[data-resin-target="justificationReasonsSelect"]');
+            expect(justificationReasonsSelect).toHaveLength(1);
+            expect(justificationReasonsSelect.props().options).toEqual(justificationReasons);
+            expect(justificationReasonsSelect.props().selectedValue).toEqual(selectedJustificationReason.value);
+            expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
+        });
+    });
+
+    describe('handlers', () => {
+        test('should call onRemoveRestrictedExternalContacts when remove button is clicked within message', () => {
+            const onRemoveRestrictedExternalContacts = jest.fn();
+            wrapper.setProps({ onRemoveRestrictedExternalContacts });
+
+            expect(onRemoveRestrictedExternalContacts).toHaveBeenCalledTimes(0);
+            wrapper
+                .find(`FormattedCompMessage[id="${pluralMessageId}"]`)
+                .children('RemoveButton')
+                .dive()
+                .simulate('click');
+            expect(onRemoveRestrictedExternalContacts).toHaveBeenCalledTimes(1);
+        });
+
+        test('should call onSelectJustificationReason with newly selected option on justification reason select change', () => {
+            const onSelectJustificationReason = jest.fn();
+            const expectedJustificationReason = { displayText: 'displayText', value: 'value' };
+            wrapper.setProps({ onSelectJustificationReason });
+
+            expect(onSelectJustificationReason).toHaveBeenCalledTimes(0);
+            wrapper
+                .find('[data-resin-target="justificationReasonsSelect"]')
+                .simulate('change', expectedJustificationReason);
+            expect(onSelectJustificationReason).toHaveBeenCalledTimes(1);
+            expect(onSelectJustificationReason).toHaveBeenCalledWith(expectedJustificationReason);
+        });
+    });
+});

--- a/src/features/unified-share-modal/__tests__/ContactRestrictionNotice.test.js
+++ b/src/features/unified-share-modal/__tests__/ContactRestrictionNotice.test.js
@@ -79,6 +79,7 @@ describe('features/unified-share-modal/ContactRestrictionNotice', () => {
             wrapper.setProps({ restrictedExternalEmails });
             const message = wrapper.find(`FormattedCompMessage[id="${singularMessageId}"]`);
             expect(message).toHaveLength(1);
+            expect(wrapper.find('Param').props().value).toBe(restrictedExternalEmails[0]);
         });
 
         test('should render plural message when more than one restricted external contact exist', () => {

--- a/src/features/unified-share-modal/__tests__/ContactsEmailsTooltip.test.js
+++ b/src/features/unified-share-modal/__tests__/ContactsEmailsTooltip.test.js
@@ -1,0 +1,85 @@
+// @flow
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import messages from '../messages';
+
+import ContactsEmailsTooltip from '../ContactsEmailsTooltip';
+
+describe('features/unified-share-modal/ContactsEmailsTooltip', () => {
+    let wrapper;
+    let contacts;
+
+    const getWrapper = (props = {}, children = <span>Target</span>) => {
+        return shallow(
+            <ContactsEmailsTooltip contacts={contacts} maxContacts={5} {...props}>
+                {children}
+            </ContactsEmailsTooltip>,
+        );
+    };
+
+    beforeEach(() => {
+        contacts = [
+            {
+                email: 'x@example.com',
+                id: '12345',
+                text: 'X User',
+                type: 'group',
+                value: 'x@example.com',
+            },
+            {
+                email: 'y@example.com',
+                id: '23456',
+                text: 'Y User',
+                type: 'user',
+                value: 'y@example.com',
+            },
+            {
+                email: 'z@example.com',
+                id: '34567',
+                text: 'Z User',
+                type: 'user',
+                value: 'z@example.com',
+            },
+        ];
+
+        wrapper = getWrapper();
+    });
+
+    test('should render default ContactsEmailsTooltip component', () => {
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render children wrapped by tooltip', () => {
+        const MyComponent = () => <span>My Component</span>;
+        wrapper = getWrapper({}, <MyComponent />);
+
+        expect(wrapper.find('Tooltip').find(MyComponent)).toHaveLength(1);
+    });
+
+    test('should disable tooltip when there are no contacts to display', () => {
+        expect(wrapper.find('Tooltip').props().isDisabled).toBe(false);
+        wrapper.setProps({ contacts: [] });
+        expect(wrapper.find('Tooltip').props().isDisabled).toBe(true);
+    });
+
+    test('should display comma separated emails on tooltip when contacts are less or equal than maxContacts', () => {
+        const expectedTooltipText = contacts.map(({ value }) => value).join(', ');
+        wrapper.setProps({ maxContacts: contacts.length + 1 });
+
+        expect(wrapper.find('Tooltip').props().text).toBe(expectedTooltipText);
+    });
+
+    test('should display message with remaining emails count on tooltip when contacts are greater than maxContacts', () => {
+        const maxContacts = contacts.length - 1;
+        const contactsToDisplay = contacts.slice(0, maxContacts);
+        const expectedEmails = contactsToDisplay.map(({ value }) => value).join(', ');
+
+        wrapper.setProps({ maxContacts });
+        const { text: message } = wrapper.find('Tooltip').props();
+
+        expect(message.props.id).toBe(messages.contactEmailsTooltipText.id);
+        expect(message.props.values.emails).toBe(expectedEmails);
+        expect(message.props.values.remainingEmailsCount).toBe(contacts.length - maxContacts);
+    });
+});

--- a/src/features/unified-share-modal/__tests__/__snapshots__/ContactsEmailsTooltip.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/ContactsEmailsTooltip.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`features/unified-share-modal/ContactsEmailsTooltip should render default ContactsEmailsTooltip component 1`] = `
+<Tooltip
+  className="bdl-ContactsEmailsTooltip"
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isDisabled={false}
+  position="top-center"
+  text="x@example.com, y@example.com, z@example.com"
+  theme="default"
+>
+  <span
+    className="bdl-ContactsEmailsTooltip-target"
+  >
+    <span>
+      Target
+    </span>
+  </span>
+</Tooltip>
+`;

--- a/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm.test.js.snap
@@ -203,6 +203,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
+    placeholder="boxui.share.messageSelectorPlaceholder"
     rows={3}
     value=""
   />
@@ -285,6 +286,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
+    placeholder="boxui.share.messageSelectorPlaceholder"
     rows={3}
     value=""
   />
@@ -418,6 +420,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
+    placeholder="boxui.share.messageSelectorPlaceholder"
     rows={3}
     value=""
   />
@@ -505,6 +508,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
+    placeholder="boxui.share.messageSelectorPlaceholder"
     rows={3}
     value=""
   />
@@ -587,6 +591,7 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       />
     }
     onChange={[Function]}
+    placeholder="boxui.share.messageSelectorPlaceholder"
     rows={3}
     value=""
   />

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -428,6 +428,31 @@ const messages = defineMessages({
         description: 'Tooltip description to explain recommendation for sharing tooltip',
         id: 'boxui.unifiedShare.recommendedSharingTooltipCalloutText',
     },
+
+    // External collab restrictions and business justifications
+    justificationSelectLabel: {
+        defaultMessage: 'Business Justification',
+        description:
+            'The label displayed at the top of the select field that allows selecting a business justification reason',
+        id: 'boxui.unifiedShare.justificationSelectLabel',
+    },
+    justificationSelectPlaceholder: {
+        defaultMessage: 'Select Justification',
+        description: 'The placeholder text of the select field that allows selecting a business justification reason',
+        id: 'boxui.unifiedShare.justificationSelectPlaceholder',
+    },
+    justificationRequiredError: {
+        defaultMessage: 'Select a justification or remove people to continue',
+        description:
+            'The error message that is displayed when a user tries to send invitations to external collaborators, but a business justification is required before proceeding',
+        id: 'boxui.unifiedShare.justificationRequiredError',
+    },
+    contactEmailsTooltipText: {
+        defaultMessage: '{emails}, and {remainingEmailsCount} more',
+        description:
+            'Text to show when the number of contact email addresses displayed on a tooltip exceeds the maximum amount that can be displayed',
+        id: 'boxui.unifiedShare.contactEmailsTooltipText',
+    },
 });
 
 export default messages;


### PR DESCRIPTION
Partial update that adds the UI components needed for the new Business Justifications flow for external collab restrictions. The components have been integrated with `EmailForm`, but the `UnifiedShareForm` updates needed to integrate with the apis and EUA are still pending. 

**Note:** There is also some pending UI polish that will be handled separately. The updates will not yet be visible and should be backwards compatible.

**After submitting with restricted external collabs:**

<img width="576" alt="Restricted External Collabs" src="https://user-images.githubusercontent.com/1322503/96501177-d81ed300-1204-11eb-8a6a-17bf6f8526ae.png">



**Restricted collabs email tooltip:**

<img width="530" alt="Restricted Collabs Tooltip" src="https://user-images.githubusercontent.com/1322503/96501240-f5ec3800-1204-11eb-9e7c-d458693b0cde.png">



**Submitting without selecting justification:**
(Note: Tooltip margin needs to be fixed)

<img width="736" alt="Justification Required Error" src="https://user-images.githubusercontent.com/1322503/96501715-96425c80-1205-11eb-87e5-5f3cba3d253f.png">



**After justification reason is selected:**

<img width="526" alt="Justification Selected" src="https://user-images.githubusercontent.com/1322503/96501785-be31c000-1205-11eb-998d-cf03129ab7c7.png">


