### PR TITLE
fix(SidebarSection): A11Y - add aria-expanded in sidebar section component

### DIFF
--- a/src/elements/content-sidebar/SidebarSection.js
+++ b/src/elements/content-sidebar/SidebarSection.js
@@ -88,6 +88,7 @@ class SidebarSection extends React.PureComponent<Props, State> {
                         data-resin-target={interactionTarget}
                         onClick={this.toggleVisibility}
                         type="button"
+                        aria-expanded={!!isOpen}
                     >
                         {title}
                         <IconCaretDown color={COLOR_999} width={8} />

--- a/src/elements/content-sidebar/SidebarSection.js
+++ b/src/elements/content-sidebar/SidebarSection.js
@@ -84,11 +84,11 @@ class SidebarSection extends React.PureComponent<Props, State> {
             <div className={sectionClassName}>
                 {title && (
                     <PlainButton
+                        aria-expanded={isOpen}
                         className="bcs-section-title"
                         data-resin-target={interactionTarget}
                         onClick={this.toggleVisibility}
                         type="button"
-                        aria-expanded={!!isOpen}
                     >
                         {title}
                         <IconCaretDown color={COLOR_999} width={8} />


### PR DESCRIPTION
In the tab panel, the"Access States" and "File Properties" buttons should have aria-expanded. I just added this aria attribute in `SidebarSection`  component.

![Screen Shot 2021-06-15 at 11 19 10 AM](https://user-images.githubusercontent.com/79931431/122088647-8d714d00-cdcb-11eb-8c90-bbe0e756af92.png)
