### PR TITLE
feat(content-sharing): Display error for existing collabs

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -76,6 +76,8 @@ be.contentSharing.noAccessError = You do not have access to this item.
 be.contentSharing.notFoundError = Could not find shared link for this item.
 # Message that appears when collaborators cannot be added to the shared link in the ContentSharing Element.
 be.contentSharing.sendInvitesError = Could not send invites.
+# Message that appears when the user attempts to invite an existing collaborator to the shared link in the ContentSharing Element.
+be.contentSharing.sendInvitesExistingCollabError = User is already a collaborator.
 # Message that appears when collaborators were added to the shared link in the ContentSharing Element.
 be.contentSharing.sendInvitesSuccess = Successfully invited collaborators.
 # Message that appears when the shared link in the ContentSharing Element was removed.

--- a/src/constants.js
+++ b/src/constants.js
@@ -292,6 +292,7 @@ export const ERROR_CODE_UNEXPECTED_EXCEPTION = 'unexpected_exception_error';
 export const ERROR_CODE_SEARCH = 'search_error';
 export const ERROR_CODE_METADATA_QUERY = 'metadata_query_error';
 export const ERROR_CODE_UNKNOWN = 'unknown_error';
+export const ERROR_CODE_EXISTING_COLLABORATOR = 'user_already_collaborator';
 
 /* ------------------ Origins ---------------------- */
 export const ORIGIN_CONTENT_PREVIEW: 'content_preview' = 'content_preview';

--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -23,6 +23,7 @@ import useCollaborators from './hooks/useCollaborators';
 import useContacts from './hooks/useContacts';
 import useInvites from './hooks/useInvites';
 import contentSharingMessages from './messages';
+import { ERROR_CODE_EXISTING_COLLABORATOR } from '../../constants';
 import type { BoxItemPermission, Collaborations, ItemType, NotificationType } from '../../common/types/core';
 import type { collaboratorsListType, item as itemFlowType } from '../../features/unified-share-modal/flowTypes';
 import type {
@@ -253,8 +254,12 @@ function SharingNotification({
             });
             closeComponent();
         },
-        handleError: () => {
-            createNotification(TYPE_ERROR, contentSharingMessages.sendInvitesError);
+        handleError: response => {
+            let error = contentSharingMessages.sendInvitesError;
+            if (response && response.code === ERROR_CODE_EXISTING_COLLABORATOR) {
+                error = contentSharingMessages.sendInvitesExistingCollabError;
+            }
+            createNotification(TYPE_ERROR, error);
             setIsLoading(false);
             closeComponent();
         },

--- a/src/elements/content-sharing/messages.js
+++ b/src/elements/content-sharing/messages.js
@@ -53,6 +53,12 @@ const messages = defineMessages({
             'Message that appears when collaborators cannot be added to the shared link in the ContentSharing Element.',
         id: 'be.contentSharing.sendInvitesError',
     },
+    sendInvitesExistingCollabError: {
+        defaultMessage: 'User is already a collaborator.',
+        description:
+            'Message that appears when the user attempts to invite an existing collaborator to the shared link in the ContentSharing Element.',
+        id: 'be.contentSharing.sendInvitesExistingCollabError',
+    },
     sendInvitesSuccess: {
         defaultMessage: 'Successfully invited collaborators.',
         description:


### PR DESCRIPTION
Show a specific error message when the user attempts to invite an existing collaborator to a shared link in Content Sharing.

<img width="665" alt="content-sharing-existing-collaborator" src="https://user-images.githubusercontent.com/2956895/98611653-2b85bd80-22a7-11eb-8d40-a491c530d9de.png">