### PR TITLE
chore(annotations): remove modify annotation feature flip logic

### DIFF
--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityMenu.js
@@ -9,29 +9,17 @@ import Pencil16 from '../../../../icon/line/Pencil16';
 import Trash16 from '../../../../icon/fill/Trash16';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 import { MenuItem } from '../../../../components/menu';
-import { isFeatureEnabled, withFeatureConsumer } from '../../../common/feature-checking';
-import type { FeatureConfig } from '../../../common/feature-checking';
 
 type AnnotationActivityMenuProps = {
     canDelete?: boolean,
     canEdit?: boolean,
-    features: FeatureConfig,
     id: string,
     onDeleteConfirm: () => void,
     onEdit: () => void,
 };
 
-const AnnotationActivityMenu = ({
-    canDelete,
-    canEdit,
-    features,
-    id,
-    onDeleteConfirm,
-    onEdit,
-}: AnnotationActivityMenuProps) => {
+const AnnotationActivityMenu = ({ canDelete, canEdit, id, onDeleteConfirm, onEdit }: AnnotationActivityMenuProps) => {
     const [isConfirmingDelete, setIsConfirmingDelete] = React.useState(false);
-
-    const isModifyEnabled = isFeatureEnabled(features, 'activityFeed.modifyAnnotations.enabled');
 
     const handleDeleteCancel = (): void => {
         setIsConfirmingDelete(false);
@@ -63,7 +51,7 @@ const AnnotationActivityMenu = ({
                     'data-resin-feature': 'annotations',
                 }}
             >
-                {canEdit && isModifyEnabled && (
+                {canEdit && (
                     <MenuItem
                         data-resin-itemid={id}
                         data-resin-target={ACTIVITY_TARGETS.ANNOTATION_OPTIONS_EDIT}
@@ -99,5 +87,4 @@ const AnnotationActivityMenu = ({
     );
 };
 
-export { AnnotationActivityMenu as AnnotationActivityMenuBase };
-export default withFeatureConsumer(AnnotationActivityMenu);
+export default AnnotationActivityMenu;

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import AnnotationActivity from '../AnnotationActivity';
 import AnnotationActivityLink from '../AnnotationActivityLink';
@@ -48,7 +48,7 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
         'data-resin-target': 'annotationLink',
     });
 
-    const getWrapper = (props = {}) => mount(<AnnotationActivity {...mockActivity} {...props} />);
+    const getWrapper = (props = {}) => shallow(<AnnotationActivity {...mockActivity} {...props} />);
 
     beforeEach(() => {
         CommentForm.default = jest.fn().mockReturnValue(<div />);
@@ -106,16 +106,23 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
 
         const wrapper = getWrapper({ ...mockActivity, ...activity });
 
-        wrapper.find(AnnotationActivityMenu).simulate('click');
-        wrapper.find('MenuItem').simulate('click');
+        wrapper
+            .find(AnnotationActivityMenu)
+            .dive()
+            .simulate('click');
+        wrapper
+            .find(AnnotationActivityMenu)
+            .dive()
+            .find('MenuItem')
+            .simulate('click');
         expect(wrapper.exists('CommentForm')).toBe(true);
 
-        // Clicking the cancel button will remove the CommentForm
+        // Firing the onCancel prop will remove the CommentForm
         wrapper
-            .find('CommentInputControls')
-            .find('Button')
-            .first()
-            .simulate('click');
+            .find('CommentForm')
+            .dive()
+            .props()
+            .onCancel();
         expect(wrapper.exists('CommentForm')).toBe(false);
     });
 

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import AnnotationActivity from '../AnnotationActivity';
 import AnnotationActivityLink from '../AnnotationActivityLink';
+import AnnotationActivityMenu from '../AnnotationActivityMenu';
 import CommentForm from '../../comment-form/CommentForm';
 import Media from '../../../../../components/media';
 import messages from '../messages';
-import { AnnotationActivityMenuBase as AnnotationActivityMenu } from '../AnnotationActivityMenu';
-import { FeatureProvider } from '../../../../common/feature-checking';
 
 jest.mock('../../Avatar', () => () => 'Avatar');
 
@@ -49,22 +48,7 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
         'data-resin-target': 'annotationLink',
     });
 
-    const defaultFeatures = {
-        activityFeed: {
-            modifyAnnotations: {
-                enabled: true,
-            },
-        },
-    };
-
-    const getWrapper = (props = {}) => shallow(<AnnotationActivity {...mockActivity} {...props} />);
-
-    const getWrapperWithFeatures = props =>
-        mount(
-            <FeatureProvider features={defaultFeatures}>
-                <AnnotationActivity {...mockActivity} {...props} />
-            </FeatureProvider>,
-        );
+    const getWrapper = (props = {}) => mount(<AnnotationActivity {...mockActivity} {...props} />);
 
     beforeEach(() => {
         CommentForm.default = jest.fn().mockReturnValue(<div />);
@@ -95,7 +79,7 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
                 permissions: { can_delete: canDelete, can_edit: canEdit },
             };
 
-            const wrapper = getWrapperWithFeatures({ item });
+            const wrapper = getWrapper({ item });
             const activityLink = wrapper.find(AnnotationActivityLink);
 
             expect(wrapper.find('ActivityTimestamp').prop('date')).toEqual(unixTime);
@@ -120,7 +104,7 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
             },
         };
 
-        const wrapper = getWrapperWithFeatures({ ...mockActivity, ...activity });
+        const wrapper = getWrapper({ ...mockActivity, ...activity });
 
         wrapper.find(AnnotationActivityMenu).simulate('click');
         wrapper.find('MenuItem').simulate('click');

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivityMenu.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivityMenu.test.js
@@ -1,17 +1,10 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import { AnnotationActivityMenuBase as AnnotationActivityMenu } from '../AnnotationActivityMenu';
+import AnnotationActivityMenu from '../AnnotationActivityMenu';
 
 describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivityMenu', () => {
     const defaults = {
-        features: {
-            activityFeed: {
-                modifyAnnotations: {
-                    enabled: true,
-                },
-            },
-        },
         id: '123',
     };
 


### PR DESCRIPTION
Changes in this PR:
- [x] remove modify annotations feature flip related logic since the feature is in production