### PR TITLE
fix(comment-form): use length check

### DIFF
--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -95,7 +95,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
         const { contacts: currentContacts } = this.props;
         const { activeMention } = this.state;
 
-        if (activeMention !== null && !currentContacts.length && prevContacts !== currentContacts) {
+        if (activeMention !== null && !currentContacts.length && prevContacts.length !== currentContacts.length) {
             // if empty set of contacts get passed in, set active mention to null
             this.setState({
                 activeMention: null,


### PR DESCRIPTION
**Issue:**
In the current experience, when the user starts typing '@' into the CommentForm, the empty search state does not show up. This is because in `componentDidUpdate`, we are performing an incorrect check of `prevContacts !== currentContacts`. 

Since prevContacts and currentContacts are two different variables, this will always result in true.

**Solution:**
The solution is to instead compare the lengths of the two variables to see if the if condition is satisfied.

**Demo:**
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/7213887/98740112-60ede200-235f-11eb-8ae5-45731da1da86.gif)
