### PR TITLE
feat(usm): Adding new external collab restriction flow

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1436,6 +1436,10 @@ boxui.unifiedShare.collaboratorListTitle = People in ‘{itemName}’
 boxui.unifiedShare.collaborators.expirationTooltipClickableText = Access expires on {date}. Click for details.
 # Text to show when the number of contact email addresses displayed on a tooltip exceeds the maximum amount that can be displayed
 boxui.unifiedShare.contactEmailsTooltipText = {emails}, and {remainingEmailsCount} more
+# Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts
+boxui.unifiedShare.contactRestrictionNotice = Invitations cannot be sent to {count, plural, one {{email}} other {{count} people}} because external collaboration is restricted due to the applied classification.
+# Label for the button that removes restricted contacts on the contact restriction notice
+boxui.unifiedShare.contactRestrictionRemoveButtonLabel = Remove {count, plural, one {the person} other {{count} people}} and continue.
 # Error message when more than the maximum number of contacts is entered
 boxui.unifiedShare.contactsExceedLimitError = Oops! The maximum number of collaborators that can be added at once is {maxContacts} collaborators. Please try again by splitting your invitations into batches.
 # Text shown in share modal when there is at least one external collaborators
@@ -1482,10 +1486,12 @@ boxui.unifiedShare.inviteDisabledTooltip = You do not have permission to invite 
 boxui.unifiedShare.inviteDisabledWeblinkTooltip = Collaborators cannot be added to bookmarks.
 # Label of the field where a user designates who to invite to collaborate on an item
 boxui.unifiedShare.inviteFieldLabel = Invite People
+# Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts and business justifications are allowed for bypassing restrictions
+boxui.unifiedShare.justifiableContactRestrictionNotice = This classified content requires a business justification to invite {count, plural, one {{email}} other {{count} people}}. Please select a business justification below.
+# Label for the button that removes restricted contacts on the contact restriction notice when business justifications are allowed for bypassing restrictions
+boxui.unifiedShare.justifiableContactRestrictionRemoveButtonLabel = Alternatively, remove {count, plural, one {the person} other {{count} people}} and continue.
 # The error message that is displayed when a user tries to send invitations to external collaborators, but a business justification is required before proceeding
 boxui.unifiedShare.justificationRequiredError = Select a justification or remove people to continue
-# The label displayed at the top of the select field that allows selecting a business justification reason
-boxui.unifiedShare.justificationSelectLabel = Business Justification
 # The placeholder text of the select field that allows selecting a business justification reason
 boxui.unifiedShare.justificationSelectPlaceholder = Select Justification
 # Call to action text for allowing the user to create a new shared link
@@ -1540,6 +1546,8 @@ boxui.unifiedShare.removeLinkConfirmationDescription = This will permanently rem
 boxui.unifiedShare.removeLinkConfirmationTitle = Remove Shared Link
 # Tooltip description for not having access to remove link
 boxui.unifiedShare.removeLinkTooltip = You do not have permission to remove the link.
+# The error message that is displayed when a user tries to send invitations to external collaborators, but restricted contacts need to be removed before proceeding
+boxui.unifiedShare.restrictedContactsError = Remove people to continue
 # Tooltip text for email shared link button (title-case)
 boxui.unifiedShare.sendSharedLink = Send Shared Link
 # Field label for shared link recipient list (title-case)

--- a/src/features/unified-share-modal/ContactRestrictionNotice.js
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.js
@@ -3,19 +3,15 @@
 import * as React from 'react';
 import noop from 'lodash/noop';
 import getProp from 'lodash/get';
-import uniqueId from 'lodash/uniqueId';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import type { InjectIntlProvidedProps } from 'react-intl';
 
-import FormattedCompMessage from '../../components/i18n/FormattedCompMessage';
-import Param from '../../components/i18n/Param';
-import Label from '../../components/label';
+import Tooltip from '../../components/tooltip';
 import PlainButton from '../../components/plain-button';
 import InlineNotice from '../../components/inline-notice';
 import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
 import SingleSelectField from '../../components/select-field/SingleSelectField';
 
-import ContactsEmailsTooltip from './ContactsEmailsTooltip';
 import messages from './messages';
 
 import type { SelectOptionProp } from '../../components/select-field/props';
@@ -25,7 +21,8 @@ import './ContactRestrictionNotice.scss';
 
 type Props = {
     error?: React.Node,
-    isLoading?: boolean,
+    isFetchingJustificationReasons?: boolean,
+    isRestrictionJustificationEnabled?: boolean,
     justificationReasons: Array<SelectOptionProp>,
     onRemoveRestrictedExternalContacts: () => void,
     onSelectJustificationReason: (justificationReasonOption: SelectOptionProp) => void,
@@ -37,7 +34,8 @@ type Props = {
 const ContactRestrictionNotice = ({
     error,
     intl,
-    isLoading,
+    isFetchingJustificationReasons,
+    isRestrictionJustificationEnabled,
     justificationReasons,
     onRemoveRestrictedExternalContacts,
     onSelectJustificationReason,
@@ -45,7 +43,6 @@ const ContactRestrictionNotice = ({
     selectedContacts,
     selectedJustificationReason,
 }: Props) => {
-    const compMessageId = uniqueId('compMessage');
     const restrictedExternalContacts = selectedContacts.filter(({ value }) => restrictedExternalEmails.includes(value));
     const restrictedExternalContactCount = restrictedExternalContacts.length;
 
@@ -53,82 +50,53 @@ const ContactRestrictionNotice = ({
         return null;
     }
 
-    const RemoveButton = ({ children }: { children: React.Node }) => (
-        <PlainButton
-            className="bdl-ContactRestrictionNotice-removeBtn"
-            data-resin-target="removeBtn"
-            onClick={onRemoveRestrictedExternalContacts}
-        >
-            {children}
-        </PlainButton>
-    );
-
-    // TODO:
-    // Switch to react-intl v3+ api once migration is complete. FormattedCompMessage is now
-    // deprecated and has some issues with components nested within <Plural/>, hence why we
-    // use two messages and use unique keys as a workaround.
-
-    const noticeDescriptionSingular = (
-        <FormattedCompMessage
-            key={compMessageId}
-            description="Notice to display when sharing a file with external collaborators requires a business justification to be provided."
-            id="boxui.unifiedShare.businessJustificationRequiredSingular"
-        >
-            This classified content requires a business justification to collaborate with{' '}
-            <span className="bdl-ContactRestrictionNotice-contactEmail">
-                <Param
-                    value={restrictedExternalContacts[0].value}
-                    description="The email address of the external user"
-                />
-            </span>
-            . Select a business justification below or <RemoveButton>remove the user</RemoveButton> to continue.
-        </FormattedCompMessage>
-    );
-
-    const noticeDescriptionPlural = (
-        <FormattedCompMessage
-            key={compMessageId}
-            description="Notice to display when sharing a file with external collaborators requires a business justification to be provided."
-            id="boxui.unifiedShare.businessJustificationRequiredPlural"
-        >
-            This classified content requires a business justification to collaborate with{' '}
-            <ContactsEmailsTooltip contacts={restrictedExternalContacts}>
-                <Param
-                    value={restrictedExternalContactCount}
-                    description="Number of external collborators currently selected"
-                />{' '}
-                people
-            </ContactsEmailsTooltip>
-            . Select a business justification below or <RemoveButton>remove them</RemoveButton> to continue.
-        </FormattedCompMessage>
-    );
-
+    const firstEmail = restrictedExternalContacts[0].value;
     const selectedValue = getProp(selectedJustificationReason, 'value', null);
-    const noticeDescription =
-        restrictedExternalContactCount === 1 ? noticeDescriptionSingular : noticeDescriptionPlural;
+    const isErrorTooltipShown = !!error;
+
+    const restrictionNoticeMessage = isRestrictionJustificationEnabled
+        ? messages.justifiableContactRestrictionNotice
+        : messages.contactRestrictionNotice;
+    const removeButtonLabelMessage = isRestrictionJustificationEnabled
+        ? messages.justifiableContactRestrictionRemoveButtonLabel
+        : messages.contactRestrictionRemoveButtonLabel;
+
+    const justificationSelectSection = isFetchingJustificationReasons ? (
+        <LoadingIndicator className="bdl-ContactRestrictionNotice-loadingIndicator" />
+    ) : (
+        <SingleSelectField
+            data-resin-target="justificationReasonsSelect"
+            options={justificationReasons}
+            onChange={onSelectJustificationReason}
+            placeholder={intl.formatMessage(messages.justificationSelectPlaceholder)}
+            selectedValue={selectedValue}
+        />
+    );
 
     return (
-        <InlineNotice
-            className="bdl-ContactRestrictionNotice"
-            data-resin-component="contactRestrictionNotice"
-            type="error"
-        >
-            <p className="bdl-ContactRestrictionNotice-description">{noticeDescription}</p>
-            <Label text={<FormattedMessage {...messages.justificationSelectLabel} />}>
-                {isLoading ? (
-                    <LoadingIndicator className="bdl-ContactRestrictionNotice-loadingIndicator" />
-                ) : (
-                    <SingleSelectField
-                        data-resin-target="justificationReasonsSelect"
-                        error={error}
-                        options={justificationReasons}
-                        onChange={onSelectJustificationReason}
-                        placeholder={intl.formatMessage(messages.justificationSelectPlaceholder)}
-                        selectedValue={selectedValue}
+        <Tooltip text={error} isShown={isErrorTooltipShown} position="middle-right" theme="error">
+            <InlineNotice
+                className="bdl-ContactRestrictionNotice"
+                data-resin-component="contactRestrictionNotice"
+                type="error"
+            >
+                <FormattedMessage
+                    {...restrictionNoticeMessage}
+                    values={{ count: restrictedExternalContactCount, email: firstEmail }}
+                />
+                {isRestrictionJustificationEnabled && justificationSelectSection}
+                <PlainButton
+                    className="bdl-ContactRestrictionNotice-removeBtn"
+                    data-resin-target="removeBtn"
+                    onClick={onRemoveRestrictedExternalContacts}
+                >
+                    <FormattedMessage
+                        {...removeButtonLabelMessage}
+                        values={{ count: restrictedExternalContactCount }}
                     />
-                )}
-            </Label>
-        </InlineNotice>
+                </PlainButton>
+            </InlineNotice>
+        </Tooltip>
     );
 };
 

--- a/src/features/unified-share-modal/ContactRestrictionNotice.scss
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.scss
@@ -2,7 +2,7 @@
 
 .bdl-ContactRestrictionNotice {
     .bdl-SelectButton {
-        margin-top: $bdl-grid-unit * 2;
+        margin: $bdl-grid-unit * 3 auto;
     }
 
     .bdl-SelectFieldDropdown {
@@ -15,12 +15,11 @@
     text-decoration: underline;
 }
 
-.bdl-ContactRestrictionNotice-description {
-    margin-bottom: $bdl-grid-unit * 2;
-}
-
 .bdl-ContactRestrictionNotice-loadingIndicator {
-    margin: 14px auto $bdl-grid-unit * 2 auto;
+    display: flex;
+    align-items: center;
+    height: 34px;
+    margin: $bdl-grid-unit * 3 auto;
 }
 
 .bdl-ContactRestrictionNotice-removeBtn {

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -486,6 +486,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             isExpanded={isInviteSectionExpanded}
                             isFetchingJustificationReasons={isFetchingJustificationReasons}
                             isExternalUserSelected={this.hasExternalContact(INVITE_COLLABS_CONTACTS_TYPE)}
+                            isRestrictionJustificationEnabled={this.shouldRequireExternalCollabJustification()}
                             justificationReasons={justificationReasons}
                             onContactInput={this.openInviteCollaborators}
                             onPillCreate={this.handleInviteCollabPillCreate}
@@ -494,7 +495,6 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             openInviteCollaboratorsSection={this.openInviteCollaboratorsSection}
                             recommendedSharingTooltipCalloutName={recommendedSharingTooltipCalloutName}
                             restrictedExternalEmails={restrictedExternalCollabEmails}
-                            shouldRequireExternalContactJustification={this.shouldRequireExternalCollabJustification()}
                             showEnterEmailsCallout={showEnterEmailsCallout}
                             submitting={submitting}
                             selectedContacts={this.state.inviteCollabsContacts}

--- a/src/features/unified-share-modal/__tests__/ContactRestrictionNotice.test.js
+++ b/src/features/unified-share-modal/__tests__/ContactRestrictionNotice.test.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
+import messages from '../messages';
+
 import { ContactRestrictionNoticeComponent as ContactRestrictionNotice } from '../ContactRestrictionNotice';
 
 describe('features/unified-share-modal/ContactRestrictionNotice', () => {
@@ -9,15 +11,13 @@ describe('features/unified-share-modal/ContactRestrictionNotice', () => {
     let selectedContacts;
     let restrictedExternalEmails;
 
-    const singularMessageId = 'boxui.unifiedShare.businessJustificationRequiredSingular';
-    const pluralMessageId = 'boxui.unifiedShare.businessJustificationRequiredPlural';
-
     const getWrapper = (props = {}) => {
         return shallow(
             <ContactRestrictionNotice
                 error=""
-                isLoading={false}
                 intl={{ formatMessage: jest.fn() }}
+                isFetchingJustificationReasons={false}
+                isRestrictionJustificationEnabled={false}
                 justificationReasons={[]}
                 onRemoveRestrictedExternalContacts={jest.fn()}
                 onSelectJustificationReason={jest.fn()}
@@ -60,9 +60,9 @@ describe('features/unified-share-modal/ContactRestrictionNotice', () => {
 
     describe('render', () => {
         test('should render default ContactRestrictionNotice component', () => {
-            expect(wrapper.is('InlineNotice')).toBe(true);
-            expect(wrapper.find(`FormattedCompMessage[id="${pluralMessageId}"]`)).toHaveLength(1);
-            expect(wrapper.find('[data-resin-target="justificationReasonsSelect"]')).toHaveLength(1);
+            expect(wrapper.is('Tooltip')).toBe(true);
+            expect(wrapper.find('InlineNotice')).toHaveLength(1);
+            expect(wrapper.find('[data-resin-target="removeBtn"]')).toHaveLength(1);
         });
 
         test('should render nothing when there are no restricted external contacts', () => {
@@ -73,51 +73,49 @@ describe('features/unified-share-modal/ContactRestrictionNotice', () => {
             expect(wrapper.isEmptyRender()).toBe(true);
         });
 
-        test('should render singular message when only one restricted external contact exists', () => {
-            restrictedExternalEmails = ['x@example.com'];
+        test.each`
+            isRestrictionJustificationEnabled | restrictionNoticeMessageId                         | removeButtonMessageId
+            ${false}                          | ${messages.contactRestrictionNotice.id}            | ${messages.contactRestrictionRemoveButtonLabel.id}
+            ${true}                           | ${messages.justifiableContactRestrictionNotice.id} | ${messages.justifiableContactRestrictionRemoveButtonLabel.id}
+        `(
+            'should select appropriate messages when isRestrictionJustificationEnabled is $isRestrictionJustificationEnabled',
+            ({ isRestrictionJustificationEnabled, restrictionNoticeMessageId, removeButtonMessageId }) => {
+                wrapper.setProps({ isRestrictionJustificationEnabled });
 
-            wrapper.setProps({ restrictedExternalEmails });
-            const message = wrapper.find(`FormattedCompMessage[id="${singularMessageId}"]`);
-            expect(message).toHaveLength(1);
-            expect(wrapper.find('Param').props().value).toBe(restrictedExternalEmails[0]);
+                const restrictionNoticeMessage = wrapper.find(`FormattedMessage[id="${restrictionNoticeMessageId}"]`);
+                const removeButtonMessage = wrapper.find(`FormattedMessage[id="${removeButtonMessageId}"]`);
+
+                expect(restrictionNoticeMessage).toHaveLength(1);
+                expect(restrictionNoticeMessage.props().values).toEqual({
+                    count: restrictedExternalEmails.length,
+                    email: selectedContacts[0].value,
+                });
+                expect(removeButtonMessage).toHaveLength(1);
+                expect(removeButtonMessage.props().values).toEqual({
+                    count: restrictedExternalEmails.length,
+                });
+            },
+        );
+
+        test('should display error tooltip when error is provided', () => {
+            const error = 'error';
+
+            wrapper.setProps({ error: undefined });
+            expect(wrapper.find('Tooltip').props().isShown).toBe(false);
+
+            wrapper.setProps({ error });
+            expect(wrapper.find('Tooltip').props().text).toBe(error);
+            expect(wrapper.find('Tooltip').props().isShown).toBe(true);
         });
 
-        test('should render plural message when more than one restricted external contact exist', () => {
-            restrictedExternalEmails = ['x@example.com', 'y@example.com', 'z@example.com'];
-
-            wrapper.setProps({ restrictedExternalEmails });
-            const message = wrapper.find(`FormattedCompMessage[id="${pluralMessageId}"]`);
-            expect(message).toHaveLength(1);
-        });
-
-        test('should pass contacts information to tooltip within message', () => {
-            const expectedContacts = selectedContacts.filter(({ value }) => restrictedExternalEmails.includes(value));
-            const message = wrapper.find(`FormattedCompMessage[id="${pluralMessageId}"]`);
-
-            expect(message.find('ContactsEmailsTooltip').props().contacts).toEqual(expectedContacts);
-            expect(
-                message
-                    .find('ContactsEmailsTooltip')
-                    .find('Param')
-                    .props().value,
-            ).toBe(expectedContacts.length);
-        });
-
-        test('should render a loading indicator instead of the justification reasons select when isLoading is true', () => {
-            wrapper.setProps({ isLoading: true });
+        test('should render a loading indicator instead of the justification reasons select when isFetchingJustificationReasons is true', () => {
+            wrapper.setProps({ isFetchingJustificationReasons: true, isRestrictionJustificationEnabled: true });
 
             expect(wrapper.find('[data-resin-target="justificationReasonsSelect"]')).toHaveLength(0);
             expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
         });
 
-        test('should pass error to justification reasons select when provided', () => {
-            const error = 'error';
-            wrapper.setProps({ error, isLoading: false });
-
-            expect(wrapper.find('[data-resin-target="justificationReasonsSelect"]').props().error).toBe(error);
-        });
-
-        test('should render justification reasons select when isLoading is false', () => {
+        test('should render justification reasons select when isFetchingJustificationReasons is false and isRestrictionJustificationEnabled is true', () => {
             const selectedJustificationReason = {
                 displayText: 'displayText1',
                 value: 'value1',
@@ -129,7 +127,12 @@ describe('features/unified-share-modal/ContactRestrictionNotice', () => {
                     value: 'value2',
                 },
             ];
-            wrapper.setProps({ isLoading: false, justificationReasons, selectedJustificationReason });
+            wrapper.setProps({
+                isFetchingJustificationReasons: false,
+                isRestrictionJustificationEnabled: true,
+                justificationReasons,
+                selectedJustificationReason,
+            });
 
             const justificationReasonsSelect = wrapper.find('[data-resin-target="justificationReasonsSelect"]');
             expect(justificationReasonsSelect).toHaveLength(1);
@@ -140,23 +143,19 @@ describe('features/unified-share-modal/ContactRestrictionNotice', () => {
     });
 
     describe('handlers', () => {
-        test('should call onRemoveRestrictedExternalContacts when remove button is clicked within message', () => {
+        test('should call onRemoveRestrictedExternalContacts when remove button is clicked', () => {
             const onRemoveRestrictedExternalContacts = jest.fn();
             wrapper.setProps({ onRemoveRestrictedExternalContacts });
 
             expect(onRemoveRestrictedExternalContacts).toHaveBeenCalledTimes(0);
-            wrapper
-                .find(`FormattedCompMessage[id="${pluralMessageId}"]`)
-                .children('RemoveButton')
-                .dive()
-                .simulate('click');
+            wrapper.find('[data-resin-target="removeBtn"]').simulate('click');
             expect(onRemoveRestrictedExternalContacts).toHaveBeenCalledTimes(1);
         });
 
         test('should call onSelectJustificationReason with newly selected option on justification reason select change', () => {
             const onSelectJustificationReason = jest.fn();
             const expectedJustificationReason = { displayText: 'displayText', value: 'value' };
-            wrapper.setProps({ onSelectJustificationReason });
+            wrapper.setProps({ isRestrictionJustificationEnabled: true, onSelectJustificationReason });
 
             expect(onSelectJustificationReason).toHaveBeenCalledTimes(0);
             wrapper

--- a/src/features/unified-share-modal/__tests__/EmailForm.test.js
+++ b/src/features/unified-share-modal/__tests__/EmailForm.test.js
@@ -306,43 +306,31 @@ describe('features/unified-share-modal/EmailForm', () => {
             );
         });
 
-        test('should trigger an error and abort submit action when restricted contacts are present and justification is allowed but not selected', () => {
-            const message = 'test message';
-            const event = { preventDefault: jest.fn() };
-            const onSubmit = jest.fn();
+        test.each`
+            isRestrictionJustificationEnabled | expectedErrorId                                    | conditionDescription
+            ${true}                           | ${'boxui.unifiedShare.justificationRequiredError'} | ${'justification is allowed but not selected'}
+            ${false}                          | ${'boxui.unifiedShare.restrictedContactsError'}    | ${'justification is not allowed'}
+        `(
+            'should trigger an error and abort submit action when restricted contacts are present and $conditionDescription',
+            ({ isRestrictionJustificationEnabled, expectedErrorId }) => {
+                const message = 'test message';
+                const event = { preventDefault: jest.fn() };
+                const onSubmit = jest.fn();
 
-            const wrapper = getWrapper({
-                onSubmit,
-                restrictedExternalEmails: [expectedContacts[1].value, expectedContacts[2].value],
-                selectedContacts: expectedContacts,
-                isRestrictionJustificationEnabled: true,
-            });
+                const wrapper = getWrapper({
+                    onSubmit,
+                    restrictedExternalEmails: [expectedContacts[1].value, expectedContacts[2].value],
+                    selectedContacts: expectedContacts,
+                    isRestrictionJustificationEnabled,
+                });
 
-            wrapper.setState({ message });
-            wrapper.instance().handleSubmit(event);
+                wrapper.setState({ message });
+                wrapper.instance().handleSubmit(event);
 
-            expect(wrapper.state('contactsRestrictionError')).toEqual('boxui.unifiedShare.justificationRequiredError');
-            expect(onSubmit).toHaveBeenCalledTimes(0);
-        });
-
-        test('should trigger an error and abort submit action when restricted contacts are present and justification is not allowed', () => {
-            const message = 'test message';
-            const event = { preventDefault: jest.fn() };
-            const onSubmit = jest.fn();
-
-            const wrapper = getWrapper({
-                onSubmit,
-                restrictedExternalEmails: [expectedContacts[1].value, expectedContacts[2].value],
-                selectedContacts: expectedContacts,
-                isRestrictionJustificationEnabled: false,
-            });
-
-            wrapper.setState({ message });
-            wrapper.instance().handleSubmit(event);
-
-            expect(wrapper.state('contactsRestrictionError')).toEqual('boxui.unifiedShare.restrictedContactsError');
-            expect(onSubmit).toHaveBeenCalledTimes(0);
-        });
+                expect(wrapper.state('contactsRestrictionError')).toBe(expectedErrorId);
+                expect(onSubmit).toHaveBeenCalledTimes(0);
+            },
+        );
 
         test('should handle errors from onSubmit prop', () => {
             const message = 'test message';

--- a/src/features/unified-share-modal/__tests__/EmailForm.test.js
+++ b/src/features/unified-share-modal/__tests__/EmailForm.test.js
@@ -141,11 +141,15 @@ describe('features/unified-share-modal/EmailForm', () => {
         test('should reset contact limit error when contact removal results in a contact count within the limit', () => {
             const wrapper = getWrapper({
                 contactLimit: 1,
+                isExpanded: true,
                 onSubmit: jest.fn().mockResolvedValue({}),
                 restrictedExternalEmails: [expectedContacts[2].value],
                 selectedContacts: [expectedContacts[1], expectedContacts[2]],
+                isRestrictionJustificationEnabled: true,
             });
 
+            // Select justification so that no restriction-related error is triggered
+            wrapper.find('ContactRestrictionNotice').simulate('selectJustificationReason', expectedJustificationReason);
             wrapper.instance().handleSubmit({ preventDefault: jest.fn() });
             expect(wrapper.state('contactsFieldError')).toBe('boxui.unifiedShare.contactsExceedLimitError');
 
@@ -177,7 +181,7 @@ describe('features/unified-share-modal/EmailForm', () => {
                 onSubmit: jest.fn().mockResolvedValue({}),
                 restrictedExternalEmails: [expectedContacts[0].value],
                 selectedContacts: expectedContacts,
-                shouldRequireExternalContactJustification: true,
+                isRestrictionJustificationEnabled: true,
             });
 
             // Trigger error by submitting without selecting a justification
@@ -287,7 +291,7 @@ describe('features/unified-share-modal/EmailForm', () => {
                     'not_included_in_contacts@example.com',
                 ],
                 selectedContacts: expectedContacts,
-                shouldRequireExternalContactJustification: true,
+                isRestrictionJustificationEnabled: true,
             });
 
             wrapper.setState({ message });
@@ -300,6 +304,44 @@ describe('features/unified-share-modal/EmailForm', () => {
                     restrictedExternalEmails: [expectedContacts[1].value, expectedContacts[2].value],
                 }),
             );
+        });
+
+        test('should trigger an error and abort submit action when restricted contacts are present and justification is allowed but not selected', () => {
+            const message = 'test message';
+            const event = { preventDefault: jest.fn() };
+            const onSubmit = jest.fn();
+
+            const wrapper = getWrapper({
+                onSubmit,
+                restrictedExternalEmails: [expectedContacts[1].value, expectedContacts[2].value],
+                selectedContacts: expectedContacts,
+                isRestrictionJustificationEnabled: true,
+            });
+
+            wrapper.setState({ message });
+            wrapper.instance().handleSubmit(event);
+
+            expect(wrapper.state('contactsRestrictionError')).toEqual('boxui.unifiedShare.justificationRequiredError');
+            expect(onSubmit).toHaveBeenCalledTimes(0);
+        });
+
+        test('should trigger an error and abort submit action when restricted contacts are present and justification is not allowed', () => {
+            const message = 'test message';
+            const event = { preventDefault: jest.fn() };
+            const onSubmit = jest.fn();
+
+            const wrapper = getWrapper({
+                onSubmit,
+                restrictedExternalEmails: [expectedContacts[1].value, expectedContacts[2].value],
+                selectedContacts: expectedContacts,
+                isRestrictionJustificationEnabled: false,
+            });
+
+            wrapper.setState({ message });
+            wrapper.instance().handleSubmit(event);
+
+            expect(wrapper.state('contactsRestrictionError')).toEqual('boxui.unifiedShare.restrictedContactsError');
+            expect(onSubmit).toHaveBeenCalledTimes(0);
         });
 
         test('should handle errors from onSubmit prop', () => {
@@ -386,22 +428,31 @@ describe('features/unified-share-modal/EmailForm', () => {
         });
     });
 
-    describe('validateJustificationReason()', () => {
+    describe('validateContactsRestrictions()', () => {
         test.each`
-            shouldRequireExternalContactJustification | selectedJustificationReason    | expectedError
-            ${false}                                  | ${null}                        | ${''}
-            ${false}                                  | ${expectedJustificationReason} | ${''}
-            ${true}                                   | ${null}                        | ${'boxui.unifiedShare.justificationRequiredError'}
-            ${true}                                   | ${expectedJustificationReason} | ${''}
+            isRestrictionJustificationEnabled | restrictedExternalEmails       | selectedJustificationReason    | expectedError
+            ${false}                          | ${[]}                          | ${null}                        | ${''}
+            ${false}                          | ${[]}                          | ${expectedJustificationReason} | ${''}
+            ${true}                           | ${[expectedContacts[0].value]} | ${null}                        | ${'boxui.unifiedShare.justificationRequiredError'}
+            ${true}                           | ${[expectedContacts[0].value]} | ${expectedJustificationReason} | ${''}
+            ${false}                          | ${[]}                          | ${null}                        | ${''}
+            ${false}                          | ${[expectedContacts[0].value]} | ${null}                        | ${'boxui.unifiedShare.restrictedContactsError'}
         `(
-            'should return "$expectedError" when shouldRequireExternalContactJustification is $shouldRequireExternalContactJustification and selectedJustificationReason is $selectedJustificationReason',
-            ({ shouldRequireExternalContactJustification, selectedJustificationReason, expectedError }) => {
+            'should return "$expectedError" when isRestrictionJustificationEnabled is $isRestrictionJustificationEnabled, restrictedExternalEmails is $restrictedExternalEmails and selectedJustificationReason is $selectedJustificationReason',
+            ({
+                isRestrictionJustificationEnabled,
+                restrictedExternalEmails,
+                selectedJustificationReason,
+                expectedError,
+            }) => {
                 const wrapper = getWrapper({
-                    shouldRequireExternalContactJustification,
+                    restrictedExternalEmails,
+                    selectedContacts: expectedContacts,
+                    isRestrictionJustificationEnabled,
                 });
 
                 wrapper.instance().handleSelectJustificationReason(selectedJustificationReason);
-                expect(wrapper.instance().validateJustificationReason()).toEqual(expectedError);
+                expect(wrapper.instance().validateContactsRestrictions()).toEqual(expectedError);
             },
         );
     });
@@ -453,17 +504,17 @@ describe('features/unified-share-modal/EmailForm', () => {
         });
 
         test.each`
-            shouldRequireExternalContactJustification | selectedJustificationReason    | restrictedExternalEmails       | expectedIsValid
-            ${false}                                  | ${null}                        | ${[]}                          | ${true}
-            ${false}                                  | ${expectedJustificationReason} | ${[expectedContacts[0].value]} | ${false}
-            ${false}                                  | ${null}                        | ${[expectedContacts[0].value]} | ${false}
-            ${true}                                   | ${null}                        | ${[expectedContacts[0].value]} | ${false}
-            ${true}                                   | ${null}                        | ${[]}                          | ${true}
-            ${true}                                   | ${expectedJustificationReason} | ${[expectedContacts[0].value]} | ${true}
+            isRestrictionJustificationEnabled | selectedJustificationReason    | restrictedExternalEmails       | expectedIsValid
+            ${false}                          | ${null}                        | ${[]}                          | ${true}
+            ${false}                          | ${expectedJustificationReason} | ${[expectedContacts[0].value]} | ${false}
+            ${false}                          | ${null}                        | ${[expectedContacts[0].value]} | ${false}
+            ${true}                           | ${null}                        | ${[expectedContacts[0].value]} | ${false}
+            ${true}                           | ${null}                        | ${[]}                          | ${true}
+            ${true}                           | ${expectedJustificationReason} | ${[expectedContacts[0].value]} | ${true}
         `(
-            'should have isValidContactPill return $expectedIsValid when shouldRequireExternalContactJustification = $shouldRequireExternalContactJustification, selectedJustificationReason = $selectedJustificationReason and restrictedExternalEmails = $restrictedExternalEmails',
+            'should have isValidContactPill return $expectedIsValid when isRestrictionJustificationEnabled = $isRestrictionJustificationEnabled, selectedJustificationReason = $selectedJustificationReason and restrictedExternalEmails = $restrictedExternalEmails',
             ({
-                shouldRequireExternalContactJustification,
+                isRestrictionJustificationEnabled,
                 selectedJustificationReason,
                 restrictedExternalEmails,
                 expectedIsValid,
@@ -472,7 +523,7 @@ describe('features/unified-share-modal/EmailForm', () => {
                 const contact = expectedContacts[0];
 
                 wrapper.instance().handleSelectJustificationReason(selectedJustificationReason);
-                wrapper.setProps({ restrictedExternalEmails, shouldRequireExternalContactJustification });
+                wrapper.setProps({ restrictedExternalEmails, isRestrictionJustificationEnabled });
 
                 const isValidContactPill = wrapper.instance().isValidContactPill(contact);
                 expect(isValidContactPill).toBe(expectedIsValid);
@@ -487,14 +538,14 @@ describe('features/unified-share-modal/EmailForm', () => {
                 justificationReasons: [expectedJustificationReason],
                 restrictedExternalEmails: [expectedContacts[0].value],
                 selectedContacts: expectedContacts,
-                shouldRequireExternalContactJustification: true,
+                isRestrictionJustificationEnabled: true,
             });
 
             wrapper.instance().validateContactField('invalid_email');
             expect(wrapper.find('ContactsField').props().error).toBe('boxui.validation.emailError');
 
             // Will fail validation since no justification reason has been selected
-            wrapper.instance().validateJustificationReason();
+            wrapper.instance().validateContactsRestrictions();
             expect(wrapper.find('ContactsField').props().error).toBe('');
             expect(wrapper.find('ContactRestrictionNotice').props().error).toBe(
                 'boxui.unifiedShare.justificationRequiredError',
@@ -506,13 +557,13 @@ describe('features/unified-share-modal/EmailForm', () => {
             expect(wrapper.find('ContactsField').props().error).toBe('boxui.validation.emailError');
         });
 
-        test('should clear selected justification reason when shouldRequireExternalContactJustification is set to false after being true', () => {
+        test('should clear selected justification reason when isRestrictionJustificationEnabled is set to false after being true', () => {
             const wrapper = getWrapper({
                 isExpanded: true,
                 justificationReasons: [expectedJustificationReason],
                 restrictedExternalEmails: [expectedContacts[0].value],
                 selectedContacts: expectedContacts,
-                shouldRequireExternalContactJustification: true,
+                isRestrictionJustificationEnabled: true,
             });
 
             wrapper.instance().handleSelectJustificationReason(expectedJustificationReason);
@@ -520,7 +571,7 @@ describe('features/unified-share-modal/EmailForm', () => {
                 expectedJustificationReason,
             );
 
-            wrapper.setProps({ shouldRequireExternalContactJustification: false });
+            wrapper.setProps({ isRestrictionJustificationEnabled: false });
             expect(wrapper.find('ContactRestrictionNotice').props().selectedJustificationReason).toBeNull();
         });
     });
@@ -628,6 +679,7 @@ describe('features/unified-share-modal/EmailForm', () => {
             const justificationReasons = [expectedJustificationReason];
             const restrictedExternalEmails = [expectedContacts[0].value];
             const selectedContacts = expectedContacts;
+            const isRestrictionJustificationEnabled = true;
 
             const wrapper = getWrapper({
                 isExpanded: true,
@@ -635,12 +687,14 @@ describe('features/unified-share-modal/EmailForm', () => {
                 justificationReasons,
                 restrictedExternalEmails,
                 selectedContacts,
+                isRestrictionJustificationEnabled,
             });
 
             expect(wrapper.find('ContactRestrictionNotice')).toHaveLength(1);
             expect(wrapper.find('ContactRestrictionNotice').props()).toEqual(
                 expect.objectContaining({
-                    isLoading: isFetchingJustificationReasons,
+                    isRestrictionJustificationEnabled,
+                    isFetchingJustificationReasons,
                     justificationReasons,
                     restrictedExternalEmails,
                     selectedContacts,

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -725,7 +725,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
 
                 wrapper.instance().updateInviteCollabsContacts(defaultContacts);
                 const externalCollabEmailForm = wrapper.find('[data-testid="invite-collaborator-container"] EmailForm');
-                expect(externalCollabEmailForm.props().shouldRequireExternalContactJustification).toBe(expectedResult);
+                expect(externalCollabEmailForm.props().isRestrictionJustificationEnabled).toBe(expectedResult);
             },
         );
     });

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
@@ -98,6 +98,7 @@ exports[`features/unified-share-modal/UnifiedShareForm closeEmailSharedLinkForm(
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -107,7 +108,6 @@ exports[`features/unified-share-modal/UnifiedShareForm closeEmailSharedLinkForm(
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -297,6 +297,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -306,7 +307,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -460,6 +460,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -469,7 +470,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -623,6 +623,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -632,7 +633,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -791,6 +791,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -800,7 +801,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -955,6 +955,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -964,7 +965,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -1120,6 +1120,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={true}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -1129,7 +1130,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -1255,6 +1255,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -1264,7 +1265,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -1420,6 +1420,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -1429,7 +1430,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -1585,6 +1585,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -1594,7 +1595,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -1751,6 +1751,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={true}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -1760,7 +1761,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -1926,6 +1926,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -1935,7 +1936,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -2090,6 +2090,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -2099,7 +2100,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -2258,6 +2258,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -2267,7 +2268,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -2424,6 +2424,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={false}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -2433,7 +2434,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           submitting={false}
           updateSelectedContacts={[Function]}
@@ -2590,6 +2590,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={true}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -2599,7 +2600,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >
@@ -2725,6 +2725,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           isExpanded={true}
           isExternalUserSelected={false}
           isFetchingJustificationReasons={false}
+          isRestrictionJustificationEnabled={false}
           justificationReasons={Array []}
           onContactInput={[Function]}
           onPillCreate={[Function]}
@@ -2734,7 +2735,6 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           recommendedSharingTooltipCalloutName={null}
           restrictedExternalEmails={Array []}
           selectedContacts={Array []}
-          shouldRequireExternalContactJustification={false}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
         >

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -430,12 +430,6 @@ const messages = defineMessages({
     },
 
     // External collab restrictions and business justifications
-    justificationSelectLabel: {
-        defaultMessage: 'Business Justification',
-        description:
-            'The label displayed at the top of the select field that allows selecting a business justification reason',
-        id: 'boxui.unifiedShare.justificationSelectLabel',
-    },
     justificationSelectPlaceholder: {
         defaultMessage: 'Select Justification',
         description: 'The placeholder text of the select field that allows selecting a business justification reason',
@@ -446,6 +440,37 @@ const messages = defineMessages({
         description:
             'The error message that is displayed when a user tries to send invitations to external collaborators, but a business justification is required before proceeding',
         id: 'boxui.unifiedShare.justificationRequiredError',
+    },
+    restrictedContactsError: {
+        defaultMessage: 'Remove people to continue',
+        description:
+            'The error message that is displayed when a user tries to send invitations to external collaborators, but restricted contacts need to be removed before proceeding',
+        id: 'boxui.unifiedShare.restrictedContactsError',
+    },
+    justifiableContactRestrictionNotice: {
+        defaultMessage:
+            'This classified content requires a business justification to invite {count, plural, one {{email}} other {{count} people}}. Please select a business justification below.',
+        description:
+            'Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts and business justifications are allowed for bypassing restrictions',
+        id: 'boxui.unifiedShare.justifiableContactRestrictionNotice',
+    },
+    justifiableContactRestrictionRemoveButtonLabel: {
+        defaultMessage: 'Alternatively, remove {count, plural, one {the person} other {{count} people}} and continue.',
+        description:
+            'Label for the button that removes restricted contacts on the contact restriction notice when business justifications are allowed for bypassing restrictions',
+        id: 'boxui.unifiedShare.justifiableContactRestrictionRemoveButtonLabel',
+    },
+    contactRestrictionNotice: {
+        defaultMessage:
+            'Invitations cannot be sent to {count, plural, one {{email}} other {{count} people}} because external collaboration is restricted due to the applied classification.',
+        description:
+            'Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts',
+        id: 'boxui.unifiedShare.contactRestrictionNotice',
+    },
+    contactRestrictionRemoveButtonLabel: {
+        defaultMessage: 'Remove {count, plural, one {the person} other {{count} people}} and continue.',
+        description: 'Label for the button that removes restricted contacts on the contact restriction notice',
+        id: 'boxui.unifiedShare.contactRestrictionRemoveButtonLabel',
     },
     contactEmailsTooltipText: {
         defaultMessage: '{emails}, and {remainingEmailsCount} more',


### PR DESCRIPTION
Partial update that adds and integrates the UI for the new external collab restriction flow. Previously it was possible to submit non-restricted invitees along with invitees restricted by an Access Policy (unrestricted invites would succeed, but a red error banner would be shown for restricted ones). Once the new flow is enabled, it will no longer be possible to submit the form with restricted invitees, and the user will be asked to remove them.

Changes should be backwards compatible and the new flow will not yet be enabled.

<img width="549" alt="Screen Shot 2020-11-05 at 7 09 06 PM" src="https://user-images.githubusercontent.com/1322503/98321651-7b5c4000-1f9a-11eb-92b0-74e01ec00a86.png">

Additionally, this PR also switches the messages from `FormattedCompMessage` to `FormattedMessage`, given that currently there are some unresolved issues with `FormattedCompMessage` that prevent us from using it. Note that the design had to be altered a bit in order to have the interactive elements be their own sentences, since `react-intl` v3+ is not yet available in EUA.

<img width="528" alt="Screen Shot 2020-11-06 at 10 58 14 AM" src="https://user-images.githubusercontent.com/1322503/98404204-04b55600-201f-11eb-9ec1-e546d04045b9.png">

