### PR TITLE
fix: error screen when preview is blocked by access policy

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -435,7 +435,7 @@ be.preview = Preview
 # Error message when Preview fails due to the files call.
 be.previewError = We’re sorry, the preview didn’t load. Please refresh the page.
 # Error message when Preview fails due to the files call which is blocked by an access policy.
-be.previewErrorBlockedByPolicy = Your access is restricted due to the classification applied to this content.
+be.previewErrorBlockedByPolicy = Your access to this content is restricted due to a security policy.
 # Message when new preview is available.
 be.previewUpdate = A new version of this file is available.
 # Previous file button title

--- a/scripts/styleguide.config.js
+++ b/scripts/styleguide.config.js
@@ -16,6 +16,7 @@ const allSections = [
             '../src/elements/content-open-with/ContentOpenWith.js',
             '../src/elements/content-picker/ContentPicker.js',
             '../src/elements/content-preview/ContentPreview.js',
+            '../src/elements/content-sharing/ContentSharing.js',
             '../src/elements/content-sidebar/ContentSidebar.js',
             '../src/elements/content-uploader/ContentUploader.js',
         ],
@@ -85,6 +86,7 @@ const allSections = [
 
             '../src/components/avatar/Avatar.tsx',
             '../src/components/badgeable/Badgeable.tsx',
+            '../src/components/category-selector/CategorySelector.tsx',
             '../src/components/label/Label.tsx',
             '../src/components/button/Button.tsx',
             '../src/components/button-group/ButtonGroup.tsx',
@@ -101,6 +103,7 @@ const allSections = [
             '../src/components/radio/RadioButton.tsx',
             '../src/components/radio/RadioGroup.tsx',
             '../src/components/menu/SelectMenuLinkItem.tsx',
+            '../src/components/time-input/TimeInput.tsx',
             '../src/components/tooltip/Tooltip.tsx',
         ],
         description: 'Box UI Elements components implement the reusable building blocks of the Box Design Language',
@@ -223,10 +226,13 @@ const allSections = [
     {
         name: 'Features',
         components: () => [
+            '../src/features/beta-feedback/BetaFeedbackBadge.js',
             '../src/features/classification/Classification.js',
+            '../src/features/collapsible-sidebar/CollapsibleSidebarLogo.js',
             '../src/features/invite-collaborators-modal/InviteCollaboratorsModal.js',
             '../src/features/left-sidebar/LeftSidebar.js',
             '../src/features/header-flyout/HeaderFlyout.js',
+            '../src/features/message-center/components/MessageCenter.js',
             '../src/features/presence/Presence.js',
             '../src/features/presence/PresenceLink.js',
             '../src/features/security-cloud-game/SecurityCloudGame.js',
@@ -235,6 +241,7 @@ const allSections = [
             '../src/features/shared-link-modal/SharedLinkModal.js',
             '../src/features/shared-link-settings-modal/SharedLinkSettingsModal.js',
             '../src/features/unified-share-modal/UnifiedShareModal.js',
+            '../src/features/virtualized-table-renderers/FormattedUser.js',
         ],
         sections: [
             {

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -40,7 +40,7 @@ const messages = defineMessages({
     previewErrorBlockedByPolicy: {
         id: 'be.previewErrorBlockedByPolicy',
         description: 'Error message when Preview fails due to the files call which is blocked by an access policy.',
-        defaultMessage: 'Your access is restricted due to the classification applied to this content.',
+        defaultMessage: 'Your access to this content is restricted due to a security policy.',
     },
     boxEditErrorBlockedByPolicy: {
         id: 'be.boxEditErrorBlockedByPolicy',

--- a/src/elements/content-preview/PreviewMask.tsx
+++ b/src/elements/content-preview/PreviewMask.tsx
@@ -17,7 +17,7 @@ export default function PreviewMask({ errorCode, extension, isLoading }: Props):
 
     return (
         <div className="bcpr-PreviewMask">
-            {errorCode ? <PreviewError /> : isLoading && <PreviewLoading extension={extension} />}
+            {errorCode ? <PreviewError errorCode={errorCode} /> : isLoading && <PreviewLoading extension={extension} />}
         </div>
     );
 }

--- a/src/elements/content-preview/__tests__/__snapshots__/PreviewError.test.js.snap
+++ b/src/elements/content-preview/__tests__/__snapshots__/PreviewError.test.js.snap
@@ -28,7 +28,7 @@ exports[`elements/content-preview/PreviewError render() should render correctly 
     className="bcpr-PreviewError-message"
   >
     <FormattedMessage
-      defaultMessage="Your access is restricted due to the classification applied to this content."
+      defaultMessage="Your access to this content is restricted due to a security policy."
       id="be.previewErrorBlockedByPolicy"
     />
   </div>


### PR DESCRIPTION
Fixes an issue where the errorType of preview errors wasn't being passed through. Now, the error screen looks like this when a user is blocked by an access policy:
<img width="500" alt="Screen Shot 2021-08-09 at 1 09 01 PM" src="https://user-images.githubusercontent.com/35543368/129645079-4793b4ad-7448-4b47-a9f1-7e0d35afd65c.png">
