### PR TITLE
fix(comments): Added Aria attributes to enhance accessibility

### DIFF
--- a/src/components/badge/Badge.scss
+++ b/src/components/badge/Badge.scss
@@ -7,7 +7,7 @@
 .badge {
     display: inline-block;
     padding: 2px 4px 3px;
-    color: $bdl-gray-62;
+    color: $bdl-gray;
     font-weight: bold;
     font-size: 10px;
     line-height: 12px;

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -111,6 +111,7 @@ class DraftJSEditor extends React.Component<Props> {
                 ariaAutoComplete: inputProps['aria-autocomplete'],
                 ariaExpanded: inputProps['aria-expanded'],
                 ariaOwneeID: inputProps['aria-owns'],
+                ariaMultiline: true,
                 role: 'textbox',
             };
         }
@@ -130,7 +131,6 @@ class DraftJSEditor extends React.Component<Props> {
                     <div>
                         <Editor
                             {...a11yProps}
-                            ariaMultiline
                             ariaLabelledBy={this.labelID}
                             ariaDescribedBy={this.descriptionID}
                             editorState={editorState}

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -111,7 +111,7 @@ class DraftJSEditor extends React.Component<Props> {
                 ariaAutoComplete: inputProps['aria-autocomplete'],
                 ariaExpanded: inputProps['aria-expanded'],
                 ariaOwneeID: inputProps['aria-owns'],
-                role: inputProps.role,
+                role: inputProps.textbox,
             };
         }
 
@@ -130,6 +130,7 @@ class DraftJSEditor extends React.Component<Props> {
                     <div>
                         <Editor
                             {...a11yProps}
+                            ariaMultiline
                             ariaLabelledBy={this.labelID}
                             ariaDescribedBy={this.descriptionID}
                             editorState={editorState}

--- a/src/components/draft-js-editor/DraftJSEditor.js
+++ b/src/components/draft-js-editor/DraftJSEditor.js
@@ -111,7 +111,7 @@ class DraftJSEditor extends React.Component<Props> {
                 ariaAutoComplete: inputProps['aria-autocomplete'],
                 ariaExpanded: inputProps['aria-expanded'],
                 ariaOwneeID: inputProps['aria-owns'],
-                role: inputProps.textbox,
+                role: 'textbox',
             };
         }
 

--- a/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
+++ b/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
@@ -66,7 +66,6 @@ describe('components/draft-js-editor/DraftJSEditor', () => {
                 'aria-autocomplete': 'list',
                 'aria-expanded': true,
                 'aria-owns': 'id',
-                role: 'textbox',
             };
             const wrapper = shallow(<DraftJSEditor {...requiredProps} inputProps={inputProps} />);
 

--- a/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
+++ b/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
@@ -75,7 +75,7 @@ describe('components/draft-js-editor/DraftJSEditor', () => {
             expect(editor.prop('ariaAutoComplete')).toEqual(inputProps['aria-autocomplete']);
             expect(editor.prop('ariaExpanded')).toEqual(inputProps['aria-expanded']);
             expect(editor.prop('ariaOwneeID')).toEqual(inputProps['aria-owns']);
-            expect(editor.prop('role')).toEqual(inputProps.textbox);
+            expect(editor.prop('role')).toEqual('textbox');
         });
     });
 

--- a/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
+++ b/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
@@ -66,7 +66,7 @@ describe('components/draft-js-editor/DraftJSEditor', () => {
                 'aria-autocomplete': 'list',
                 'aria-expanded': true,
                 'aria-owns': 'id',
-                role: 'combobox',
+                role: 'textbox',
             };
             const wrapper = shallow(<DraftJSEditor {...requiredProps} inputProps={inputProps} />);
 
@@ -75,7 +75,7 @@ describe('components/draft-js-editor/DraftJSEditor', () => {
             expect(editor.prop('ariaAutoComplete')).toEqual(inputProps['aria-autocomplete']);
             expect(editor.prop('ariaExpanded')).toEqual(inputProps['aria-expanded']);
             expect(editor.prop('ariaOwneeID')).toEqual(inputProps['aria-owns']);
-            expect(editor.prop('role')).toEqual(inputProps.role);
+            expect(editor.prop('role')).toEqual(inputProps.textbox);
         });
     });
 

--- a/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
+++ b/src/components/draft-js-editor/__tests__/DraftJSEditor.test.js
@@ -66,6 +66,7 @@ describe('components/draft-js-editor/DraftJSEditor', () => {
                 'aria-autocomplete': 'list',
                 'aria-expanded': true,
                 'aria-owns': 'id',
+                role: 'textbox',
             };
             const wrapper = shallow(<DraftJSEditor {...requiredProps} inputProps={inputProps} />);
 


### PR DESCRIPTION
According to the communication held with WebAim, the role combobox had to be switched to textbox and the aria-multiline attribute had to be added.

<img width="997" alt="Screen Shot 2021-07-21 at 10 35 37" src="https://user-images.githubusercontent.com/81333063/126518028-54a4d40e-2627-43c0-9465-91fab9ef8093.png">
