### PR TITLE
fix(commentform): A11Y - color contrast correction

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
@@ -37,7 +37,7 @@
 
     .bcs-CommentForm-tip {
         margin-top: 10px;
-        color: $bdl-gray-50;
+        color: $bdl-gray-62;
     }
 
     .bcs-CommentFormControls {


### PR DESCRIPTION
The grey (#09090) "@mention users to notify them" text presents an insufficient contrast ratio of 3.2:1 with the white background

![image](https://user-images.githubusercontent.com/19536369/123447361-249a8980-d5b0-11eb-9d44-323ce07c3788.png)

The fix should change the color to #767676:

![image](https://user-images.githubusercontent.com/19536369/123447486-4bf15680-d5b0-11eb-8b4a-95c1aec39277.png)
