### PR TITLE
fix: update shield tooltip wording

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -15,7 +15,7 @@ be.activitySidebar.activityFeed.taskMissingError = This task no longer exists
 # Label for add action
 be.add = Add
 # Text to display when app is disabled by applied access policy
-be.additionalTab.blockedByShieldAccessPolicy = Use of this app has been disabled by the applied access policy
+be.additionalTab.blockedByShieldAccessPolicy = Use of this app is blocked due to a security policy.
 # Error message when an app activity deletion fails
 be.api.appActivityDeleteErrorMessage = There was an error deleting this item.
 # Error message when a comment creation fails due to a conflict

--- a/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
+++ b/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
@@ -4,7 +4,7 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render di
 <AdditionalTabTooltip
   defaultTooltipText={
     <FormattedMessage
-      defaultMessage="Use of this app has been disabled by the applied access policy"
+      defaultMessage="Use of this app is blocked due to a security policy."
       id="be.additionalTab.blockedByShieldAccessPolicy"
     />
   }

--- a/src/elements/content-sidebar/additional-tabs/messages.js
+++ b/src/elements/content-sidebar/additional-tabs/messages.js
@@ -9,7 +9,7 @@ import { defineMessages } from 'react-intl';
 const messages = defineMessages({
     blockedByShieldAccessPolicy: {
         id: 'be.additionalTab.blockedByShieldAccessPolicy',
-        defaultMessage: 'Use of this app has been disabled by the applied access policy',
+        defaultMessage: 'Use of this app is blocked due to a security policy.',
         description: 'Text to display when app is disabled by applied access policy',
     },
 });


### PR DESCRIPTION
This is part of an update to unify tooltip wording for various shield restrictions.

The old tooptip:
![image](https://user-images.githubusercontent.com/35543368/127200816-081cc7a6-fd1e-4568-8fe9-34cddd5876f5.png)

The new tooltip:
<img width="354" alt="Screen Shot 2021-07-27 at 10 33 10 AM" src="https://user-images.githubusercontent.com/35543368/127200910-c8810f51-c2ad-4c6e-937d-943111667133.png">
