### PR TITLE
fix(ContentPreview): A11Y - remove index zero to avoid tab stops

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1269,10 +1269,9 @@ class ContentPreview extends React.PureComponent<Props, State> {
         const onHeaderClose = currentVersionId === selectedVersionId ? onClose : this.updateVersionToCurrent;
 
         /* eslint-disable jsx-a11y/no-static-element-interactions */
-        /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
         return (
             <Internationalize language={language} messages={messages}>
-                <div id={this.id} className={styleClassName} ref={measureRef} onKeyDown={this.onKeyDown} tabIndex={0}>
+                <div id={this.id} className={styleClassName} ref={measureRef} onKeyDown={this.onKeyDown}>
                     {hasHeader && (
                         <PreviewHeader
                             file={file}


### PR DESCRIPTION
fix(ContentPreview): A11Y - remove index zero to avoid tab stops

The file preview itself is contained in one` <div>` elements with `tabindex="0"`. This `<div>` in the keyboard navigation flow, creating invisible Tab stops with no functionality. This are likely to create confusion for screen reader and keyboard users. For this reason I removed `tabindex=0 `in the `ContentPreview` component.

Before change 
![Screen Shot 2021-06-18 at 3 57 07 PM](https://user-images.githubusercontent.com/79931431/122615331-f962e800-d04d-11eb-9f89-e35c3f8fd6c2.png)
After change
![Screen Shot 2021-06-18 at 3 58 52 PM](https://user-images.githubusercontent.com/79931431/122615434-23b4a580-d04e-11eb-8be0-ac024fde39c3.png)


