### PR TITLE
fix(metadata): improved color contrast on edit icon button

### DIFF
--- a/src/icons/general/IconEdit.tsx
+++ b/src/icons/general/IconEdit.tsx
@@ -4,7 +4,7 @@ import AccessibleSVG from '../accessible-svg';
 
 import { Icon } from '../iconTypes';
 
-const IconEdit = ({ className = '', color = '#999', height = 14, title, width = 14 }: Icon) => (
+const IconEdit = ({ className = '', color = '#767676', height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG className={`icon-edit ${className}`} height={height} title={title} viewBox="0 0 14 14" width={width}>
         <path
             className="fill-color"

--- a/src/icons/general/__tests__/__snapshots__/IconEdit.test.tsx.snap
+++ b/src/icons/general/__tests__/__snapshots__/IconEdit.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`icons/general/IconEdit should correctly render default icon 1`] = `
   <path
     className="fill-color"
     d="M3.21 7.89l6.47-6.48a2 2 0 0 1 2.88 2.78h-.05L6 10.72 3.21 7.89zM2.24 9l2.83 2.83L1.67 13c-.52.18-.79-.1-.62-.61z"
-    fill="#999"
+    fill="#767676"
   />
 </AccessibleSVG>
 `;
@@ -26,7 +26,7 @@ exports[`icons/general/IconEdit should correctly render icon with specified prop
   <path
     className="fill-color"
     d="M3.21 7.89l6.47-6.48a2 2 0 0 1 2.88 2.78h-.05L6 10.72 3.21 7.89zM2.24 9l2.83 2.83L1.67 13c-.52.18-.79-.1-.62-.61z"
-    fill="#999"
+    fill="#767676"
   />
 </AccessibleSVG>
 `;


### PR DESCRIPTION
The edit icon on the Metadata section used to have a #999 fill color, which does not meet the minimum contrast requirement over white background. 

<img width="289" alt="Screen Shot 2021-07-01 at 10 18 36" src="https://user-images.githubusercontent.com/81333063/124149318-15a35380-da56-11eb-82b2-047e3776e29a.png">

Color had to be changed to #767676 in order to meet minimum contrast required.

<img width="288" alt="Screen Shot 2021-07-01 at 10 19 07" src="https://user-images.githubusercontent.com/81333063/124149481-3e2b4d80-da56-11eb-9681-f804c7cb1278.png">
