### PR TITLE
feat(content-picker): add flag for hiding pagination buttons

### DIFF
--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -89,6 +89,7 @@ type Props = {
     initialPageSize: number,
     isHeaderLogoVisible?: boolean,
     isLarge: boolean,
+    isPaginationVisible?: boolean,
     isSmall: boolean,
     isTouch: boolean,
     language?: string,
@@ -179,6 +180,7 @@ class ContentPicker extends Component<Props, State> {
         showSelectedButton: true,
         clearSelectedItemsOnNavigation: false,
         isHeaderLogoVisible: true,
+        isPaginationVisible: true,
     };
 
     /**
@@ -1191,6 +1193,7 @@ class ContentPicker extends Component<Props, State> {
             apiHost,
             uploadHost,
             isHeaderLogoVisible,
+            isPaginationVisible,
             isSmall,
             className,
             measureRef,
@@ -1282,12 +1285,14 @@ class ContentPicker extends Component<Props, State> {
                             cancelButtonLabel={cancelButtonLabel}
                             renderCustomActionButtons={renderCustomActionButtons}
                         >
-                            <OffsetBasedPagination
-                                offset={offset}
-                                onOffsetChange={this.paginate}
-                                pageSize={currentPageSize}
-                                totalCount={totalCount}
-                            />
+                            {isPaginationVisible && (
+                                <OffsetBasedPagination
+                                    offset={offset}
+                                    onOffsetChange={this.paginate}
+                                    pageSize={currentPageSize}
+                                    totalCount={totalCount}
+                                />
+                            )}
                         </Footer>
                     </div>
                     {allowUpload && !!this.appElement ? (

--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -1285,14 +1285,14 @@ class ContentPicker extends Component<Props, State> {
                             cancelButtonLabel={cancelButtonLabel}
                             renderCustomActionButtons={renderCustomActionButtons}
                         >
-                            {isPaginationVisible && (
+                            {isPaginationVisible ? (
                                 <OffsetBasedPagination
                                     offset={offset}
                                     onOffsetChange={this.paginate}
                                     pageSize={currentPageSize}
                                     totalCount={totalCount}
                                 />
-                            )}
+                            ) : null}
                         </Footer>
                     </div>
                     {allowUpload && !!this.appElement ? (

--- a/src/elements/content-picker/README.md
+++ b/src/elements/content-picker/README.md
@@ -34,6 +34,7 @@ var ContentPicker = require('./ContentPicker').default;
 | initialPage | number | 1 | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
 | initialPageSize | number | 50 | *See the [developer docs](https://developer.box.com/docs/box-content-explorer#section-options).* |
 | isHeaderLogoVisible | boolean | true | Indicates whether or not the Logo in the Header is shown. |
+| isPaginationVisible | boolean | true | Indicates whether or not the pagination buttons in the Footer are shown. |
 | isTouch | boolean |  | *See the [developer docs](https://developer.box.com/guides/embed/ui-elements/picker/#Options).* |
 | language | string |  | *See the [Internationalization](../README.md#internationalization) section* |
 | logoUrl | string |  | *See the [developer docs](https://developer.box.com/guides/embed/ui-elements/picker/#Options).* |


### PR DESCRIPTION
Changes in this PR:
- [x] add flag in ContentPicker to decide whether or not the Pagination buttons in the Footer should be shown
