### PR TITLE
fix(annotations): use correct value for isOpen prop

### DIFF
--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -56,6 +56,7 @@ const AnnotationActivity = ({
 
     const handleEdit = () => {
         setIsEditing(true);
+        setIsInputOpen(true);
     };
 
     const handleOnSelect = () => {
@@ -118,14 +119,14 @@ const AnnotationActivity = ({
                     <div>
                         <ActivityTimestamp date={createdAtTimestamp} />
                     </div>
-                    {isEditing && currentUser ? (
+                    {isEditing && isInputOpen && currentUser ? (
                         <CommentForm
                             className="bcs-AnnotationActivity-editor"
                             entityId={id}
                             getAvatarUrl={getAvatarUrl}
                             getMentionWithQuery={getMentionWithQuery}
                             isEditing={isEditing}
-                            isOpen={isInputOpen}
+                            isOpen={isEditing}
                             mentionSelectorContacts={mentionSelectorContacts}
                             onCancel={handleFormCancel}
                             onFocus={handleFormFocus}

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -119,14 +119,14 @@ const AnnotationActivity = ({
                     <div>
                         <ActivityTimestamp date={createdAtTimestamp} />
                     </div>
-                    {isEditing && isInputOpen && currentUser ? (
+                    {isEditing && currentUser ? (
                         <CommentForm
                             className="bcs-AnnotationActivity-editor"
                             entityId={id}
                             getAvatarUrl={getAvatarUrl}
                             getMentionWithQuery={getMentionWithQuery}
                             isEditing={isEditing}
-                            isOpen={isEditing}
+                            isOpen={isInputOpen}
                             mentionSelectorContacts={mentionSelectorContacts}
                             onCancel={handleFormCancel}
                             onFocus={handleFormFocus}

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -46,7 +46,6 @@ const AnnotationActivity = ({
     onEdit = noop,
     onSelect = noop,
 }: Props) => {
-    const [isInputOpen, setIsInputOpen] = React.useState(false);
     const [isEditing, setIsEditing] = React.useState(false);
     const { created_at, created_by, description, error, file_version, id, isPending, permissions = {}, target } = item;
 
@@ -56,22 +55,17 @@ const AnnotationActivity = ({
 
     const handleEdit = () => {
         setIsEditing(true);
-        setIsInputOpen(true);
     };
 
     const handleOnSelect = () => {
         onSelect(item);
     };
 
-    const handleFormFocus = (): void => setIsInputOpen(true);
-
     const handleFormCancel = (): void => {
-        setIsInputOpen(false);
         setIsEditing(false);
     };
 
     const handleFormSubmit = ({ text }): void => {
-        setIsInputOpen(false);
         setIsEditing(false);
         onEdit(id, text, permissions);
     };
@@ -126,10 +120,9 @@ const AnnotationActivity = ({
                             getAvatarUrl={getAvatarUrl}
                             getMentionWithQuery={getMentionWithQuery}
                             isEditing={isEditing}
-                            isOpen={isInputOpen}
+                            isOpen={isEditing}
                             mentionSelectorContacts={mentionSelectorContacts}
                             onCancel={handleFormCancel}
-                            onFocus={handleFormFocus}
                             updateComment={handleFormSubmit}
                             user={currentUser}
                             tagged_message={message}

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
@@ -108,8 +108,15 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
 
         wrapper.find('AnnotationActivityMenu').simulate('click');
         wrapper.find('MenuItem').simulate('click');
-
         expect(wrapper.exists('CommentForm')).toBe(true);
+
+        // Clicking the cancel button will remove the CommentForm
+        wrapper
+            .find('CommentInputControls')
+            .find('Button')
+            .first()
+            .simulate('click');
+        expect(wrapper.exists('CommentForm')).toBe(false);
     });
 
     test('should correctly render annotation activity of another file version', () => {

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
@@ -95,6 +95,23 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
         },
     );
 
+    test('should render CommentForm if user clicks on the Modify menu item', () => {
+        const activity = {
+            item: {
+                ...mockAnnotation,
+                isPending: false,
+                permissions: { can_edit: true },
+            },
+        };
+
+        const wrapper = mount(<AnnotationActivity {...mockActivity} {...activity} />);
+
+        wrapper.find('AnnotationActivityMenu').simulate('click');
+        wrapper.find('MenuItem').simulate('click');
+
+        expect(wrapper.exists('CommentForm')).toBe(true);
+    });
+
     test('should correctly render annotation activity of another file version', () => {
         const wrapper = getWrapper({ isCurrentVersion: false });
 

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -33,7 +33,7 @@ type Props = {
     isOpen: boolean,
     mentionSelectorContacts?: SelectorItems<>,
     onCancel: Function,
-    onFocus: Function,
+    onFocus?: Function,
     onSubmit?: Function,
     showTip?: boolean,
     tagged_message?: string,


### PR DESCRIPTION
Changes in this PR:
- [x] we are now using isEditing value to determine whether or not we should be showing the Cancel / Post buttons

The issue is that before when we clicked on the Modify button, the form input would show up but the Cancel / Post buttons would not show up until the user clicks to focus the input field.

The correct UX is that when the user clicks on the Modify button, we should immediately see the Cancel / Post buttons.
<img width="331" alt="Screen Shot 2020-10-20 at 9 23 05 AM" src="https://user-images.githubusercontent.com/7213887/96618529-e975e700-12b9-11eb-980a-3c7c15d54af0.png">
