### PR TITLE
fix(uploads): update multiput support for mobile safari

### DIFF
--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -27,7 +27,7 @@ class Browser {
      * @return {number} navigator maxTouchPoints
      */
     static getMaxTouchPoints(): number {
-        const maxTouchPoints = global.navigator.maxTouchPoints;
+        const { maxTouchPoints } = global.navigator;
         return !!maxTouchPoints && typeof maxTouchPoints === 'number' ? maxTouchPoints : 0;
     }
 

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -18,13 +18,35 @@ class Browser {
     }
 
     /**
-     * Returns whether browser is mobile.
+     * Returns the max touch points for touchscreen devices
+     * Helps in mocking out.
+     *
+     * Only supported in the following browsers:
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints
+     *
+     * @return {number} navigator maxTouchPoints
+     */
+    static getMaxTouchPoints(): number {
+        const maxTouchPoints = global.navigator.maxTouchPoints;
+        return !!maxTouchPoints && typeof maxTouchPoints === 'number' ? maxTouchPoints : 0;
+    }
+
+    /**
+     * Returns whether browser is mobile, including tablets.
+     *
+     * We rely on user agent (UA) to avoid matching desktops with touchscreens.
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
+     *
+     * Also captures iOS 13+ mobile devices for browsers that request the desktop website since mac does not have any desktops with touchscreens as of Mar 2021.
      *
      * @return {boolean} Whether browser is mobile
      */
     static isMobile(): boolean {
-        // Relying on the user agent to avoid desktop browsers on machines with touch screens.
-        return /iphone|ipad|ipod|android|blackberry|bb10|mini|windows\sce|palm/i.test(Browser.getUserAgent());
+        return (
+            /iphone|ipad|ipod|android|blackberry|bb10|mini|windows\sce|palm/i.test(Browser.getUserAgent()) ||
+            /Mobi/i.test(Browser.getUserAgent()) ||
+            (/Macintosh/i.test(Browser.getUserAgent()) && Browser.getMaxTouchPoints() > 0)
+        );
     }
 
     /**

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -18,34 +18,17 @@ class Browser {
     }
 
     /**
-     * Returns the max touch points for touchscreen devices
-     * Helps in mocking out.
-     *
-     * Only supported in the following browsers:
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints
-     *
-     * @return {number} navigator maxTouchPoints
-     */
-    static getMaxTouchPoints(): number {
-        const { maxTouchPoints } = global.navigator;
-        return !!maxTouchPoints && typeof maxTouchPoints === 'number' ? maxTouchPoints : 0;
-    }
-
-    /**
      * Returns whether browser is mobile, including tablets.
      *
      * We rely on user agent (UA) to avoid matching desktops with touchscreens.
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop
      *
-     * Also captures iOS 13+ mobile devices for browsers that request the desktop website since mac does not have any desktops with touchscreens as of Mar 2021.
-     *
      * @return {boolean} Whether browser is mobile
      */
     static isMobile(): boolean {
+        const userAgent = Browser.getUserAgent();
         return (
-            /iphone|ipad|ipod|android|blackberry|bb10|mini|windows\sce|palm/i.test(Browser.getUserAgent()) ||
-            /Mobi/i.test(Browser.getUserAgent()) ||
-            (/Macintosh/i.test(Browser.getUserAgent()) && Browser.getMaxTouchPoints() > 0)
+            /iphone|ipad|ipod|android|blackberry|bb10|mini|windows\sce|palm/i.test(userAgent) || /Mobi/i.test(userAgent)
         );
     }
 
@@ -66,6 +49,27 @@ class Browser {
     static isSafari() {
         const userAgent = Browser.getUserAgent();
         return /AppleWebKit/i.test(userAgent) && !/Chrome\//i.test(userAgent);
+    }
+
+    /**
+     * Returns whether browser is Mobile Safari.
+     *
+     * @see https://developer.chrome.com/docs/multidevice/user-agent/
+     * @return {boolean} Whether browser is Mobile Safari
+     */
+    static isMobileSafari() {
+        return Browser.isMobile() && Browser.isSafari() && !Browser.isMobileChromeOniOS();
+    }
+
+    /**
+     * Returns whether browser is Mobile Chrome on iOS.
+     *
+     * @see https://developer.chrome.com/docs/multidevice/user-agent/
+     * @return {boolean} Whether browser is Mobile Chrome on iOS
+     */
+    static isMobileChromeOniOS() {
+        const userAgent = Browser.getUserAgent();
+        return Browser.isMobile() && /AppleWebKit/i.test(userAgent) && /CriOS\//i.test(userAgent);
     }
 
     /**

--- a/src/utils/__tests__/Browser.test.js
+++ b/src/utils/__tests__/Browser.test.js
@@ -1,5 +1,16 @@
 import browser from '../Browser';
 
+describe('util/Browser/getMaxTouchPoints', () => {
+    test.each([
+        [5, 5],
+        [undefined, 0],
+        [null, 0],
+    ])('should return maxTouchPoints if exists: %o', (maxTouchPoints, expected) => {
+        global.navigator.maxTouchPoints = maxTouchPoints;
+        expect(browser.getMaxTouchPoints()).toEqual(expected);
+    });
+});
+
 describe('util/Browser/isMobile()', () => {
     test('should return false if not mobile', () => {
         browser.getUserAgent = jest.fn().mockReturnValueOnce('foobar');
@@ -19,6 +30,25 @@ describe('util/Browser/isMobile()', () => {
         ${'palm'}
     `('should return true for $device', ({ device }) => {
         browser.getUserAgent = jest.fn().mockReturnValueOnce(device);
+        expect(browser.isMobile()).toBeTruthy();
+    });
+
+    test('should return true if user agent contains the string "Mobi"', () => {
+        browser.getUserAgent = jest
+            .fn()
+            .mockReturnValueOnce(
+                'Mozilla/5.0 (iPad; CPU OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1',
+            );
+        expect(browser.isMobile()).toBeTruthy();
+    });
+
+    test('should return true if user agent belongs to Macintosh and has touchscreen', () => {
+        browser.getUserAgent = jest
+            .fn()
+            .mockReturnValue(
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15',
+            );
+        browser.getMaxTouchPoints = jest.fn().mockReturnValueOnce(5);
         expect(browser.isMobile()).toBeTruthy();
     });
 });

--- a/src/utils/__tests__/Browser.test.js
+++ b/src/utils/__tests__/Browser.test.js
@@ -1,16 +1,5 @@
 import browser from '../Browser';
 
-describe('util/Browser/getMaxTouchPoints', () => {
-    test.each([
-        [5, 5],
-        [undefined, 0],
-        [null, 0],
-    ])('should return maxTouchPoints if exists: %o', (maxTouchPoints, expected) => {
-        global.navigator.maxTouchPoints = maxTouchPoints;
-        expect(browser.getMaxTouchPoints()).toEqual(expected);
-    });
-});
-
 describe('util/Browser/isMobile()', () => {
     test('should return false if not mobile', () => {
         browser.getUserAgent = jest.fn().mockReturnValueOnce('foobar');
@@ -41,16 +30,6 @@ describe('util/Browser/isMobile()', () => {
             );
         expect(browser.isMobile()).toBeTruthy();
     });
-
-    test('should return true if user agent belongs to Macintosh and has touchscreen', () => {
-        browser.getUserAgent = jest
-            .fn()
-            .mockReturnValue(
-                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15',
-            );
-        browser.getMaxTouchPoints = jest.fn().mockReturnValueOnce(5);
-        expect(browser.isMobile()).toBeTruthy();
-    });
 });
 
 describe('util/Browser/isIE()', () => {
@@ -73,6 +52,41 @@ describe('util/Browser/isSafari()', () => {
     `('should return $result when user agent is $userAgent', ({ result, userAgent }) => {
         browser.getUserAgent = jest.fn().mockReturnValueOnce(userAgent);
         expect(browser.isSafari()).toBe(result);
+    });
+});
+
+describe('util/Browser/isMobileSafari()', () => {
+    afterEach(() => {
+        browser.getUserAgent = jest.fn().mockReset();
+    });
+
+    test.each`
+        result   | userAgent
+        ${true}  | ${'AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1'}
+        ${false} | ${'AppleWebKit/4.0'}
+        ${false} | ${'Trident'}
+        ${false} | ${'AppleWebKit/7.8 (KHTML, like Gecko) Chrome/1.2.3.4 Safari/5.6'}
+        ${false} | ${'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/87.0.4280.77 Mobile/15E148 Safari/604.1'}
+    `('should return $result when user agent is $userAgent', ({ result, userAgent }) => {
+        browser.getUserAgent = jest.fn().mockReturnValue(userAgent);
+        expect(browser.isMobileSafari()).toBe(result);
+    });
+});
+
+describe('util/Browser/isMobileChromeOniOS()', () => {
+    afterEach(() => {
+        browser.getUserAgent = jest.fn().mockReset();
+    });
+
+    test.each`
+        result   | userAgent
+        ${true}  | ${'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/87.0.4280.77 Mobile/15E148 Safari/604.1'}
+        ${false} | ${'AppleWebKit/4.0'}
+        ${false} | ${'Trident'}
+        ${false} | ${'AppleWebKit/7.8 (KHTML, like Gecko) Chrome/1.2.3.4 Safari/5.6'}
+    `('should return $result when user agent is $userAgent', ({ result, userAgent }) => {
+        browser.getUserAgent = jest.fn().mockReturnValue(userAgent);
+        expect(browser.isMobileChromeOniOS()).toBe(result);
     });
 });
 

--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -1,9 +1,12 @@
+import browser from '../Browser';
+
 import {
     toISOStringNoMS,
     getFileLastModifiedAsISONoMSIfPossible,
     tryParseJson,
     isDataTransferItemAFolder,
     isDataTransferItemAPackage,
+    isMultiputSupported,
     getFileFromDataTransferItem,
     getPackageFileFromDataTransferItem,
     doesFileContainAPIOptions,
@@ -388,6 +391,32 @@ describe('util/uploads', () => {
             };
 
             expect(getDataTransferItemId(item, rootFolderId)).toBe('hi_0_123123');
+        });
+    });
+
+    describe('isMultiputSupported()', () => {
+        let windowSpy;
+
+        beforeEach(() => {
+            windowSpy = jest.spyOn(window, 'window', 'get');
+        });
+
+        afterEach(() => {
+            windowSpy.mockRestore();
+        });
+
+        test.each([
+            ['mobile safari', true, true, false],
+            ['web safari', false, true, true],
+            ['mobile other browsers', true, false, true],
+        ])('should return whether multiput is supported on device: %o', (test, mobile, safari, expected) => {
+            windowSpy.mockImplementation(() => ({
+                crypto: { subtle: true },
+                location: { protocol: 'https:' },
+            }));
+            browser.isMobile = jest.fn().mockReturnValueOnce(mobile);
+            browser.isSafari = jest.fn().mockReturnValueOnce(safari);
+            expect(isMultiputSupported()).toEqual(expected);
         });
     });
 });

--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -406,16 +406,15 @@ describe('util/uploads', () => {
         });
 
         test.each([
-            ['mobile safari', true, true, false],
-            ['web safari', false, true, true],
-            ['mobile other browsers', true, false, true],
-        ])('should return whether multiput is supported on device: %o', (test, mobile, safari, expected) => {
+            ['mobile safari', true, false],
+            ['web safari', false, true],
+            ['mobile other browsers', false, true],
+        ])('should return whether multiput is supported on device: %o', (test, mobileSafari, expected) => {
             windowSpy.mockImplementation(() => ({
                 crypto: { subtle: true },
                 location: { protocol: 'https:' },
             }));
-            browser.isMobile = jest.fn().mockReturnValueOnce(mobile);
-            browser.isSafari = jest.fn().mockReturnValueOnce(safari);
+            browser.isMobileSafari = jest.fn().mockReturnValueOnce(mobileSafari);
             expect(isMultiputSupported()).toEqual(expected);
         });
     });

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -5,6 +5,8 @@
  */
 import getProp from 'lodash/get';
 
+import Browser from '../utils/Browser';
+
 import type {
     UploadFile,
     UploadFileWithAPIOptions,
@@ -335,11 +337,17 @@ function getDataTransferItemId(
 }
 
 /**
- * Multiput uploads require the use of crypto, which is only supported in secure contexts
+ * Multiput uploads require the use of crypto, which is only supported in secure contexts.
+ * Multiput uploads is not supported on mobile iOS Safari.
  */
 function isMultiputSupported(): boolean {
     const cryptoObj = window.crypto || window.msCrypto;
-    return window.location.protocol === 'https:' && cryptoObj && cryptoObj.subtle;
+
+    if (Browser.isMobile() && Browser.isSafari()) {
+        return false;
+    } else {
+        return window.location.protocol === 'https:' && cryptoObj && cryptoObj.subtle;
+    }
 }
 
 export {

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -5,7 +5,7 @@
  */
 import getProp from 'lodash/get';
 
-import Browser from '../utils/Browser';
+import Browser from './Browser';
 
 import type {
     UploadFile,
@@ -345,9 +345,9 @@ function isMultiputSupported(): boolean {
 
     if (Browser.isMobile() && Browser.isSafari()) {
         return false;
-    } else {
-        return window.location.protocol === 'https:' && cryptoObj && cryptoObj.subtle;
     }
+
+    return window.location.protocol === 'https:' && cryptoObj && cryptoObj.subtle;
 }
 
 export {

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -343,7 +343,7 @@ function getDataTransferItemId(
 function isMultiputSupported(): boolean {
     const cryptoObj = window.crypto || window.msCrypto;
 
-    if (Browser.isMobile() && Browser.isSafari()) {
+    if (Browser.isMobileSafari()) {
         return false;
     }
 


### PR DESCRIPTION
Multiput uploads is not supported on Mobile Safari, and instead will use Plain Upload for all file sizes. This is due to a WebkitBlobResourceError when blob urls are attempted to be read to upload file data. The blob urls are created internally by the browser.