### PR TITLE
fix(button): tweak white-buttons with poor focus states

### DIFF
--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -49,7 +49,7 @@
         }
 
         &:focus {
-            border-color: darken($bdl-gray-30, 14%);
+            border-color: $bdl-gray;
             box-shadow: 0 1px 2px fade-out($black, .9);
         }
     }


### PR DESCRIPTION
white buttons doesn't compliant a11y standards, so we have to add a visual indicator for focus states.

- Adds border color that fulfill 3:1 contrast
- white buttons focus state now is a11y compliant