### PR TITLE
fix(DraftJSMentionSelectorCore): Dynamically removed and reapplied alert Mention feature

### DIFF
--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -74,6 +74,8 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
         startMentionMessage: <DefaultStartMentionMessage />,
     };
 
+    mentorSelectorRef: { current: null | HTMLDivElement } = React.createRef();
+
     constructor(props: Props) {
         super(props);
         const mentionTriggers = props.mentionTriggers.reduce((prev, current) => `${prev}\\${current}`, '');
@@ -179,8 +181,11 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
      */
     handleChange = (nextEditorState: EditorState) => {
         const { onChange } = this.props;
-
         const activeMention = this.getActiveMentionForEditorState(nextEditorState);
+
+        if (activeMention !== null) {
+            this.buildAccessibleAlert(activeMention);
+        }
 
         this.setState(
             {
@@ -228,6 +233,25 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
         return !!(activeMention && activeMention.mentionString && contacts.length);
     };
 
+    buildAccessibleAlert = (activeMention: Object) => {
+        const { isFocused } = this.state;
+        const { contacts } = this.props;
+        let alertElement = null;
+        const addAlert = activeMention && activeMention.mentionString?.length > 0 && isFocused;
+        const previousElement = document.querySelector('[data-testid="accessibility-alert"]');
+        if (previousElement) {
+            previousElement.remove();
+        }
+        if (this.mentorSelectorRef.current !== null && addAlert) {
+            alertElement = document.createElement('span');
+            alertElement.setAttribute('class', 'accessibility-hidden');
+            alertElement.setAttribute('data-testid', 'accessibility-alert');
+            alertElement.setAttribute('role', 'alert');
+            alertElement.innerText = contacts.length > 0 ? `${contacts.length} users found` : 'No users found';
+            this.mentorSelectorRef.current.appendChild(alertElement);
+        }
+    };
+
     render() {
         const {
             className,
@@ -251,7 +275,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
         const showMentionStartState = !!(onMention && activeMention && !activeMention.mentionString && isFocused);
 
         return (
-            <div className={classes}>
+            <div className={classes} ref={this.mentorSelectorRef}>
                 <SelectorDropdown
                     onSelect={this.handleContactSelected}
                     selector={


### PR DESCRIPTION
In order to make multiple announcements using the same alert element, the role attribute must be dynamically removed and reapplied every time an alert is made. I used of ARIA alerts to inform screen reader users of how many results have been found (e.g., "3 users found", "No users found", etc.)

No user found

<img width="1494" alt="Screen Shot 2021-06-25 at 6 02 40 PM" src="https://user-images.githubusercontent.com/79931431/123492613-9dfda080-d5df-11eb-8b82-5adf44689bd4.png">

1 User found

<img width="1497" alt="Screen Shot 2021-06-25 at 6 02 25 PM" src="https://user-images.githubusercontent.com/79931431/123492620-a524ae80-d5df-11eb-8e6c-af98cd6a6aab.png">

