### PR TITLE
fix(typography): fixed low contrast text on preview

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
@@ -37,7 +37,7 @@
 
     .bcs-CommentForm-tip {
         margin-top: 10px;
-        color: $bdl-gray-50;
+        color: $bdl-gray-80;
     }
 
     .bcs-CommentFormControls {

--- a/src/elements/content-sidebar/activity-feed/common/activity-timestamp/ActivityTimestamp.scss
+++ b/src/elements/content-sidebar/activity-feed/common/activity-timestamp/ActivityTimestamp.scss
@@ -1,7 +1,7 @@
 @import '../../../../../styles/variables';
 
 .bcs-ActivityTimestamp {
-    color: $bdl-gray-62;
+    color: $bdl-gray-80;
     font-size: 12px;
     line-height: 20px;
     cursor: default;

--- a/src/features/classification/Classification.scss
+++ b/src/features/classification/Classification.scss
@@ -16,5 +16,5 @@
 }
 
 .bdl-Classification-missingMessage {
-    color: $bdl-gray-50;
+    color: $bdl-gray-80;
 }

--- a/src/features/item-details/ItemProperties.scss
+++ b/src/features/item-details/ItemProperties.scss
@@ -4,7 +4,7 @@
     margin: 0;
 
     dt {
-        color: $bdl-gray-62;
+        color: $bdl-gray-80;
     }
 
     dd {


### PR DESCRIPTION
Fixed text on the Preview Panel with low contrast (updated value to bdl-gray-80)

<img width="336" alt="Screen Shot 2021-04-12 at 10 06 33" src="https://user-images.githubusercontent.com/81333063/114417074-e677f700-9b76-11eb-8794-b7aa64a9e4a4.png">
<img width="336" alt="Screen Shot 2021-04-12 at 10 06 25" src="https://user-images.githubusercontent.com/81333063/114417076-e7a92400-9b76-11eb-801f-6f4ac6818a2c.png">
<img width="344" alt="Screen Shot 2021-04-12 at 10 03 07" src="https://user-images.githubusercontent.com/81333063/114417078-e7a92400-9b76-11eb-98b3-b1e7b27fa3db.png">
