### PR TITLE
fix(TaskForm): A11Y - Give users the option to enter a date by hand

### DIFF
--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -449,6 +449,7 @@ class TaskForm extends React.Component<Props, State> {
                             }}
                             isDisabled={isForbiddenErrorOnEdit}
                             isRequired={false}
+                            isTextInputAllowed
                             label={<FormattedMessage {...messages.tasksAddTaskFormDueDateLabel} />}
                             minDate={new Date()}
                             name="taskDueDate"


### PR DESCRIPTION
When the field receives keyboard focus, a date picker dialog appears. This dialog is moderately accessible to screen reader users, but it would be better to give users the option to enter a date by hand instead. I added `isTextInputAllowed = true` in order to enable this feature. 

<img width="1070" alt="Screen Shot 2021-07-02 at 3 40 50 PM" src="https://user-images.githubusercontent.com/79931431/124326409-eb33c200-db4b-11eb-8ccd-8c7d08538c3f.png">

