### PR TITLE
feat(content-picker): pass flag to hide logo in ContentPicker

### DIFF
--- a/src/elements/common/header/Header.js
+++ b/src/elements/common/header/Header.js
@@ -15,7 +15,7 @@ import './Header.scss';
 
 type Props = {
     intl: any,
-    isHeaderLogoVisible: boolean,
+    isHeaderLogoVisible?: boolean,
     isSmall: boolean,
     logoUrl?: string,
     onSearch: Function,
@@ -24,7 +24,7 @@ type Props = {
 };
 
 // eslint-disable-next-line react/prop-types
-const Header = ({ isHeaderLogoVisible, view, isSmall, searchQuery, onSearch, logoUrl, intl }: Props) => {
+const Header = ({ isHeaderLogoVisible = true, view, isSmall, searchQuery, onSearch, logoUrl, intl }: Props) => {
     const search = ({ currentTarget }: { currentTarget: HTMLInputElement }) => onSearch(currentTarget.value);
     const isFolder = view === VIEW_FOLDER;
     const isSearch = view === VIEW_SEARCH;

--- a/src/elements/common/header/Header.js
+++ b/src/elements/common/header/Header.js
@@ -15,6 +15,7 @@ import './Header.scss';
 
 type Props = {
     intl: any,
+    isHeaderLogoVisible: boolean,
     isSmall: boolean,
     logoUrl?: string,
     onSearch: Function,
@@ -23,13 +24,13 @@ type Props = {
 };
 
 // eslint-disable-next-line react/prop-types
-const Header = ({ view, isSmall, searchQuery, onSearch, logoUrl, intl }: Props) => {
+const Header = ({ isHeaderLogoVisible, view, isSmall, searchQuery, onSearch, logoUrl, intl }: Props) => {
     const search = ({ currentTarget }: { currentTarget: HTMLInputElement }) => onSearch(currentTarget.value);
     const isFolder = view === VIEW_FOLDER;
     const isSearch = view === VIEW_SEARCH;
     return (
         <div className="be-header">
-            <Logo isSmall={isSmall} url={logoUrl} />
+            {isHeaderLogoVisible && <Logo isSmall={isSmall} url={logoUrl} />}
             <div className="be-search">
                 <input
                     aria-label="search"

--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -87,7 +87,7 @@ type Props = {
     extensions: string[],
     initialPage: number,
     initialPageSize: number,
-    isHeaderLogoVisible: boolean,
+    isHeaderLogoVisible?: boolean,
     isLarge: boolean,
     isSmall: boolean,
     isTouch: boolean,

--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -87,6 +87,7 @@ type Props = {
     extensions: string[],
     initialPage: number,
     initialPageSize: number,
+    isHeaderLogoVisible: boolean,
     isLarge: boolean,
     isSmall: boolean,
     isTouch: boolean,
@@ -177,6 +178,7 @@ class ContentPicker extends Component<Props, State> {
         contentUploaderProps: {},
         showSelectedButton: true,
         clearSelectedItemsOnNavigation: false,
+        isHeaderLogoVisible: true,
     };
 
     /**
@@ -1188,6 +1190,7 @@ class ContentPicker extends Component<Props, State> {
             sharedLinkPassword,
             apiHost,
             uploadHost,
+            isHeaderLogoVisible,
             isSmall,
             className,
             measureRef,
@@ -1228,6 +1231,7 @@ class ContentPicker extends Component<Props, State> {
                     <div className="be-app-element" onKeyDown={this.onKeyDown} tabIndex={0}>
                         <Header
                             view={view}
+                            isHeaderLogoVisible={isHeaderLogoVisible}
                             isSmall={isSmall}
                             searchQuery={searchQuery}
                             logoUrl={logoUrl}

--- a/src/elements/content-picker/README.md
+++ b/src/elements/content-picker/README.md
@@ -33,6 +33,7 @@ var ContentPicker = require('./ContentPicker').default;
 | extensions | Array&lt;string&gt; | `[]` | *See the [developer docs](https://developer.box.com/guides/embed/ui-elements/picker/#Options).* |
 | initialPage | number | 1 | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
 | initialPageSize | number | 50 | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
+| isHeaderLogoVisible | boolean | true | Indicates whether or not the Logo in the Header is shown. |
 | isTouch | boolean |  | *See the [developer docs](https://developer.box.com/guides/embed/ui-elements/picker/#Options).* |
 | language | string |  | *See the [Internationalization](../README.md#internationalization) section* |
 | logoUrl | string |  | *See the [developer docs](https://developer.box.com/guides/embed/ui-elements/picker/#Options).* |


### PR DESCRIPTION
**Changes in this PR:**
- [x] add flag in ContentPicker called `isHeaderLogoVisible` which will toggle the visibility of the Logo that is shown in the Header in ContentPicker

**Demo:**
<img width="1502" alt="Screen Shot 2021-06-16 at 2 04 06 PM" src="https://user-images.githubusercontent.com/7213887/122294511-f8468500-ceac-11eb-973d-2873e1dd798b.png">
