### PR TITLE
fix(activity): annotation activity width truncation after deletion

### DIFF
--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -37,6 +37,7 @@
         display: flex;
         flex: 1 1 auto;
         flex-direction: column;
+        width: 100%;
         overflow-x: hidden;
         overflow-y: auto;
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -96,7 +96,6 @@
     }
 
     .bcs-activity-feed-active-state {
-        width: 100%;
         padding-bottom: $bdl-grid-unit * 4;
     }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -37,7 +37,7 @@
         display: flex;
         flex: 1 1 auto;
         flex-direction: column;
-        width: 100%;
+        width: 100%; // Explicit width required since flex-direction is column
         overflow-x: hidden;
         overflow-y: auto;
 


### PR DESCRIPTION
**Main Issue:**
There was an intermittent bug found in IE11 where when the user deletes a comment in the activity sidebar, sometimes the comments in the sidebar would get truncated.

**Solution:**
The fix is to move the `width: 100%` style on the `.bcs-activity-feed-active-state` element to the parent element.

**Demo:**
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/7213887/106054857-6f67b200-60a1-11eb-9c4d-12662455f28c.gif)



- [x] cross browser testing