### PR TITLE
fix(AccountSettings): A11Y- incorrect use of nav tag in TabviewPrimitive

### DIFF
--- a/src/components/tab-view/TabViewPrimitive.js
+++ b/src/components/tab-view/TabViewPrimitive.js
@@ -197,7 +197,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
     calculatePrevIndex = (currentIndex: number, childrenCount: number) =>
         (currentIndex - 1 + childrenCount) % childrenCount;
 
-    /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+    /* eslint-disable jsx-a11y/interactive-supports-focus */
     renderTabs() {
         const { children, selectedIndex, isDynamic } = this.props;
         const { tabsContainerOffsetLeft } = this.state;
@@ -205,7 +205,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
         const style = isDynamic ? { left: `${tabsContainerOffsetLeft}px` } : {};
 
         return (
-            <nav
+            <div
                 className="tabs"
                 role="tablist"
                 ref={ref => {
@@ -268,7 +268,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
                         </button>
                     );
                 })}
-            </nav>
+            </div>
         );
     }
 

--- a/src/components/tab-view/TabViewPrimitive.js
+++ b/src/components/tab-view/TabViewPrimitive.js
@@ -197,7 +197,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
     calculatePrevIndex = (currentIndex: number, childrenCount: number) =>
         (currentIndex - 1 + childrenCount) % childrenCount;
 
-    /* eslint-disable jsx-a11y/interactive-supports-focus */
+    /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
     renderTabs() {
         const { children, selectedIndex, isDynamic } = this.props;
         const { tabsContainerOffsetLeft } = this.state;
@@ -208,6 +208,7 @@ class TabViewPrimitive extends React.Component<Props, State> {
             <div
                 className="tabs"
                 role="tablist"
+                tabIndex="0"
                 ref={ref => {
                     this.tabsContainer = ref;
                 }}

--- a/src/components/tab-view/__tests__/TabViewPrimitive.test.js
+++ b/src/components/tab-view/__tests__/TabViewPrimitive.test.js
@@ -248,7 +248,7 @@ describe('components/tab-view/TabViewPrimitive', () => {
                     </TabViewPrimitive>,
                 );
                 component.setState({ tabsContainerOffsetLeft });
-                const tab = component.find('nav');
+                const tab = component.find('.tabs');
 
                 expect(tab.prop('style')).toEqual(style);
             });


### PR DESCRIPTION
fix(AccountSettings): A11Y- incorrect use of nav tag in TabviewPrimitive

Page regions such as `<header>, <nav>, <main>, <aside>, and <footer>` programmatically define the essential semantic structure of a page. The `<nav>` region should usually be applied only to the primary navigation, for this reason I changed the nav tag for a div tag.

![image](https://user-images.githubusercontent.com/79931431/119571023-7b752f00-bd76-11eb-8214-d15a81141d4a.png)
