### PR TITLE
feat(security-controls): Update app restriction copy

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1140,8 +1140,6 @@ boxui.securityControls.allAppNames = All applications: {appsList}
 boxui.securityControls.appDownloadBlacklist = Download restricted for some applications: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
 boxui.securityControls.appDownloadBlacklistOverflow = Download restricted for some applications: {appNames} +{remainingAppCount} more
-# Bullet point that summarizes application download blocked restriction applied to classification
-boxui.securityControls.appDownloadBlock = Some application restrictions apply.
 # Bullet point that summarizes application download restriction applied to classification
 boxui.securityControls.appDownloadRestricted = Download restricted for some applications.
 # Bullet point that summarizes application download restriction applied to classification

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -141,7 +141,9 @@ describe('features/classification/security-controls/utils', () => {
                     accessLevel: BLOCK,
                 },
             };
-            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([{ message: messages.appDownloadBlock }]);
+            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([
+                { message: messages.appDownloadRestricted },
+            ]);
         });
 
         test.each([WHITELIST, BLACKLIST])(

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -69,11 +69,6 @@ const messages = defineMessages({
         description: 'Bullet point that summarizes external collaboration restriction applied to classification',
         id: 'boxui.securityControls.externalCollabDomainList',
     },
-    appDownloadBlock: {
-        defaultMessage: 'Some application restrictions apply.',
-        description: 'Bullet point that summarizes application download blocked restriction applied to classification',
-        id: 'boxui.securityControls.appDownloadBlock',
-    },
     appDownloadRestricted: {
         defaultMessage: 'Download restricted for some applications.',
         description: 'Bullet point that summarizes application download restriction applied to classification',

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -101,7 +101,7 @@ const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array
 
     switch (accessLevel) {
         case BLOCK:
-            items.push({ message: messages.appDownloadBlock });
+            items.push({ message: messages.appDownloadRestricted });
             break;
         case WHITELIST:
         case BLACKLIST: {


### PR DESCRIPTION
Updating the copy for app restrictions in which all app downloads are blocked.

Note: Translations for the new copy are already available.