### PR TITLE
fix(preview): Made status pills larger to improve accessibility

### DIFF
--- a/src/components/label-pill/LabelPill.tsx
+++ b/src/components/label-pill/LabelPill.tsx
@@ -33,7 +33,7 @@ export interface LabelPillProps {
 }
 
 const LabelPillContainer = React.forwardRef((props: LabelPillProps, ref: React.Ref<HTMLSpanElement>) => {
-    const { children, type = LabelPillStatus.DEFAULT, size = LabelPillSize.REGULAR, className, ...rest } = props;
+    const { children, type = LabelPillStatus.DEFAULT, size = LabelPillSize.LARGE, className, ...rest } = props;
     const labelPillClasses = classNames(
         'bdl-LabelPill',
         `bdl-LabelPill--${type}`,

--- a/src/components/label-pill/__tests__/__snapshots__/LabelPill.test.tsx.snap
+++ b/src/components/label-pill/__tests__/__snapshots__/LabelPill.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/label-pill/LabelPill should include DOM for tooltip if specified 1`] = `
 <LabelPill>
   <span
-    className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeRegular"
+    className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeLarge"
   >
     <LabelPillText>
       <span
@@ -27,7 +27,7 @@ exports[`components/label-pill/LabelPill should include DOM for tooltip if speci
 exports[`components/label-pill/LabelPill should render default DOM with icon component 1`] = `
 <LabelPill>
   <span
-    className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeRegular"
+    className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeLarge"
   >
     <LabelPillIcon
       Component={[Function]}
@@ -53,7 +53,7 @@ exports[`components/label-pill/LabelPill should render default DOM with icon com
 exports[`components/label-pill/LabelPill should render default DOM with message 1`] = `
 <LabelPill>
   <span
-    className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeRegular"
+    className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeLarge"
   >
     <LabelPillText>
       <span

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskDueDate.test.js.snap
@@ -13,7 +13,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskDueDate should rende
       type="error"
     >
       <span
-        className="bdl-LabelPill bdl-LabelPill--error bdl-LabelPill--sizeRegular"
+        className="bdl-LabelPill bdl-LabelPill--error bdl-LabelPill--sizeLarge"
         data-testid="task-overdue-date"
       >
         <LabelPillText>

--- a/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/task-new/__tests__/__snapshots__/TaskStatus.test.js.snap
@@ -8,7 +8,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
     type="success"
   >
     <span
-      className="bdl-LabelPill bdl-LabelPill--success bdl-LabelPill--sizeRegular"
+      className="bdl-LabelPill bdl-LabelPill--success bdl-LabelPill--sizeLarge"
     >
       <LabelPillText>
         <span
@@ -35,7 +35,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
     type="success"
   >
     <span
-      className="bdl-LabelPill bdl-LabelPill--success bdl-LabelPill--sizeRegular"
+      className="bdl-LabelPill bdl-LabelPill--success bdl-LabelPill--sizeLarge"
     >
       <LabelPillText>
         <span
@@ -62,7 +62,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
     type="default"
   >
     <span
-      className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeRegular"
+      className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeLarge"
     >
       <LabelPillText>
         <span
@@ -89,7 +89,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
     type="default"
   >
     <span
-      className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeRegular"
+      className="bdl-LabelPill bdl-LabelPill--default bdl-LabelPill--sizeLarge"
     >
       <LabelPillText>
         <span
@@ -116,7 +116,7 @@ exports[`elements/content-sidebar/ActivityFeed/task-new/TaskStatus should render
     type="error"
   >
     <span
-      className="bdl-LabelPill bdl-LabelPill--error bdl-LabelPill--sizeRegular"
+      className="bdl-LabelPill bdl-LabelPill--error bdl-LabelPill--sizeLarge"
     >
       <LabelPillText>
         <span


### PR DESCRIPTION
Status pills on the preview page had accessibility issues, since the text was too small and could be troublesome to read for people with visual disabilities. The pills have a "Large" version which is used in this fix.