### PR TITLE
fix(CreateNewFolder): [A11Y]- Add aria described by pilled selector

### DIFF
--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -201,6 +201,7 @@ class PillSelector extends React.Component<Props, State> {
         const ariaAttrs = {
             'aria-invalid': hasError,
             'aria-errormessage': this.errorMessageID,
+            'aria-describedBy': this.errorMessageID,
         };
 
         return (

--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -201,7 +201,7 @@ class PillSelector extends React.Component<Props, State> {
         const ariaAttrs = {
             'aria-invalid': hasError,
             'aria-errormessage': this.errorMessageID,
-            'aria-describedBy': this.errorMessageID,
+            'aria-describedby': this.errorMessageID,
         };
 
         return (

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
@@ -25,6 +25,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
       tabIndex={-1}
     />
     <textarea
+      aria-describedBy="errorMessage2"
       aria-errormessage="errorMessage2"
       aria-invalid={false}
       autoComplete="off"

--- a/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
+++ b/src/components/pill-selector-dropdown/__tests__/__snapshots__/PillSelector.test.js.snap
@@ -25,7 +25,7 @@ exports[`components/pill-selector-dropdown/PillSelector render() should render d
       tabIndex={-1}
     />
     <textarea
-      aria-describedBy="errorMessage2"
+      aria-describedby="errorMessage2"
       aria-errormessage="errorMessage2"
       aria-invalid={false}
       autoComplete="off"


### PR DESCRIPTION
fix(CreateNewFolder): [A11Y]- Add aria described by pilled selector

Error Messages are provided but not in an accesible way in Pill selector component (Create New Folder Form). Screen reader users get no indication of the error.  I added a missing `aria-describedby` attribute in the `textarea` to be read when a form validation occurs. `Aria-invalid` (exists in Tooltips component) and `aria-describedby` are used together to indicate an error when any field are not in the expected format.

<img width="1390" alt="Screen Shot 2021-05-24 at 3 51 14 PM" src="https://user-images.githubusercontent.com/79931431/119406129-f4598580-bca7-11eb-8721-0a5afda38691.png">
