### PR TITLE
fix(buttons): highlighting button properly on focus

### DIFF
--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -121,7 +121,8 @@ button svg {
     &:not(.bdl-is-disabled),
     &:not(.is-disabled) {
         &:focus {
-            border-color: $primary-color;
+            background-color: lighten($primary-color, 8%);
+            border: 2px solid $primary-color;
             box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);
         }
 

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -122,7 +122,7 @@ button svg {
     &:not(.is-disabled) {
         &:focus {
             background-color: lighten($primary-color, 8%);
-            border: 2px solid $primary-color;
+            border: 1px solid $primary-color;
             box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);
         }
 


### PR DESCRIPTION
Buttons didn't receive proper focus behaviour, and looked
![image](https://user-images.githubusercontent.com/81333063/132248823-d515161b-cba4-4df2-9409-375431614150.png)

In order to highlight correctly I used the hover behavior so the focus outline is noticeable
![image](https://user-images.githubusercontent.com/81333063/132248840-8adcf55c-ea9e-4b8e-8ec1-d33d285286e8.png)