### PR TITLE
ci: Fix CircleCI issue with missing PR Number

### DIFF
--- a/scripts/commitlint.sh
+++ b/scripts/commitlint.sh
@@ -6,6 +6,10 @@
 set -o errexit
 if [ -n "${CIRCLE_PULL_REQUEST}" ]
 then
+  # Sometimes CIRCLE_PR_NUMBER is missing
+  # See also: https://discuss.circleci.com/t/circle-pr-number-missing-from-environment-variables/3745/2
+  CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
+  echo "Retrieving PR Details: https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}"
   PULL_REQUEST_DETAILS=$(curl https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER})
   BASE_SHA1=$(node -pe 'JSON.parse(process.argv[1]).base.sha' "${PULL_REQUEST_DETAILS}")
   echo "Base SHA1: $BASE_SHA1"


### PR DESCRIPTION
Fixes an issue where CircleCI does not set the `CIRCLE_PR_NUMBER` env variable correctly. This is very apparent on `dependabot` commits