### PR TITLE
fix(content-picker): Add spacing between user and size tags

### DIFF
--- a/src/elements/common/item/ItemSubDetails.scss
+++ b/src/elements/common/item/ItemSubDetails.scss
@@ -8,7 +8,8 @@
     }
 }
 
-.bce-item-row {
+.bce-item-row,
+.bcp-item-row {
     .bdl-ItemSubDetails-size {
         &::before {
             padding-right: 3px;


### PR DESCRIPTION
In the Content Picker, the modified-by user tag and the item size tag sit right next to each other, without any spacing. This PR fixes this bug by reusing styles from the Content Explorer in the Content Picker. There are no changes to the Content Explorer.

**Before:**
<img width="1188" alt="content-picker-size-spacing-before" src="https://user-images.githubusercontent.com/2956895/115622520-d2d23c00-a2ac-11eb-95a1-413a5e2f9000.png">

**After:**
<img width="1148" alt="content-picker-size-spacing-after" src="https://user-images.githubusercontent.com/2956895/115622534-d6fe5980-a2ac-11eb-8824-249e69fa2c82.png">
