### PR TITLE
fix(usm): Fix line overlap on ContactRestrictionNotice

### DIFF
--- a/src/features/unified-share-modal/ContactRestrictionNotice.js
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.js
@@ -103,6 +103,7 @@ const ContactRestrictionNotice = ({
                     {...restrictionNoticeMessage}
                     values={{ count: restrictedExternalContactCount, email: firstEmail }}
                 />
+                &nbsp;
                 {isRestrictionJustificationEnabled && justificationSelectSection}
                 <PlainButton
                     className="bdl-ContactRestrictionNotice-removeBtn"

--- a/src/features/unified-share-modal/ContactRestrictionNotice.scss
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.scss
@@ -24,5 +24,6 @@
 
 .bdl-ContactRestrictionNotice-removeBtn {
     color: $bdl-gray;
+    text-align: left;
     text-decoration: underline;
 }

--- a/src/features/unified-share-modal/ContactRestrictionNotice.scss
+++ b/src/features/unified-share-modal/ContactRestrictionNotice.scss
@@ -1,6 +1,8 @@
 @import '../../styles/variables';
 
 .bdl-ContactRestrictionNotice {
+    color: $bdl-gray;
+
     .bdl-SelectButton {
         margin: $bdl-grid-unit * 3 auto;
     }


### PR DESCRIPTION
Text was overlapping in cases in which the remove button fit within the last line of the paragraph and justifications were disabled.

**Before:**

<img width="481" alt="Screen Shot 2020-12-07 at 1 16 24 PM" src="https://user-images.githubusercontent.com/1322503/101411033-1e9fbe00-3895-11eb-85ef-6f71917a58a6.png">


**After:**

<img width="503" alt="Screen Shot 2020-12-07 at 1 18 09 PM" src="https://user-images.githubusercontent.com/1322503/101411037-20698180-3895-11eb-8efa-e60738aeb917.png">
