### PR TITLE
fix(annotations): disable modify menu item

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -1281,7 +1281,7 @@ class Feed extends Base {
                 }
             },
             errorCallback: (e: ErrorResponseData, code: string) => {
-                this.updateCommentErrorCallback(e, code, commentId);
+                this.feedErrorCallback(true, e, code);
             },
         });
     };

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
@@ -42,6 +42,8 @@ const AnnotationActivityMenu = ({ canDelete, canEdit, id, onDeleteConfirm, onEdi
         targetAttachment: 'bottom right',
     };
 
+    const shouldDisableModifyMenuItem = true;
+
     return (
         <TetherComponent {...tetherProps}>
             <Media.Menu
@@ -52,7 +54,7 @@ const AnnotationActivityMenu = ({ canDelete, canEdit, id, onDeleteConfirm, onEdi
                     'data-resin-feature': 'annotations',
                 }}
             >
-                {canEdit && (
+                {!shouldDisableModifyMenuItem && canEdit && (
                     <MenuItem
                         data-resin-itemid={id}
                         data-resin-target={ACTIVITY_TARGETS.ANNOTATION_OPTIONS_EDIT}

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
@@ -95,30 +95,6 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
         },
     );
 
-    test('should render CommentForm if user clicks on the Modify menu item', () => {
-        const activity = {
-            item: {
-                ...mockAnnotation,
-                isPending: false,
-                permissions: { can_edit: true },
-            },
-        };
-
-        const wrapper = mount(<AnnotationActivity {...mockActivity} {...activity} />);
-
-        wrapper.find('AnnotationActivityMenu').simulate('click');
-        wrapper.find('MenuItem').simulate('click');
-        expect(wrapper.exists('CommentForm')).toBe(true);
-
-        // Clicking the cancel button will remove the CommentForm
-        wrapper
-            .find('CommentInputControls')
-            .find('Button')
-            .first()
-            .simulate('click');
-        expect(wrapper.exists('CommentForm')).toBe(false);
-    });
-
     test('should correctly render annotation activity of another file version', () => {
         const wrapper = getWrapper({ isCurrentVersion: false });
 

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivityMenu.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivityMenu.test.js
@@ -21,10 +21,10 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityMe
         },
     );
 
-    test('should render the edit annotation activity menu item if canEdit is true', () => {
+    test('should not render the edit annotation activity menu item if canEdit is true and shouldDisableModifyMenuItem is true', () => {
         const wrapper = getWrapper({ canEdit: true });
 
-        expect(wrapper.exists('[data-testid="edit-annotation-activity"]')).toBe(true);
+        expect(wrapper.exists('[data-testid="edit-annotation-activity"]')).toBe(false);
     });
 
     test('should show the delete confirm menu when confirming delete', () => {
@@ -37,16 +37,11 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityMe
     });
 
     test('should render resin tags', () => {
-        const wrapper = getWrapper({ canDelete: true, canEdit: true });
+        const wrapper = getWrapper({ canDelete: true });
 
         expect(wrapper.find("[data-testid='delete-annotation-activity']").props()).toMatchObject({
             'data-resin-itemid': '123',
             'data-resin-target': 'activityfeed-annotation-delete',
-        });
-
-        expect(wrapper.find("[data-testid='edit-annotation-activity']").props()).toMatchObject({
-            'data-resin-itemid': '123',
-            'data-resin-target': 'activityfeed-annotation-edit',
         });
     });
 });


### PR DESCRIPTION
Changes in this PR:
- add flag to hide Modify menu item
- revert update comment UX

<img width="339" alt="Screen Shot 2020-10-21 at 2 02 57 PM" src="https://user-images.githubusercontent.com/7213887/96787385-7dbd7800-13a6-11eb-9f14-320945b08122.png">
