### PR TITLE
fix(pills): improved color contrast for accessibility

### DIFF
--- a/src/components/badge/Badge.scss
+++ b/src/components/badge/Badge.scss
@@ -7,7 +7,7 @@
 .badge {
     display: inline-block;
     padding: 2px 4px 3px;
-    color: $bdl-gray-62;
+    color: $bdl-gray;
     font-weight: bold;
     font-size: 10px;
     line-height: 12px;


### PR DESCRIPTION
<img width="451" alt="Screen Shot 2021-08-04 at 10 27 44" src="https://user-images.githubusercontent.com/81333063/128208894-32615829-428d-4a4b-b6ec-1a8d4a4a04b3.png">

Improved color contrast for the pills text since it failed to be compliant with Accessibility standards.