### PR TITLE
fix: tooltip text for shield access restriction

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1483,7 +1483,7 @@ boxui.unifiedShare.disabledCreateLinkTooltip = You do not have permission to cre
 # Tooltip text for when shared permission option is not available due to security policy
 boxui.unifiedShare.disabledMaliciousContentShareLinkPermission = This option isn’t available for this item due to a security policy.
 # Tooltip text for when shared permission option is not available due to restriction or classification
-boxui.unifiedShare.disabledShareLinkPermission = This option isn’t available for this item due to a security restriction or classification.
+boxui.unifiedShare.disabledShareLinkPermission = This option is not available due to a security policy.
 # Text used in button label to describe permission level - editor
 boxui.unifiedShare.editorLevelButtonLabel = Invite as Editor
 # Description for Editor permission level in invitee permission dropdown

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessMenu.test.js.snap
@@ -124,7 +124,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
         position="top-center"
         text={
           <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+            defaultMessage="This option is not available due to a security policy."
             id="boxui.unifiedShare.disabledShareLinkPermission"
           />
         }
@@ -233,7 +233,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
         position="top-center"
         text={
           <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+            defaultMessage="This option is not available due to a security policy."
             id="boxui.unifiedShare.disabledShareLinkPermission"
           />
         }
@@ -261,7 +261,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
         position="top-center"
         text={
           <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+            defaultMessage="This option is not available due to a security policy."
             id="boxui.unifiedShare.disabledShareLinkPermission"
           />
         }
@@ -289,7 +289,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
         position="top-center"
         text={
           <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+            defaultMessage="This option is not available due to a security policy."
             id="boxui.unifiedShare.disabledShareLinkPermission"
           />
         }
@@ -414,7 +414,7 @@ exports[`features/unified-share-modal/SharedLinkAccessMenu render() should rende
         position="top-center"
         text={
           <FormattedMessage
-            defaultMessage="This option isn’t available for this item due to a security restriction or classification."
+            defaultMessage="This option is not available due to a security policy."
             id="boxui.unifiedShare.disabledShareLinkPermission"
           />
         }

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -7,7 +7,7 @@ const messages = defineMessages({
         id: 'boxui.unifiedShare.contentSharedWithExternalCollaborators',
     },
     disabledShareLinkPermission: {
-        defaultMessage: 'This option isn’t available for this item due to a security restriction or classification.',
+        defaultMessage: 'This option is not available due to a security policy.',
         description:
             'Tooltip text for when shared permission option is not available due to restriction or classification',
         id: 'boxui.unifiedShare.disabledShareLinkPermission',


### PR DESCRIPTION
This is part of a series of changes to unify tooltip wording for shield access restrictions.

The old tooltip:
![image](https://user-images.githubusercontent.com/35543368/127246076-59a23da8-830a-4ef0-850e-0c5a631faae4.png)

The new tooltip:
<img width="449" alt="Screen Shot 2021-07-27 at 12 45 54 PM" src="https://user-images.githubusercontent.com/35543368/127246113-4e3f7d95-0150-427f-8744-9c07d4804549.png">
