### PR TITLE
feat(shared-link-permission-menu): add ftux for shared link permission menu

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1511,7 +1511,7 @@ boxui.unifiedShare.ftuxNewUSMUserBody = We’ve simplified the sharing experienc
 # This title appears in the callout when loading the modal, to let users know about the new UI
 boxui.unifiedShare.ftuxNewUsmUserTitle = Simplified sharing for files and folders
 # Label for the LabelPill that is shown when the user first opens the SharedLinkPermissions dropdown and sees the Can Edit option
-boxui.unifiedShare.ftuxSharedLinkPermissionsEdit = NEW
+boxui.unifiedShare.ftuxSharedLinkPermissionsEditTag = NEW
 # Label for a Group contact type
 boxui.unifiedShare.groupLabel = Group
 # Invite Collaborators disabled state tooltip

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1510,6 +1510,8 @@ boxui.unifiedShare.ftuxLinkText = Read more about shared link security here.
 boxui.unifiedShare.ftuxNewUSMUserBody = We’ve simplified the sharing experience when you click 'Share'. Invite people to this item here and toggle the link on or off below for easy sharing.
 # This title appears in the callout when loading the modal, to let users know about the new UI
 boxui.unifiedShare.ftuxNewUsmUserTitle = Simplified sharing for files and folders
+# Label for the LabelPill that is shown when the user first opens the SharedLinkPermissions dropdown and sees the Can Edit option
+boxui.unifiedShare.ftuxSharedLinkPermissionsEdit = NEW
 # Label for a Group contact type
 boxui.unifiedShare.groupLabel = Group
 # Invite Collaborators disabled state tooltip

--- a/src/components/label-pill/LabelPill.scss
+++ b/src/components/label-pill/LabelPill.scss
@@ -41,6 +41,10 @@
     background-color: $bdl-watermelon-red-50;
 }
 
+.bdl-LabelPill--ftux {
+    background-color: $bdl-box-blue-20;
+}
+
 .bdl-LabelPill-iconContent {
     position: relative;
     top: 2px;

--- a/src/components/label-pill/LabelPill.stories.tsx
+++ b/src/components/label-pill/LabelPill.stories.tsx
@@ -11,6 +11,7 @@ const typeOptions: LabelPillStatus[] = [
     LabelPillStatus.DEFAULT,
     LabelPillStatus.ALERT,
     LabelPillStatus.ERROR,
+    LabelPillStatus.FTUX,
     LabelPillStatus.HIGHLIGHT,
     LabelPillStatus.INFO,
     LabelPillStatus.SUCCESS,
@@ -58,6 +59,9 @@ export const severalComponents = () => (
         <LabelPill.Pill type={LabelPillStatus.WARNING} size={select(sizeLabel, sizeOptions, LabelPillSize.REGULAR)}>
             <LabelPill.Icon Component={Shield16} />
             <LabelPill.Text>CONFIDENTIAL</LabelPill.Text>
+        </LabelPill.Pill>{' '}
+        <LabelPill.Pill type={LabelPillStatus.FTUX} size={select(sizeLabel, sizeOptions, LabelPillSize.REGULAR)}>
+            <LabelPill.Text>NEW</LabelPill.Text>
         </LabelPill.Pill>{' '}
         <LabelPill.Pill type={LabelPillStatus.ALERT} size={select(sizeLabel, sizeOptions, LabelPillSize.REGULAR)}>
             <LabelPill.Text>DUE JUL 9 AT 11:59 PM</LabelPill.Text>

--- a/src/components/label-pill/LabelPill.tsx
+++ b/src/components/label-pill/LabelPill.tsx
@@ -9,6 +9,7 @@ import './LabelPill.scss';
 export enum LabelPillStatus {
     DEFAULT = 'default',
     INFO = 'info',
+    FTUX = 'ftux',
     HIGHLIGHT = 'highlight',
     SUCCESS = 'success',
     WARNING = 'warning',

--- a/src/features/unified-share-modal/SharedLinkPermissionMenu.js
+++ b/src/features/unified-share-modal/SharedLinkPermissionMenu.js
@@ -8,10 +8,13 @@ import DropdownMenu, { MenuToggle } from '../../components/dropdown-menu';
 import LabelPill from '../../components/label-pill';
 import PlainButton from '../../components/plain-button';
 import { Menu, SelectMenuItem } from '../../components/menu';
+import type { TargetingApi } from '../targeting/types';
 
 import type { permissionLevelType } from './flowTypes';
 import { CAN_EDIT, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY } from './constants';
 import messages from './messages';
+
+import './SharedLinkPermissionMenu.scss';
 
 type Props = {
     allowedPermissionLevels: Array<permissionLevelType>,
@@ -21,6 +24,7 @@ type Props = {
     ) => Promise<{ permissionLevel: permissionLevelType }>,
     isEditableSharedLinkFTUXEnabled: boolean,
     permissionLevel?: permissionLevelType,
+    sharedLinkEditTagTargetingApi: TargetingApi,
     submitting: boolean,
     trackingProps: {
         onChangeSharedLinkPermissionLevel?: Function,
@@ -47,8 +51,15 @@ class SharedLinkPermissionMenu extends Component<Props> {
     };
 
     render() {
-        const { allowedPermissionLevels, permissionLevel, submitting, trackingProps } = this.props;
+        const {
+            allowedPermissionLevels,
+            permissionLevel,
+            sharedLinkEditTagTargetingApi,
+            submitting,
+            trackingProps,
+        } = this.props;
         const { sharedLinkPermissionsMenuButtonProps } = trackingProps;
+        const { canShow } = sharedLinkEditTagTargetingApi;
 
         if (!permissionLevel) {
             return null;
@@ -85,10 +96,10 @@ class SharedLinkPermissionMenu extends Component<Props> {
                             isSelected={level === permissionLevel}
                             onClick={() => this.onChangePermissionLevel(level)}
                         >
-                            <div>
+                            <div className="ums-share-permissions-menu-item">
                                 <span>{permissionLevels[level].label}</span>
-                                {level === CAN_EDIT && (
-                                    <LabelPill.Pill type="ftux">
+                                {level === CAN_EDIT && canShow && (
+                                    <LabelPill.Pill className="ftux-editable-shared-link" type="ftux">
                                         <LabelPill.Text>
                                             <FormattedMessage {...messages.ftuxSharedLinkPermissionsEdit} />
                                         </LabelPill.Text>

--- a/src/features/unified-share-modal/SharedLinkPermissionMenu.js
+++ b/src/features/unified-share-modal/SharedLinkPermissionMenu.js
@@ -22,7 +22,6 @@ type Props = {
     changePermissionLevel: (
         newPermissionLevel: permissionLevelType,
     ) => Promise<{ permissionLevel: permissionLevelType }>,
-    isEditableSharedLinkFTUXEnabled: boolean,
     permissionLevel?: permissionLevelType,
     sharedLinkEditTagTargetingApi?: TargetingApi,
     submitting: boolean,
@@ -101,7 +100,7 @@ class SharedLinkPermissionMenu extends Component<Props> {
                                 {level === CAN_EDIT && canShow && (
                                     <LabelPill.Pill className="ftux-editable-shared-link" type="ftux">
                                         <LabelPill.Text>
-                                            <FormattedMessage {...messages.ftuxSharedLinkPermissionsEdit} />
+                                            <FormattedMessage {...messages.ftuxSharedLinkPermissionsEditTag} />
                                         </LabelPill.Text>
                                     </LabelPill.Pill>
                                 )}

--- a/src/features/unified-share-modal/SharedLinkPermissionMenu.js
+++ b/src/features/unified-share-modal/SharedLinkPermissionMenu.js
@@ -24,7 +24,7 @@ type Props = {
     ) => Promise<{ permissionLevel: permissionLevelType }>,
     isEditableSharedLinkFTUXEnabled: boolean,
     permissionLevel?: permissionLevelType,
-    sharedLinkEditTagTargetingApi: TargetingApi,
+    sharedLinkEditTagTargetingApi?: TargetingApi,
     submitting: boolean,
     trackingProps: {
         onChangeSharedLinkPermissionLevel?: Function,
@@ -59,7 +59,7 @@ class SharedLinkPermissionMenu extends Component<Props> {
             trackingProps,
         } = this.props;
         const { sharedLinkPermissionsMenuButtonProps } = trackingProps;
-        const { canShow } = sharedLinkEditTagTargetingApi;
+        const canShow = sharedLinkEditTagTargetingApi ? sharedLinkEditTagTargetingApi.canShow : false;
 
         if (!permissionLevel) {
             return null;

--- a/src/features/unified-share-modal/SharedLinkPermissionMenu.js
+++ b/src/features/unified-share-modal/SharedLinkPermissionMenu.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
 import DropdownMenu, { MenuToggle } from '../../components/dropdown-menu';
+import LabelPill from '../../components/label-pill';
 import PlainButton from '../../components/plain-button';
 import { Menu, SelectMenuItem } from '../../components/menu';
 
@@ -18,6 +19,7 @@ type Props = {
     changePermissionLevel: (
         newPermissionLevel: permissionLevelType,
     ) => Promise<{ permissionLevel: permissionLevelType }>,
+    isEditableSharedLinkFTUXEnabled: boolean,
     permissionLevel?: permissionLevelType,
     submitting: boolean,
     trackingProps: {
@@ -85,6 +87,13 @@ class SharedLinkPermissionMenu extends Component<Props> {
                         >
                             <div>
                                 <span>{permissionLevels[level].label}</span>
+                                {level === CAN_EDIT && (
+                                    <LabelPill.Pill type="ftux">
+                                        <LabelPill.Text>
+                                            <FormattedMessage {...messages.ftuxSharedLinkPermissionsEdit} />
+                                        </LabelPill.Text>
+                                    </LabelPill.Pill>
+                                )}
                             </div>
                         </SelectMenuItem>
                     ))}

--- a/src/features/unified-share-modal/SharedLinkPermissionMenu.scss
+++ b/src/features/unified-share-modal/SharedLinkPermissionMenu.scss
@@ -1,0 +1,10 @@
+.ums-share-permissions-menu {
+    .ums-share-permissions-menu-item {
+        display: flex;
+        align-items: center;
+
+        .ftux-editable-shared-link {
+            margin-left: 10px;
+        }
+    }
+}

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -61,7 +61,7 @@ type Props = {
     onSettingsClick?: Function,
     onToggleSharedLink: Function,
     sharedLink: sharedLinkType,
-    sharedLinkEditTagTargetingApi: TargetingApi,
+    sharedLinkEditTagTargetingApi?: TargetingApi,
     showSharedLinkSettingsCallout: boolean,
     submitting: boolean,
     tooltips: { [componentIdentifier: tooltipComponentIdentifierType]: React.Node },

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -14,6 +14,7 @@ import IconClock from '../../icons/general/IconClock';
 import IconGlobe from '../../icons/general/IconGlobe';
 import { bdlWatermelonRed } from '../../styles/variables';
 import type { ItemType } from '../../common/types/core';
+import type { TargetingApi } from '../targeting/types';
 import { isBoxNote } from '../../utils/file';
 import Browser from '../../utils/Browser';
 
@@ -60,6 +61,7 @@ type Props = {
     onSettingsClick?: Function,
     onToggleSharedLink: Function,
     sharedLink: sharedLinkType,
+    sharedLinkEditTagTargetingApi: TargetingApi,
     showSharedLinkSettingsCallout: boolean,
     submitting: boolean,
     tooltips: { [componentIdentifier: tooltipComponentIdentifierType]: React.Node },
@@ -204,6 +206,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             onDismissTooltip,
             onEmailSharedLinkClick,
             sharedLink,
+            sharedLinkEditTagTargetingApi,
             submitting,
             trackingProps,
             triggerCopyOnLoad,
@@ -326,6 +329,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                             canChangePermissionLevel={canChangeAccessLevel}
                             changePermissionLevel={changeSharedLinkPermissionLevel}
                             permissionLevel={permissionLevel}
+                            sharedLinkEditTagTargetingApi={sharedLinkEditTagTargetingApi}
                             submitting={submitting}
                             trackingProps={{
                                 onChangeSharedLinkPermissionLevel,

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -627,6 +627,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             onSettingsClick,
             sendSharedLinkError,
             sharedLink,
+            sharedLinkEditTagTargetingApi,
             showEnterEmailsCallout = false,
             showSharedLinkSettingsCallout = false,
             submitting,
@@ -671,6 +672,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             onCopySuccess={onCopySuccess}
                             onCopyError={onCopyError}
                             sharedLink={sharedLink}
+                            sharedLinkEditTagTargetingApi={sharedLinkEditTagTargetingApi}
                             showSharedLinkSettingsCallout={showSharedLinkSettingsCallout}
                             submitting={submitting || isFetching}
                             trackingProps={sharedLinkTracking}

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -128,6 +128,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
     };
 
     renderUSF = () => {
+        const { sharedLinkEditTagTargetingApi } = this.props;
         const { isFetching, sharedLinkLoaded, shouldRenderFTUXTooltip } = this.state;
         return (
             <UnifiedShareForm
@@ -135,6 +136,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
                 handleFtuxCloseClick={this.handleFtuxCloseClick}
                 isFetching={isFetching}
                 openConfirmModal={this.openConfirmModal}
+                sharedLinkEditTagTargetingApi={sharedLinkEditTagTargetingApi}
                 sharedLinkLoaded={sharedLinkLoaded}
                 shouldRenderFTUXTooltip={shouldRenderFTUXTooltip}
             />

--- a/src/features/unified-share-modal/__tests__/SharedLinkPermissionMenu.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkPermissionMenu.test.js
@@ -5,6 +5,9 @@ import SharedLinkPermissionMenu from '../SharedLinkPermissionMenu';
 
 describe('features/unified-share-modal/SharedLinkPermissionMenu', () => {
     const allowedPermissionLevels = [CAN_EDIT, CAN_VIEW_DOWNLOAD, CAN_VIEW_ONLY];
+    const defaultSharedLinkEditTagTargetingApi = {
+        canShow: false,
+    };
 
     describe('render()', () => {
         [
@@ -40,6 +43,7 @@ describe('features/unified-share-modal/SharedLinkPermissionMenu', () => {
                         canChangePermissionLevel
                         changePermissionLevel={() => {}}
                         permissionLevel={permissionLevel}
+                        sharedLinkEditTagTargetingApi={defaultSharedLinkEditTagTargetingApi}
                         submitting={submitting}
                     />,
                 );
@@ -55,11 +59,30 @@ describe('features/unified-share-modal/SharedLinkPermissionMenu', () => {
                     canChangePermissionLevel
                     changePermissionLevel={() => {}}
                     permissionLevel=""
+                    sharedLinkEditTagTargetingApi={defaultSharedLinkEditTagTargetingApi}
                     submitting={false}
                 />,
             );
 
             expect(emptySharedLinkPermissionMenu).toMatchSnapshot();
+        });
+
+        test.each`
+            canShow  | length | should
+            ${true}  | ${1}   | ${'should render LabelPillText if canShow is true'}
+            ${false} | ${0}   | ${'should not render LabelPillText if canShow is false'}
+        `('$should ', ({ canShow, length }) => {
+            const wrapper = shallow(
+                <SharedLinkPermissionMenu
+                    allowedPermissionLevels={allowedPermissionLevels}
+                    changePermissionLevel={() => {}}
+                    permissionLevel={CAN_EDIT}
+                    sharedLinkEditTagTargetingApi={{ canShow }}
+                    submitting={false}
+                />,
+            );
+
+            expect(wrapper.find('LabelPillText')).toHaveLength(length);
         });
     });
 
@@ -73,6 +96,7 @@ describe('features/unified-share-modal/SharedLinkPermissionMenu', () => {
                     canChangePermissionLevel={false}
                     changePermissionLevel={permissionLevelSpy}
                     permissionLevel={CAN_VIEW_DOWNLOAD}
+                    sharedLinkEditTagTargetingApi={defaultSharedLinkEditTagTargetingApi}
                     submitting={false}
                     trackingProps={{
                         onChangeSharedLinkPermissionLevel: changeMenuMock,
@@ -95,6 +119,7 @@ describe('features/unified-share-modal/SharedLinkPermissionMenu', () => {
                     canChangePermissionLevel={false}
                     changePermissionLevel={permissionLevelSpy}
                     permissionLevel={CAN_VIEW_ONLY}
+                    sharedLinkEditTagTargetingApi={defaultSharedLinkEditTagTargetingApi}
                     submitting={false}
                     trackingProps={{
                         onChangeSharedLinkPermissionLevel: changeMenuMock,

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
@@ -34,16 +34,6 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
-        <LabelPill
-          type="ftux"
-        >
-          <LabelPillText>
-            <FormattedMessage
-              defaultMessage="NEW"
-              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
-            />
-          </LabelPillText>
-        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -112,16 +102,6 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
-        <LabelPill
-          type="ftux"
-        >
-          <LabelPillText>
-            <FormattedMessage
-              defaultMessage="NEW"
-              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
-            />
-          </LabelPillText>
-        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -190,16 +170,6 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
-        <LabelPill
-          type="ftux"
-        >
-          <LabelPillText>
-            <FormattedMessage
-              defaultMessage="NEW"
-              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
-            />
-          </LabelPillText>
-        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -268,16 +238,6 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
-        <LabelPill
-          type="ftux"
-        >
-          <LabelPillText>
-            <FormattedMessage
-              defaultMessage="NEW"
-              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
-            />
-          </LabelPillText>
-        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -346,16 +306,6 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
-        <LabelPill
-          type="ftux"
-        >
-          <LabelPillText>
-            <FormattedMessage
-              defaultMessage="NEW"
-              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
-            />
-          </LabelPillText>
-        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -424,16 +374,6 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
-        <LabelPill
-          type="ftux"
-        >
-          <LabelPillText>
-            <FormattedMessage
-              defaultMessage="NEW"
-              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
-            />
-          </LabelPillText>
-        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
@@ -27,7 +27,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canEdit"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can edit"
@@ -41,7 +43,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewDownload"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view and download"
@@ -55,7 +59,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewOnly"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view only"
@@ -95,7 +101,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canEdit"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can edit"
@@ -109,7 +117,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewDownload"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view and download"
@@ -123,7 +133,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewOnly"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view only"
@@ -163,7 +175,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canEdit"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can edit"
@@ -177,7 +191,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewDownload"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view and download"
@@ -191,7 +207,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewOnly"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view only"
@@ -231,7 +249,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canEdit"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can edit"
@@ -245,7 +265,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewDownload"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view and download"
@@ -259,7 +281,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewOnly"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view only"
@@ -299,7 +323,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canEdit"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can edit"
@@ -313,7 +339,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewDownload"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view and download"
@@ -327,7 +355,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewOnly"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view only"
@@ -367,7 +397,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canEdit"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can edit"
@@ -381,7 +413,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewDownload"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view and download"
@@ -395,7 +429,9 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
       key="canViewOnly"
       onClick={[Function]}
     >
-      <div>
+      <div
+        className="ums-share-permissions-menu-item"
+      >
         <span>
           <FormattedMessage
             defaultMessage="Can view only"

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkPermissionMenu.test.js.snap
@@ -34,6 +34,16 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
+        <LabelPill
+          type="ftux"
+        >
+          <LabelPillText>
+            <FormattedMessage
+              defaultMessage="NEW"
+              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
+            />
+          </LabelPillText>
+        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -102,6 +112,16 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
+        <LabelPill
+          type="ftux"
+        >
+          <LabelPillText>
+            <FormattedMessage
+              defaultMessage="NEW"
+              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
+            />
+          </LabelPillText>
+        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -170,6 +190,16 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
+        <LabelPill
+          type="ftux"
+        >
+          <LabelPillText>
+            <FormattedMessage
+              defaultMessage="NEW"
+              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
+            />
+          </LabelPillText>
+        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -238,6 +268,16 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
+        <LabelPill
+          type="ftux"
+        >
+          <LabelPillText>
+            <FormattedMessage
+              defaultMessage="NEW"
+              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
+            />
+          </LabelPillText>
+        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -306,6 +346,16 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
+        <LabelPill
+          type="ftux"
+        >
+          <LabelPillText>
+            <FormattedMessage
+              defaultMessage="NEW"
+              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
+            />
+          </LabelPillText>
+        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem
@@ -374,6 +424,16 @@ exports[`features/unified-share-modal/SharedLinkPermissionMenu render() it shoul
             id="boxui.unifiedShare.sharedLinkPermissionsEdit"
           />
         </span>
+        <LabelPill
+          type="ftux"
+        >
+          <LabelPillText>
+            <FormattedMessage
+              defaultMessage="NEW"
+              id="boxui.unifiedShare.ftuxSharedLinkPermissionsEdit"
+            />
+          </LabelPillText>
+        </LabelPill>
       </div>
     </SelectMenuItem>
     <SelectMenuItem

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -366,6 +366,8 @@ export type USMProps = BaseUnifiedShareProps & {
     onRemoveLink: () => void,
     /** Handler function for when the USM is closed */
     onRequestClose?: Function,
+    /** Whether the FTUX tag should be rendered for the Can Edit option */
+    sharedLinkEditTagTargetingApi?: TargetingApi,
 };
 
 // Prop types for the Unified Share Form, passed from the Unified Share Modal
@@ -379,7 +381,7 @@ export type USFProps = BaseUnifiedShareProps & {
     /** Function for opening the Remove Link Confirm Modal */
     openConfirmModal: () => void,
     /** Whether the FTUX tag should be rendered for the Can Edit option */
-    sharedLinkEditTagTargetingApi: TargetingApi,
+    sharedLinkEditTagTargetingApi?: TargetingApi,
     /** Whether the shared link has loaded */
     sharedLinkLoaded: boolean,
     /** Whether the FTUX tooltip should be rendered */

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import * as constants from './constants';
 import type { BoxItemPermission, ItemType } from '../../common/types/core';
+import type { TargetingApi } from '../targeting/types';
 
 // DRY: Invert the constants so that we can construct the appropriate enum types
 const accessLevelValues = {
@@ -377,6 +378,8 @@ export type USFProps = BaseUnifiedShareProps & {
     isFetching: boolean,
     /** Function for opening the Remove Link Confirm Modal */
     openConfirmModal: () => void,
+    /** Whether the FTUX tag should be rendered for the Can Edit option */
+    sharedLinkEditTagTargetingApi: TargetingApi,
     /** Whether the shared link has loaded */
     sharedLinkLoaded: boolean,
     /** Whether the FTUX tooltip should be rendered */

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -208,11 +208,11 @@ const messages = defineMessages({
         description: 'Label for a shared link permission level',
         id: 'boxui.unifiedShare.sharedLinkPermissionsViewOnly',
     },
-    ftuxSharedLinkPermissionsEdit: {
+    ftuxSharedLinkPermissionsEditTag: {
         defaultMessage: 'NEW',
         description:
             'Label for the LabelPill that is shown when the user first opens the SharedLinkPermissions dropdown and sees the Can Edit option',
-        id: 'boxui.unifiedShare.ftuxSharedLinkPermissionsEdit',
+        id: 'boxui.unifiedShare.ftuxSharedLinkPermissionsEditTag',
     },
     sharedLinkPermissionsEdit: {
         defaultMessage: 'Can edit',

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -208,6 +208,12 @@ const messages = defineMessages({
         description: 'Label for a shared link permission level',
         id: 'boxui.unifiedShare.sharedLinkPermissionsViewOnly',
     },
+    ftuxSharedLinkPermissionsEdit: {
+        defaultMessage: 'NEW',
+        description:
+            'Label for the LabelPill that is shown when the user first opens the SharedLinkPermissions dropdown and sees the Can Edit option',
+        id: 'boxui.unifiedShare.ftuxSharedLinkPermissionsEdit',
+    },
     sharedLinkPermissionsEdit: {
         defaultMessage: 'Can edit',
         description: 'Label for a shared link permission to show for an editable box note / file',


### PR DESCRIPTION
**Changes in this PR:**
- [x] pass `sharedLinkEditTagTargetingApi` down from parent app that helps indicate when the `New` LabelPillText should be visible within the SharedLinkPermissionMenu component

**Demo:**
<img width="436" alt="Screen Shot 2021-09-01 at 1 53 20 PM" src="https://user-images.githubusercontent.com/7213887/131743578-36a02159-e3d6-4531-a226-0578cf6dd173.png">
