### PR TITLE
feat(in-app-messenger): add new template for modal

### DIFF
--- a/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
+++ b/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
@@ -13,7 +13,7 @@ import Button from '../../../../components/button';
 import MessagePreviewContent from '../../../message-preview-content/MessagePreviewContent';
 import type { Token } from '../../../../common/types/core';
 import { messageActions } from '../../types/message-actions';
-import { type MessageActions, type PreviewTitleBodyTwoButtonsModalParams } from '../../types';
+import { type MessageActions, type PreviewTitleBodyTwoButtonsParams } from '../../types';
 
 import './styles/PreviewTitleBodyTwoButtonsModalTemplate.scss';
 
@@ -22,7 +22,7 @@ type Props = {
     contentPreviewProps?: ContentPreviewProps,
     getToken: (folderID: string | number) => Promise<Token>,
     onAction: (MessageActions, ...Array<any>) => any,
-    params: PreviewTitleBodyTwoButtonsModalParams,
+    params: PreviewTitleBodyTwoButtonsParams,
 };
 
 const handleClose = onAction => {

--- a/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
+++ b/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
@@ -1,10 +1,5 @@
 // @flow
 
-/**
- * This component is intended to be passed to TemplateContainer as templateComponent prop, like this:
- *   <TemplateContainer templateID='my-template' templateComponent=MyTemplate/>
- */
-
 import * as React from 'react';
 
 import PrimaryButton from '../../../../components/primary-button';

--- a/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
+++ b/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
@@ -1,0 +1,98 @@
+// @flow
+
+/**
+ * This component is intended to be passed to TemplateContainer as templateComponent prop, like this:
+ *   <TemplateContainer templateID='my-template' templateComponent=MyTemplate/>
+ */
+
+import * as React from 'react';
+
+import PrimaryButton from '../../../../components/primary-button';
+import { Modal, ModalActions } from '../../../../components/modal';
+import Button from '../../../../components/button';
+import MessagePreviewContent from '../../../message-preview-content/MessagePreviewContent';
+import { messageActions } from '../../types/message-actions';
+import { MessageActions, type PreviewTitleBodyTwoButtonsModalParams } from '../../types';
+
+import './styles/PreviewTitleBodyTwoButtonsModalTemplate.scss';
+
+type Props = {
+    apiHost: string,
+    contentPreviewProps?: ContentPreviewProps,
+    getToken: (folderID: string | number) => Promise<Token>,
+    onAction: (MessageActions, ...Array<any>) => any,
+    params: PreviewTitleBodyTwoButtonsModalParams,
+};
+
+const handleClose = onAction => {
+    onAction([messageActions.close]);
+};
+
+const handleButton1Click = (onAction, button1) => {
+    if (button1) {
+        onAction(button1.actions);
+    }
+};
+
+const handleButton2Click = (onAction, button2) => {
+    if (button2) {
+        onAction(button2.actions);
+    }
+};
+
+const PreviewTitleBodyTwoButtonsModalTemplate = ({
+    apiHost,
+    contentPreviewProps,
+    getToken,
+    onAction,
+    params: { body, button1, button2, fileUpload: { fileId, sharedLinkUrl } = {}, title },
+}: Props) => {
+    return (
+        <Modal
+            className="bdl-PreviewTitleBodyTwoButtonsModalTemplate"
+            closeButtonProps={{ 'data-resin-target': 'dismiss' }}
+            isOpen
+            onRequestClose={() => handleClose(onAction)}
+            shouldNotUsePortal
+            title=""
+        >
+            <div className="bdl-PreviewTitleBodyTwoButtonsModalTemplate-contentContainer">
+                {/* eslint-disable react/no-danger */}
+                <div
+                    className="bdl-PreviewTitleBodyTwoButtonsModalTemplate-title"
+                    dangerouslySetInnerHTML={{
+                        __html: title,
+                    }}
+                />
+                <div
+                    className="bdl-PreviewTitleBodyTwoButtonsModalTemplate-body"
+                    dangerouslySetInnerHTML={{
+                        __html: body,
+                    }}
+                />
+                {/* eslint-enable react/no-danger */}
+                <div className="bdl-PreviewTitleBodyTwoButtonsModalTemplate-previewContainer">
+                    <MessagePreviewContent
+                        apiHost={apiHost}
+                        contentPreviewProps={contentPreviewProps}
+                        fileId={fileId}
+                        getToken={getToken}
+                        sharedLink={sharedLinkUrl}
+                    />
+                </div>
+                <ModalActions>
+                    <PrimaryButton data-resin-target="cta1" onClick={() => handleButton1Click(onAction, button1)}>
+                        {button1.label}
+                    </PrimaryButton>
+                    {button2 && (
+                        <Button data-resin-target="cta2" onClick={() => handleButton2Click(onAction, button2)}>
+                            {button2.label}
+                        </Button>
+                    )}
+                </ModalActions>
+            </div>
+        </Modal>
+    );
+};
+
+export default PreviewTitleBodyTwoButtonsModalTemplate;

--- a/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
+++ b/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate.js
@@ -11,8 +11,9 @@ import PrimaryButton from '../../../../components/primary-button';
 import { Modal, ModalActions } from '../../../../components/modal';
 import Button from '../../../../components/button';
 import MessagePreviewContent from '../../../message-preview-content/MessagePreviewContent';
+import type { Token } from '../../../../common/types/core';
 import { messageActions } from '../../types/message-actions';
-import { MessageActions, type PreviewTitleBodyTwoButtonsModalParams } from '../../types';
+import { type MessageActions, type PreviewTitleBodyTwoButtonsModalParams } from '../../types';
 
 import './styles/PreviewTitleBodyTwoButtonsModalTemplate.scss';
 
@@ -28,15 +29,9 @@ const handleClose = onAction => {
     onAction([messageActions.close]);
 };
 
-const handleButton1Click = (onAction, button1) => {
-    if (button1) {
-        onAction(button1.actions);
-    }
-};
-
-const handleButton2Click = (onAction, button2) => {
-    if (button2) {
-        onAction(button2.actions);
+const handleButtonClick = (onAction, button) => {
+    if (button) {
+        onAction(button.actions);
     }
 };
 
@@ -54,7 +49,6 @@ const PreviewTitleBodyTwoButtonsModalTemplate = ({
             isOpen
             onRequestClose={() => handleClose(onAction)}
             shouldNotUsePortal
-            title=""
         >
             <div className="bdl-PreviewTitleBodyTwoButtonsModalTemplate-contentContainer">
                 {/* eslint-disable react/no-danger */}
@@ -81,11 +75,11 @@ const PreviewTitleBodyTwoButtonsModalTemplate = ({
                     />
                 </div>
                 <ModalActions>
-                    <PrimaryButton data-resin-target="cta1" onClick={() => handleButton1Click(onAction, button1)}>
+                    <PrimaryButton data-resin-target="cta1" onClick={() => handleButtonClick(onAction, button1)}>
                         {button1.label}
                     </PrimaryButton>
                     {button2 && (
-                        <Button data-resin-target="cta2" onClick={() => handleButton2Click(onAction, button2)}>
+                        <Button data-resin-target="cta2" onClick={() => handleButtonClick(onAction, button2)}>
                             {button2.label}
                         </Button>
                     )}

--- a/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsPopoutTemplate.js
+++ b/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsPopoutTemplate.js
@@ -26,15 +26,9 @@ type Props = {
     params: PreviewTitleBodyTwoButtonsPopoutParams,
 };
 
-const handleButton1Click = (onAction, button1) => {
-    if (button1) {
-        onAction(button1.actions);
-    }
-};
-
-const handleButton2Click = (onAction, button2) => {
-    if (button2) {
-        onAction(button2.actions);
+const handleButtonClick = (onAction, button) => {
+    if (button) {
+        onAction(button.actions);
     }
 };
 
@@ -75,13 +69,13 @@ const PreviewTitleBodyTwoButtonsPopoutTemplate = ({
                         {/* eslint-enable react/no-danger */}
                         <div className="bdl-PreviewTitleBodyTwoButtonsPopoutTemplate-buttons">
                             {button2 && (
-                                <Button data-resin-target="cta2" onClick={() => handleButton2Click(onAction, button2)}>
+                                <Button data-resin-target="cta2" onClick={() => handleButtonClick(onAction, button2)}>
                                     {button2.label}
                                 </Button>
                             )}
                             <PrimaryButton
                                 data-resin-target="cta1"
-                                onClick={() => handleButton1Click(onAction, button1)}
+                                onClick={() => handleButtonClick(onAction, button1)}
                             >
                                 {button1.label}
                             </PrimaryButton>

--- a/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsPopoutTemplate.js
+++ b/src/features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsPopoutTemplate.js
@@ -14,7 +14,7 @@ import MessagePreviewContent from '../../../message-preview-content/MessagePrevi
 import type { Token } from '../../../../common/types/core';
 import type { MessageActions } from '../../types';
 
-import { type PreviewTitleBodyTwoButtonsPopoutParams } from '../../types';
+import { type PreviewTitleBodyTwoButtonsParams } from '../../types';
 
 import './styles/PreviewTitleBodyTwoButtonsPopoutTemplate.scss';
 
@@ -23,7 +23,7 @@ type Props = {
     contentPreviewProps?: ContentPreviewProps,
     getToken: (folderID: string | number) => Promise<Token>,
     onAction: (MessageActions, ...Array<any>) => any,
-    params: PreviewTitleBodyTwoButtonsPopoutParams,
+    params: PreviewTitleBodyTwoButtonsParams,
 };
 
 const handleButtonClick = (onAction, button) => {

--- a/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
+++ b/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
@@ -55,7 +55,12 @@ describe('features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButt
 
     describe.each([paramsConfigs.all, paramsConfigs.missingButton2])('%o', ({ params }) => {
         test('renders correctly', () => {
-            getWrapper(params);
+            const wrapper = getWrapper(params);
+            expect(wrapper.find('.bdl-PreviewTitleBodyTwoButtonsModalTemplate').length).toEqual(1);
+            expect(wrapper.find('.bdl-PreviewTitleBodyTwoButtonsModalTemplate-title').length).toEqual(1);
+            expect(wrapper.find('.bdl-PreviewTitleBodyTwoButtonsModalTemplate-body').length).toEqual(1);
+            expect(wrapper.find('.bdl-PreviewTitleBodyTwoButtonsModalTemplate-previewContainer').length).toEqual(1);
+            expect(wrapper.find('PrimaryButton').length).toEqual(1);
         });
     });
 

--- a/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
+++ b/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
@@ -31,7 +31,7 @@ describe('features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButt
                 body: 'body',
                 button1: {
                     label: 'button1',
-                    actions: 'actions1',
+                    actions: ['actions1'],
                 },
                 footnote: 'footnote',
                 fileUpload: {

--- a/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
+++ b/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
@@ -12,11 +12,11 @@ describe('features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButt
                 body: 'body',
                 button1: {
                     label: 'button1',
-                    actions: 'actions1',
+                    actions: ['actions1'],
                 },
                 button2: {
                     label: 'button2',
-                    actions: 'actions2',
+                    actions: ['actions2'],
                 },
                 fileUpload: {
                     fileId: '1234',
@@ -71,10 +71,10 @@ describe('features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButt
     }
 
     test('should call onAction(button1.actions) if button1 is clicked', () =>
-        checkClickElement(wrapper => wrapper.find('PrimaryButton'), true, 'actions1'));
+        checkClickElement(wrapper => wrapper.find('PrimaryButton'), true, ['actions1']));
 
     test('should call onAction(button2.actions) if button2 is clicked', () =>
-        checkClickElement(wrapper => wrapper.find('Button'), true, 'actions2'));
+        checkClickElement(wrapper => wrapper.find('Button'), true, ['actions2']));
 
     test('should not call onAction if clicked else where', () =>
         checkClickElement(

--- a/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
+++ b/src/features/in-app-messenger/contextual/templates/__tests__/PreviewTitleBodyTwoButtonsModalTemplate.test.js
@@ -1,0 +1,84 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import PreviewTitleBodyTwoButtonsModalTemplate from '../PreviewTitleBodyTwoButtonsModalTemplate';
+
+describe('features/in-app-messenger/contextual/templates/PreviewTitleBodyTwoButtonsModalTemplate', () => {
+    const onAction = jest.fn();
+
+    const paramsConfigs = {
+        all: {
+            params: {
+                body: 'body',
+                button1: {
+                    label: 'button1',
+                    actions: 'actions1',
+                },
+                button2: {
+                    label: 'button2',
+                    actions: 'actions2',
+                },
+                fileUpload: {
+                    fileId: '1234',
+                    sharedLinkUrl: 'https://shared-link.com',
+                },
+                templateID: 'preview-title-body-two-buttons-modal-template',
+                title: 'title',
+            },
+        },
+        missingButton2: {
+            params: {
+                body: 'body',
+                button1: {
+                    label: 'button1',
+                    actions: 'actions1',
+                },
+                footnote: 'footnote',
+                fileUpload: {
+                    fileId: '1234',
+                    sharedLinkUrl: 'https://shared-link.com',
+                },
+                templateID: 'image-title-body-two-buttons-modal-template',
+                title: 'title',
+            },
+        },
+    };
+
+    const getWrapper = params =>
+        shallow(<PreviewTitleBodyTwoButtonsModalTemplate onAction={onAction} params={params} />);
+
+    beforeEach(() => {});
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe.each([paramsConfigs.all, paramsConfigs.missingButton2])('%o', ({ params }) => {
+        test('renders correctly', () => {
+            getWrapper(params);
+        });
+    });
+
+    function checkClickElement(findElement, expectCalled, ...expectCalledWith) {
+        const element = findElement(getWrapper(paramsConfigs.all.params));
+        element.simulate('click');
+        if (expectCalled) {
+            expect(onAction).toHaveBeenCalledTimes(1);
+            expect(onAction).toHaveBeenCalledWith(...expectCalledWith);
+        } else {
+            expect(onAction).toHaveBeenCalledTimes(0);
+        }
+    }
+
+    test('should call onAction(button1.actions) if button1 is clicked', () =>
+        checkClickElement(wrapper => wrapper.find('PrimaryButton'), true, 'actions1'));
+
+    test('should call onAction(button2.actions) if button2 is clicked', () =>
+        checkClickElement(wrapper => wrapper.find('Button'), true, 'actions2'));
+
+    test('should not call onAction if clicked else where', () =>
+        checkClickElement(
+            wrapper => wrapper.find('.bdl-PreviewTitleBodyTwoButtonsModalTemplate-contentContainer'),
+            false,
+        ));
+});

--- a/src/features/in-app-messenger/contextual/templates/styles/PreviewTitleBodyTwoButtonsModalTemplate.scss
+++ b/src/features/in-app-messenger/contextual/templates/styles/PreviewTitleBodyTwoButtonsModalTemplate.scss
@@ -1,0 +1,78 @@
+@import '../../../../../styles/variables';
+
+$width: 660px;
+$supported-width: 1.1 * $width;
+
+.bdl-PreviewTitleBodyTwoButtonsModalTemplate {
+    @media only screen and (max-width: $supported-width - 1px) {
+        display: none;
+    }
+
+    letter-spacing: .3px;
+
+    .bdl-PreviewTitleBodyTwoButtonsModalTemplate-previewContainer {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 20px 0;
+
+        .MessagePreviewContent {
+            width: 400px;
+            max-height: 200px;
+
+            .MessagePreviewGhost-ghost {
+                width: 400px;
+                max-height: 200px;
+            }
+        }
+
+        .bp-container {
+            max-width: 400px;
+            max-height: 200px;
+
+            .bp {
+                background-color: $white;
+            }
+        }
+    }
+
+    .modal-actions {
+        justify-content: center;
+        margin-top: 0;
+
+        .btn {
+            height: 40px;
+            padding: 0 30px;
+        }
+    }
+
+    .modal-content {
+        margin-top: 0;
+
+        .bdl-PreviewTitleBodyTwoButtonsModalTemplate-body a {
+            font-weight: bold;
+        }
+
+        .footnote {
+            font-size: 8px;
+        }
+    }
+
+    .modal-dialog {
+        width: $width;
+        padding: 40px 120px;
+    }
+
+    .modal-header {
+        margin-right: 0;
+    }
+
+    .bdl-PreviewTitleBodyTwoButtonsModalTemplate-title {
+        width: 100%;
+        margin: 0 0 16px 0;
+        font-weight: bold;
+        font-size: 18px;
+        text-align: center;
+        word-wrap: break-word;
+    }
+}

--- a/src/features/in-app-messenger/types/index.js
+++ b/src/features/in-app-messenger/types/index.js
@@ -1,4 +1,4 @@
 // @flow
 
-export type { PreviewTitleBodyTwoButtonsPopoutParams, PreviewTitleBodyTwoButtonsModalParams } from './template-params';
+export type { PreviewTitleBodyTwoButtonsParams } from './template-params';
 export type { MessageActions } from './message-actions';

--- a/src/features/in-app-messenger/types/index.js
+++ b/src/features/in-app-messenger/types/index.js
@@ -1,5 +1,4 @@
 // @flow
 
-// eslint-disable-next-line import/prefer-default-export
-export type { PreviewTitleBodyTwoButtonsPopoutParams } from './template-params';
+export type { PreviewTitleBodyTwoButtonsPopoutParams, PreviewTitleBodyTwoButtonsModalParams } from './template-params';
 export type { MessageActions } from './message-actions';

--- a/src/features/in-app-messenger/types/template-params.js
+++ b/src/features/in-app-messenger/types/template-params.js
@@ -18,3 +18,12 @@ export type PreviewTitleBodyTwoButtonsPopoutParams = {|
     title: string,
     ...PreviewParams,
 |};
+
+export type PreviewTitleBodyTwoButtonsModalParams = {|
+    body: string,
+    button1: ButtonParam,
+    button2?: ButtonParam,
+    templateID: string,
+    title: string,
+    ...PreviewParams,
+|};

--- a/src/features/in-app-messenger/types/template-params.js
+++ b/src/features/in-app-messenger/types/template-params.js
@@ -10,16 +10,7 @@ type ButtonParam = {
     label: string,
 };
 
-export type PreviewTitleBodyTwoButtonsPopoutParams = {|
-    body: string,
-    button1: ButtonParam,
-    button2?: ButtonParam,
-    templateID: string,
-    title: string,
-    ...PreviewParams,
-|};
-
-export type PreviewTitleBodyTwoButtonsModalParams = {|
+export type PreviewTitleBodyTwoButtonsParams = {|
     body: string,
     button1: ButtonParam,
     button2?: ButtonParam,


### PR DESCRIPTION
Add new template for in-app messenger leveraging preview component
<img width="675" alt="Screenshot 2021-06-16 at 20 58 24" src="https://user-images.githubusercontent.com/23643342/122277077-c3a2ef80-cee5-11eb-8b77-d25b089556a1.png">
