### PR TITLE
fix(metadata): Fixed lost focus on search

### DIFF
--- a/src/components/search-form/SearchForm.js
+++ b/src/components/search-form/SearchForm.js
@@ -129,7 +129,18 @@ class SearchForm extends React.Component<Props, State> {
     searchInput: ?HTMLInputElement;
 
     render() {
-        const { action, className, intl, isLoading, method, name, queryParams, useClearButton, ...rest } = this.props;
+        const {
+            action,
+            className,
+            intl,
+            isLoading,
+            method,
+            name,
+            queryParams,
+            onSubmit,
+            useClearButton,
+            ...rest
+        } = this.props;
         const { isEmpty } = this.state;
 
         const inputProps = omit(rest, [
@@ -152,13 +163,24 @@ class SearchForm extends React.Component<Props, State> {
 
         const SearchActions = () => (
             <div className="action-buttons">
-                <button
-                    type="button"
-                    className="action-button search-button"
-                    title={formatMessage(messages.searchButtonTitle)}
-                >
-                    <Search16 />
-                </button>
+                {onSubmit ? (
+                    <button
+                        type="button"
+                        className="action-button search-button"
+                        title={formatMessage(messages.searchButtonTitle)}
+                    >
+                        <Search16 />
+                    </button>
+                ) : (
+                    <div
+                        type="button"
+                        className="action-button search-button"
+                        title={formatMessage(messages.searchButtonTitle)}
+                    >
+                        <Search16 />
+                    </div>
+                )}
+
                 <button
                     className="action-button clear-button"
                     onClick={this.onClearHandler}

--- a/src/components/search-form/SearchForm.js
+++ b/src/components/search-form/SearchForm.js
@@ -172,11 +172,7 @@ class SearchForm extends React.Component<Props, State> {
                         <Search16 />
                     </button>
                 ) : (
-                    <div
-                        type="button"
-                        className="action-button search-button"
-                        title={formatMessage(messages.searchButtonTitle)}
-                    >
+                    <div className="action-button search-button">
                         <Search16 />
                     </div>
                 )}

--- a/src/components/search-form/__tests__/SearchForm.test.js
+++ b/src/components/search-form/__tests__/SearchForm.test.js
@@ -21,9 +21,11 @@ describe('components/search-form/SearchForm', () => {
     });
 
     test('should correctly render default component', () => {
-        const wrapper = mount(<SearchForm placeholder="search" />);
+        const onSubmitSpy = sinon.spy();
+        const wrapper = mount(<SearchForm onSubmit={onSubmitSpy} placeholder="search" value="cheese" />);
         expect(wrapper.find('form').length === 1).toBeTruthy();
         expect(wrapper.find('input').length === 1).toBeTruthy();
+
         expect(wrapper.find('button').length === 2).toBeTruthy();
         expect(wrapper.find('form').prop('method')).toEqual('get');
         expect(wrapper.find('input').prop('name')).toEqual('search');


### PR DESCRIPTION
Hi guys!

We had to do some changes on the search component, since focus got out of sight after tabbing  from the input text field. The Search button has some instances where the OnSubmit action is not defined and receives focus nevertheless. the approach to fix this was to make sure that the onSubmit prop was defined in order to render it as a <button>, otherwise it gets rendered as a <div>.

Renders as a button while onSubmit exists
<img width="1041" alt="Screen Shot 2021-07-13 at 17 51 25" src="https://user-images.githubusercontent.com/81333063/125535264-2b70c08e-123f-4cdd-aeb1-6ee7dc2e6e9c.png">

Renders as a div when is undefined
<img width="897" alt="Screen Shot 2021-07-13 at 17 53 40" src="https://user-images.githubusercontent.com/81333063/125535415-c31dc33a-48e1-4fff-97ad-b458b23be0af.png">

This prevents lost focus on the component.