### PR TITLE
feat(presence): Hide additional collaborator count

### DIFF
--- a/src/features/presence/PresenceAvatarList.tsx
+++ b/src/features/presence/PresenceAvatarList.tsx
@@ -21,6 +21,7 @@ export type Props = {
     avatarAttributes?: React.HTMLAttributes<HTMLDivElement>;
     className?: string;
     collaborators: Array<Collaborator>;
+    hideAdditionalCount?: boolean;
     hideTooltips?: boolean;
     maxAdditionalCollaborators?: number;
     maxDisplayedAvatars?: number;
@@ -33,6 +34,7 @@ function PresenceAvatarList(props: Props, ref: React.Ref<HTMLDivElement>): JSX.E
         avatarAttributes,
         className,
         collaborators,
+        hideAdditionalCount,
         hideTooltips,
         maxAdditionalCollaborators = 99,
         maxDisplayedAvatars = 3,
@@ -94,7 +96,7 @@ function PresenceAvatarList(props: Props, ref: React.Ref<HTMLDivElement>): JSX.E
                 );
             })}
 
-            {collaborators.length > maxDisplayedAvatars && (
+            {!hideAdditionalCount && collaborators.length > maxDisplayedAvatars && (
                 <div
                     className={classNames('bdl-PresenceAvatarList-count', 'avatar')}
                     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex

--- a/src/features/presence/__tests__/PresenceAvatarList.test.tsx
+++ b/src/features/presence/__tests__/PresenceAvatarList.test.tsx
@@ -41,6 +41,18 @@ describe('features/presence/PresenceAvatarList', () => {
             expect(wrapper.exists('.bdl-PresenceAvatarList-count')).toBe(true);
         });
 
+        test('should hide additional count if hideAdditionalCount is specified', () => {
+            const maxDisplayedAvatars = 3;
+            const wrapper = getWrapper({
+                hideAdditionalCount: true,
+                maxDisplayedAvatars,
+            });
+
+            expect(wrapper.exists('.bdl-PresenceAvatarList')).toBe(true);
+            expect(wrapper.find(PresenceAvatar).length).toBe(maxDisplayedAvatars);
+            expect(wrapper.exists('.bdl-PresenceAvatarList-count')).toBe(false);
+        });
+
         test.each(['focus', 'mouseenter'])(
             'should show tooltip when correponding avatar encounters %s event',
             event => {


### PR DESCRIPTION
Adds prop to hide the additional collaborator count when it exceeds `maxDisplayedAvatars`