### PR TITLE
fix(content-explorer): Get text reps in initial /folders call

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -365,7 +365,8 @@ export const X_REP_HINT_PNG_DIMENSIONS_DEFAULT: '1024x1024' = '1024x1024';
 
 // If unable to fetch jpg thumbnail, grab png rep of first page. Certain file types do not have a thumbnail rep but do have a first page rep.
 // Get the PDF rep as well, which ensures that the Preview SDK loads linearized reps for customers with PDF optimization enabled.
-export const X_REP_HINT_HEADER_DIMENSIONS_DEFAULT = `[jpg?dimensions=${X_REP_HINT_JPG_DIMENSIONS_DEFAULT}&paged=false,png?dimensions=${X_REP_HINT_PNG_DIMENSIONS_DEFAULT}][pdf]`;
+// Get the text rep as well, which ensures that large text files load in the Preview SDK.
+export const X_REP_HINT_HEADER_DIMENSIONS_DEFAULT = `[jpg?dimensions=${X_REP_HINT_JPG_DIMENSIONS_DEFAULT}&paged=false,png?dimensions=${X_REP_HINT_PNG_DIMENSIONS_DEFAULT}][pdf][text]`;
 
 /* ------------------ Representations Response ---------- */
 export const REPRESENTATIONS_RESPONSE_ERROR: 'error' = 'error';


### PR DESCRIPTION
Fixes an issue in Content Explorer where previewing large .txt files would remain stuck in a loading state, due to the pending status of their pdf representations. Now we're fetching the text representation, which is the expected representation for .txt files. I tested for any regressions in Content Explorer by previewing all supported file types.

Before:
![before](https://user-images.githubusercontent.com/14035562/127403535-ec2ca6f6-46a7-46b5-ba4f-00929c132db8.png)

After:
![after](https://user-images.githubusercontent.com/14035562/127403552-3c93d7dd-23ee-45aa-aeea-d12fd0c2a511.png)