### PR TITLE
fix(flyouts): made flyout button keyboard accessible

### DIFF
--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -290,8 +290,8 @@ class Flyout extends React.Component<Props, State> {
         }
     };
 
-    handleKeyPress = event => {
-        if (event.key === 'Enter') {
+    handleKeyPress = (e: KeyboardEvent) => {
+        if (e.key === 'Enter') {
             this.openOverlay();
             this.focusButton();
         }

--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import TetherComponent from 'react-tether';
 import uniqueId from 'lodash/uniqueId';
+import { KEYS } from '../../constants';
 
 import './Flyout.scss';
 
@@ -290,8 +291,8 @@ class Flyout extends React.Component<Props, State> {
         }
     };
 
-    handleKeyPress = (e: KeyboardEvent) => {
-        if (e.key === 'Enter') {
+    handleKeyPress = () => {
+        if (KEYS.enter) {
             this.openOverlay();
             this.focusButton();
         }

--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -273,7 +273,6 @@ class Flyout extends React.Component<Props, State> {
         const { openOnHover, openOnHoverDelayTimeout } = this.props;
         if (openOnHover) {
             clearTimeout(this.hoverDelay);
-
             this.hoverDelay = setTimeout(() => {
                 this.openOverlay();
             }, openOnHoverDelayTimeout);
@@ -288,6 +287,13 @@ class Flyout extends React.Component<Props, State> {
             this.hoverDelay = setTimeout(() => {
                 this.closeOverlay();
             }, openOnHoverDelayTimeout);
+        }
+    };
+
+    handleKeyPress = event => {
+        if (event.key === 'Enter') {
+            this.openOverlay();
+            this.focusButton();
         }
     };
 
@@ -379,8 +385,10 @@ class Flyout extends React.Component<Props, State> {
             key: this.overlayButtonID,
             role: 'button',
             onClick: this.handleButtonClick,
+            onKeyPress: this.handleKeyPress,
             onMouseEnter: this.handleButtonHover,
             onMouseLeave: this.handleButtonHoverLeave,
+            tabindex: '0',
             'aria-haspopup': 'true',
             'aria-expanded': isVisible ? 'true' : 'false',
         };

--- a/src/constants.js
+++ b/src/constants.js
@@ -169,7 +169,7 @@ export const DELIMITER_SLASH: 'slash' = 'slash';
 export const DELIMITER_CARET: 'caret' = 'caret';
 
 /* ---------------------- Defaults -------------------------- */
-export const DEFAULT_PREVIEW_VERSION = '2.69.0';
+export const DEFAULT_PREVIEW_VERSION = '2.72.0';
 export const DEFAULT_LOCALE = 'en-US';
 export const DEFAULT_PATH_STATIC = 'platform/elements';
 export const DEFAULT_PATH_STATIC_PREVIEW = 'platform/preview';


### PR DESCRIPTION
Hey guys! The Flyouts button can't be used while navigating on keyboard, so we had to make some adjustments in order to be  focusable and activated with the Enter key.

<img width="468" alt="Screen Shot 2021-05-06 at 09 18 22" src="https://user-images.githubusercontent.com/81333063/117683187-7068af00-b179-11eb-98ce-954bebf3562c.png">
