### PR TITLE
feat(tooltip): add classname to tether element component

### DIFF
--- a/src/components/tooltip/Tooltip.js.flow
+++ b/src/components/tooltip/Tooltip.js.flow
@@ -47,6 +47,8 @@ type Props = {
     showCloseButton?: boolean,
     /** stop click|keypress event bubbling */
     stopBubble?: boolean,
+    /** A CSS class for the tether element component */
+    tetherElementClassName?: string,
     /** Text to show in the tooltip */
     text?: React.Node,
     /** Tooltip theme */

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -98,6 +98,8 @@ export type TooltipProps = {
     showCloseButton?: boolean;
     /** stop click|keypress event bubbling */
     stopBubble?: boolean;
+    /** A CSS class for the tether element component */
+    tetherElementClassName?: string;
     /** Text to show in the tooltip */
     text?: React.ReactNode;
 } & Partial<DefaultTooltipProps>;
@@ -215,6 +217,7 @@ class Tooltip extends React.Component<TooltipProps, State> {
             position = TooltipPosition.TOP_CENTER,
             showCloseButton,
             stopBubble,
+            tetherElementClassName,
             text,
             theme,
         } = this.props;
@@ -284,6 +287,7 @@ class Tooltip extends React.Component<TooltipProps, State> {
             enabled: boolean | undefined;
             targetAttachment: TetherPosition;
             offset?: string;
+            className?: string;
         } = {
             attachment: tetherPosition.attachment,
             bodyElement: bodyEl,
@@ -292,6 +296,10 @@ class Tooltip extends React.Component<TooltipProps, State> {
             enabled: showTooltip,
             targetAttachment: tetherPosition.targetAttachment,
         };
+
+        if (tetherElementClassName) {
+            tetherProps.className = tetherElementClassName;
+        }
 
         if (offset) {
             tetherProps.offset = offset;

--- a/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -282,6 +282,14 @@ describe('components/tooltip/Tooltip', () => {
 
             expect(wrapper.prop('offset')).toEqual(offset);
         });
+
+        test('should render correctly with tetherElementClassName', () => {
+            expect(
+                getWrapper({
+                    tetherElementClassName: 'tether-element-class-name',
+                }),
+            ).toMatchSnapshot();
+        });
     });
 
     describe('should stop event propagation when stopBubble is set', () => {

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -171,6 +171,38 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
 </TetherComponent>
 `;
 
+exports[`components/tooltip/Tooltip render() should render correctly with tetherElementClassName 1`] = `
+<TetherComponent
+  attachment="bottom center"
+  bodyElement={<body />}
+  className="tether-element-class-name"
+  classPrefix="tooltip"
+  constraints={
+    Array [
+      Object {
+        "attachment": "together",
+        "to": "window",
+      },
+    ]
+  }
+  enabled={false}
+  renderElementTag="div"
+  renderElementTo={null}
+  targetAttachment="top center"
+>
+  <div
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    tabIndex="0"
+  >
+    Hello
+  </div>
+</TetherComponent>
+`;
+
 exports[`components/tooltip/Tooltip render() should render with close button if isShown and showCloseButton are true 1`] = `
 <TetherComponent
   attachment="bottom center"


### PR DESCRIPTION
- Add the ability to add a specific class to the tether element. We don't necessarily want to target all .tooltip-element classes. My use case changing z-index:
before:
<img width="484" alt="Screen Shot 2021-05-10 at 11 46 30 AM" src="https://user-images.githubusercontent.com/75504287/117709148-74023300-b185-11eb-9eae-6266216c4b9e.png">
after (with class):
<img width="474" alt="Screen Shot 2021-05-10 at 11 44 41 AM" src="https://user-images.githubusercontent.com/75504287/117709317-a2800e00-b185-11eb-87db-072a2d9a88fa.png">

