### PR TITLE
feat(assets): Add Key icon asset

### DIFF
--- a/src/icon/line/Key16.js.flow
+++ b/src/icon/line/Key16.js.flow
@@ -1,0 +1,29 @@
+// @flow
+/* eslint-disable react/jsx-sort-props */
+import * as React from 'react';
+import * as vars from '../../styles/variables';
+import AccessibleSVG from '../../icons/accessible-svg';
+import type { Icon } from '../../icons/flowTypes';
+
+/**
+ * This is an auto-generated component and should not be edited
+ * manually in contributor pull requests.
+ *
+ * If you have problems with this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Bug_report.md
+ *
+ * If there are missing features in this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Feature_request.md
+ */
+
+const Key16 = (props: Icon) => (
+    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...props}>
+        <path
+            d="M14.5 1a.5.5 0 01.5.5v3c0 .133-.053.26-.146.354l-1 1A.504.504 0 0113.5 6H12v2a.5.5 0 01-.41.492l-.09.008h-2V10a.493.493 0 01-.078.268l-.058.075-1.358 1.438-.01.419A4.003 4.003 0 014 16c-2.21 0-4-1.79-4-4s1.79-4 4-4l.324-.012 7.847-6.864c.068-.06.151-.1.24-.116L12.5 1zM14 2h-1.313L4.829 8.876A.497.497 0 014.512 9l-.124-.01-.092-.001-.175.008-.297.008A3 3 0 107 12l.006-.32-.005-.12a.5.5 0 01.135-.314L8.5 9.8V8a.5.5 0 01.41-.492L9 7.5h2v-2a.5.5 0 01.41-.492L11.5 5h1.792L14 4.292V2zM4 10a2 2 0 11.001 3.999A2 2 0 014 10zm0 1a1 1 0 100 2 1 1 0 000-2z"
+            fill={vars.bdlGray}
+            fillRule="evenodd"
+        />
+    </AccessibleSVG>
+);
+
+export default Key16;

--- a/src/icon/line/Key16.stories.tsx
+++ b/src/icon/line/Key16.stories.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import Key16 from './Key16';
+
+export const key16 = () => <Key16 />;
+
+export default {
+    title: 'Icon|Line|Key16',
+    component: Key16,
+    parameters: {
+        notes: "`import Key16 from 'box-ui-elements/es/icon/line/Key16';`",
+    },
+};

--- a/src/icon/line/Key16.tsx
+++ b/src/icon/line/Key16.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable react/jsx-sort-props */
+import * as React from 'react';
+import * as vars from '../../styles/variables';
+import AccessibleSVG, { SVGProps } from '../../components/accessible-svg/AccessibleSVG';
+
+/**
+ * This is an auto-generated component and should not be edited
+ * manually in contributor pull requests.
+ *
+ * If you have problems with this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Bug_report.md
+ *
+ * If there are missing features in this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Feature_request.md
+ */
+
+const Key16 = (props: SVGProps) => (
+    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...props}>
+        <path
+            d="M14.5 1a.5.5 0 01.5.5v3c0 .133-.053.26-.146.354l-1 1A.504.504 0 0113.5 6H12v2a.5.5 0 01-.41.492l-.09.008h-2V10a.493.493 0 01-.078.268l-.058.075-1.358 1.438-.01.419A4.003 4.003 0 014 16c-2.21 0-4-1.79-4-4s1.79-4 4-4l.324-.012 7.847-6.864c.068-.06.151-.1.24-.116L12.5 1zM14 2h-1.313L4.829 8.876A.497.497 0 014.512 9l-.124-.01-.092-.001-.175.008-.297.008A3 3 0 107 12l.006-.32-.005-.12a.5.5 0 01.135-.314L8.5 9.8V8a.5.5 0 01.41-.492L9 7.5h2v-2a.5.5 0 01.41-.492L11.5 5h1.792L14 4.292V2zM4 10a2 2 0 11.001 3.999A2 2 0 014 10zm0 1a1 1 0 100 2 1 1 0 000-2z"
+            fill={vars.bdlGray}
+            fillRule="evenodd"
+        />
+    </AccessibleSVG>
+);
+
+export default Key16;


### PR DESCRIPTION
Adding Key icon asset from `design-assets`