### PR TITLE
fix(collapsible-sidebar): prevent h-scrollbar from appearing

### DIFF
--- a/src/features/collapsible-sidebar/CollapsibleSidebar.stories.js
+++ b/src/features/collapsible-sidebar/CollapsibleSidebar.stories.js
@@ -311,11 +311,11 @@ export const basic = () => {
 };
 
 basic.story = {
-    name: 'Top-left, basic',
+    name: 'Basic Usage',
 };
 
 export default {
-    title: 'Components|CollapsibleSidebar',
+    title: 'Features|CollapsibleSidebar',
     component: CollapsibleSidebar,
     parameters: {
         notes,

--- a/src/features/collapsible-sidebar/CollapsibleSidebar.stories.md
+++ b/src/features/collapsible-sidebar/CollapsibleSidebar.stories.md
@@ -1,1 +1,57 @@
 `import CollapsibleSidebar from 'box-ui-elements/es/components/collapsible-sidebar';`
+
+A sidebar navigation component with custom scrollbars (normalized scrollbar appearance across browsers).
+
+- `CollapsibleSidebar`
+  - `expanded` prop; whether the component is horizontally expanded (i.e., detect screen size and collapse the sidebar using this prop)
+- `CollapsibleSidebarLogo` pinned to top
+- `CollapsibleSidebarFooter` pinned to bottom
+- `CollapsibleSidebarNav` wraps nav items with scrollbar and scroll shadow effect
+  - `CollapsibleSidebarItem` horizontally collapsible container
+    - `collapsedElement`|`expandedElement` usually a `CollapsibleSidebarMenuItem`
+  - `CollapsibleSidebarMenuItem` standard display element for nav entries
+    - `text` prop (optional); usually unset when collapsed
+    - `icon` prop (optional) + `tooltipMessage` prop; typical collapsed presentation
+
+## Example
+
+```js
+<CollapsibleSidebar expanded={isExpanded}>
+  <CollapsibleSidebarLogo linkProps={{}} onToggle={fn} expanded={isExpanded} />
+  <CollapsibleSidebarNav
+    className="my-nav-wrapper"
+    customScrollBarProps={{ /* react-scrollbars-custom props */ }}
+  >
+    <ul>
+      <li>
+        <CollapsibleSidebarItem
+          expanded={isExpanded}
+          collapsedElement={
+            <CollapsibleSidebarMenuItem
+              as={Link}
+              href="/"
+              icon={<Folder16 height={20} width={20} />}
+              linkClassName="is-currentPage"
+            />
+          }
+          expandedElement={
+            <CollapsibleSidebarMenuItem
+              as={Link}
+              href="/"
+              icon={<Folder16 height={20} width={20} />}
+              linkClassName="is-currentPage"
+              text="All Files"
+            />
+          }
+          tooltipMessage="All Files Link"
+        />
+      </li>
+    </ul>
+  </CollapsibleSidebarNav>
+  <CollapsibleSidebarFooter>
+    <ul>
+      {*/ More li > CollapsibleSidebarItem components */}
+    </ul>
+  </CollapsibleSidebarFooter>
+</CollapsibleSidebar>
+```

--- a/src/features/collapsible-sidebar/CollapsibleSidebarNav.js
+++ b/src/features/collapsible-sidebar/CollapsibleSidebarNav.js
@@ -46,6 +46,8 @@ type Props = {
 
     /** Additional classes */
     className?: string,
+    /** Props for react-scrollbars-custom Scrollbar component */
+    customScrollBarProps?: {},
 };
 
 type State = {
@@ -126,7 +128,7 @@ class CollapsibleSidebarNav extends React.Component<Props, State> {
     throttleOnUpdateHandler = throttle(this.onUpdateHandler, 50);
 
     render() {
-        const { className, children } = this.props;
+        const { className, children, customScrollBarProps = {} } = this.props;
         const { isScrolling, scrollShadowClassName } = this.state;
 
         const classes = classNames('bdl-CollapsibleSidebar-nav', className, {
@@ -138,6 +140,7 @@ class CollapsibleSidebarNav extends React.Component<Props, State> {
                 <Scrollbar
                     ref={this.scrollRef}
                     className={scrollShadowClassName}
+                    noScrollX
                     onScroll={this.throtteldOnScrollHandler}
                     onUpdate={this.throttleOnUpdateHandler}
                     renderer={props => {
@@ -157,6 +160,7 @@ class CollapsibleSidebarNav extends React.Component<Props, State> {
                     trackYProps={{
                         style: { background: 'none', top: '0', height: '100%', width: '8px', marginRight: '1px' },
                     }}
+                    {...customScrollBarProps}
                 >
                     <div className={classes}>{children}</div>
                 </Scrollbar>

--- a/src/features/collapsible-sidebar/__tests__/CollapsibleSidebarNav.test.js
+++ b/src/features/collapsible-sidebar/__tests__/CollapsibleSidebarNav.test.js
@@ -39,6 +39,18 @@ describe('components/core/collapsible-sidebar/CollapsibleSidebarNav', () => {
         expect(sidebar).toMatchSnapshot();
     });
 
+    test('passes customScrollBarProps to Scrollbar from react-scrollbars-custom', () => {
+        const customProps = { noScrollY: true };
+        const sidebar = getWrapper({
+            children: [<span key="1">abc</span>, <span key="2">def</span>],
+            expanded: true,
+            className: 'foo',
+            customScrollBarProps: customProps,
+        });
+
+        expect(sidebar.find('Scrollbar').props()).toMatchObject(customProps);
+    });
+
     test('should check scroll shadow if content height changes', () => {
         const sidebar = getWrapper({
             children: [<span key="1">abc</span>, <span key="2">def</span>],

--- a/src/features/collapsible-sidebar/__tests__/__snapshots__/CollapsibleSidebarNav.test.js.snap
+++ b/src/features/collapsible-sidebar/__tests__/__snapshots__/CollapsibleSidebarNav.test.js.snap
@@ -18,6 +18,7 @@ exports[`components/core/collapsible-sidebar/CollapsibleSidebarNav render 1`] = 
       fallbackScrollbarWidth={20}
       minimalThumbSize={30}
       momentum={true}
+      noScrollX={true}
       onScroll={[Function]}
       onUpdate={[Function]}
       renderer={[Function]}


### PR DESCRIPTION
- CollapsibleSidebar was not intended to support horizontal scroll
  and allowing it can cause issues. Adds `noScrollX` prop
  to the custom scrollbar library to prevent it.
- Also adds `customScrollBarProps` to allow consumers to add/change
  props to the `react-custom-scrollbars` package. (Custom props
  should be used sparingly to avoid coupling with 3rd party API
  instead of the internal defaults).
  - https://github.com/xobotyi/react-scrollbars-custom#props