### PR TITLE
fix(draftjs): Tweak contrast color

### DIFF
--- a/src/components/draft-js-editor/DraftJSEditor.scss
+++ b/src/components/draft-js-editor/DraftJSEditor.scss
@@ -2,6 +2,7 @@
 
 .public-DraftEditorPlaceholder-root {
     margin: 8px 10px;
+    color: $bdl-gray-62;
 }
 
 .bdl-is-disabled .public-DraftStyleDefault-block,


### PR DESCRIPTION
placeholder text had insufficient contrast color

Before
![Screen Shot 2021-07-06 at 1 13 53 PM](https://user-images.githubusercontent.com/380315/124647812-13793480-de5c-11eb-9871-d001db8bcfe2.png)

After
![Screen Shot 2021-07-06 at 1 14 01 PM](https://user-images.githubusercontent.com/380315/124647854-1d9b3300-de5c-11eb-8d7d-342d1b3f5bb6.png)
