### PR TITLE
feat(shared-link-section): add warning copy

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1590,6 +1590,8 @@ boxui.unifiedShare.sendSharedLinkFieldLabel = Email Shared Link
 boxui.unifiedShare.settingsButtonLabel = Open shared link settings popup
 # This tooltip appears over the shared link toggle, explaining what happens when it is clicked
 boxui.unifiedShare.sharedLinkDisabledTooltipCopy = Create and copy link for sharing
+# Text shown in share modal when shared link is editable and is open to public access
+boxui.unifiedShare.sharedLinkEditablePubliclyAvailable = Publicly available for anyone to view and download. Any logged in users with the link can edit.
 # Tooltip describing when this shared link will expire. {expiration, date, long} is the formatted date
 boxui.unifiedShare.sharedLinkExpirationTooltip = This link will expire and be inaccessible on {expiration, date, long}.
 # Label for a shared link permission to show for an editable box note / file

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -322,7 +322,17 @@ class SharedLinkSection extends React.Component<Props, State> {
                         <span className="security-indicator-icon-globe">
                             <IconGlobe height={12} width={12} />
                         </span>
-                        <FormattedMessage {...messages.sharedLinkPubliclyAvailable} />
+                        {permissionLevel === CAN_EDIT ? (
+                            <FormattedMessage
+                                data-testid="shared-link-editable-publicly-available-message"
+                                {...messages.sharedLinkEditablePubliclyAvailable}
+                            />
+                        ) : (
+                            <FormattedMessage
+                                data-testid="shared-link-publicly-available-message"
+                                {...messages.sharedLinkPubliclyAvailable}
+                            />
+                        )}
                     </div>
                 )}
             </>

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
+import { ANYONE_WITH_LINK, CAN_EDIT, CAN_VIEW_DOWNLOAD } from '../constants';
 
 import SharedLinkSection from '../SharedLinkSection';
 
@@ -52,6 +53,27 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
             }),
         ).toMatchSnapshot();
     });
+
+    test.each`
+        permissionLevel      | testID
+        ${CAN_EDIT}          | ${'shared-link-editable-publicly-available-message'}
+        ${CAN_VIEW_DOWNLOAD} | ${'shared-link-publicly-available-message'}
+    `(
+        'should render correct message based on permissionLevel and when accessLevel is ANYONE_WITH_LINK',
+        ({ testID, permissionLevel }) => {
+            const wrapper = getWrapper({
+                sharedLink: {
+                    accessLevel: ANYONE_WITH_LINK,
+                    canChangeAccessLevel: false,
+                    enterpriseName: 'Box',
+                    expirationTimestamp: 0,
+                    url: 'https://example.com/shared-link',
+                    permissionLevel,
+                },
+            });
+            expect(wrapper.find(`[data-testid="${testID}"]`).length).toEqual(1);
+        },
+    );
 
     test('should render a default component when there is a shared link but user lacks permission to toggle off', () => {
         const wrapper = getWrapper({

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -234,6 +234,12 @@ const messages = defineMessages({
         description: 'Text shown in share modal when shared link is open to public access',
         id: 'boxui.unifiedShare.sharedLinkPubliclyAvailable',
     },
+    sharedLinkEditablePubliclyAvailable: {
+        defaultMessage:
+            'Publicly available for anyone to view and download. Any logged in users with the link can edit.',
+        description: 'Text shown in share modal when shared link is editable and is open to public access',
+        id: 'boxui.unifiedShare.sharedLinkEditablePubliclyAvailable',
+    },
     upgradeGetMoreAccessControlsDescription: {
         defaultMessage:
             '62% of customers on your plan {upgradeGetMoreAccessControlsLink} to manage collaborators’ access and permission settings',


### PR DESCRIPTION
**Changes in this PR:**
- [x] in the new Editable Shared Links feature, users now have the ability to set the Edit option in the SharedLinkPermissionMenu dropdown in the Unified Share Modal. We want to add a new warning message when the access level is set to `ANYONE_WITH_LINK` and when the permissionLevel is set to `CAN_EDIT`. 

**Demo:**
<img width="513" alt="Screen Shot 2021-08-17 at 2 36 35 PM" src="https://user-images.githubusercontent.com/7213887/129807209-7d8a89a8-f7a9-4a77-bb28-a3ffeee7321c.png">

<img width="536" alt="Screen Shot 2021-08-17 at 2 36 43 PM" src="https://user-images.githubusercontent.com/7213887/129807205-eed4f274-20e2-430d-9a43-9088ff20469f.png">
