### PR TITLE
fix(annotations): use correct pencil icon

### DIFF
--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
@@ -3,10 +3,10 @@ import * as React from 'react';
 import TetherComponent from 'react-tether';
 import { FormattedMessage } from 'react-intl';
 import DeleteConfirmation from '../common/delete-confirmation';
-import IconTrash from '../../../../icons/general/IconTrash';
 import Media from '../../../../components/media';
 import messages from './messages';
 import Pencil16 from '../../../../icon/line/Pencil16';
+import Trash16 from '../../../../icon/fill/Trash16';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 import { bdlGray } from '../../../../styles/variables';
 import { MenuItem } from '../../../../components/menu';
@@ -72,7 +72,7 @@ const AnnotationActivityMenu = ({ canDelete, canEdit, id, onDeleteConfirm, onEdi
                         data-testid="delete-annotation-activity"
                         onClick={handleDeleteClick}
                     >
-                        <IconTrash color={bdlGray} />
+                        <Trash16 color={bdlGray} />
                         <FormattedMessage {...messages.annotationActivityDeleteMenuItem} />
                     </MenuItem>
                 )}

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
@@ -3,10 +3,10 @@ import * as React from 'react';
 import TetherComponent from 'react-tether';
 import { FormattedMessage } from 'react-intl';
 import DeleteConfirmation from '../common/delete-confirmation';
-import IconEdit from '../../../../icons/general/IconEdit';
 import IconTrash from '../../../../icons/general/IconTrash';
 import Media from '../../../../components/media';
 import messages from './messages';
+import Pencil16 from '../../../../icon/line/Pencil16';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 import { bdlGray } from '../../../../styles/variables';
 import { MenuItem } from '../../../../components/menu';
@@ -61,7 +61,7 @@ const AnnotationActivityMenu = ({ canDelete, canEdit, id, onDeleteConfirm, onEdi
                         data-testid="edit-annotation-activity"
                         onClick={onEdit}
                     >
-                        <IconEdit color={bdlGray} />
+                        <Pencil16 />
                         <FormattedMessage {...messages.annotationActivityEditMenuItem} />
                     </MenuItem>
                 )}


### PR DESCRIPTION
Changes in this PR:
- [x] use Pencil16 component 

<img width="341" alt="Screen Shot 2020-10-22 at 11 43 57 AM" src="https://user-images.githubusercontent.com/7213887/96918424-1e6f6e80-145f-11eb-893e-b64b5893c482.png">
