### PR TITLE
fix(checkbox): render label in case text exist

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -75,7 +75,7 @@ const Checkbox = ({
                     to the underlying <input> */}
             <span className="checkbox-pointer-target" />
             <span className={classNames('bdl-Checkbox-labelTooltipWrapper', { 'accessibility-hidden': hideLabel })}>
-                <label htmlFor={inputID}>{label}</label>
+                {label && <label htmlFor={inputID}>{label}</label>}
                 {tooltip && <CheckboxTooltip tooltip={tooltip} />}
             </span>
         </span>


### PR DESCRIPTION
To test this we should be located in AccountSettings > Sharing:

Email Notifications:
![image](https://user-images.githubusercontent.com/19536369/129100630-bba15fa4-0d13-4ca4-8c88-f1b9bff00d59.png)


Checkbox render a Label element. It should be not rendered in case label text is not setted.

