### PR TITLE
fix(Toggle): A11Y - When shared link does not exist maintain focus on the switch

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -324,10 +324,6 @@ be.executeIntegrationOpenWithErrorSubHeader = Please try again later.
 be.expand = Expand
 # Label for face skill section in the preview sidebar
 be.faceSkill = Faces
-# Call-to-action text describing what to do to navigate to specified feedback form
-be.feedbackCtaText = Click to provide feedback
-# Accessible text used to describe the form used for feedback
-be.feedbackFormDescription = Beta Feedback Form
 # File access stats error message
 be.fileAccessStatsErrorHeaderMessage = Something went wrong when fetching the access stats.
 # File classification error message
@@ -378,22 +374,6 @@ be.loadingState = Please wait while the items load...
 be.logo = Logo
 # Indicator on the footer that max items have been selected.
 be.max = max
-# Title for all categories
-be.messageCenter.all = All
-# Title for Box education category
-be.messageCenter.boxEducation = Box Education
-# Displayed when there was an error fetching posts
-be.messageCenter.errorFetchingPosts = Sorry, we are having trouble showing posts at the moment. It may help to refresh the page.
-# Title for product category
-be.messageCenter.events = Events
-# Displayed when there are no posts to display
-be.messageCenter.noPosts = There are no posts for this category at the moment.
-# Error message for preview not loading an image
-be.messageCenter.previewError = Sorry, we're having trouble showing this image. 
-# Title for product category
-be.messageCenter.product = Product
-# Title for the message center modal
-be.messageCenter.title = What's New
 # Message shown when there are no items for provided metadata query.
 be.metadataState = There are no items in this folder.
 # Text for modified date with modified prefix.
@@ -772,52 +752,6 @@ boxui.collaboratorAvatars.viewAdditionalPeopleText = View additional people
 boxui.collapsiblesidebar.collapseBtnLabel = Collapse
 # Aria label for toggle button that expands/collapses sidebar (collapsed state)
 boxui.collapsiblesidebar.expandBtnLabel = Expand
-# Icon title for a Box item of type bookmark or web-link
-boxui.contentExplorer.bookmark = Bookmark
-# Aria label for the folder breadcrumb
-boxui.contentExplorer.breadcrumb = Breadcrumb
-# Text shown on button used to close the content explorer
-boxui.contentExplorer.cancel = Cancel
-# Text shown on button used to choose an item
-boxui.contentExplorer.choose = Choose
-# Aria label for button to navigate back to the previous folder
-boxui.contentExplorer.clickToGoBack = Click to go back
-# Icon title for a Box item of type folder that has collaborators
-boxui.contentExplorer.collaboratedFolder = Collaborated Folder
-# Text shown on button used to copy an item to a different folder
-boxui.contentExplorer.copy = Copy
-# Text shown in the list when the folder being viewed is empty
-boxui.contentExplorer.emptyFolder = There are no subfolders in this folder.
-# Text shown in the list when there are no search results
-boxui.contentExplorer.emptySearch = Sorry, we couldn't find what you're looking for.
-# Icon title for a Box item of type folder that has collaborators outside of the user's enterprise
-boxui.contentExplorer.externalFolder = External Folder
-# Icon title for a Box item of type file
-boxui.contentExplorer.file = File
-# Text shown on button used to move an item to a different folder
-boxui.contentExplorer.move = Move
-# Text shown as the header for a column of item names in the list
-boxui.contentExplorer.name = Name
-# Text shown on button used to create a new folder
-boxui.contentExplorer.newFolder = New Folder
-# Text shown to indicate the number of items selected
-boxui.contentExplorer.numSelected = {numSelected} Selected
-# Icon title for a Box item of type folder that is private and has no collaborators
-boxui.contentExplorer.personalFolder = Personal Folder
-# Results label for number of items on list when it's just 1
-boxui.contentExplorer.result = {itemsCount} result
-# Results label for number of items on list
-boxui.contentExplorer.results = {itemsCount} results
-# Placeholder text shown in the search input
-boxui.contentExplorer.searchPlaceholder = Search
-# Text shown in the breadcrumbs when showing search results
-boxui.contentExplorer.searchResults = Search Results
-# Select All label for select all items check box
-boxui.contentExplorer.selectAll = Select All
-# Label for radio input to select an item from the item list, {name} is the item name
-boxui.contentExplorer.selectItem = Select {name}
-# Text shown when hovering over a disabled new folder button because the user lacks permissions to create a folder
-boxui.contentexplorer.newFolder.forbidden = You do not have permission to create a folder here.
 # Cancel button text
 boxui.core.cancel = Cancel
 # Close button text
@@ -830,42 +764,12 @@ boxui.core.copy = Copy
 boxui.core.done = Done
 # Displays the navigation step index to the user of where they are in the guide. e.g. 1 of 4
 boxui.core.guidetooltip.navigation = {currentStepIndex} of {totalNumSteps}
-# Label for "Alt" key
-boxui.core.hotkeys.altKey = Alt
-# Label for "Control" key
-boxui.core.hotkeys.ctrlKey = Ctrl
-# Label for "Enter" key
-boxui.core.hotkeys.enterKey = Enter
-# Label for "Esc" key
-boxui.core.hotkeys.escKey = Esc
-# Title for keyboard shortcut help modal
-boxui.core.hotkeys.hotkeyModalTitle = Keyboard Shortcuts
-# Describes a hotkey sequence, e.g. "shift+g then shift+a". {key1} is the first key ("shift+g" in our example) and {key2} is the second ("shift+a" in our example).
-boxui.core.hotkeys.hotkeySequence = {key1} then {key2}
-# Label for "Shift" key
-boxui.core.hotkeys.shiftKey = Shift
-# Label for "Spacebar" key
-boxui.core.hotkeys.spacebarKey = Spacebar
 # Okay button text
 boxui.core.okay = Okay
 # Optional text for labels
 boxui.core.optional = optional
 # Save button text
 boxui.core.save = Save
-# Description for keyboard shortcut to deselect all items in the file list
-boxui.core.selection.deselectAllDescription = Deselect all items
-# Description for keyboard shortcut to select next item in the file list
-boxui.core.selection.downDescription = Select next item
-# Description for keyboard shortcut to select all items in the file list
-boxui.core.selection.selectAllDescription = Select all items
-# Description for keyboard shortcut to add next item to current selection in the file list
-boxui.core.selection.shiftDownDescription = Add next item to current selection
-# Description for keyboard shortcut to add previous item to current selection in the file list
-boxui.core.selection.shiftUpDescription = Add previous item to current selection
-# Description for keyboard shortcut to select previous item in the file list
-boxui.core.selection.shiftXDescription = Select current item
-# Description for keyboard shortcut to select previous item in the file list
-boxui.core.selection.upDescription = Select previous item
 # Send button text
 boxui.core.send = Send
 # Button for opening date picker
@@ -1030,106 +934,8 @@ boxui.metadataInstanceFields.fieldSetValue = Set Value
 boxui.metadataInstanceFields.invalidMetadataFieldType = Invalid metadata field type!
 # Button to close modal
 boxui.modalDialog.closeModalText = Close Modal
-# Text shown on button to close the modal used to create a new folder
-boxui.newFolderModal.cancel = Cancel
-# Text shown on button to create a new folder
-boxui.newFolderModal.create = Create
-# Label text shown on top of the folder name input when creating a new folder
-boxui.newFolderModal.folderName.label = Folder Name
-# Placeholder text shown in the folder name input when creating a new folder
-boxui.newFolderModal.folderName.placeholder = My New Folder
-# Title shown in the modal used to create a new folder. "parentFolderName" should not be translated
-boxui.newFolderModal.title = Create a New Folder in "{parentFolderName}"
 # Button to clear notification
 boxui.notification.clearNotification = Clear Notification
-# Description for when someone last viewed a document less than a minute ago
-boxui.presence.accessedInTheLastMinute = Viewed less than a minute ago
-# Description for someone who is currently viewing or editing a document
-boxui.presence.activeNow = Active now
-# Description for when someone last commented on a document less than a minute ago
-boxui.presence.commentedIntheLastMinute = Commented less than a minute ago
-# Text on button to get shared link for the item
-boxui.presence.getLinkButton = Get Link
-# Text on button to invite collaborators to this item
-boxui.presence.inviteButton = Invite People
-# Description for when someone last edited a document less than a minute ago
-boxui.presence.modifiedIntheLastMinute = Edited less than a minute ago
-# Text for link at footer of the Recent Activity panel
-boxui.presence.previewPresenceFlyoutAccessStatsLink = See all activity
-# Text on button embedded within tooltip that is visible on page load
-boxui.presence.previewPresenceFlyoutActivityCTA = View Recent Activity
-# Tooltip text visible on page load, to prompt the user to press a button to view activity
-boxui.presence.previewPresenceFlyoutCopy = Quickly see who has commented on, edited, or viewed this file.
-# Description for when someone last previewed a document less than a minute ago
-boxui.presence.previewedIntheLastMinute = Previewed less than a minute ago
-# Header on presence dropdown list that represents recent activity on the item
-boxui.presence.recentActivity = Recent Activity
-# Description for when someone last viewed a document, {timeAgo} is a relative time like 2 months ago
-boxui.presence.timeSinceLastAccessed = Viewed {timeAgo}
-# Description for when someone last commented on a document, {timeAgo} is a relative time like 2 months ago
-boxui.presence.timeSinceLastCommented = Commented {timeAgo}
-# Description for when someone last edited a document, {timeAgo} is a relative time like 2 months ago
-boxui.presence.timeSinceLastModified = Edited {timeAgo}
-# Description for when someone last previewed a document, {timeAgo} is a relative time like 2 months ago
-boxui.presence.timeSinceLastPreviewed = Previewed {timeAgo}
-# Text on the add filter button, on click generates another filter row
-boxui.queryBar.addFilterButtonText = + Add Filter
-# Text on the apply filter button, on click applies the filters
-boxui.queryBar.applyFiltersButtonText = Apply
-# Text on the columns button, on click opens a menu which allows users to choose which columns to render
-boxui.queryBar.columnsButtonText = Columns
-# Text on the columns button, if one or more columns have been hidden then it will display this text
-boxui.queryBar.columnsHiddenButtonText = {count, plural, one {1 Column Hidden} other {{count} Columns Hidden}}
-# Text on the connector dropdown, on click should open a dropdown showing either AND or OR
-boxui.queryBar.connectorAndText = AND
-# Text on the connector dropdown, on click should open a dropdown showing either AND or OR
-boxui.queryBar.connectorOrText = OR
-# Text on the label, the first condition will show WHERE
-boxui.queryBar.connectorWhereText = WHERE
-# Text on the filters button, on click opens a menu which allows users to filter through the files
-boxui.queryBar.filtersButtonText = Modify Filters
-# Header text shown in template dropdown
-boxui.queryBar.metadataViewTemplateListHeaderTitle = METADATA TEMPLATES
-# Text on the filters button, will display a number in front of the filters text indicating how many filters are applied
-boxui.queryBar.multipleFiltersButtonText = {number} Filters
-# Text on the filters dropdown that is displayed when no filters have been inserted
-boxui.queryBar.noFiltersAppliedText = No Filters Applied
-# Text on the templates button when templates have been loaded and there are no templates in the enterprise
-boxui.queryBar.noTemplatesText = No Templates Available
-# Placeholder text on the value button, on click should open a dropdown
-boxui.queryBar.selectValuePlaceholderText = Select value
-# Text on the templates button, on click opens a menu which allows users to select a metadata templates
-boxui.queryBar.templatesButtonText = Select Metadata
-# Text on the templates button when templates are still being loaded
-boxui.queryBar.templatesLoadingButtonText = Template Name
-# Text displayed on the Tooltip for an input field
-boxui.queryBar.tooltipEnterValueError = Please Enter a Value
-# Text displayed on the Tooltip for an input field of type float
-boxui.queryBar.tooltipInvalidFloatError = Please Enter a Decimal Number
-# Text displayed on the Tooltip for an input field of type number
-boxui.queryBar.tooltipInvalidNumberError = Please Enter an Integer
-# Text displayed on the Tooltip for a date field
-boxui.queryBar.tooltipSelectDateError = Please Select a Date
-# Text displayed on the Tooltip for a value field
-boxui.queryBar.tooltipSelectValueError = Please Select a Value
-# Icon title for a Box item of type bookmark or web-link
-boxui.quickSearch.bookmark = Bookmark
-# Icon title for a Box item of type folder that has collaborators
-boxui.quickSearch.collaboratedFolder = Collaborated Folder
-# Icon title for a Box item of type folder that has collaborators outside of the user's enterprise
-boxui.quickSearch.externalFolder = External Folder
-# Icon title for a Box item of type file
-boxui.quickSearch.file = File
-# Title for a parent folder icon next to the name of the parent folder for a quick search result item
-boxui.quickSearch.parentFolder = Parent Folder
-# Icon title for a Box item of type folder that is private and has no collaborators
-boxui.quickSearch.personalFolder = Personal Folder
-# Text for a quick search result describing the date when the user last updated the item
-boxui.quickSearch.updatedText = {date, date, medium} by {user}
-# Statement describing when and who last updated a quick search result item, capitalize if appropriate
-boxui.quickSearch.updatedTextToday = Today by {user}
-# Statement describing when and who last updated a quick search result item, capitalize if appropriate
-boxui.quickSearch.updatedTextYesterday = Yesterday by {user}
 # The time that an event occurred
 boxui.readableTime.eventTime = {time, date, medium}
 # The time that an event occurred at a given date with the year included
@@ -1148,10 +954,6 @@ boxui.searchForm.clearButtonTitle = Clear
 boxui.searchForm.searchButtonTitle = Search
 # Label for a search input
 boxui.searchForm.searchLabel = Search query
-# Instructional message displayed on the embed widget security drag-drop game
-boxui.securityCloudGame.instructions = For security purposes, please drag the white cloud into the dark cloud.
-# Success message shown when a user successfully drags the cloud into position.
-boxui.securityCloudGame.success = Success!
 # Name list of all applications download restriction applied to classification
 boxui.securityControls.allAppNames = All applications: {appsList}
 # Bullet point that summarizes application download restriction applied to classification
@@ -1236,44 +1038,14 @@ boxui.share.accessType = ACCESS TYPE
 boxui.share.canEdit = Can edit
 # Label for a shared link permission level
 boxui.share.canView = Can view
-# Text for Co-owner permission level in permissions table
-boxui.share.coownerLevelText = Co-owner
-# Text for permissions table Delete column
-boxui.share.deleteTableHeaderText = Delete
-# Text for permissions table Download column
-boxui.share.downloadTableHeaderText = Download
-# Text for permissions table Edit column
-boxui.share.editTableHeaderText = Edit
-# Text for Editor permission level in permissions table
-boxui.share.editorLevelText = Editor
 # Field label for shared link recipient list (title-case)
 boxui.share.emailSharedLink = Email Shared Link
 # Error message when user tries to send shared link as email without entering any recipients
 boxui.share.enterAtLeastOneEmail = Enter at least one valid email
-# Text for permissions table Get Link column
-boxui.share.getLinkTableHeaderText = Get Link
-# Label for a Group contact type
-boxui.share.groupLabel = Group
-# Text on button to cancel and close the invite collaborators modal.
-boxui.share.inviteCollaboratorsModalCancelButton = Cancel
-# Text on button to send invitations to collaborators for an item
-boxui.share.inviteCollaboratorsModalSendInvites = Send Invites
-# Title of the Invite Collaborators Modal. {itemName} is the name of the file / folder being shared
-boxui.share.inviteCollaboratorsModalTitle = Invite to {itemName}
-# Label of the field where a user designates who to invite to collaborate on an item
-boxui.share.inviteFieldLabel = Invite
-# Label to invite editors to a file in the invite collab modal
-boxui.share.inviteFileEditorsLabel = Invite people to become editors of this file.
-# Label of the field where a user designates which permissions a collaborator will have on an item
-boxui.share.inviteePermissionsFieldLabel = Invitee Permissions
-# Tooltip text a user can use to learn more about collaborator permission options
-boxui.share.inviteePermissionsLearnMore = Learn More
 # Label for "Message" text box to email the shared link (title-case)
 boxui.share.message = Message
 # Placeholder text for message section
 boxui.share.messageSelectorPlaceholder = Add a message
-# Text for permissions table Owner column
-boxui.share.ownerTableHeaderText = Owner
 # Description of a company shared link for a file with view and download permissions
 boxui.share.peopleInCompanyCanDownloadFile = Anyone in your company with the link can view and download this file.
 # Description of a company shared link for a folder with view and download permissions
@@ -1332,24 +1104,8 @@ boxui.share.peopleWithLinkCanViewFile = Anyone with the link can view this file.
 boxui.share.peopleWithLinkCanViewFolder = Anyone with the link can view this folder.
 # Label for "People with the link" option
 boxui.share.peopleWithTheLink = People with the link
-# Text for permissions table Permission Levels column
-boxui.share.permissionLevelsTableHeaderText = Permission Levels
-# Label for optional personal message to include when inviting collaborators to an item
-boxui.share.personalMessageLabel = Personal Message
 # Placeholder text for the pill selector
 boxui.share.pillSelectorPlaceholder = Add names or email addresses
-# Text for permissions table Preview column
-boxui.share.previewTableHeaderText = Preview
-# Text for Previewer permission level in permissions table
-boxui.share.previewerLevelText = Previewer
-# Text for Previewer Uploader permission level in permissions table
-boxui.share.previewerUploaderLevelText = Previewer Uploader
-# Text on a badge encouraging users to refer a friend to sign up for Box
-boxui.share.referAFriendBadgeText = REFER
-# Text on a link to the "Reward Center", where users can refer a friend to sign up for Box
-boxui.share.referAFriendRewardCenterLinkText = Click Here
-# Text encouraging users to refer a friend to sign up for Box
-boxui.share.referAFriendText = Want a free month of Box? Refer your friend!
 # Label for option to remove shared link
 boxui.share.removeLink = Remove Link
 # Description for confirmation modal to remove a shared link
@@ -1414,38 +1170,8 @@ boxui.share.sharedLinkSettings.vanityNamePlaceholder = Enter a custom path (12 o
 boxui.share.sharedLinkSettings.vanityURLWarning = Custom URLs should not be used when sharing sensitive content.
 # Accessible label for shared link input field
 boxui.share.sharedLinkURLLabel = URL
-# Label for link to upgrade to get more access controls for inviting collaborators to an item
-boxui.share.upgradeGetMoreAccessControls = Get More Access Controls
-# Text for permissions table Upload column
-boxui.share.uploadTableHeaderText = Upload
-# Text for Uploader permission level in permissions table
-boxui.share.uploaderLevelText = Uploader
 # Text label for custom URL section
 boxui.share.vanityURLEnableText = Publish content broadly with a custom, non-private URL
-# Text for Viewer permission level in permissions table
-boxui.share.viewerLevelText = Viewer
-# Text for Viewer Uploader permission level in permissions table
-boxui.share.viewerUploaderLevelText = Viewer Uploader
-# Description of permissions granted to users who have access to the shared link
-boxui.shareMenu.downloadOnly = Download Only
-# Description of permissions granted when inviting a collab to this item
-boxui.shareMenu.editAndComment = Edit and Comment
-# Label for menu option to get shared link for item (title-case)
-boxui.shareMenu.getSharedLink = Get Shared Link
-# Label for disabled menu option when user does not have permission to get shared link for item
-boxui.shareMenu.insufficientPermissionsMenuOption = Insufficient sharing permissions. Please contact the folder owner.
-# Tooltip to show when user does not have permission to invite collaborators to item
-boxui.shareMenu.insufficientPermissionsTooltip = You have insufficient permissions to invite collaborators.
-# Label for menu option to invite collaborators to item
-boxui.shareMenu.inviteCollabs = Invite Collaborators
-# Tooltip to show when only owners and co-owners are allowed to invite collaborators to item
-boxui.shareMenu.ownerCoownerOnlyTooltip = You have insufficient permissions to invite collaborators. Only the owner and co-owners can invite collaborators.
-# Description of permissions granted to users who have access to the shared link
-boxui.shareMenu.shortcutOnly = Shortcut Only
-# Description of permissions granted to users who have access to the shared link
-boxui.shareMenu.viewAndDownload = View and Download
-# Description of permissions granted to users who have access to the shared link
-boxui.shareMenu.viewOnly = View Only
 # Error message for empty time formats. "HH:MM A" should be localized.
 boxui.timeInput.emptyTimeError = Required field. Enter a time in the format HH:MM A.
 # Error message for invalid time formats. "HH:MM A" should be localized.

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -324,6 +324,10 @@ be.executeIntegrationOpenWithErrorSubHeader = Please try again later.
 be.expand = Expand
 # Label for face skill section in the preview sidebar
 be.faceSkill = Faces
+# Call-to-action text describing what to do to navigate to specified feedback form
+be.feedbackCtaText = Click to provide feedback
+# Accessible text used to describe the form used for feedback
+be.feedbackFormDescription = Beta Feedback Form
 # File access stats error message
 be.fileAccessStatsErrorHeaderMessage = Something went wrong when fetching the access stats.
 # File classification error message
@@ -374,6 +378,22 @@ be.loadingState = Please wait while the items load...
 be.logo = Logo
 # Indicator on the footer that max items have been selected.
 be.max = max
+# Title for all categories
+be.messageCenter.all = All
+# Title for Box education category
+be.messageCenter.boxEducation = Box Education
+# Displayed when there was an error fetching posts
+be.messageCenter.errorFetchingPosts = Sorry, we are having trouble showing posts at the moment. It may help to refresh the page.
+# Title for product category
+be.messageCenter.events = Events
+# Displayed when there are no posts to display
+be.messageCenter.noPosts = There are no posts for this category at the moment.
+# Error message for preview not loading an image
+be.messageCenter.previewError = Sorry, we're having trouble showing this image. 
+# Title for product category
+be.messageCenter.product = Product
+# Title for the message center modal
+be.messageCenter.title = What's New
 # Message shown when there are no items for provided metadata query.
 be.metadataState = There are no items in this folder.
 # Text for modified date with modified prefix.
@@ -752,6 +772,52 @@ boxui.collaboratorAvatars.viewAdditionalPeopleText = View additional people
 boxui.collapsiblesidebar.collapseBtnLabel = Collapse
 # Aria label for toggle button that expands/collapses sidebar (collapsed state)
 boxui.collapsiblesidebar.expandBtnLabel = Expand
+# Icon title for a Box item of type bookmark or web-link
+boxui.contentExplorer.bookmark = Bookmark
+# Aria label for the folder breadcrumb
+boxui.contentExplorer.breadcrumb = Breadcrumb
+# Text shown on button used to close the content explorer
+boxui.contentExplorer.cancel = Cancel
+# Text shown on button used to choose an item
+boxui.contentExplorer.choose = Choose
+# Aria label for button to navigate back to the previous folder
+boxui.contentExplorer.clickToGoBack = Click to go back
+# Icon title for a Box item of type folder that has collaborators
+boxui.contentExplorer.collaboratedFolder = Collaborated Folder
+# Text shown on button used to copy an item to a different folder
+boxui.contentExplorer.copy = Copy
+# Text shown in the list when the folder being viewed is empty
+boxui.contentExplorer.emptyFolder = There are no subfolders in this folder.
+# Text shown in the list when there are no search results
+boxui.contentExplorer.emptySearch = Sorry, we couldn't find what you're looking for.
+# Icon title for a Box item of type folder that has collaborators outside of the user's enterprise
+boxui.contentExplorer.externalFolder = External Folder
+# Icon title for a Box item of type file
+boxui.contentExplorer.file = File
+# Text shown on button used to move an item to a different folder
+boxui.contentExplorer.move = Move
+# Text shown as the header for a column of item names in the list
+boxui.contentExplorer.name = Name
+# Text shown on button used to create a new folder
+boxui.contentExplorer.newFolder = New Folder
+# Text shown to indicate the number of items selected
+boxui.contentExplorer.numSelected = {numSelected} Selected
+# Icon title for a Box item of type folder that is private and has no collaborators
+boxui.contentExplorer.personalFolder = Personal Folder
+# Results label for number of items on list when it's just 1
+boxui.contentExplorer.result = {itemsCount} result
+# Results label for number of items on list
+boxui.contentExplorer.results = {itemsCount} results
+# Placeholder text shown in the search input
+boxui.contentExplorer.searchPlaceholder = Search
+# Text shown in the breadcrumbs when showing search results
+boxui.contentExplorer.searchResults = Search Results
+# Select All label for select all items check box
+boxui.contentExplorer.selectAll = Select All
+# Label for radio input to select an item from the item list, {name} is the item name
+boxui.contentExplorer.selectItem = Select {name}
+# Text shown when hovering over a disabled new folder button because the user lacks permissions to create a folder
+boxui.contentexplorer.newFolder.forbidden = You do not have permission to create a folder here.
 # Cancel button text
 boxui.core.cancel = Cancel
 # Close button text
@@ -764,12 +830,42 @@ boxui.core.copy = Copy
 boxui.core.done = Done
 # Displays the navigation step index to the user of where they are in the guide. e.g. 1 of 4
 boxui.core.guidetooltip.navigation = {currentStepIndex} of {totalNumSteps}
+# Label for "Alt" key
+boxui.core.hotkeys.altKey = Alt
+# Label for "Control" key
+boxui.core.hotkeys.ctrlKey = Ctrl
+# Label for "Enter" key
+boxui.core.hotkeys.enterKey = Enter
+# Label for "Esc" key
+boxui.core.hotkeys.escKey = Esc
+# Title for keyboard shortcut help modal
+boxui.core.hotkeys.hotkeyModalTitle = Keyboard Shortcuts
+# Describes a hotkey sequence, e.g. "shift+g then shift+a". {key1} is the first key ("shift+g" in our example) and {key2} is the second ("shift+a" in our example).
+boxui.core.hotkeys.hotkeySequence = {key1} then {key2}
+# Label for "Shift" key
+boxui.core.hotkeys.shiftKey = Shift
+# Label for "Spacebar" key
+boxui.core.hotkeys.spacebarKey = Spacebar
 # Okay button text
 boxui.core.okay = Okay
 # Optional text for labels
 boxui.core.optional = optional
 # Save button text
 boxui.core.save = Save
+# Description for keyboard shortcut to deselect all items in the file list
+boxui.core.selection.deselectAllDescription = Deselect all items
+# Description for keyboard shortcut to select next item in the file list
+boxui.core.selection.downDescription = Select next item
+# Description for keyboard shortcut to select all items in the file list
+boxui.core.selection.selectAllDescription = Select all items
+# Description for keyboard shortcut to add next item to current selection in the file list
+boxui.core.selection.shiftDownDescription = Add next item to current selection
+# Description for keyboard shortcut to add previous item to current selection in the file list
+boxui.core.selection.shiftUpDescription = Add previous item to current selection
+# Description for keyboard shortcut to select previous item in the file list
+boxui.core.selection.shiftXDescription = Select current item
+# Description for keyboard shortcut to select previous item in the file list
+boxui.core.selection.upDescription = Select previous item
 # Send button text
 boxui.core.send = Send
 # Button for opening date picker
@@ -934,8 +1030,106 @@ boxui.metadataInstanceFields.fieldSetValue = Set Value
 boxui.metadataInstanceFields.invalidMetadataFieldType = Invalid metadata field type!
 # Button to close modal
 boxui.modalDialog.closeModalText = Close Modal
+# Text shown on button to close the modal used to create a new folder
+boxui.newFolderModal.cancel = Cancel
+# Text shown on button to create a new folder
+boxui.newFolderModal.create = Create
+# Label text shown on top of the folder name input when creating a new folder
+boxui.newFolderModal.folderName.label = Folder Name
+# Placeholder text shown in the folder name input when creating a new folder
+boxui.newFolderModal.folderName.placeholder = My New Folder
+# Title shown in the modal used to create a new folder. "parentFolderName" should not be translated
+boxui.newFolderModal.title = Create a New Folder in "{parentFolderName}"
 # Button to clear notification
 boxui.notification.clearNotification = Clear Notification
+# Description for when someone last viewed a document less than a minute ago
+boxui.presence.accessedInTheLastMinute = Viewed less than a minute ago
+# Description for someone who is currently viewing or editing a document
+boxui.presence.activeNow = Active now
+# Description for when someone last commented on a document less than a minute ago
+boxui.presence.commentedIntheLastMinute = Commented less than a minute ago
+# Text on button to get shared link for the item
+boxui.presence.getLinkButton = Get Link
+# Text on button to invite collaborators to this item
+boxui.presence.inviteButton = Invite People
+# Description for when someone last edited a document less than a minute ago
+boxui.presence.modifiedIntheLastMinute = Edited less than a minute ago
+# Text for link at footer of the Recent Activity panel
+boxui.presence.previewPresenceFlyoutAccessStatsLink = See all activity
+# Text on button embedded within tooltip that is visible on page load
+boxui.presence.previewPresenceFlyoutActivityCTA = View Recent Activity
+# Tooltip text visible on page load, to prompt the user to press a button to view activity
+boxui.presence.previewPresenceFlyoutCopy = Quickly see who has commented on, edited, or viewed this file.
+# Description for when someone last previewed a document less than a minute ago
+boxui.presence.previewedIntheLastMinute = Previewed less than a minute ago
+# Header on presence dropdown list that represents recent activity on the item
+boxui.presence.recentActivity = Recent Activity
+# Description for when someone last viewed a document, {timeAgo} is a relative time like 2 months ago
+boxui.presence.timeSinceLastAccessed = Viewed {timeAgo}
+# Description for when someone last commented on a document, {timeAgo} is a relative time like 2 months ago
+boxui.presence.timeSinceLastCommented = Commented {timeAgo}
+# Description for when someone last edited a document, {timeAgo} is a relative time like 2 months ago
+boxui.presence.timeSinceLastModified = Edited {timeAgo}
+# Description for when someone last previewed a document, {timeAgo} is a relative time like 2 months ago
+boxui.presence.timeSinceLastPreviewed = Previewed {timeAgo}
+# Text on the add filter button, on click generates another filter row
+boxui.queryBar.addFilterButtonText = + Add Filter
+# Text on the apply filter button, on click applies the filters
+boxui.queryBar.applyFiltersButtonText = Apply
+# Text on the columns button, on click opens a menu which allows users to choose which columns to render
+boxui.queryBar.columnsButtonText = Columns
+# Text on the columns button, if one or more columns have been hidden then it will display this text
+boxui.queryBar.columnsHiddenButtonText = {count, plural, one {1 Column Hidden} other {{count} Columns Hidden}}
+# Text on the connector dropdown, on click should open a dropdown showing either AND or OR
+boxui.queryBar.connectorAndText = AND
+# Text on the connector dropdown, on click should open a dropdown showing either AND or OR
+boxui.queryBar.connectorOrText = OR
+# Text on the label, the first condition will show WHERE
+boxui.queryBar.connectorWhereText = WHERE
+# Text on the filters button, on click opens a menu which allows users to filter through the files
+boxui.queryBar.filtersButtonText = Modify Filters
+# Header text shown in template dropdown
+boxui.queryBar.metadataViewTemplateListHeaderTitle = METADATA TEMPLATES
+# Text on the filters button, will display a number in front of the filters text indicating how many filters are applied
+boxui.queryBar.multipleFiltersButtonText = {number} Filters
+# Text on the filters dropdown that is displayed when no filters have been inserted
+boxui.queryBar.noFiltersAppliedText = No Filters Applied
+# Text on the templates button when templates have been loaded and there are no templates in the enterprise
+boxui.queryBar.noTemplatesText = No Templates Available
+# Placeholder text on the value button, on click should open a dropdown
+boxui.queryBar.selectValuePlaceholderText = Select value
+# Text on the templates button, on click opens a menu which allows users to select a metadata templates
+boxui.queryBar.templatesButtonText = Select Metadata
+# Text on the templates button when templates are still being loaded
+boxui.queryBar.templatesLoadingButtonText = Template Name
+# Text displayed on the Tooltip for an input field
+boxui.queryBar.tooltipEnterValueError = Please Enter a Value
+# Text displayed on the Tooltip for an input field of type float
+boxui.queryBar.tooltipInvalidFloatError = Please Enter a Decimal Number
+# Text displayed on the Tooltip for an input field of type number
+boxui.queryBar.tooltipInvalidNumberError = Please Enter an Integer
+# Text displayed on the Tooltip for a date field
+boxui.queryBar.tooltipSelectDateError = Please Select a Date
+# Text displayed on the Tooltip for a value field
+boxui.queryBar.tooltipSelectValueError = Please Select a Value
+# Icon title for a Box item of type bookmark or web-link
+boxui.quickSearch.bookmark = Bookmark
+# Icon title for a Box item of type folder that has collaborators
+boxui.quickSearch.collaboratedFolder = Collaborated Folder
+# Icon title for a Box item of type folder that has collaborators outside of the user's enterprise
+boxui.quickSearch.externalFolder = External Folder
+# Icon title for a Box item of type file
+boxui.quickSearch.file = File
+# Title for a parent folder icon next to the name of the parent folder for a quick search result item
+boxui.quickSearch.parentFolder = Parent Folder
+# Icon title for a Box item of type folder that is private and has no collaborators
+boxui.quickSearch.personalFolder = Personal Folder
+# Text for a quick search result describing the date when the user last updated the item
+boxui.quickSearch.updatedText = {date, date, medium} by {user}
+# Statement describing when and who last updated a quick search result item, capitalize if appropriate
+boxui.quickSearch.updatedTextToday = Today by {user}
+# Statement describing when and who last updated a quick search result item, capitalize if appropriate
+boxui.quickSearch.updatedTextYesterday = Yesterday by {user}
 # The time that an event occurred
 boxui.readableTime.eventTime = {time, date, medium}
 # The time that an event occurred at a given date with the year included
@@ -954,6 +1148,10 @@ boxui.searchForm.clearButtonTitle = Clear
 boxui.searchForm.searchButtonTitle = Search
 # Label for a search input
 boxui.searchForm.searchLabel = Search query
+# Instructional message displayed on the embed widget security drag-drop game
+boxui.securityCloudGame.instructions = For security purposes, please drag the white cloud into the dark cloud.
+# Success message shown when a user successfully drags the cloud into position.
+boxui.securityCloudGame.success = Success!
 # Name list of all applications download restriction applied to classification
 boxui.securityControls.allAppNames = All applications: {appsList}
 # Bullet point that summarizes application download restriction applied to classification
@@ -1038,14 +1236,44 @@ boxui.share.accessType = ACCESS TYPE
 boxui.share.canEdit = Can edit
 # Label for a shared link permission level
 boxui.share.canView = Can view
+# Text for Co-owner permission level in permissions table
+boxui.share.coownerLevelText = Co-owner
+# Text for permissions table Delete column
+boxui.share.deleteTableHeaderText = Delete
+# Text for permissions table Download column
+boxui.share.downloadTableHeaderText = Download
+# Text for permissions table Edit column
+boxui.share.editTableHeaderText = Edit
+# Text for Editor permission level in permissions table
+boxui.share.editorLevelText = Editor
 # Field label for shared link recipient list (title-case)
 boxui.share.emailSharedLink = Email Shared Link
 # Error message when user tries to send shared link as email without entering any recipients
 boxui.share.enterAtLeastOneEmail = Enter at least one valid email
+# Text for permissions table Get Link column
+boxui.share.getLinkTableHeaderText = Get Link
+# Label for a Group contact type
+boxui.share.groupLabel = Group
+# Text on button to cancel and close the invite collaborators modal.
+boxui.share.inviteCollaboratorsModalCancelButton = Cancel
+# Text on button to send invitations to collaborators for an item
+boxui.share.inviteCollaboratorsModalSendInvites = Send Invites
+# Title of the Invite Collaborators Modal. {itemName} is the name of the file / folder being shared
+boxui.share.inviteCollaboratorsModalTitle = Invite to {itemName}
+# Label of the field where a user designates who to invite to collaborate on an item
+boxui.share.inviteFieldLabel = Invite
+# Label to invite editors to a file in the invite collab modal
+boxui.share.inviteFileEditorsLabel = Invite people to become editors of this file.
+# Label of the field where a user designates which permissions a collaborator will have on an item
+boxui.share.inviteePermissionsFieldLabel = Invitee Permissions
+# Tooltip text a user can use to learn more about collaborator permission options
+boxui.share.inviteePermissionsLearnMore = Learn More
 # Label for "Message" text box to email the shared link (title-case)
 boxui.share.message = Message
 # Placeholder text for message section
 boxui.share.messageSelectorPlaceholder = Add a message
+# Text for permissions table Owner column
+boxui.share.ownerTableHeaderText = Owner
 # Description of a company shared link for a file with view and download permissions
 boxui.share.peopleInCompanyCanDownloadFile = Anyone in your company with the link can view and download this file.
 # Description of a company shared link for a folder with view and download permissions
@@ -1104,8 +1332,24 @@ boxui.share.peopleWithLinkCanViewFile = Anyone with the link can view this file.
 boxui.share.peopleWithLinkCanViewFolder = Anyone with the link can view this folder.
 # Label for "People with the link" option
 boxui.share.peopleWithTheLink = People with the link
+# Text for permissions table Permission Levels column
+boxui.share.permissionLevelsTableHeaderText = Permission Levels
+# Label for optional personal message to include when inviting collaborators to an item
+boxui.share.personalMessageLabel = Personal Message
 # Placeholder text for the pill selector
 boxui.share.pillSelectorPlaceholder = Add names or email addresses
+# Text for permissions table Preview column
+boxui.share.previewTableHeaderText = Preview
+# Text for Previewer permission level in permissions table
+boxui.share.previewerLevelText = Previewer
+# Text for Previewer Uploader permission level in permissions table
+boxui.share.previewerUploaderLevelText = Previewer Uploader
+# Text on a badge encouraging users to refer a friend to sign up for Box
+boxui.share.referAFriendBadgeText = REFER
+# Text on a link to the "Reward Center", where users can refer a friend to sign up for Box
+boxui.share.referAFriendRewardCenterLinkText = Click Here
+# Text encouraging users to refer a friend to sign up for Box
+boxui.share.referAFriendText = Want a free month of Box? Refer your friend!
 # Label for option to remove shared link
 boxui.share.removeLink = Remove Link
 # Description for confirmation modal to remove a shared link
@@ -1170,8 +1414,38 @@ boxui.share.sharedLinkSettings.vanityNamePlaceholder = Enter a custom path (12 o
 boxui.share.sharedLinkSettings.vanityURLWarning = Custom URLs should not be used when sharing sensitive content.
 # Accessible label for shared link input field
 boxui.share.sharedLinkURLLabel = URL
+# Label for link to upgrade to get more access controls for inviting collaborators to an item
+boxui.share.upgradeGetMoreAccessControls = Get More Access Controls
+# Text for permissions table Upload column
+boxui.share.uploadTableHeaderText = Upload
+# Text for Uploader permission level in permissions table
+boxui.share.uploaderLevelText = Uploader
 # Text label for custom URL section
 boxui.share.vanityURLEnableText = Publish content broadly with a custom, non-private URL
+# Text for Viewer permission level in permissions table
+boxui.share.viewerLevelText = Viewer
+# Text for Viewer Uploader permission level in permissions table
+boxui.share.viewerUploaderLevelText = Viewer Uploader
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.downloadOnly = Download Only
+# Description of permissions granted when inviting a collab to this item
+boxui.shareMenu.editAndComment = Edit and Comment
+# Label for menu option to get shared link for item (title-case)
+boxui.shareMenu.getSharedLink = Get Shared Link
+# Label for disabled menu option when user does not have permission to get shared link for item
+boxui.shareMenu.insufficientPermissionsMenuOption = Insufficient sharing permissions. Please contact the folder owner.
+# Tooltip to show when user does not have permission to invite collaborators to item
+boxui.shareMenu.insufficientPermissionsTooltip = You have insufficient permissions to invite collaborators.
+# Label for menu option to invite collaborators to item
+boxui.shareMenu.inviteCollabs = Invite Collaborators
+# Tooltip to show when only owners and co-owners are allowed to invite collaborators to item
+boxui.shareMenu.ownerCoownerOnlyTooltip = You have insufficient permissions to invite collaborators. Only the owner and co-owners can invite collaborators.
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.shortcutOnly = Shortcut Only
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.viewAndDownload = View and Download
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.viewOnly = View Only
 # Error message for empty time formats. "HH:MM A" should be localized.
 boxui.timeInput.emptyTimeError = Required field. Enter a time in the format HH:MM A.
 # Error message for invalid time formats. "HH:MM A" should be localized.

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import classNames from 'classnames';
+import noop from 'lodash/noop';
 
 import './Toggle.scss';
 
@@ -8,6 +9,8 @@ type Props = {
     className?: string,
     /** Description of the input */
     description?: React.Node,
+    /** Function to get the DOM reference to the html input */
+    getDOMRef?: React.LegacyRef<HTMLInputElement>,
     isDisabled?: boolean, // @TODO: eventually call this `disabled`
     /** Toggle state */
     isOn?: boolean, // @TODO: eventually call this `checked`
@@ -28,6 +31,7 @@ type Props = {
 const Toggle = ({
     className = '',
     description,
+    getDOMRef = noop,
     isDisabled,
     isOn,
     isToggleRightAligned = false,
@@ -59,6 +63,7 @@ const Toggle = ({
                     checked={isOn}
                     className="toggle-simple-input"
                     disabled={isDisabled}
+                    ref={getDOMRef}
                     name={name}
                     onBlur={onBlur}
                     onChange={onChange}

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -8,7 +8,6 @@ type Props = {
     className?: string,
     /** Description of the input */
     description?: React.Node,
-    /** Function to get the DOM reference to the html input */
     isDisabled?: boolean, // @TODO: eventually call this `disabled`
     /** Toggle state */
     isOn?: boolean, // @TODO: eventually call this `checked`

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -10,7 +10,7 @@ type Props = {
     /** Description of the input */
     description?: React.Node,
     /** Function to get the DOM reference to the html input */
-    getDOMRef?: React.LegacyRef<HTMLInputElement>,
+    getDOMRef?: Function,
     isDisabled?: boolean, // @TODO: eventually call this `disabled`
     /** Toggle state */
     isOn?: boolean, // @TODO: eventually call this `checked`

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
 import classNames from 'classnames';
-import noop from 'lodash/noop';
 
 import './Toggle.scss';
 
@@ -10,7 +9,6 @@ type Props = {
     /** Description of the input */
     description?: React.Node,
     /** Function to get the DOM reference to the html input */
-    getDOMRef?: Function,
     isDisabled?: boolean, // @TODO: eventually call this `disabled`
     /** Toggle state */
     isOn?: boolean, // @TODO: eventually call this `checked`
@@ -28,54 +26,58 @@ type Props = {
     value?: any,
 };
 
-const Toggle = ({
-    className = '',
-    description,
-    getDOMRef = noop,
-    isDisabled,
-    isOn,
-    isToggleRightAligned = false,
-    label,
-    name,
-    onBlur,
-    onChange,
-    ...rest
-}: Props) => {
-    const classes = classNames('toggle-container', className, {
-        'is-toggle-right-aligned': isToggleRightAligned,
-    });
-    let toggleElements = [
-        <div key="toggle-simple-switch" className="toggle-simple-switch" />,
-        <div key="toggle-simple-label" className="toggle-simple-label">
-            {label}
-        </div>,
-    ];
+const Toggle = React.forwardRef<Props, HTMLInputElement>(
+    (
+        {
+            className = '',
+            description,
+            isDisabled,
+            isOn,
+            isToggleRightAligned = false,
+            label,
+            name,
+            onBlur,
+            onChange,
+            ...rest
+        }: Props,
+        ref,
+    ) => {
+        const classes = classNames('toggle-container', className, {
+            'is-toggle-right-aligned': isToggleRightAligned,
+        });
+        let toggleElements = [
+            <div key="toggle-simple-switch" className="toggle-simple-switch" />,
+            <div key="toggle-simple-label" className="toggle-simple-label">
+                {label}
+            </div>,
+        ];
 
-    if (isToggleRightAligned) {
-        toggleElements = toggleElements.reverse();
-    }
+        if (isToggleRightAligned) {
+            toggleElements = toggleElements.reverse();
+        }
 
-    return (
-        <div className={classes}>
-            {/* eslint-disable-next-line jsx-a11y/label-has-for */}
-            <label className="toggle-simple">
-                <input
-                    checked={isOn}
-                    className="toggle-simple-input"
-                    disabled={isDisabled}
-                    ref={getDOMRef}
-                    name={name}
-                    onBlur={onBlur}
-                    onChange={onChange}
-                    type="checkbox"
-                    {...rest}
-                />
-                {toggleElements}
-            </label>
-            {description ? <div className="toggle-simple-description">{description}</div> : null}
-        </div>
-    );
-};
+        return (
+            <div className={classes}>
+                {/* eslint-disable-next-line jsx-a11y/label-has-for */}
+                <label className="toggle-simple">
+                    <input
+                        checked={isOn}
+                        className="toggle-simple-input"
+                        disabled={isDisabled}
+                        ref={ref}
+                        name={name}
+                        onBlur={onBlur}
+                        onChange={onChange}
+                        type="checkbox"
+                        {...rest}
+                    />
+                    {toggleElements}
+                </label>
+                {description ? <div className="toggle-simple-description">{description}</div> : null}
+            </div>
+        );
+    },
+);
 
 export type ToggleProps = Props;
 export default Toggle;

--- a/src/components/toggle/__tests__/__snapshots__/ToggleField.test.js.snap
+++ b/src/components/toggle/__tests__/__snapshots__/ToggleField.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/toggle/ToggleField should render isOn=false with value=null 1`] = `
-<Toggle
+<ForwardRef
   isOn={false}
   label="Enter things"
   name="toggle"
@@ -12,7 +12,7 @@ exports[`components/toggle/ToggleField should render isOn=false with value=null 
 `;
 
 exports[`components/toggle/ToggleField should render isOn=false with value=undefined 1`] = `
-<Toggle
+<ForwardRef
   isOn={false}
   label="Enter things"
   name="toggle"
@@ -22,7 +22,7 @@ exports[`components/toggle/ToggleField should render isOn=false with value=undef
 `;
 
 exports[`components/toggle/ToggleField should render isOn=true with value=value 1`] = `
-<Toggle
+<ForwardRef
   isOn={true}
   label="Enter things"
   name="toggle"

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -129,10 +129,12 @@ class SharedLinkSection extends React.Component<Props, State> {
             this.setState({ isAutoCreatingSharedLink: true });
             addSharedLink();
         }
+
         if (!prevProps.sharedLink.url && sharedLink.url) {
             this.setState({ isAutoCreatingSharedLink: false });
-        } else if (!prevProps.sharedLink.url && !sharedLink.url && this.toggleRef) {
-            this.toggleRef.focus();
+            if (this.toggleRef) {
+                this.toggleRef.focus();
+            }
         }
 
         if (

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -156,12 +156,6 @@ class SharedLinkSection extends React.Component<Props, State> {
                     onCopyError();
                 });
         }
-
-        if (sharedLink.url === null) {
-            if (this.toggleRef) {
-                this.toggleRef.focus();
-            }
-        }
     }
 
     canAddSharedLink = (isSharedLinkEnabled: boolean, canAddLink: boolean) => {

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -70,7 +70,7 @@ class SharedLinkSection extends React.Component<Props, State> {
         autoCreateSharedLink: false,
     };
 
-    toggleRef: HTMLInputElement | null | undefined;
+    toggleRef: HTMLInputElement | null;
 
     constructor(props: Props) {
         super(props);

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -132,6 +132,8 @@ class SharedLinkSection extends React.Component<Props, State> {
 
         if (!prevProps.sharedLink.url && sharedLink.url) {
             this.setState({ isAutoCreatingSharedLink: false });
+        } else if (!sharedLink.url && this.toggleRef) {
+            this.toggleRef.focus();
         }
 
         if (
@@ -152,12 +154,6 @@ class SharedLinkSection extends React.Component<Props, State> {
                     this.setState({ isCopySuccessful: false });
                     onCopyError();
                 });
-        }
-
-        if (sharedLink.url === null) {
-            if (this.toggleRef) {
-                this.toggleRef.focus();
-            }
         }
     }
 

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -407,7 +407,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                     label={linkText}
                     name="toggle"
                     onChange={onToggleSharedLink}
-                    getDOMRef={ref => {
+                    ref={ref => {
                         this.toggleRef = ref;
                     }}
                 />

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -129,10 +129,9 @@ class SharedLinkSection extends React.Component<Props, State> {
             this.setState({ isAutoCreatingSharedLink: true });
             addSharedLink();
         }
-
         if (!prevProps.sharedLink.url && sharedLink.url) {
             this.setState({ isAutoCreatingSharedLink: false });
-        } else if (!sharedLink.url && this.toggleRef) {
+        } else if (!prevProps.sharedLink.url && !sharedLink.url && this.toggleRef) {
             this.toggleRef.focus();
         }
 

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -70,6 +70,8 @@ class SharedLinkSection extends React.Component<Props, State> {
         autoCreateSharedLink: false,
     };
 
+    toggleRef: HTMLInputElement | null | undefined;
+
     constructor(props: Props) {
         super(props);
 
@@ -150,6 +152,12 @@ class SharedLinkSection extends React.Component<Props, State> {
                     this.setState({ isCopySuccessful: false });
                     onCopyError();
                 });
+        }
+
+        if (sharedLink.url === null) {
+            if (this.toggleRef) {
+                this.toggleRef.focus();
+            }
         }
     }
 
@@ -402,6 +410,9 @@ class SharedLinkSection extends React.Component<Props, State> {
                     label={linkText}
                     name="toggle"
                     onChange={onToggleSharedLink}
+                    getDOMRef={ref => {
+                        this.toggleRef = ref;
+                    }}
                 />
             </div>
         );

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -156,6 +156,12 @@ class SharedLinkSection extends React.Component<Props, State> {
                     onCopyError();
                 });
         }
+
+        if (sharedLink.url === null) {
+            if (this.toggleRef) {
+                this.toggleRef.focus();
+            }
+        }
     }
 
     canAddSharedLink = (isSharedLinkEnabled: boolean, canAddLink: boolean) => {

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -390,7 +390,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     shouldAutoFocusSharedLink = () => {
         const { focusSharedLinkOnLoad, sharedLink, sharedLinkLoaded, createSharedLinkOnLoad } = this.props;
 
-        if (!createSharedLinkOnLoad) {
+        if (!createSharedLinkOnLoad && !focusSharedLinkOnLoad) {
             return false;
         }
         // if not forcing focus or not a newly added shared link, return false

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -388,7 +388,11 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     };
 
     shouldAutoFocusSharedLink = () => {
-        const { focusSharedLinkOnLoad, sharedLink, sharedLinkLoaded } = this.props;
+        const { focusSharedLinkOnLoad, sharedLink, sharedLinkLoaded, createSharedLinkOnLoad } = this.props;
+
+        if (!createSharedLinkOnLoad) {
+            return false;
+        }
         // if not forcing focus or not a newly added shared link, return false
         if (!(focusSharedLinkOnLoad || sharedLink.isNewSharedLink)) {
             return false;

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -555,6 +555,18 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
 
         test('should return true if forced focus and link is loaded', () => {
             const wrapper = getWrapper({
+                focusSharedLinkOnLoad: true,
+                sharedLink: {
+                    isNewSharedLink: false,
+                },
+                sharedLinkLoaded: true,
+            });
+
+            expect(wrapper.instance().shouldAutoFocusSharedLink()).toBe(true);
+        });
+
+        test('should return true if forced focus and link is loaded and createSharedLinkOnLoad is true', () => {
+            const wrapper = getWrapper({
                 createSharedLinkOnLoad: true,
                 focusSharedLinkOnLoad: true,
                 sharedLink: {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -555,6 +555,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
 
         test('should return true if forced focus and link is loaded', () => {
             const wrapper = getWrapper({
+                createSharedLinkOnLoad: true,
                 focusSharedLinkOnLoad: true,
                 sharedLink: {
                     isNewSharedLink: false,
@@ -567,6 +568,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
 
         test('should return true if new shared link and link is loaded', () => {
             const wrapper = getWrapper({
+                createSharedLinkOnLoad: true,
                 focusSharedLinkOnLoad: false,
                 sharedLink: {
                     isNewSharedLink: true,

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -24,6 +24,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
       className="share-toggle-container"
     >
       <Toggle
+        getDOMRef={[Function]}
         isDisabled={false}
         isOn={true}
         label={
@@ -203,6 +204,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
         className="share-toggle-container"
       >
         <Toggle
+          getDOMRef={[Function]}
           isDisabled={true}
           isOn={true}
           label={
@@ -350,6 +352,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         className="share-toggle-container"
       >
         <Toggle
+          getDOMRef={[Function]}
           isDisabled={false}
           isOn={false}
           label={
@@ -390,6 +393,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       className="share-toggle-container"
     >
       <Toggle
+        getDOMRef={[Function]}
         isDisabled={false}
         isOn={true}
         label={
@@ -527,6 +531,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       className="share-toggle-container"
     >
       <Toggle
+        getDOMRef={[Function]}
         isDisabled={true}
         isOn={false}
         label={
@@ -561,6 +566,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled c
     className="share-toggle-container"
   >
     <Toggle
+      getDOMRef={[Function]}
       isDisabled={true}
       isOn={false}
       label={
@@ -594,6 +600,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled r
     className="share-toggle-container"
   >
     <Toggle
+      getDOMRef={[Function]}
       isDisabled={true}
       isOn={true}
       label={
@@ -646,6 +653,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
         className="share-toggle-container"
       >
         <Toggle
+          getDOMRef={[Function]}
           isDisabled={true}
           isOn={true}
           label={
@@ -790,6 +798,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       className="share-toggle-container"
     >
       <Toggle
+        getDOMRef={[Function]}
         isDisabled={false}
         isOn={true}
         label={
@@ -928,6 +937,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       className="share-toggle-container"
     >
       <Toggle
+        getDOMRef={[Function]}
         isDisabled={false}
         isOn={true}
         label={
@@ -1091,6 +1101,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
       className="share-toggle-container"
     >
       <Toggle
+        getDOMRef={[Function]}
         isDisabled={false}
         isOn={true}
         label={

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -23,8 +23,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
     <div
       className="share-toggle-container"
     >
-      <Toggle
-        getDOMRef={[Function]}
+      <ForwardRef
         isDisabled={false}
         isOn={true}
         label={
@@ -203,8 +202,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
       <div
         className="share-toggle-container"
       >
-        <Toggle
-          getDOMRef={[Function]}
+        <ForwardRef
           isDisabled={true}
           isOn={true}
           label={
@@ -351,8 +349,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       <div
         className="share-toggle-container"
       >
-        <Toggle
-          getDOMRef={[Function]}
+        <ForwardRef
           isDisabled={false}
           isOn={false}
           label={
@@ -392,8 +389,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
     <div
       className="share-toggle-container"
     >
-      <Toggle
-        getDOMRef={[Function]}
+      <ForwardRef
         isDisabled={false}
         isOn={true}
         label={
@@ -530,8 +526,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
     <div
       className="share-toggle-container"
     >
-      <Toggle
-        getDOMRef={[Function]}
+      <ForwardRef
         isDisabled={true}
         isOn={false}
         label={
@@ -565,8 +560,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled c
   <div
     className="share-toggle-container"
   >
-    <Toggle
-      getDOMRef={[Function]}
+    <ForwardRef
       isDisabled={true}
       isOn={false}
       label={
@@ -599,8 +593,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled r
   <div
     className="share-toggle-container"
   >
-    <Toggle
-      getDOMRef={[Function]}
+    <ForwardRef
       isDisabled={true}
       isOn={true}
       label={
@@ -652,8 +645,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
       <div
         className="share-toggle-container"
       >
-        <Toggle
-          getDOMRef={[Function]}
+        <ForwardRef
           isDisabled={true}
           isOn={true}
           label={
@@ -797,8 +789,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <div
       className="share-toggle-container"
     >
-      <Toggle
-        getDOMRef={[Function]}
+      <ForwardRef
         isDisabled={false}
         isOn={true}
         label={
@@ -936,8 +927,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <div
       className="share-toggle-container"
     >
-      <Toggle
-        getDOMRef={[Function]}
+      <ForwardRef
         isDisabled={false}
         isOn={true}
         label={
@@ -1100,8 +1090,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
     <div
       className="share-toggle-container"
     >
-      <Toggle
-        getDOMRef={[Function]}
+      <ForwardRef
         isDisabled={false}
         isOn={true}
         label={


### PR DESCRIPTION
fix(Toggle): A11Y - When shared link does not exist maintain focus on the switch

When the sharing option has been deactivated and `Create shared link` is triggered, the form changes and focus is set to the read-only textbox that contains the URL. This skips over the `Link Settings` option, meaning a screen reader user will not know that this option is available. Instead of setting focus to the URL, maintain focus on the switch.

![Screen Shot 2021-05-28 at 5 56 10 PM](https://user-images.githubusercontent.com/79931431/120048912-158ae080-bfde-11eb-9e16-d3f961d6a755.png)
