### PR TITLE
fix(draftjs): Adds description for screenReader users

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -121,7 +121,7 @@ be.contentSidebar.activityFeed.commentForm.approvalSelectDate = Select a date
 # Mentioning call to action displayed below the comment input
 be.contentSidebar.activityFeed.commentForm.atMentionTip = @mention users to notify them.
 # Mentioning call to action detailed description for screen reader users
-be.contentSidebar.activityFeed.commentForm.atMentionTipDescription = Use the @ symbol to mention users, and use the up and down arrow keys to scroll through autocomplete suggestions.
+be.contentSidebar.activityFeed.commentForm.atMentionTipDescription = Use the @ symbol to mention users and use the up and down arrow keys to scroll through autocomplete suggestions.
 # Text for cancel button
 be.contentSidebar.activityFeed.commentForm.commentCancel = Cancel
 # Accessible label for comment input field

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -120,6 +120,8 @@ be.contentSidebar.activityFeed.commentForm.approvalDueDate = Due Date
 be.contentSidebar.activityFeed.commentForm.approvalSelectDate = Select a date
 # Mentioning call to action displayed below the comment input
 be.contentSidebar.activityFeed.commentForm.atMentionTip = @mention users to notify them.
+# Mentioning call to action detailed description for screen reader users
+be.contentSidebar.activityFeed.commentForm.atMentionTipDescription = Use the @ symbol to mention users, and use the up and down arrow keys to scroll through autocomplete suggestions.
 # Text for cancel button
 be.contentSidebar.activityFeed.commentForm.commentCancel = Cancel
 # Accessible label for comment input field

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -11,7 +11,6 @@ import 'draft-js/dist/Draft.css';
 import Tooltip from '../tooltip';
 
 import commonMessages from '../../common/messages';
-import messages from '../../elements/content-sidebar/activity-feed/comment-form/messages';
 import './DraftJSEditor.scss';
 
 const OptionalFormattedMessage = () => (
@@ -20,6 +19,7 @@ const OptionalFormattedMessage = () => (
     </span>
 );
 type Props = {
+    description: React.Node,
     editorState: EditorState,
     error?: ?Object,
     hideLabel?: boolean,
@@ -91,6 +91,7 @@ class DraftJSEditor extends React.Component<Props> {
             isDisabled,
             isRequired,
             label,
+            description,
             onFocus,
             placeholder,
         } = this.props;
@@ -121,7 +122,7 @@ class DraftJSEditor extends React.Component<Props> {
                     {!isRequired && <OptionalFormattedMessage />}
                 </span>
                 <span className={classNames({ 'accessibility-hidden': true })} id={this.commentFormTip}>
-                    <FormattedMessage {...messages.atMentionTipDescription} />
+                    {description}
                 </span>
 
                 <Tooltip isShown={!!error} position="bottom-left" text={error ? error.message : ''} theme="error">

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -19,7 +19,7 @@ const OptionalFormattedMessage = () => (
     </span>
 );
 type Props = {
-    description: React.Node,
+    description?: React.Node,
     editorState: EditorState,
     error?: ?Object,
     hideLabel?: boolean,
@@ -80,7 +80,7 @@ class DraftJSEditor extends React.Component<Props> {
 
     labelID = uniqueId('label');
 
-    commentFormTip = uniqueId('comment-form-tip');
+    commentFormTipID = uniqueId('comment-form-tip');
 
     render() {
         const {
@@ -121,7 +121,7 @@ class DraftJSEditor extends React.Component<Props> {
                     {label}
                     {!isRequired && <OptionalFormattedMessage />}
                 </span>
-                <span className={classNames({ 'accessibility-hidden': true })} id={this.commentFormTip}>
+                <span className="accessibility-hidden" id={this.commentFormTipID}>
                     {description}
                 </span>
 
@@ -131,7 +131,7 @@ class DraftJSEditor extends React.Component<Props> {
                         <Editor
                             {...a11yProps}
                             ariaLabelledBy={this.labelID}
-                            ariaDescribedBy={this.commentFormTip}
+                            ariaDescribedBy={this.commentFormTipID}
                             editorState={editorState}
                             handleReturn={this.handleReturn}
                             onBlur={handleBlur}

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -121,7 +121,7 @@ class DraftJSEditor extends React.Component<Props> {
                     {label}
                     {!isRequired && <OptionalFormattedMessage />}
                 </span>
-                <span className="accessibility-hidden" id={this.descriptionID}>
+                <span className="accessibility-hidden screenreader-description" id={this.descriptionID}>
                     {description}
                 </span>
 

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -80,7 +80,7 @@ class DraftJSEditor extends React.Component<Props> {
 
     labelID = uniqueId('label');
 
-    commentFormTipID = uniqueId('comment-form-tip');
+    descriptionID = uniqueId('description');
 
     render() {
         const {
@@ -121,7 +121,7 @@ class DraftJSEditor extends React.Component<Props> {
                     {label}
                     {!isRequired && <OptionalFormattedMessage />}
                 </span>
-                <span className="accessibility-hidden" id={this.commentFormTipID}>
+                <span className="accessibility-hidden" id={this.descriptionID}>
                     {description}
                 </span>
 
@@ -131,7 +131,7 @@ class DraftJSEditor extends React.Component<Props> {
                         <Editor
                             {...a11yProps}
                             ariaLabelledBy={this.labelID}
-                            ariaDescribedBy={this.commentFormTipID}
+                            ariaDescribedBy={this.descriptionID}
                             editorState={editorState}
                             handleReturn={this.handleReturn}
                             onBlur={handleBlur}

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -11,6 +11,7 @@ import 'draft-js/dist/Draft.css';
 import Tooltip from '../tooltip';
 
 import commonMessages from '../../common/messages';
+import messages from '../../elements/content-sidebar/activity-feed/comment-form/messages';
 import './DraftJSEditor.scss';
 
 const OptionalFormattedMessage = () => (
@@ -79,6 +80,8 @@ class DraftJSEditor extends React.Component<Props> {
 
     labelID = uniqueId('label');
 
+    commentFormTip = uniqueId('comment-form-tip');
+
     render() {
         const {
             editorState,
@@ -117,6 +120,9 @@ class DraftJSEditor extends React.Component<Props> {
                     {label}
                     {!isRequired && <OptionalFormattedMessage />}
                 </span>
+                <span className={classNames({ 'accessibility-hidden': true })} id={this.commentFormTip}>
+                    <FormattedMessage {...messages.atMentionTipDescription} />
+                </span>
 
                 <Tooltip isShown={!!error} position="bottom-left" text={error ? error.message : ''} theme="error">
                     {/* need div so tooltip can set aria-describedby */}
@@ -124,6 +130,7 @@ class DraftJSEditor extends React.Component<Props> {
                         <Editor
                             {...a11yProps}
                             ariaLabelledBy={this.labelID}
+                            ariaDescribedBy={this.commentFormTip}
                             editorState={editorState}
                             handleReturn={this.handleReturn}
                             onBlur={handleBlur}

--- a/src/components/draft-js-editor/DraftJSEditor.stories.js
+++ b/src/components/draft-js-editor/DraftJSEditor.stories.js
@@ -31,6 +31,7 @@ export const basic = () => {
                     isDisabled={boolean('isDisabled', false)}
                     isRequired={boolean('isRequired', true)}
                     label="Draft.js Editor Example"
+                    description="Description for screenReader users"
                     onBlur={() => null}
                     onChange={setEditorState}
                     onFocus={() => null}

--- a/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
+++ b/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
@@ -11,6 +11,7 @@ describe('components/draft-js-editor/DraftJSEditor', () => {
     const requiredProps = {
         editorState: EditorState.createEmpty(),
         label: 'Label text',
+        description: 'talesss',
         onBlur: () => {},
         onChange: sandbox.stub(),
         onFocus: () => {},
@@ -40,6 +41,12 @@ describe('components/draft-js-editor/DraftJSEditor', () => {
             const wrapper = shallow(<DraftJSEditor {...requiredProps} isRequired={false} />);
 
             expect(wrapper.find('OptionalFormattedMessage').exists()).toBe(true);
+        });
+
+        test('should set description when specified', () => {
+            const wrapper = shallow(<DraftJSEditor {...requiredProps} />);
+
+            expect(wrapper.find('.screenreader-description').text()).toEqual(requiredProps.description);
         });
 
         test('should call handleChange when <Editor /> onchange called', () => {

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelector.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelector.js
@@ -28,6 +28,7 @@ const mentionStrategy = (contentBlock, callback, contentState) => {
 type Props = {
     className?: string,
     contacts: SelectorItems<>,
+    description: React.Node,
     editorState?: EditorState,
     hideLabel?: boolean,
     isDisabled?: boolean,
@@ -250,6 +251,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
             isDisabled,
             isRequired,
             label,
+            description,
             mentionTriggers,
             name,
             onMention,
@@ -278,6 +280,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
                         isDisabled={isDisabled}
                         isRequired={isRequired}
                         label={label}
+                        description={description}
                         mentionTriggers={mentionTriggers}
                         onBlur={handleBlur}
                         onChange={handleChange}

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelector.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelector.js
@@ -28,7 +28,7 @@ const mentionStrategy = (contentBlock, callback, contentState) => {
 type Props = {
     className?: string,
     contacts: SelectorItems<>,
-    description: React.Node,
+    description?: React.Node,
     editorState?: EditorState,
     hideLabel?: boolean,
     isDisabled?: boolean,

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -40,6 +40,7 @@ const MentionStartState = ({ message }: MentionStartStateProps) => <div classNam
 type Props = {
     className?: string,
     contacts: SelectorItems<>,
+    description: React.Node,
     editorState: EditorState,
     error?: ?Object,
     hideLabel?: boolean,
@@ -238,6 +239,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
             isDisabled,
             isRequired,
             label,
+            description,
             onReturn,
             placeholder,
             selectorRow,
@@ -263,6 +265,7 @@ class DraftJSMentionSelector extends React.Component<Props, State> {
                             isFocused={isFocused}
                             isRequired={isRequired}
                             label={label}
+                            description={description}
                             onBlur={this.handleBlur}
                             onFocus={this.handleFocus}
                             onChange={this.handleChange}

--- a/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
+++ b/src/components/form-elements/draft-js-mention-selector/DraftJSMentionSelectorCore.js
@@ -40,7 +40,7 @@ const MentionStartState = ({ message }: MentionStartStateProps) => <div classNam
 type Props = {
     className?: string,
     contacts: SelectorItems<>,
-    description: React.Node,
+    description?: React.Node,
     editorState: EditorState,
     error?: ?Object,
     hideLabel?: boolean,

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -142,6 +142,7 @@ class CommentForm extends React.Component<Props, State> {
                             isRequired={isOpen}
                             name="commentText"
                             label={formatMessage(messages.commentLabel)}
+                            description={formatMessage(messages.atMentionTipDescription)}
                             onChange={this.onMentionSelectorChangeHandler}
                             onFocus={onFocus}
                             onMention={getMentionWithQuery}

--- a/src/elements/content-sidebar/activity-feed/comment-form/messages.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/messages.js
@@ -66,7 +66,7 @@ const messages = defineMessages({
     atMentionTipDescription: {
         id: 'be.contentSidebar.activityFeed.commentForm.atMentionTipDescription',
         defaultMessage:
-            'Use the @ symbol to mention users, and use the up and down arrow keys to scroll through autocomplete suggestions.',
+            'Use the @ symbol to mention users and use the up and down arrow keys to scroll through autocomplete suggestions.',
         description: 'Mentioning call to action detailed description for screen reader users',
     },
 });

--- a/src/elements/content-sidebar/activity-feed/comment-form/messages.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/messages.js
@@ -63,6 +63,12 @@ const messages = defineMessages({
         defaultMessage: '@mention users to notify them.',
         description: 'Mentioning call to action displayed below the comment input',
     },
+    atMentionTipDescription: {
+        id: 'be.contentSidebar.activityFeed.commentForm.atMentionTipDescription',
+        defaultMessage:
+            'Use the @ symbol to mention users, and use the up and down arrow keys to scroll through autocomplete suggestions.',
+        description: 'Mentioning call to action detailed description for screen reader users',
+    },
 });
 
 export default messages;


### PR DESCRIPTION
Adds verbose description for screenReader users, explaining how to use the draftJS **mention** feature

![Screen Shot 2021-07-12 at 6 34 35 PM](https://user-images.githubusercontent.com/380315/125368612-35812400-e340-11eb-895f-9ad6d8028922.png)
