### PR TITLE
fix(content-sharing): Show notifications for initial data calls

### DIFF
--- a/src/elements/content-sharing/ContentSharing.js
+++ b/src/elements/content-sharing/ContentSharing.js
@@ -46,7 +46,7 @@ type ContentSharingProps = {
     /** token - Valid access token */
     token: string,
     /** uuid - Unique identifier, used for refreshing element visibility when called from the ES6 wrapper */
-    uuid?: number,
+    uuid?: string,
 };
 
 const createAPI = (apiHost, itemID, itemType, token) =>
@@ -113,6 +113,7 @@ function ContentSharing({
                     language={language}
                     messages={messages}
                     setIsVisible={setIsVisible}
+                    uuid={uuid}
                 />
             )}
         </>

--- a/src/elements/content-sharing/SharingModal.js
+++ b/src/elements/content-sharing/SharingModal.js
@@ -12,7 +12,9 @@ import { FormattedMessage } from 'react-intl';
 import type { $AxiosError } from 'axios';
 import API from '../../api';
 import Internationalize from '../common/Internationalize';
-import ErrorMask from '../../components/error-mask/ErrorMask';
+import NotificationsWrapper from '../../components/notification/NotificationsWrapper';
+import Notification from '../../components/notification/Notification';
+import { DURATION_SHORT, TYPE_ERROR } from '../../components/notification/constants';
 import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
 import UnifiedShareModal from '../../features/unified-share-modal';
 import SharedLinkSettingsModal from '../../features/shared-link-settings-modal';
@@ -54,6 +56,7 @@ type SharingModalProps = {
     language: string,
     messages?: StringMap,
     setIsVisible: (arg: boolean) => void,
+    uuid?: string,
 };
 
 function SharingModal({
@@ -66,11 +69,13 @@ function SharingModal({
     language,
     messages,
     setIsVisible,
+    uuid,
 }: SharingModalProps) {
     const [item, setItem] = React.useState<itemFlowType | null>(null);
     const [sharedLink, setSharedLink] = React.useState<ContentSharingSharedLinkType | null>(null);
     const [currentUserID, setCurrentUserID] = React.useState<string | null>(null);
-    const [componentErrorMessage, setComponentErrorMessage] = React.useState<Object | null>(null);
+    const [initialDataErrorMessage, setInitialDataErrorMessage] = React.useState<Object | null>(null);
+    const [isInitialDataErrorVisible, setIsInitialDataErrorVisible] = React.useState<boolean>(false);
     const [collaboratorsList, setCollaboratorsList] = React.useState<collaboratorsListType | null>(null);
     const [onAddLink, setOnAddLink] = React.useState<null | SharedLinkUpdateLevelFnType>(null);
     const [onRemoveLink, setOnRemoveLink] = React.useState<null | SharedLinkUpdateLevelFnType>(null);
@@ -88,18 +93,23 @@ function SharingModal({
     const [getContactsByEmail, setGetContactsByEmail] = React.useState<null | GetContactsByEmailFnType>(null);
     const [sendInvites, setSendInvites] = React.useState<null | SendInvitesFnType>(null);
     const [isLoading, setIsLoading] = React.useState<boolean>(true);
+
     // Handle successful GET requests to /files or /folders
     const handleGetItemSuccess = React.useCallback((itemData: ContentSharingItemAPIResponse) => {
         const { item: itemFromAPI, sharedLink: sharedLinkFromAPI } = convertItemResponse(itemData);
-        setComponentErrorMessage(null);
         setItem(itemFromAPI);
         setSharedLink(sharedLinkFromAPI);
         setIsLoading(false);
     }, []);
 
-    // Handle component-level errors
+    // Handle initial data retrieval errors
     const getError = React.useCallback(
         (error: $AxiosError<Object> | ErrorResponseData) => {
+            if (isInitialDataErrorVisible) return; // display only one component-level notification at a time
+
+            setIsInitialDataErrorVisible(true);
+            setIsLoading(false);
+
             let errorObject;
             if (error.status) {
                 errorObject = contentSharingMessages[CONTENT_SHARING_ERRORS[error.status]];
@@ -108,10 +118,9 @@ function SharingModal({
             } else {
                 errorObject = contentSharingMessages.loadingError;
             }
-
-            setComponentErrorMessage(errorObject);
+            setInitialDataErrorMessage(errorObject);
         },
-        [setComponentErrorMessage],
+        [isInitialDataErrorVisible],
     );
 
     // Reset state if the API has changed
@@ -119,13 +128,21 @@ function SharingModal({
         setChangeSharedLinkAccessLevel(null);
         setChangeSharedLinkPermissionLevel(null);
         setCollaboratorsList(null);
+        setInitialDataErrorMessage(null);
         setCurrentUserID(null);
+        setIsInitialDataErrorVisible(false);
+        setIsLoading(true);
         setItem(null);
         setOnAddLink(null);
         setOnRemoveLink(null);
         setSharedLink(null);
-        setIsLoading(true);
     }, [api]);
+
+    // Refresh error state if the uuid has changed
+    React.useEffect(() => {
+        setInitialDataErrorMessage(null);
+        setIsInitialDataErrorVisible(false);
+    }, [uuid]);
 
     // Get initial data for the item
     React.useEffect(() => {
@@ -141,10 +158,10 @@ function SharingModal({
             }
         };
 
-        if (api && !isEmpty(api) && isVisible && !item && !sharedLink) {
+        if (api && !isEmpty(api) && !initialDataErrorMessage && isVisible && !item && !sharedLink) {
             getItem();
         }
-    }, [api, getError, handleGetItemSuccess, isVisible, item, itemID, itemType, sharedLink]);
+    }, [api, initialDataErrorMessage, getError, handleGetItemSuccess, isVisible, item, itemID, itemType, sharedLink]);
 
     // Get initial data for the user
     React.useEffect(() => {
@@ -152,7 +169,7 @@ function SharingModal({
             const { id, userEnterpriseData } = convertUserResponse(userData);
             setCurrentUserID(id);
             setSharedLink(prevSharedLink => ({ ...prevSharedLink, ...userEnterpriseData }));
-            setComponentErrorMessage(null);
+            setInitialDataErrorMessage(null);
             setIsLoading(false);
         };
 
@@ -164,10 +181,10 @@ function SharingModal({
             });
         };
 
-        if (api && !isEmpty(api) && item && sharedLink && !currentUserID) {
+        if (api && !isEmpty(api) && !initialDataErrorMessage && item && sharedLink && !currentUserID) {
             getUserData();
         }
-    }, [getError, item, itemID, itemType, sharedLink, currentUserID, api]);
+    }, [getError, item, itemID, itemType, sharedLink, currentUserID, api, initialDataErrorMessage]);
 
     // Set the getContactsByEmail function. This call is not associated with a banner notification,
     // which is why it exists at this level and not in SharingNotification
@@ -178,8 +195,23 @@ function SharingModal({
         setGetContactsByEmail((): GetContactsByEmailFnType => getContactsByEmailFn);
     }
 
-    if (componentErrorMessage) {
-        return <ErrorMask errorHeader={<FormattedMessage {...componentErrorMessage} />} />;
+    // Display a notification if there is an error in retrieving initial data
+    if (initialDataErrorMessage) {
+        return isInitialDataErrorVisible ? (
+            <Internationalize language={language} messages={messages}>
+                <NotificationsWrapper>
+                    <Notification
+                        onClose={() => setIsInitialDataErrorVisible(false)}
+                        type={TYPE_ERROR}
+                        duration={DURATION_SHORT}
+                    >
+                        <span>
+                            <FormattedMessage {...initialDataErrorMessage} />
+                        </span>
+                    </Notification>
+                </NotificationsWrapper>
+            </Internationalize>
+        ) : null;
     }
 
     // Ensure that all necessary data has been received before rendering child components.

--- a/src/elements/content-sharing/__tests__/SharingModal.test.js
+++ b/src/elements/content-sharing/__tests__/SharingModal.test.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { FormattedMessage } from 'react-intl';
-import ErrorMask from '../../../components/error-mask/ErrorMask';
 import LoadingIndicator from '../../../components/loading-indicator/LoadingIndicator';
 import SharingModal from '../SharingModal';
 import Notification from '../../../components/notification/Notification';
@@ -248,7 +247,6 @@ describe('elements/content-sharing/SharingModal', () => {
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FILE });
             });
-
             expect(wrapper.exists(LoadingIndicator)).toBe(true);
 
             wrapper.update();
@@ -323,7 +321,7 @@ describe('elements/content-sharing/SharingModal', () => {
             api = createAPIMock({ getFile }, { getFolderFields }, { getUser });
         });
 
-        test('should show the ErrorMask and skip the call to getUser() if the call to getFile() fails', async () => {
+        test('should show the initial data error notification and skip the call to getUser() if the call to getFile() fails', async () => {
             let wrapper;
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FILE });
@@ -332,12 +330,12 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(getFile).toHaveBeenCalled();
             expect(getUser).not.toHaveBeenCalled();
             expect(convertItemResponse).not.toHaveBeenCalled();
-            expect(wrapper.exists(ErrorMask)).toBe(true);
+            expect(wrapper.find(Notification).prop('type')).toBe(TYPE_ERROR);
             expect(wrapper.exists(UnifiedShareModal)).toBe(false);
             expect(wrapper.exists(SharingNotification)).toBe(false);
         });
 
-        test('should show the ErrorMask and skip the call to getUser() if the call to getFolderFields() fails', async () => {
+        test('should show the initial data error notification and skip the call to getUser() if the call to getFolderFields() fails', async () => {
             let wrapper;
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FOLDER });
@@ -346,7 +344,7 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(getFolderFields).toHaveBeenCalled();
             expect(getUser).not.toHaveBeenCalled();
             expect(convertItemResponse).not.toHaveBeenCalled();
-            expect(wrapper.exists(ErrorMask)).toBe(true);
+            expect(wrapper.find(Notification).prop('type')).toBe(TYPE_ERROR);
             expect(wrapper.exists(UnifiedShareModal)).toBe(false);
             expect(wrapper.exists(SharingNotification)).toBe(false);
         });
@@ -360,7 +358,20 @@ describe('elements/content-sharing/SharingModal', () => {
 
             wrapper.update();
             expect(wrapper.exists(LoadingIndicator)).toBe(false);
-            expect(wrapper.exists(ErrorMask)).toBe(true);
+            expect(wrapper.find(Notification).prop('type')).toBe(TYPE_ERROR);
+        });
+
+        test('should close the initial data error notification when onClose() is called', async () => {
+            let wrapper;
+            await act(async () => {
+                wrapper = getWrapper({ api, itemType: TYPE_FILE });
+            });
+            wrapper.update();
+            await act(async () => {
+                wrapper.find(Notification).invoke('onClose')();
+            });
+            wrapper.update();
+            expect(wrapper.exists(Notification)).toBe(false);
         });
     });
 
@@ -380,7 +391,7 @@ describe('elements/content-sharing/SharingModal', () => {
             api = createAPIMock({ getFile }, { getFolderFields }, { getUser });
         });
 
-        test('should show the ErrorMask if the call to getFile() succeeds, but the call to getUser() fails', async () => {
+        test('should show the initial data error notification if the call to getFile() succeeds, but the call to getUser() fails', async () => {
             let wrapper;
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FILE });
@@ -390,12 +401,12 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(convertItemResponse).toHaveBeenCalledWith(MOCK_ITEM_API_RESPONSE);
             expect(getUser).toHaveBeenCalled();
             expect(convertUserResponse).not.toHaveBeenCalled();
-            expect(wrapper.exists(ErrorMask)).toBe(true);
+            expect(wrapper.find(Notification).prop('type')).toBe(TYPE_ERROR);
             expect(wrapper.exists(UnifiedShareModal)).toBe(false);
             expect(wrapper.exists(SharingNotification)).toBe(false);
         });
 
-        test('should show the ErrorMask if the call to getFolderFields() succeeds, but the call to getUser() fails', async () => {
+        test('should show the initial data error notification if the call to getFolderFields() succeeds, but the call to getUser() fails', async () => {
             let wrapper;
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FOLDER });
@@ -405,7 +416,7 @@ describe('elements/content-sharing/SharingModal', () => {
             expect(convertItemResponse).toHaveBeenCalledWith(MOCK_ITEM_API_RESPONSE);
             expect(getUser).toHaveBeenCalled();
             expect(convertUserResponse).not.toHaveBeenCalled();
-            expect(wrapper.exists(ErrorMask)).toBe(true);
+            expect(wrapper.find(Notification).prop('type')).toBe(TYPE_ERROR);
             expect(wrapper.exists(UnifiedShareModal)).toBe(false);
             expect(wrapper.exists(SharingNotification)).toBe(false);
         });
@@ -415,16 +426,15 @@ describe('elements/content-sharing/SharingModal', () => {
             await act(async () => {
                 wrapper = getWrapper({ api, itemType: TYPE_FOLDER });
             });
-
             expect(wrapper.exists(LoadingIndicator)).toBe(true);
 
             wrapper.update();
             expect(wrapper.exists(LoadingIndicator)).toBe(false);
-            expect(wrapper.exists(ErrorMask)).toBe(true);
+            expect(wrapper.find(Notification).prop('type')).toBe(TYPE_ERROR);
         });
     });
 
-    describe('with specific errors', () => {
+    describe('with specific initial data errors', () => {
         test.each`
             status   | expectedErrorName
             ${'400'} | ${'badRequestError'}
@@ -449,14 +459,11 @@ describe('elements/content-sharing/SharingModal', () => {
                 });
                 wrapper.update();
                 expect(getFolderFields).toHaveBeenCalled();
-                expect(wrapper.exists(ErrorMask)).toBe(true);
-                expect(
-                    wrapper
-                        .find(ErrorMask)
-                        .find(FormattedMessage)
-                        .at(1) // the error header appears after the IconSadCloud title
-                        .prop('id'),
-                ).toBe(`be.contentSharing.${expectedErrorName}`);
+                const initialDataErrorNotification = wrapper.find(Notification);
+                expect(initialDataErrorNotification.prop('type')).toBe(TYPE_ERROR);
+                expect(initialDataErrorNotification.find(FormattedMessage).prop('id')).toBe(
+                    `be.contentSharing.${expectedErrorName}`,
+                );
             },
         );
 
@@ -484,14 +491,11 @@ describe('elements/content-sharing/SharingModal', () => {
                 });
                 wrapper.update();
                 expect(getFolderFields).toHaveBeenCalled();
-                expect(wrapper.exists(ErrorMask)).toBe(true);
-                expect(
-                    wrapper
-                        .find(ErrorMask)
-                        .find(FormattedMessage)
-                        .at(1)
-                        .prop('id'),
-                ).toBe(`be.contentSharing.${expectedErrorName}`);
+                const initialDataErrorNotification = wrapper.find(Notification);
+                expect(initialDataErrorNotification.prop('type')).toBe(TYPE_ERROR);
+                expect(initialDataErrorNotification.find(FormattedMessage).prop('id')).toBe(
+                    `be.contentSharing.${expectedErrorName}`,
+                );
             },
         );
 
@@ -510,14 +514,11 @@ describe('elements/content-sharing/SharingModal', () => {
             });
             wrapper.update();
             expect(getFolderFields).toHaveBeenCalled();
-            expect(wrapper.exists(ErrorMask)).toBe(true);
-            expect(
-                wrapper
-                    .find(ErrorMask)
-                    .find(FormattedMessage)
-                    .at(1)
-                    .prop('id'),
-            ).toBe(`be.contentSharing.loadingError`);
+            const initialDataErrorNotification = wrapper.find(Notification);
+            expect(initialDataErrorNotification.prop('type')).toBe(TYPE_ERROR);
+            expect(initialDataErrorNotification.find(FormattedMessage).prop('id')).toBe(
+                `be.contentSharing.loadingError`,
+            );
         });
     });
 


### PR DESCRIPTION
Show error notifications when initial data API calls fail. These notifications replace the `ErrorMask`, which previously took up the entire page.

<img width="593" alt="content-sharing-initial-data-notification" src="https://user-images.githubusercontent.com/2956895/96530154-a9701f00-123b-11eb-8bdb-7073c248028b.png">
