### PR TITLE
Fix contrast on date picker

### DIFF
--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -68,7 +68,7 @@
     .date-picker-clear-btn {
         path {
             transition: fill linear .1s;
-            fill: $bdl-gray-40;
+            fill: $bdl-gray-50;
         }
     }
 

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -125,6 +125,7 @@ class DraftJSEditor extends React.Component<Props> {
                             {...a11yProps}
                             ariaLabelledBy={this.labelID}
                             editorState={editorState}
+                            ariaDescribedBy="miguel"
                             handleReturn={this.handleReturn}
                             onBlur={handleBlur}
                             onChange={handleChange}

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -35,7 +35,11 @@ type MentionStartStateProps = {
     message?: React.Node,
 };
 
-const MentionStartState = ({ message }: MentionStartStateProps) => <div className="mention-start-state">{message}</div>;
+const MentionStartState = ({ message }: MentionStartStateProps) => (
+    <div className="mention-start-state" aria-live="assertive" role="alert">
+        {message}
+    </div>
+);
 
 type Props = {
     className?: string,
@@ -250,8 +254,11 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
 
         const showMentionStartState = !!(onMention && activeMention && !activeMention.mentionString && isFocused);
 
+        const Tales = ({ contactsL }) => <div aria-live="polite"> {contactsL} users found. </div>;
+
         return (
             <div className={classes}>
+                {this.shouldDisplayMentionLookup() ? <Tales contacts={contacts.length} /> : null}
                 <SelectorDropdown
                     onSelect={this.handleContactSelected}
                     selector={


### PR DESCRIPTION
The cancel button on the date picker used to have a #a7a7a7 fill color which has low contrast. 
<img width="153" alt="Screen Shot 2021-06-24 at 11 51 19" src="https://user-images.githubusercontent.com/81333063/123303528-817c3e00-d4e3-11eb-890a-0188f030c259.png">

It has been adjusted to #909090 to improve the contrast ratio
<img width="150" alt="Screen Shot 2021-06-24 at 11 57 08" src="https://user-images.githubusercontent.com/81333063/123303619-9c4eb280-d4e3-11eb-8a38-6cddc9066792.png">
