### PR TITLE
docs(colors): show contrast ratios

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
         "@testing-library/react": "^10.4.3",
         "@testing-library/react-hooks": "^3.3.0",
         "@types/classnames": "^2.2.9",
+        "@types/color": "^3.0.2",
         "@types/enzyme": "^3.10.4",
         "@types/history": "^4.7.5",
         "@types/jest": "^25.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5354,10 +5354,24 @@
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
   integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
 
-"@types/color-name@^1.1.1":
+"@types/color-convert@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
+  integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*", "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.2.tgz#3779043e782f562aa9157b5fc6bd07e14fd8e7f3"
+  integrity sha512-INiJl6sfNn8iyC5paxVzqiVUEj2boIlFki02uRTAkKwAj++7aAF+ZfEv/XrIeBa0XI/fTZuDHW8rEEcEVnON+Q==
+  dependencies:
+    "@types/color-convert" "*"
 
 "@types/emoji-regex@^8.0.0":
   version "8.0.0"


### PR DESCRIPTION
- Show WCAG contrast ratio (against white) next to colors, to make it easier to pick accessible color combinations
- Slightly more compact and responsive layout for the palette documentation

Wide:

![Screen Shot 2021-07-09 at 7 37 29 PM](https://user-images.githubusercontent.com/1571667/125150176-b519b380-e0f2-11eb-9c02-cf5a35210dfa.png)

Narrow:

<img alt="narrow" width="500px" src="https://user-images.githubusercontent.com/1571667/125150212-fad67c00-e0f2-11eb-9f47-d81a77d9202d.png" />
