### PR TITLE
feat(in-app-messenger): add new template for popout

### DIFF
--- a/src/features/in-app-messenger/contextual/templates/PreviewTitleBody2ButtonsPopoutTemplate.js
+++ b/src/features/in-app-messenger/contextual/templates/PreviewTitleBody2ButtonsPopoutTemplate.js
@@ -1,0 +1,94 @@
+// @flow
+
+/**
+ * This component is intended to be passed to TemplateContainer as templateComponent prop, like this:
+ *   <TemplateContainer templateID='my-template' templateComponent=MyTemplate/>
+ */
+
+import * as React from 'react';
+
+import Button from '../../../../components/button/Button';
+import Overlay from '../../../../components/flyout/Overlay';
+import MessagePreviewContent from '../../../message-center/components/templates/common/MessagePreviewContent';
+
+import { type PreviewTitleBody2ButtonsPopoutParams } from '../../types';
+
+import './styles/PreviewTitleBody2ButtonsPopoutTemplate.scss';
+
+type Props = {
+    apiHost: string,
+    contentPreviewProps?: ContentPreviewProps,
+    getToken: (folderID: string | number) => void,
+    onAction: Function,
+    params: PreviewTitleBody2ButtonsPopoutParams,
+};
+
+const handleButton1Click = (onAction, button1) => {
+    if (button1) {
+        onAction(button1.actions);
+    }
+};
+
+const handleButton2Click = (onAction, button2) => {
+    if (button2) {
+        onAction(button2.actions);
+    }
+};
+
+const PreviewTitleBody2ButtonsPopoutTemplate = ({
+    apiHost,
+    contentPreviewProps,
+    getToken,
+    onAction,
+    params: { body, button1, button2, fileUpload: { fileId, sharedLinkUrl } = {}, title },
+}: Props) => {
+    return (
+        <div className="bdl-PreviewTitleBody2ButtonsPopoutTemplate">
+            <Overlay>
+                <div className="content-container">
+                    <div className="preview-container">
+                        <MessagePreviewContent
+                            apiHost={apiHost}
+                            contentPreviewProps={contentPreviewProps}
+                            fileId={fileId}
+                            getToken={getToken}
+                            sharedLink={sharedLinkUrl}
+                        />
+                    </div>
+                    <div className="main-container">
+                        {/* eslint-disable react/no-danger */}
+                        <div
+                            className="title"
+                            dangerouslySetInnerHTML={{
+                                __html: title,
+                            }}
+                        />
+                        <div
+                            className="body"
+                            dangerouslySetInnerHTML={{
+                                __html: body,
+                            }}
+                        />
+                        {/* eslint-enable react/no-danger */}
+                        <div className="buttons">
+                            {button2 && (
+                                <Button data-resin-target="cta2" onClick={() => handleButton2Click(onAction, button2)}>
+                                    {button2.label}
+                                </Button>
+                            )}
+                            <Button
+                                className="btn-primary"
+                                data-resin-target="cta1"
+                                onClick={() => handleButton1Click(onAction, button1)}
+                            >
+                                {button1.label}
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            </Overlay>
+        </div>
+    );
+};
+
+export default PreviewTitleBody2ButtonsPopoutTemplate;

--- a/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBody2ButtonsPopoutTemplate.test.js
+++ b/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBody2ButtonsPopoutTemplate.test.js
@@ -1,0 +1,85 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+
+import PreviewTitleBody2ButtonsPopoutTemplate from '../PreviewTitleBody2ButtonsPopoutTemplate';
+
+const sandbox = sinon.sandbox.create();
+
+describe('features/in-app-messenger/contextual/templates/PreviewTitleBody2ButtonsPopoutTemplate', () => {
+    const onActionSpy = sandbox.spy();
+
+    const paramsConfigs = {
+        all: {
+            params: {
+                body: 'body',
+                button1: {
+                    label: 'button1',
+                    actions: 'actions1',
+                },
+                button2: {
+                    label: 'button2',
+                    actions: 'actions2',
+                },
+                fileUpload: {
+                    fileId: '1234',
+                    sharedLinkUrl: 'https://shared-link.com',
+                },
+                templateID: 'preview-title-body-2buttons-template',
+                title: 'title',
+            },
+        },
+        missingButton2: {
+            params: {
+                body: 'body',
+                button1: {
+                    label: 'button1',
+                    actions: 'actions1',
+                },
+                footnote: 'footnote',
+                fileUpload: {
+                    fileId: '1234',
+                    sharedLinkUrl: 'https://shared-link.com',
+                },
+                templateID: 'image-title-body-2buttons-template',
+                title: 'title',
+            },
+        },
+    };
+
+    const getWrapper = params =>
+        shallow(<PreviewTitleBody2ButtonsPopoutTemplate onAction={onActionSpy} params={params} />);
+
+    beforeEach(() => {});
+
+    afterEach(() => {
+        sandbox.verify();
+        sandbox.reset();
+    });
+
+    describe.each([paramsConfigs.all, paramsConfigs.missingButton2])('%o', ({ params }) => {
+        test('renders correctly', () => {
+            getWrapper(params);
+        });
+    });
+
+    function checkClickElement(findElement, expectCalled, ...expectCalledWith) {
+        const element = findElement(getWrapper(paramsConfigs.all.params));
+        element.simulate('click');
+        if (expectCalled) {
+            expect(onActionSpy.callCount).toBe(1);
+            expect(onActionSpy.calledWith(...expectCalledWith)).toBe(true);
+        } else {
+            expect(onActionSpy.callCount).toBe(0);
+        }
+    }
+
+    test('should call onAction(button1.actions) if button1 is clicked', () =>
+        checkClickElement(wrapper => wrapper.find('Button').at(1), true, 'actions1'));
+
+    test('should call onAction(button2.actions) if button2 is clicked', () =>
+        checkClickElement(wrapper => wrapper.find('Button').at(0), true, 'actions2'));
+
+    test('should not call onAction if clicked else where', () =>
+        checkClickElement(wrapper => wrapper.find('Overlay'), false));
+});

--- a/src/features/in-app-messenger/contextual/templates/styles/PreviewTitleBody2ButtonsPopoutTemplate.scss
+++ b/src/features/in-app-messenger/contextual/templates/styles/PreviewTitleBody2ButtonsPopoutTemplate.scss
@@ -1,0 +1,114 @@
+@import '../../../../../styles/variables';
+
+$width: 610px;
+$supported-width: 1.1 * $width;
+$supported-height: 400px;
+
+$button-height: 32px;
+
+// tweak button so primary button and its clickable area is larger and secondary button is smaller
+$primary-button-padding: 24px;
+$secondary-button-padding: 0;
+$secondary-button-margin-right: 15px;
+
+.bdl-PreviewTitleBody2ButtonsPopoutTemplate {
+    // media css should be in its separate file as convention, but this is an exception as this particular
+    // media css here only applies to this template.
+    @media only screen and (max-width: $supported-width - 1px) {
+        display: none;
+    }
+
+    @media only screen and (max-height: $supported-height - 1px) {
+        display: none;
+    }
+
+    letter-spacing: .3px;
+
+    .overlay {
+        border: 1px solid $bdl-gray-10;
+        border-radius: 2px;
+
+        .content-container {
+            display: flex;
+            width: $width;
+            padding: 30px;
+
+            .preview-container {
+                display: flex;
+                flex-shrink: 0;
+                align-items: center;
+                justify-content: center;
+
+                .MessagePreviewContent {
+                    width: 170px;
+                    height: 170px;
+                }
+
+                .bp-container {
+                    min-width: 170px;
+                }
+            }
+
+            .main-container {
+                display: flex;
+                flex-direction: column;
+                flex-grow: 1;
+                justify-content: space-around;
+                min-width: 50%;
+                margin-left: 30px;
+                line-height: 20px;
+
+                .title {
+                    margin: 0;
+                    margin-bottom: 16px;
+                    font-weight: bold;
+                    font-size: 15px;
+                    word-wrap: break-word;
+                }
+
+                .body {
+                    font-size: 13px;
+
+                    a {
+                        font-weight: bold;
+                    }
+                }
+
+                .footnote {
+                    margin-top: 10px;
+                    font-size: 8px;
+                }
+
+                .buttons {
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: flex-end;
+                    margin-top: 16px;
+
+                    .btn {
+                        height: $button-height;
+                        margin-top: 0;
+                        margin-bottom: 0;
+                        border-width: 0;
+
+                        &:not(.btn-primary) {
+                            margin-right: $secondary-button-margin-right;
+                            padding-right: $secondary-button-padding;
+                            padding-left: $secondary-button-padding;
+                            color: $bdl-box-blue;
+
+                            &:not(.is-disabled):hover {
+                                background-color: inherit;
+                            }
+                        }
+
+                        &.btn-primary {
+                            padding-right: $primary-button-padding;
+                            padding-left: $primary-button-padding;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/features/in-app-messenger/types/index.js
+++ b/src/features/in-app-messenger/types/index.js
@@ -1,0 +1,4 @@
+// @flow
+
+// eslint-disable-next-line import/prefer-default-export
+export type { PreviewTitleBody2ButtonsPopoutParams } from './template-params';

--- a/src/features/in-app-messenger/types/template-params.js
+++ b/src/features/in-app-messenger/types/template-params.js
@@ -1,0 +1,14 @@
+// @flow
+
+type PreviewParams = {|
+    fileUpload?: { fileId: string, sharedLinkUrl: string },
+|};
+
+export type PreviewTitleBody2ButtonsPopoutParams = {|
+    body: HTMLParam,
+    button1: ButtonParam,
+    button2?: ButtonParam,
+    templateID: string,
+    title: HTMLParam,
+    ...PreviewParams,
+|};


### PR DESCRIPTION
Add a new template for in-app messenger leveraging preview component
<img width="634" alt="Screenshot 2021-05-27 at 15 06 36" src="https://user-images.githubusercontent.com/23643342/119831700-d1c0aa00-befd-11eb-9543-3b99ee5bec8b.png">
