### PR TITLE
fix(tooltip): Modify tooltip to allow rerender after closed by user

### DIFF
--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -135,14 +135,12 @@ class Tooltip extends React.Component<TooltipProps, State> {
         this.setState({ hasRendered: true });
     }
 
-    componentDidUpdate(prevProps: TooltipProps, prevState: State) {
+    componentDidUpdate(prevProps: TooltipProps) {
         // Reset wasClosedByUser state when isShown transitions from false to true
         if (this.isControlled()) {
             if (!prevProps.isShown && this.props.isShown) {
                 this.setState({ wasClosedByUser: false });
             }
-        } else if (!prevState.isShown && this.state.isShown) {
-            this.setState({ wasClosedByUser: false });
         }
     }
 

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -88,7 +88,7 @@ export type TooltipProps = {
     /** A CSS class for the tooltip */
     className?: string;
     /** Should the tooltip show again after user closes it once it is eligible again. Defaults to `false` */
-    shouldTooltipShowAferUserClose?: boolean;
+    shouldTooltipShowAfterUserClose?: boolean;
     /** Forces the tooltip to be shown or hidden (useful for errors) */
     isShown?: boolean;
     /** Whether to add tabindex=0.  Defaults to `true` */
@@ -197,13 +197,13 @@ class Tooltip extends React.Component<TooltipProps, State> {
     };
 
     isShown = () => {
-        const { isShown: isShownProp, shouldTooltipShowAferUserClose = false } = this.props;
+        const { isShown: isShownProp, shouldTooltipShowAfterUserClose = false } = this.props;
         const isControlled = this.isControlled();
 
         const isShown = isControlled ? isShownProp : this.state.isShown;
 
         const showTooltip =
-            isShown && (shouldTooltipShowAferUserClose || !this.state.wasClosedByUser) && this.state.hasRendered;
+            isShown && (shouldTooltipShowAfterUserClose || !this.state.wasClosedByUser) && this.state.hasRendered;
 
         return showTooltip;
     };

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -87,6 +87,8 @@ export type TooltipProps = {
     children: React.ReactChild;
     /** A CSS class for the tooltip */
     className?: string;
+    /** Should the tooltip show again after user closes it once it is eligible again. Defaults to `false` */
+    shouldTooltipShowAferUserClose?: boolean;
     /** Forces the tooltip to be shown or hidden (useful for errors) */
     isShown?: boolean;
     /** Whether to add tabindex=0.  Defaults to `true` */
@@ -195,12 +197,13 @@ class Tooltip extends React.Component<TooltipProps, State> {
     };
 
     isShown = () => {
-        const { isShown: isShownProp } = this.props;
+        const { isShown: isShownProp, shouldTooltipShowAferUserClose = false } = this.props;
         const isControlled = this.isControlled();
 
         const isShown = isControlled ? isShownProp : this.state.isShown;
 
-        const showTooltip = isShown && !this.state.wasClosedByUser && this.state.hasRendered;
+        const showTooltip =
+            isShown && (shouldTooltipShowAferUserClose || !this.state.wasClosedByUser) && this.state.hasRendered;
 
         return showTooltip;
     };

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -126,11 +126,6 @@ class Tooltip extends React.Component<TooltipProps, State> {
         this.state = { isShown: !!props.isShown, hasRendered: false, wasClosedByUser: false };
     }
 
-    isControlled = () => {
-        const { isShown: isShownProp } = this.props;
-        return typeof isShownProp !== 'undefined';
-    };
-
     componentDidMount() {
         this.setState({ hasRendered: true });
     }
@@ -194,6 +189,11 @@ class Tooltip extends React.Component<TooltipProps, State> {
     handleBlur = (event: React.SyntheticEvent<HTMLElement>) => {
         this.setState({ isShown: false });
         this.fireChildEvent('onBlur', event);
+    };
+
+    isControlled = () => {
+        const { isShown: isShownProp } = this.props;
+        return typeof isShownProp !== 'undefined';
     };
 
     handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {

--- a/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -40,26 +40,13 @@ describe('components/tooltip/Tooltip', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should not render the close button if wasClosedByUser state is true', () => {
-            const wrapper = getWrapper({
-                isShown: true,
-                showCloseButton: true,
-            });
-            wrapper.setState({ wasClosedByUser: true });
-            expect(wrapper).toMatchSnapshot();
-        });
-
-        test('should render tooltip again if shouldTooltipShowAfterUserClose is true after close', () => {
-            const wrapper = shallow<Tooltip>(
-                <Tooltip shouldTooltipShowAfterUserClose text="hi">
-                    <button />
-                </Tooltip>,
-            );
-
-            expect(wrapper.state('wasClosedByUser')).toBe(false);
-            wrapper.instance().closeTooltip();
-            expect(wrapper.state('wasClosedByUser')).toBe(true);
-            expect(wrapper).toMatchSnapshot();
+        test('should not render with close button if showCloseButton is false', () => {
+            expect(
+                getWrapper({
+                    isShown: true,
+                    showCloseButton: false,
+                }),
+            ).toMatchSnapshot();
         });
 
         test('should not render with close button if isShown is false', () => {
@@ -379,6 +366,39 @@ describe('components/tooltip/Tooltip', () => {
             });
             expect(stop).toHaveBeenCalledTimes(1);
             expect(nativeStop).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('componentDidUpdate', () => {
+        test('should reset wasClosedByUser to false if isShown state is transitioned from false to true', () => {
+            const wrapper = shallow<Tooltip>(
+                <Tooltip text="hi">
+                    <button />
+                </Tooltip>,
+            );
+
+            expect(wrapper.state('wasClosedByUser')).toBe(false);
+            wrapper.instance().closeTooltip();
+            expect(wrapper.state('wasClosedByUser')).toBe(true);
+
+            wrapper.setState({ isShown: true });
+            expect(wrapper.state('wasClosedByUser')).toBe(false);
+        });
+
+        test('should reset wasClosedByUser to false if isShown prop is transitioned from false to true', () => {
+            const wrapper = shallow<Tooltip>(
+                <Tooltip text="hi" isShown>
+                    <button />
+                </Tooltip>,
+            );
+
+            expect(wrapper.state('wasClosedByUser')).toBe(false);
+            wrapper.instance().closeTooltip();
+
+            expect(wrapper.state('wasClosedByUser')).toBe(true);
+            wrapper.setProps({ isShown: false });
+            wrapper.setProps({ isShown: true });
+            expect(wrapper.state('wasClosedByUser')).toBe(false);
         });
     });
 

--- a/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -370,21 +370,6 @@ describe('components/tooltip/Tooltip', () => {
     });
 
     describe('componentDidUpdate', () => {
-        test('should reset wasClosedByUser to false if isShown state is transitioned from false to true', () => {
-            const wrapper = shallow<Tooltip>(
-                <Tooltip text="hi">
-                    <button />
-                </Tooltip>,
-            );
-
-            expect(wrapper.state('wasClosedByUser')).toBe(false);
-            wrapper.instance().closeTooltip();
-            expect(wrapper.state('wasClosedByUser')).toBe(true);
-
-            wrapper.setState({ isShown: true });
-            expect(wrapper.state('wasClosedByUser')).toBe(false);
-        });
-
         test('should reset wasClosedByUser to false if isShown prop is transitioned from false to true', () => {
             const wrapper = shallow<Tooltip>(
                 <Tooltip text="hi" isShown>

--- a/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -40,13 +40,26 @@ describe('components/tooltip/Tooltip', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should not render with close button if showCloseButton is false', () => {
-            expect(
-                getWrapper({
-                    isShown: true,
-                    showCloseButton: false,
-                }),
-            ).toMatchSnapshot();
+        test('should not render the close button if wasClosedByUser state is true', () => {
+            const wrapper = getWrapper({
+                isShown: true,
+                showCloseButton: true,
+            });
+            wrapper.setState({ wasClosedByUser: true });
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('should render tooltip again if shouldTooltipShowAferUserClose is true after close', () => {
+            const wrapper = shallow<Tooltip>(
+                <Tooltip shouldTooltipShowAferUserClose text="hi">
+                    <button />
+                </Tooltip>,
+            );
+
+            expect(wrapper.state('wasClosedByUser')).toBe(false);
+            wrapper.instance().closeTooltip();
+            expect(wrapper.state('wasClosedByUser')).toBe(true);
+            expect(wrapper).toMatchSnapshot();
         });
 
         test('should not render with close button if isShown is false', () => {

--- a/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -49,9 +49,9 @@ describe('components/tooltip/Tooltip', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should render tooltip again if shouldTooltipShowAferUserClose is true after close', () => {
+        test('should render tooltip again if shouldTooltipShowAfterUserClose is true after close', () => {
             const wrapper = shallow<Tooltip>(
-                <Tooltip shouldTooltipShowAferUserClose text="hi">
+                <Tooltip shouldTooltipShowAfterUserClose text="hi">
                     <button />
                 </Tooltip>,
             );

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -224,6 +224,35 @@ exports[`components/tooltip/Tooltip render() should render tooltip again if shou
 </TetherComponent>
 `;
 
+exports[`components/tooltip/Tooltip render() should render tooltip again if shouldTooltipShowAfterUserClose is true after close 1`] = `
+<TetherComponent
+  attachment="bottom center"
+  bodyElement={<body />}
+  classPrefix="tooltip"
+  constraints={
+    Array [
+      Object {
+        "attachment": "together",
+        "to": "window",
+      },
+    ]
+  }
+  enabled={false}
+  renderElementTag="div"
+  renderElementTo={null}
+  targetAttachment="top center"
+>
+  <button
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    tabIndex="0"
+  />
+</TetherComponent>
+`;
+
 exports[`components/tooltip/Tooltip render() should render with close button if isShown and showCloseButton are true 1`] = `
 <TetherComponent
   attachment="bottom center"

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/tooltip/Tooltip render() should match snapshot when stopBubble is set 1`] = `
 <div
   className="tooltip bdl-Tooltip"
-  id="tooltip24"
+  id="tooltip25"
   onClick={[Function]}
   onContextMenu={[Function]}
   onKeyPress={[Function]}
@@ -20,6 +20,30 @@ exports[`components/tooltip/Tooltip render() should match snapshot when stopBubb
 `;
 
 exports[`components/tooltip/Tooltip render() should not render the close button if wasClosedByUser state is true 1`] = `
+<TetherComponent
+  attachment="bottom center"
+  bodyElement={<body />}
+  classPrefix="tooltip"
+  constraints={
+    Array [
+      Object {
+        "attachment": "together",
+        "to": "window",
+      },
+    ]
+  }
+  enabled={false}
+  renderElementTag="div"
+  renderElementTo={null}
+  targetAttachment="top center"
+>
+  <div>
+    Hello
+  </div>
+</TetherComponent>
+`;
+
+exports[`components/tooltip/Tooltip render() should not render the close button if wasClosedByUser state is true 2`] = `
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
@@ -63,41 +87,6 @@ exports[`components/tooltip/Tooltip render() should not render with close button
 >
   <div>
     Hello
-  </div>
-</TetherComponent>
-`;
-
-exports[`components/tooltip/Tooltip render() should not render with close button if showCloseButton is false 1`] = `
-<TetherComponent
-  attachment="bottom center"
-  bodyElement={<body />}
-  classPrefix="tooltip"
-  constraints={
-    Array [
-      Object {
-        "attachment": "together",
-        "to": "window",
-      },
-    ]
-  }
-  enabled={true}
-  renderElementTag="div"
-  renderElementTo={null}
-  targetAttachment="top center"
->
-  <div
-    aria-describedby="tooltip3"
-  >
-    Hello
-  </div>
-  <div
-    aria-hidden={false}
-    aria-live="polite"
-    className="tooltip bdl-Tooltip"
-    id="tooltip3"
-    role="tooltip"
-  >
-    hi
   </div>
 </TetherComponent>
 `;
@@ -158,7 +147,7 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
   targetAttachment="top center"
 >
   <div
-    aria-describedby="tooltip5"
+    aria-describedby="tooltip6"
   >
     Hello
   </div>
@@ -166,7 +155,7 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
     aria-hidden={false}
     aria-live="polite"
     className="tooltip bdl-Tooltip is-callout"
-    id="tooltip5"
+    id="tooltip6"
     role="tooltip"
   >
     hi
@@ -203,6 +192,35 @@ exports[`components/tooltip/Tooltip render() should render correctly with tether
   >
     Hello
   </div>
+</TetherComponent>
+`;
+
+exports[`components/tooltip/Tooltip render() should render tooltip again if shouldTooltipShowAferUserClose is true after close 1`] = `
+<TetherComponent
+  attachment="bottom center"
+  bodyElement={<body />}
+  classPrefix="tooltip"
+  constraints={
+    Array [
+      Object {
+        "attachment": "together",
+        "to": "window",
+      },
+    ]
+  }
+  enabled={false}
+  renderElementTag="div"
+  renderElementTo={null}
+  targetAttachment="top center"
+>
+  <button
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    tabIndex="0"
+  />
 </TetherComponent>
 `;
 

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`components/tooltip/Tooltip render() should match snapshot when stopBubble is set 1`] = `
 <div
   className="tooltip bdl-Tooltip"
-  id="tooltip25"
+  id="tooltip24"
   onClick={[Function]}
   onContextMenu={[Function]}
   onKeyPress={[Function]}
@@ -20,30 +20,6 @@ exports[`components/tooltip/Tooltip render() should match snapshot when stopBubb
 `;
 
 exports[`components/tooltip/Tooltip render() should not render the close button if wasClosedByUser state is true 1`] = `
-<TetherComponent
-  attachment="bottom center"
-  bodyElement={<body />}
-  classPrefix="tooltip"
-  constraints={
-    Array [
-      Object {
-        "attachment": "together",
-        "to": "window",
-      },
-    ]
-  }
-  enabled={false}
-  renderElementTag="div"
-  renderElementTo={null}
-  targetAttachment="top center"
->
-  <div>
-    Hello
-  </div>
-</TetherComponent>
-`;
-
-exports[`components/tooltip/Tooltip render() should not render the close button if wasClosedByUser state is true 2`] = `
 <TetherComponent
   attachment="bottom center"
   bodyElement={<body />}
@@ -87,6 +63,41 @@ exports[`components/tooltip/Tooltip render() should not render with close button
 >
   <div>
     Hello
+  </div>
+</TetherComponent>
+`;
+
+exports[`components/tooltip/Tooltip render() should not render with close button if showCloseButton is false 1`] = `
+<TetherComponent
+  attachment="bottom center"
+  bodyElement={<body />}
+  classPrefix="tooltip"
+  constraints={
+    Array [
+      Object {
+        "attachment": "together",
+        "to": "window",
+      },
+    ]
+  }
+  enabled={true}
+  renderElementTag="div"
+  renderElementTo={null}
+  targetAttachment="top center"
+>
+  <div
+    aria-describedby="tooltip3"
+  >
+    Hello
+  </div>
+  <div
+    aria-hidden={false}
+    aria-live="polite"
+    className="tooltip bdl-Tooltip"
+    id="tooltip3"
+    role="tooltip"
+  >
+    hi
   </div>
 </TetherComponent>
 `;
@@ -147,7 +158,7 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
   targetAttachment="top center"
 >
   <div
-    aria-describedby="tooltip6"
+    aria-describedby="tooltip5"
   >
     Hello
   </div>
@@ -155,7 +166,7 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
     aria-hidden={false}
     aria-live="polite"
     className="tooltip bdl-Tooltip is-callout"
-    id="tooltip6"
+    id="tooltip5"
     role="tooltip"
   >
     hi
@@ -192,35 +203,6 @@ exports[`components/tooltip/Tooltip render() should render correctly with tether
   >
     Hello
   </div>
-</TetherComponent>
-`;
-
-exports[`components/tooltip/Tooltip render() should render tooltip again if shouldTooltipShowAfterUserClose is true after close 1`] = `
-<TetherComponent
-  attachment="bottom center"
-  bodyElement={<body />}
-  classPrefix="tooltip"
-  constraints={
-    Array [
-      Object {
-        "attachment": "together",
-        "to": "window",
-      },
-    ]
-  }
-  enabled={false}
-  renderElementTag="div"
-  renderElementTo={null}
-  targetAttachment="top center"
->
-  <button
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    tabIndex="0"
-  />
 </TetherComponent>
 `;
 

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -195,35 +195,6 @@ exports[`components/tooltip/Tooltip render() should render correctly with tether
 </TetherComponent>
 `;
 
-exports[`components/tooltip/Tooltip render() should render tooltip again if shouldTooltipShowAferUserClose is true after close 1`] = `
-<TetherComponent
-  attachment="bottom center"
-  bodyElement={<body />}
-  classPrefix="tooltip"
-  constraints={
-    Array [
-      Object {
-        "attachment": "together",
-        "to": "window",
-      },
-    ]
-  }
-  enabled={false}
-  renderElementTag="div"
-  renderElementTo={null}
-  targetAttachment="top center"
->
-  <button
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    tabIndex="0"
-  />
-</TetherComponent>
-`;
-
 exports[`components/tooltip/Tooltip render() should render tooltip again if shouldTooltipShowAfterUserClose is true after close 1`] = `
 <TetherComponent
   attachment="bottom center"


### PR DESCRIPTION
add optional prop `shouldTooltipShowAferUserClose` to `Tooltip.tsx`
add logic to allow for the tooltip to be opened again if it was closed by the user for restarting onboarding experiences multiple times