### PR TITLE
fix(datepicker): improving color contrast

### DIFF
--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -68,7 +68,7 @@
     .date-picker-clear-btn {
         path {
             transition: fill linear .1s;
-            fill: $bdl-gray-40;
+            fill: $bdl-gray-50;
         }
     }
 


### PR DESCRIPTION
The cancel button on the date picker used to have a #a7a7a7 fill color which has low contrast.
<img width="153" alt="Screen Shot 2021-06-24 at 11 51 19" src="https://user-images.githubusercontent.com/81333063/123308589-79270180-d4e9-11eb-9f59-029e712d2a07.png">

It has been adjusted to #909090 to improve the contrast ratio
<img width="150" alt="Screen Shot 2021-06-24 at 11 57 08" src="https://user-images.githubusercontent.com/81333063/123308607-7d531f00-d4e9-11eb-962b-3262f81847b2.png">
