### PR TITLE
feat(content-picker): pass id and name from ContentPicker

### DIFF
--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -1242,6 +1242,7 @@ class ContentPicker extends Component<Props, State> {
                             onShareAccessChange={this.changeShareAccess}
                         />
                         <Footer
+                            currentCollection={currentCollection}
                             selectedCount={selectedCount}
                             selectedItems={this.getSelectedItems()}
                             hasHitSelectionLimit={hasHitSelectionLimit}

--- a/src/elements/content-picker/Footer.js
+++ b/src/elements/content-picker/Footer.js
@@ -7,12 +7,13 @@
 import React from 'react';
 import type { Node } from 'react';
 import { FormattedMessage } from 'react-intl';
+import type { Collection, BoxItem } from '../../common/types/core';
 import Button from '../../components/button';
 import ButtonGroup from '../../components/button-group';
 import IconCheck from '../../icons/general/IconCheck';
 import IconClose from '../../icons/general/IconClose';
 import messages from '../common/messages';
-import type { BoxItem } from '../../common/types/core';
+
 import PrimaryButton from '../../components/primary-button';
 import Tooltip from '../common/Tooltip';
 import './Footer.scss';
@@ -21,6 +22,7 @@ type Props = {
     cancelButtonLabel?: string,
     children?: any,
     chooseButtonLabel?: string,
+    currentCollection: Collection,
     hasHitSelectionLimit: boolean,
     isSingleSelect: boolean,
     onCancel: Function,
@@ -37,6 +39,7 @@ type Props = {
 };
 
 const Footer = ({
+    currentCollection,
     selectedCount,
     selectedItems,
     onSelectedClick,
@@ -70,7 +73,14 @@ const Footer = ({
             {children}
 
             {renderCustomActionButtons ? (
-                renderCustomActionButtons({ onCancel, onChoose, selectedCount, selectedItems })
+                renderCustomActionButtons({
+                    currentFolderId: currentCollection.id,
+                    currentFolderName: currentCollection.name,
+                    onCancel,
+                    onChoose,
+                    selectedCount,
+                    selectedItems,
+                })
             ) : (
                 <ButtonGroup className="bcp-footer-actions">
                     <Tooltip text={cancelButtonLabel || <FormattedMessage {...messages.cancel} />}>

--- a/src/elements/content-picker/__tests__/Footer.test.js
+++ b/src/elements/content-picker/__tests__/Footer.test.js
@@ -5,6 +5,7 @@ import Footer from '../Footer';
 describe('elements/content-picker/Footer', () => {
     const defaultProps = {
         children: <div className="footer-child" />,
+        currentCollection: { id: '123', name: 'Folder' },
         hasHitSelectionLimit: false,
         isSingleSelect: false,
         onCancel: () => {},
@@ -37,6 +38,8 @@ describe('elements/content-picker/Footer', () => {
 
             expect(wrapper.find('.custom-button').length).toBe(1);
             expect(renderCustomActionButtons).toHaveBeenCalledWith({
+                currentFolderId: defaultProps.currentCollection.id,
+                currentFolderName: defaultProps.currentCollection.name,
                 onCancel: defaultProps.onCancel,
                 onChoose: defaultProps.onChoose,
                 selectedCount: defaultProps.selectedCount,


### PR DESCRIPTION
**Changes in this PR:**
- [x] in the parent app of ContentPicker, if we want to perform a move action and the user wants to undo the move action, we need to have context of the parent folder as well as parent name for the items that have been moved. So, we want to pass currentCollection down from ContentPicker to Footer so that Footer will be able to pass `name` and `id` back up to the parent app.