### PR TITLE
fix(uploads): update multiput support for mobile chrome ios

### DIFF
--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -406,16 +406,20 @@ describe('util/uploads', () => {
         });
 
         test.each([
-            ['mobile safari', true, false],
-            ['web safari', false, true],
-            ['mobile other browsers', false, true],
-        ])('should return whether multiput is supported on device: %o', (test, mobileSafari, expected) => {
-            windowSpy.mockImplementation(() => ({
-                crypto: { subtle: true },
-                location: { protocol: 'https:' },
-            }));
-            browser.isMobileSafari = jest.fn().mockReturnValueOnce(mobileSafari);
-            expect(isMultiputSupported()).toEqual(expected);
-        });
+            ['mobile safari', true, false, false],
+            ['mobile chrome on ios', false, true, false],
+            ['mobile other browsers', false, false, true],
+        ])(
+            'should return whether multiput is supported on device: %o',
+            (test, mobileSafari, mobileChromeOniOS, expected) => {
+                windowSpy.mockImplementation(() => ({
+                    crypto: { subtle: true },
+                    location: { protocol: 'https:' },
+                }));
+                browser.isMobileSafari = jest.fn().mockReturnValueOnce(mobileSafari);
+                browser.isMobileChromeOniOS = jest.fn().mockReturnValueOnce(mobileChromeOniOS);
+                expect(isMultiputSupported()).toEqual(expected);
+            },
+        );
     });
 });

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -343,7 +343,7 @@ function getDataTransferItemId(
 function isMultiputSupported(): boolean {
     const cryptoObj = window.crypto || window.msCrypto;
 
-    if (Browser.isMobileSafari()) {
+    if (Browser.isMobileSafari() || Browser.isMobileChromeOniOS()) {
         return false;
     }
 


### PR DESCRIPTION
File uploads on mobile chrome on ios will use Plain Uploads and no longer support multiput uploads.