### PR TITLE
feat(shared-link-permission-menu): add edit option

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1592,18 +1592,14 @@ boxui.unifiedShare.settingsButtonLabel = Open shared link settings popup
 boxui.unifiedShare.sharedLinkDisabledTooltipCopy = Create and copy link for sharing
 # Tooltip describing when this shared link will expire. {expiration, date, long} is the formatted date
 boxui.unifiedShare.sharedLinkExpirationTooltip = This link will expire and be inaccessible on {expiration, date, long}.
-# Label for a shared link permission to show for editable box notes
+# Label for a shared link permission to show for an editable box note / file
 boxui.unifiedShare.sharedLinkPermissionsEdit = Can edit
 # Text to use in the tooltip when presenting an editable Box Note (DO NOT TRANSLATE "Box Notes")
 boxui.unifiedShare.sharedLinkPermissionsEditTooltip = This permission can only be changed in Box Notes
 # Label for a shared link permission level
 boxui.unifiedShare.sharedLinkPermissionsViewDownload = Can view and download
-# Description for Can view and download option
-boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription = Users can view and download
 # Label for a shared link permission level
 boxui.unifiedShare.sharedLinkPermissionsViewOnly = Can view only
-# Description for Can view only option
-boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription = Users can view only
 # Text shown in share modal when shared link is open to public access
 boxui.unifiedShare.sharedLinkPubliclyAvailable = This content is publicly available to anyone with the link.
 # Label for the shared link section of the unified share modal

--- a/src/features/unified-share-modal/SharedLinkPermissionMenu.js
+++ b/src/features/unified-share-modal/SharedLinkPermissionMenu.js
@@ -9,7 +9,7 @@ import PlainButton from '../../components/plain-button';
 import { Menu, SelectMenuItem } from '../../components/menu';
 
 import type { permissionLevelType } from './flowTypes';
-import { CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from './constants';
+import { CAN_EDIT, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from './constants';
 import messages from './messages';
 
 type Props = {
@@ -53,13 +53,14 @@ class SharedLinkPermissionMenu extends Component<Props> {
         }
 
         const permissionLevels = {
+            [CAN_EDIT]: {
+                label: <FormattedMessage {...messages.sharedLinkPermissionsEdit} />,
+            },
             [CAN_VIEW_DOWNLOAD]: {
                 label: <FormattedMessage {...messages.sharedLinkPermissionsViewDownload} />,
-                description: <FormattedMessage {...messages.sharedLinkPermissionsViewDownloadDescription} />,
             },
             [CAN_VIEW_ONLY]: {
                 label: <FormattedMessage {...messages.sharedLinkPermissionsViewOnly} />,
-                description: <FormattedMessage {...messages.sharedLinkPermissionsViewOnlyDescription} />,
             },
         };
 
@@ -83,8 +84,7 @@ class SharedLinkPermissionMenu extends Component<Props> {
                             onClick={() => this.onChangePermissionLevel(level)}
                         >
                             <div>
-                                <strong>{permissionLevels[level].label}</strong>
-                                <small className="usm-menu-description"> {permissionLevels[level].description} </small>
+                                <span>{permissionLevels[level].label}</span>
                             </div>
                         </SelectMenuItem>
                     ))}

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -30,7 +30,7 @@ import type {
     tooltipComponentIdentifierType,
     USMConfig,
 } from './flowTypes';
-import { PEOPLE_IN_ITEM, ANYONE_WITH_LINK, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from './constants';
+import { PEOPLE_IN_ITEM, ANYONE_WITH_LINK, CAN_EDIT, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from './constants';
 
 type Props = {
     addSharedLink: () => void,
@@ -193,6 +193,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             canChangeAccessLevel,
             enterpriseName,
             isEditAllowed,
+            isEditSettingAvailable,
             isDownloadSettingAvailable,
             permissionLevel,
             url,
@@ -218,7 +219,7 @@ class SharedLinkSection extends React.Component<Props, State> {
         const hideEmailButton = config && config.showEmailSharedLinkForm === false;
 
         const isEditableBoxNote = isBoxNote(convertToBoxItem(item)) && isEditAllowed;
-        let allowedPermissionLevels = [CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];
+        let allowedPermissionLevels = [CAN_EDIT, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];
 
         if (!canChangeAccessLevel) {
             // remove all but current level
@@ -228,6 +229,11 @@ class SharedLinkSection extends React.Component<Props, State> {
         // if we cannot set the download value, we remove this option from the dropdown
         if (!isDownloadSettingAvailable) {
             allowedPermissionLevels = allowedPermissionLevels.filter(level => level !== CAN_VIEW_DOWNLOAD);
+        }
+
+        // if the user cannot edit, we remove this option from the dropdown
+        if (!isEditSettingAvailable) {
+            allowedPermissionLevels = allowedPermissionLevels.filter(level => level !== CAN_EDIT);
         }
 
         return (

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -42,6 +42,7 @@ type Props = {
     ) => Promise<{ permissionLevel: permissionLevelType }>,
     config?: USMConfig,
     intl: any,
+    isAllowEditSharedLinkForFileEnabled: boolean,
     item: itemtype,
     itemType: ItemType,
     onCopyError?: () => void,
@@ -172,6 +173,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             changeSharedLinkAccessLevel,
             changeSharedLinkPermissionLevel,
             config,
+            isAllowEditSharedLinkForFileEnabled,
             item,
             itemType,
             intl,
@@ -232,7 +234,7 @@ class SharedLinkSection extends React.Component<Props, State> {
         }
 
         // if the user cannot edit, we remove this option from the dropdown
-        if (!isEditSettingAvailable) {
+        if (!isEditSettingAvailable || !isAllowEditSharedLinkForFileEnabled) {
             allowedPermissionLevels = allowedPermissionLevels.filter(level => level !== CAN_EDIT);
         }
 

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -616,6 +616,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             getSharedLinkContacts,
             getContactAvatarUrl,
             intl,
+            isAllowEditSharedLinkForFileEnabled,
             isFetching,
             item,
             onAddLink,
@@ -659,6 +660,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             changeSharedLinkAccessLevel={changeSharedLinkAccessLevel}
                             changeSharedLinkPermissionLevel={changeSharedLinkPermissionLevel}
                             intl={intl}
+                            isAllowEditSharedLinkForFileEnabled={isAllowEditSharedLinkForFileEnabled}
                             item={item}
                             itemType={item.type}
                             onDismissTooltip={onDismissTooltip}

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -26,6 +26,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
     static defaultProps = {
         displayInModal: true,
         initiallySelectedContacts: [],
+        isAllowEditSharedLinkForFileEnabled: false,
         createSharedLinkOnLoad: false,
         focusSharedLinkOnLoad: false,
         restrictedExternalCollabEmails: [],

--- a/src/features/unified-share-modal/__tests__/SharedLinkPermissionMenu.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkPermissionMenu.test.js
@@ -1,13 +1,21 @@
 import React from 'react';
 
-import { CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from '../constants';
+import { CAN_EDIT, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from '../constants';
 import SharedLinkPermissionMenu from '../SharedLinkPermissionMenu';
 
 describe('features/unified-share-modal/SharedLinkPermissionMenu', () => {
-    const allowedPermissionLevels = [CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];
+    const allowedPermissionLevels = [CAN_EDIT, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];
 
     describe('render()', () => {
         [
+            {
+                submitting: true,
+                permissionLevel: CAN_EDIT,
+            },
+            {
+                submitting: false,
+                permissionLevel: CAN_EDIT,
+            },
             {
                 submitting: true,
                 permissionLevel: CAN_VIEW_DOWNLOAD,

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -185,6 +185,29 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
             expect(wrapper).toMatchSnapshot();
         });
     });
+    [
+        {
+            isEditSettingAvailable: true,
+        },
+        {
+            isEditSettingAvailable: false,
+        },
+    ].forEach(({ isEditSettingAvailable }) => {
+        test('should render proper list of permission options based on the the edit setting availability', () => {
+            const wrapper = getWrapper({
+                sharedLink: {
+                    accessLevel: 'peopleInYourCompany',
+                    canChangeAccessLevel: true,
+                    enterpriseName: 'Box',
+                    isEditSettingAvailable,
+                    expirationTimestamp: 0,
+                    url: 'https://example.com/shared-link',
+                },
+            });
+
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
 
     test('should render disabled create shared link message when item share is false and url is empty', () => {
         const sharedLink = { url: '', canChangeAccessLevel: true };

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
@@ -12,6 +12,142 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
   >
     <MenuToggle>
       <FormattedMessage
+        defaultMessage="Can edit"
+        id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+      />
+    </MenuToggle>
+  </PlainButton>
+  <Menu
+    className="ums-share-permissions-menu"
+    isHidden={false}
+    isSubmenu={false}
+  >
+    <SelectMenuItem
+      isSelected={true}
+      key="canEdit"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can edit"
+            id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
+      isSelected={false}
+      key="canViewDownload"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can view and download"
+            id="boxui.unifiedShare.sharedLinkPermissionsViewDownload"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
+      isSelected={false}
+      key="canViewOnly"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can view only"
+            id="boxui.unifiedShare.sharedLinkPermissionsViewOnly"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+  </Menu>
+</DropdownMenu>
+`;
+
+exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 2`] = `
+<DropdownMenu
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isRightAligned={false}
+>
+  <PlainButton
+    className="lnk"
+    disabled={false}
+  >
+    <MenuToggle>
+      <FormattedMessage
+        defaultMessage="Can edit"
+        id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+      />
+    </MenuToggle>
+  </PlainButton>
+  <Menu
+    className="ums-share-permissions-menu"
+    isHidden={false}
+    isSubmenu={false}
+  >
+    <SelectMenuItem
+      isSelected={true}
+      key="canEdit"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can edit"
+            id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
+      isSelected={false}
+      key="canViewDownload"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can view and download"
+            id="boxui.unifiedShare.sharedLinkPermissionsViewDownload"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
+      isSelected={false}
+      key="canViewOnly"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can view only"
+            id="boxui.unifiedShare.sharedLinkPermissionsViewOnly"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+  </Menu>
+</DropdownMenu>
+`;
+
+exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 3`] = `
+<DropdownMenu
+  constrainToScrollParent={false}
+  constrainToWindow={true}
+  isRightAligned={false}
+>
+  <PlainButton
+    className="lnk is-disabled bdl-is-disabled"
+    disabled={true}
+  >
+    <MenuToggle>
+      <FormattedMessage
         defaultMessage="Can view and download"
         id="boxui.unifiedShare.sharedLinkPermissionsViewDownload"
       />
@@ -23,27 +159,31 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
     isSubmenu={false}
   >
     <SelectMenuItem
+      isSelected={false}
+      key="canEdit"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can edit"
+            id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
       isSelected={true}
       key="canViewDownload"
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownload"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view and download"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -52,29 +192,19 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnly"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view only"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
   </Menu>
 </DropdownMenu>
 `;
 
-exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 2`] = `
+exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 4`] = `
 <DropdownMenu
   constrainToScrollParent={false}
   constrainToWindow={true}
@@ -97,27 +227,31 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
     isSubmenu={false}
   >
     <SelectMenuItem
+      isSelected={false}
+      key="canEdit"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can edit"
+            id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
       isSelected={true}
       key="canViewDownload"
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownload"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view and download"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -126,29 +260,19 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnly"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view only"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
   </Menu>
 </DropdownMenu>
 `;
 
-exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 3`] = `
+exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 5`] = `
 <DropdownMenu
   constrainToScrollParent={false}
   constrainToWindow={true}
@@ -172,26 +296,30 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
   >
     <SelectMenuItem
       isSelected={false}
+      key="canEdit"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can edit"
+            id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
+      isSelected={false}
       key="canViewDownload"
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownload"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view and download"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -200,29 +328,19 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnly"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view only"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
   </Menu>
 </DropdownMenu>
 `;
 
-exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 4`] = `
+exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it should render correct menu 6`] = `
 <DropdownMenu
   constrainToScrollParent={false}
   constrainToWindow={true}
@@ -246,26 +364,30 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
   >
     <SelectMenuItem
       isSelected={false}
+      key="canEdit"
+      onClick={[Function]}
+    >
+      <div>
+        <span>
+          <FormattedMessage
+            defaultMessage="Can edit"
+            id="boxui.unifiedShare.sharedLinkPermissionsEdit"
+          />
+        </span>
+      </div>
+    </SelectMenuItem>
+    <SelectMenuItem
+      isSelected={false}
       key="canViewDownload"
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view and download"
             id="boxui.unifiedShare.sharedLinkPermissionsViewDownload"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view and download"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -274,22 +396,12 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       onClick={[Function]}
     >
       <div>
-        <strong>
+        <span>
           <FormattedMessage
             defaultMessage="Can view only"
             id="boxui.unifiedShare.sharedLinkPermissionsViewOnly"
           />
-        </strong>
-        <small
-          className="usm-menu-description"
-        >
-           
-          <FormattedMessage
-            defaultMessage="Users can view only"
-            id="boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription"
-          />
-           
-        </small>
+        </span>
       </div>
     </SelectMenuItem>
   </Menu>

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -1162,7 +1162,6 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <SharedLinkPermissionMenu
       allowedPermissionLevels={
         Array [
-          "canEdit",
           "canViewOnly",
         ]
       }

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -1041,6 +1041,281 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
 </div>
 `;
 
+exports[`features/unified-share-modal/SharedLinkSection should render proper list of permission options based on the the edit setting availability 1`] = `
+<div
+  className="be"
+>
+  <hr
+    className="bdl-SharedLinkSection-separator"
+  />
+  <label>
+    <span
+      className="label bdl-Label"
+    >
+      <FormattedMessage
+        defaultMessage="Share Link"
+        id="boxui.unifiedShare.sharedLinkSectionLabel"
+      />
+    </span>
+  </label>
+  <div
+    className="shared-link-toggle-row"
+  >
+    <div
+      className="share-toggle-container"
+    >
+      <Toggle
+        isDisabled={false}
+        isOn={true}
+        label={
+          <FormattedMessage
+            defaultMessage="Shared link is created"
+            id="boxui.unifiedShare.linkShareOn"
+          />
+        }
+        name="toggle"
+      />
+    </div>
+  </div>
+  <div
+    className="shared-link-field-row"
+  >
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        triggerCopyOnLoad={false}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      position="top-left"
+      text={
+        <FormattedMessage
+          defaultMessage="Send Shared Link"
+          id="boxui.unifiedShare.sendSharedLink"
+        />
+      }
+      theme="default"
+    >
+      <Button
+        className="email-shared-link-btn"
+        isLoading={false}
+        showRadar={false}
+        type="button"
+      >
+        <IconMail />
+      </Button>
+    </Tooltip>
+  </div>
+  <div
+    className="shared-link-access-row"
+  >
+    <SharedLinkAccessMenu
+      accessLevel="peopleInYourCompany"
+      accessLevelsDisabledReason={Object {}}
+      allowedAccessLevels={Object {}}
+      changeAccessLevel={[Function]}
+      enterpriseName="Box"
+      itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
+      trackingProps={
+        Object {
+          "onChangeSharedLinkAccessLevel": undefined,
+          "onSharedLinkAccessMenuOpen": undefined,
+          "sharedLinkAccessMenuButtonProps": undefined,
+        }
+      }
+    />
+    <SharedLinkPermissionMenu
+      allowedPermissionLevels={
+        Array [
+          "canEdit",
+          "canViewOnly",
+        ]
+      }
+      canChangePermissionLevel={true}
+      changePermissionLevel={[Function]}
+      trackingProps={
+        Object {
+          "onChangeSharedLinkPermissionLevel": undefined,
+          "sharedLinkPermissionsMenuButtonProps": undefined,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`features/unified-share-modal/SharedLinkSection should render proper list of permission options based on the the edit setting availability 2`] = `
+<div
+  className="be"
+>
+  <hr
+    className="bdl-SharedLinkSection-separator"
+  />
+  <label>
+    <span
+      className="label bdl-Label"
+    >
+      <FormattedMessage
+        defaultMessage="Share Link"
+        id="boxui.unifiedShare.sharedLinkSectionLabel"
+      />
+    </span>
+  </label>
+  <div
+    className="shared-link-toggle-row"
+  >
+    <div
+      className="share-toggle-container"
+    >
+      <Toggle
+        isDisabled={false}
+        isOn={true}
+        label={
+          <FormattedMessage
+            defaultMessage="Shared link is created"
+            id="boxui.unifiedShare.linkShareOn"
+          />
+        }
+        name="toggle"
+      />
+    </div>
+  </div>
+  <div
+    className="shared-link-field-row"
+  >
+    <Tooltip
+      className="usm-ftux-tooltip"
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      isShown={false}
+      onDismiss={[Function]}
+      position="middle-right"
+      showCloseButton={true}
+      theme="callout"
+    >
+      <TextInputWithCopyButton
+        autofocus={false}
+        buttonDefaultText={
+          <FormattedMessage
+            defaultMessage="Copy"
+            id="boxui.core.copy"
+          />
+        }
+        buttonProps={Object {}}
+        buttonSuccessText={
+          <FormattedMessage
+            defaultMessage="Copied"
+            id="boxui.core.copied"
+          />
+        }
+        className="shared-link-field-container"
+        hideOptionalLabel={true}
+        label=""
+        readOnly={true}
+        successStateDuration={3000}
+        triggerCopyOnLoad={false}
+        type="url"
+        value="https://example.com/shared-link"
+      />
+    </Tooltip>
+    <Tooltip
+      constrainToScrollParent={false}
+      constrainToWindow={true}
+      isDisabled={false}
+      position="top-left"
+      text={
+        <FormattedMessage
+          defaultMessage="Send Shared Link"
+          id="boxui.unifiedShare.sendSharedLink"
+        />
+      }
+      theme="default"
+    >
+      <Button
+        className="email-shared-link-btn"
+        isLoading={false}
+        showRadar={false}
+        type="button"
+      >
+        <IconMail />
+      </Button>
+    </Tooltip>
+  </div>
+  <div
+    className="shared-link-access-row"
+  >
+    <SharedLinkAccessMenu
+      accessLevel="peopleInYourCompany"
+      accessLevelsDisabledReason={Object {}}
+      allowedAccessLevels={Object {}}
+      changeAccessLevel={[Function]}
+      enterpriseName="Box"
+      itemType="file"
+      onDismissTooltip={[Function]}
+      tooltipContent={null}
+      trackingProps={
+        Object {
+          "onChangeSharedLinkAccessLevel": undefined,
+          "onSharedLinkAccessMenuOpen": undefined,
+          "sharedLinkAccessMenuButtonProps": undefined,
+        }
+      }
+    />
+    <SharedLinkPermissionMenu
+      allowedPermissionLevels={
+        Array [
+          "canViewOnly",
+        ]
+      }
+      canChangePermissionLevel={true}
+      changePermissionLevel={[Function]}
+      trackingProps={
+        Object {
+          "onChangeSharedLinkPermissionLevel": undefined,
+          "sharedLinkPermissionsMenuButtonProps": undefined,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`features/unified-share-modal/SharedLinkSection should render settings link when handler is provided and shared link is enabled 1`] = `
 <PlainButton
   className="shared-link-settings-btn"

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
@@ -61,6 +61,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -155,6 +156,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -249,6 +251,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -346,6 +349,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -440,6 +444,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -533,6 +538,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -627,6 +633,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -721,6 +728,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -815,6 +823,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -909,6 +918,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -1011,6 +1021,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -1105,6 +1116,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -1203,6 +1215,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={true}
       item={
         Object {
@@ -1300,6 +1313,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -1391,6 +1405,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           "Editor",
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -1486,6 +1501,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {
@@ -1585,6 +1601,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
           },
         ]
       }
+      isAllowEditSharedLinkForFileEnabled={false}
       isFetching={false}
       item={
         Object {

--- a/src/features/unified-share-modal/constants.js
+++ b/src/features/unified-share-modal/constants.js
@@ -6,6 +6,7 @@ const ANYONE_IN_COMPANY: 'peopleInYourCompany' = 'peopleInYourCompany';
 const PEOPLE_IN_ITEM: 'peopleInThisItem' = 'peopleInThisItem';
 
 // Shared link permission level constants
+const CAN_EDIT: 'canEdit' = 'canEdit';
 const CAN_VIEW_DOWNLOAD: 'canViewDownload' = 'canViewDownload';
 const CAN_VIEW_ONLY: 'canViewOnly' = 'canViewOnly';
 
@@ -94,6 +95,7 @@ export {
     ALLOWED_ACCESS_LEVELS,
     ANYONE_IN_COMPANY,
     ANYONE_WITH_LINK,
+    CAN_EDIT,
     CAN_VIEW_DOWNLOAD,
     CAN_VIEW_ONLY,
     COLLAB_GROUP_TYPE,

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -12,6 +12,7 @@ const accessLevelValues = {
 export type accessLevelType = $Keys<typeof accessLevelValues>;
 
 const permissionLevelValues = {
+    [constants.CAN_EDIT]: 'CAN_EDIT',
     [constants.CAN_VIEW_DOWNLOAD]: 'CAN_VIEW_DOWNLOAD',
     [constants.CAN_VIEW_ONLY]: 'CAN_VIEW_ONLY',
 };

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -161,6 +161,7 @@ export type sharedLinkType = {
     isDownloadAllowed: boolean,
     isDownloadSettingAvailable: boolean,
     isEditAllowed: boolean,
+    isEditSettingAvailable: boolean,
     isNewSharedLink: boolean,
     isPreviewAllowed: boolean,
     permissionLevel: permissionLevelType,

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -372,7 +372,7 @@ export type USFProps = BaseUnifiedShareProps & {
     /** Function for closing the FTUX tooltip */
     handleFtuxCloseClick: () => void,
     /** Whether the allow edit shared link for file FF is enabled */
-    isAllowEditSharedLinkForFileEnabled?: boolean,
+    isAllowEditSharedLinkForFileEnabled: boolean,
     /** Whether the data for the USM/USF is being fetched */
     isFetching: boolean,
     /** Function for opening the Remove Link Confirm Modal */

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -357,6 +357,8 @@ export type USMProps = BaseUnifiedShareProps & {
     closeConfirmModal: () => void,
     /** Whether initial data for the USM has already been received */
     initialDataReceived: boolean,
+    /** Whether the allow edit shared link for file FF is enabled */
+    isAllowEditSharedLinkForFileEnabled?: boolean,
     /** Whether the USM is open */
     isOpen?: boolean,
     /** Handler function that removes the shared link, used in the Remove Link Confirm Modal */
@@ -369,6 +371,8 @@ export type USMProps = BaseUnifiedShareProps & {
 export type USFProps = BaseUnifiedShareProps & {
     /** Function for closing the FTUX tooltip */
     handleFtuxCloseClick: () => void,
+    /** Whether the allow edit shared link for file FF is enabled */
+    isAllowEditSharedLinkForFileEnabled?: boolean,
     /** Whether the data for the USM/USF is being fetched */
     isFetching: boolean,
     /** Function for opening the Remove Link Confirm Modal */

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -203,11 +203,6 @@ const messages = defineMessages({
         description: 'Label for a shared link permission level',
         id: 'boxui.unifiedShare.sharedLinkPermissionsViewDownload',
     },
-    sharedLinkPermissionsViewDownloadDescription: {
-        defaultMessage: 'Users can view and download',
-        description: 'Description for Can view and download option',
-        id: 'boxui.unifiedShare.sharedLinkPermissionsViewDownloadDescription',
-    },
     sharedLinkPermissionsViewOnly: {
         defaultMessage: 'Can view only',
         description: 'Label for a shared link permission level',
@@ -215,18 +210,13 @@ const messages = defineMessages({
     },
     sharedLinkPermissionsEdit: {
         defaultMessage: 'Can edit',
-        description: 'Label for a shared link permission to show for editable box notes',
+        description: 'Label for a shared link permission to show for an editable box note / file',
         id: 'boxui.unifiedShare.sharedLinkPermissionsEdit',
     },
     sharedLinkPermissionsEditTooltip: {
         defaultMessage: 'This permission can only be changed in Box Notes',
         description: 'Text to use in the tooltip when presenting an editable Box Note (DO NOT TRANSLATE "Box Notes")',
         id: 'boxui.unifiedShare.sharedLinkPermissionsEditTooltip',
-    },
-    sharedLinkPermissionsViewOnlyDescription: {
-        defaultMessage: 'Users can view only',
-        description: 'Description for Can view only option',
-        id: 'boxui.unifiedShare.sharedLinkPermissionsViewOnlyDescription',
     },
     sharedLinkDisabledTooltipCopy: {
         defaultMessage: 'Create and copy link for sharing',


### PR DESCRIPTION
**Changes in this PR:**
- [x] update SharedLinkPermissionMenu items to only show the label and not the description
- [x] removed related messages for SharedLinkPermissionMenu that are for the descriptions
- [x] add CAN_EDIT option to list of possible `allowedPermissionLevels`

**Demo:**
<img width="552" alt="Screen Shot 2021-08-11 at 3 29 16 PM" src="https://user-images.githubusercontent.com/7213887/129112942-b24751b3-3b9d-4d62-ba33-5dcd91d265bb.png">
