### PR TITLE
feat(shared-link-section): add tooltip ftux

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1504,6 +1504,10 @@ boxui.unifiedShare.enterAtLeastOneEmail = Enter at least one valid email
 boxui.unifiedShare.enterEmailAddressesCalloutText = Share this item with coworkers by entering their email addresses
 # This is label for the button so a user understands the new interface
 boxui.unifiedShare.ftuxConfirmLabel = Got it
+# Text for the body of the tooltip for the ftux experience when the edit option is available for the user
+boxui.unifiedShare.ftuxEditPermissionTooltipBody = Select the new edit option to easily share your file with people or groups.
+# Text for the title of the tooltip for the ftux experience when the edit option is available for the user
+boxui.unifiedShare.ftuxEditPermissionTooltipTitle = Collaboration made easy
 # Text on the link which allows to learn more about link security
 boxui.unifiedShare.ftuxLinkText = Read more about shared link security here.
 # This text describes the purpose of the new UI, using the button label to open the modal

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 
 import PlainButton from '../../components/plain-button';
 import Button from '../../components/button';
+import GuideTooltip from '../../components/guide-tooltip';
 import TextInputWithCopyButton from '../../components/text-input-with-copy-button';
 import Toggle from '../../components/toggle/Toggle';
 import Tooltip from '../../components/tooltip';
@@ -62,6 +63,7 @@ type Props = {
     onToggleSharedLink: Function,
     sharedLink: sharedLinkType,
     sharedLinkEditTagTargetingApi?: TargetingApi,
+    sharedLinkEditTooltipTargetingApi?: TargetingApi,
     showSharedLinkSettingsCallout: boolean,
     submitting: boolean,
     tooltips: { [componentIdentifier: tooltipComponentIdentifierType]: React.Node },
@@ -94,7 +96,14 @@ class SharedLinkSection extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        const { sharedLink, autoCreateSharedLink, addSharedLink, submitting } = this.props;
+        const {
+            sharedLink,
+            autoCreateSharedLink,
+            addSharedLink,
+            sharedLinkEditTooltipTargetingApi,
+            submitting,
+        } = this.props;
+        const { canShow, onShow } = sharedLinkEditTooltipTargetingApi;
 
         if (
             autoCreateSharedLink &&
@@ -106,6 +115,11 @@ class SharedLinkSection extends React.Component<Props, State> {
         ) {
             this.setState({ isAutoCreatingSharedLink: true });
             addSharedLink();
+        }
+
+        // if ESL ftux tooltip is showing on initial mount, we call onShow
+        if (canShow) {
+            onShow();
         }
     }
 
@@ -207,6 +221,7 @@ class SharedLinkSection extends React.Component<Props, State> {
             onEmailSharedLinkClick,
             sharedLink,
             sharedLinkEditTagTargetingApi,
+            sharedLinkEditTooltipTargetingApi,
             submitting,
             trackingProps,
             triggerCopyOnLoad,
@@ -324,18 +339,30 @@ class SharedLinkSection extends React.Component<Props, State> {
                         }}
                     />
                     {!isEditableBoxNote && accessLevel !== PEOPLE_IN_ITEM && (
-                        <SharedLinkPermissionMenu
-                            allowedPermissionLevels={allowedPermissionLevels}
-                            canChangePermissionLevel={canChangeAccessLevel}
-                            changePermissionLevel={changeSharedLinkPermissionLevel}
-                            permissionLevel={permissionLevel}
-                            sharedLinkEditTagTargetingApi={sharedLinkEditTagTargetingApi}
-                            submitting={submitting}
-                            trackingProps={{
-                                onChangeSharedLinkPermissionLevel,
-                                sharedLinkPermissionsMenuButtonProps,
+                        <GuideTooltip
+                            isShown={
+                                allowedPermissionLevels.includes(CAN_EDIT) && sharedLinkEditTooltipTargetingApi.canShow
+                            }
+                            title={intl.formatMessage(messages.ftuxEditPermissionTooltipTitle)}
+                            body={intl.formatMessage(messages.ftuxEditPermissionTooltipBody)}
+                            onDismiss={() => {
+                                const { onComplete } = sharedLinkEditTooltipTargetingApi;
+                                onComplete();
                             }}
-                        />
+                        >
+                            <SharedLinkPermissionMenu
+                                allowedPermissionLevels={allowedPermissionLevels}
+                                canChangePermissionLevel={canChangeAccessLevel}
+                                changePermissionLevel={changeSharedLinkPermissionLevel}
+                                permissionLevel={permissionLevel}
+                                sharedLinkEditTagTargetingApi={sharedLinkEditTagTargetingApi}
+                                submitting={submitting}
+                                trackingProps={{
+                                    onChangeSharedLinkPermissionLevel,
+                                    sharedLinkPermissionsMenuButtonProps,
+                                }}
+                            />
+                        </GuideTooltip>
                     )}
                     {isEditableBoxNote && (
                         <Tooltip text={<FormattedMessage {...messages.sharedLinkPermissionsEditTooltip} />}>

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -103,7 +103,6 @@ class SharedLinkSection extends React.Component<Props, State> {
             sharedLinkEditTooltipTargetingApi,
             submitting,
         } = this.props;
-        const { canShow, onShow } = sharedLinkEditTooltipTargetingApi;
 
         if (
             autoCreateSharedLink &&
@@ -118,7 +117,8 @@ class SharedLinkSection extends React.Component<Props, State> {
         }
 
         // if ESL ftux tooltip is showing on initial mount, we call onShow
-        if (canShow) {
+        if (sharedLinkEditTooltipTargetingApi && sharedLinkEditTooltipTargetingApi.canShow) {
+            const { onShow } = sharedLinkEditTooltipTargetingApi;
             onShow();
         }
     }
@@ -341,13 +341,15 @@ class SharedLinkSection extends React.Component<Props, State> {
                     {!isEditableBoxNote && accessLevel !== PEOPLE_IN_ITEM && (
                         <GuideTooltip
                             isShown={
-                                allowedPermissionLevels.includes(CAN_EDIT) && sharedLinkEditTooltipTargetingApi.canShow
+                                allowedPermissionLevels.includes(CAN_EDIT) && sharedLinkEditTooltipTargetingApi?.canShow
                             }
                             title={intl.formatMessage(messages.ftuxEditPermissionTooltipTitle)}
                             body={intl.formatMessage(messages.ftuxEditPermissionTooltipBody)}
                             onDismiss={() => {
-                                const { onComplete } = sharedLinkEditTooltipTargetingApi;
-                                onComplete();
+                                if (sharedLinkEditTooltipTargetingApi) {
+                                    const { onComplete } = sharedLinkEditTooltipTargetingApi;
+                                    onComplete();
+                                }
                             }}
                         >
                             <SharedLinkPermissionMenu

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -628,6 +628,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             sendSharedLinkError,
             sharedLink,
             sharedLinkEditTagTargetingApi,
+            sharedLinkEditTooltipTargetingApi,
             showEnterEmailsCallout = false,
             showSharedLinkSettingsCallout = false,
             submitting,
@@ -673,6 +674,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             onCopyError={onCopyError}
                             sharedLink={sharedLink}
                             sharedLinkEditTagTargetingApi={sharedLinkEditTagTargetingApi}
+                            sharedLinkEditTooltipTargetingApi={sharedLinkEditTooltipTargetingApi}
                             showSharedLinkSettingsCallout={showSharedLinkSettingsCallout}
                             submitting={submitting || isFetching}
                             trackingProps={sharedLinkTracking}

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -128,7 +128,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
     };
 
     renderUSF = () => {
-        const { sharedLinkEditTagTargetingApi } = this.props;
+        const { sharedLinkEditTagTargetingApi, sharedLinkEditTooltipTargetingApi } = this.props;
         const { isFetching, sharedLinkLoaded, shouldRenderFTUXTooltip } = this.state;
         return (
             <UnifiedShareForm
@@ -137,6 +137,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
                 isFetching={isFetching}
                 openConfirmModal={this.openConfirmModal}
                 sharedLinkEditTagTargetingApi={sharedLinkEditTagTargetingApi}
+                sharedLinkEditTooltipTargetingApi={sharedLinkEditTooltipTargetingApi}
                 sharedLinkLoaded={sharedLinkLoaded}
                 shouldRenderFTUXTooltip={shouldRenderFTUXTooltip}
             />

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -54,6 +54,56 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
         ).toMatchSnapshot();
     });
 
+    test('should render GuideTooltip with isShown set to true if canShow is true', () => {
+        const wrapper = getWrapper({
+            isAllowEditSharedLinkForFileEnabled: true,
+            sharedLink: {
+                accessLevel: ANYONE_WITH_LINK,
+                canChangeAccessLevel: false,
+                enterpriseName: 'Box',
+                expirationTimestamp: 0,
+                isEditSettingAvailable: true,
+                permissionLevel: CAN_EDIT,
+                url: 'https://example.com/shared-link',
+            },
+            sharedLinkEditTooltipTargetingApi: {
+                canShow: true,
+                onComplete: jest.fn(),
+                onShow: jest.fn(),
+            },
+        });
+
+        expect(wrapper.find('GuideTooltip').props().isShown).toBe(true);
+    });
+
+    test('should call onComplete when GuideTooltip is dismissed', () => {
+        const onComplete = jest.fn();
+        const wrapper = getWrapper({
+            isAllowEditSharedLinkForFileEnabled: true,
+            sharedLink: {
+                accessLevel: ANYONE_WITH_LINK,
+                canChangeAccessLevel: false,
+                enterpriseName: 'Box',
+                expirationTimestamp: 0,
+                isEditSettingAvailable: true,
+                permissionLevel: CAN_EDIT,
+                url: 'https://example.com/shared-link',
+            },
+            sharedLinkEditTooltipTargetingApi: {
+                canShow: true,
+                onComplete,
+                onShow: jest.fn(),
+            },
+        });
+
+        wrapper
+            .find('GuideTooltip')
+            .dive()
+            .simulate('dismiss');
+
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
     test.each`
         permissionLevel      | testID
         ${CAN_EDIT}          | ${'shared-link-editable-publicly-available-message'}
@@ -289,6 +339,29 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
 
             expect(addSharedLink).toBeCalledTimes(0);
             expect(wrapper.state().isAutoCreatingSharedLink).toBe(false);
+        });
+
+        test('should call onShow when sharedLinkEditTooltipTargetingApi.canShow is true', () => {
+            const onShow = jest.fn();
+            getWrapper({
+                isAllowEditSharedLinkForFileEnabled: true,
+                sharedLink: {
+                    accessLevel: ANYONE_WITH_LINK,
+                    canChangeAccessLevel: false,
+                    enterpriseName: 'Box',
+                    expirationTimestamp: 0,
+                    isEditSettingAvailable: true,
+                    permissionLevel: CAN_EDIT,
+                    url: 'https://example.com/shared-link',
+                },
+                sharedLinkEditTooltipTargetingApi: {
+                    canShow: true,
+                    onComplete: jest.fn(),
+                    onShow,
+                },
+            });
+
+            expect(onShow).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -146,21 +146,26 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
         }
       }
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={
-        Array [
-          "canViewOnly",
-        ]
-      }
-      canChangePermissionLevel={true}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
+    <GuideTooltip
+      isShown={false}
+      onDismiss={[Function]}
+    >
+      <SharedLinkPermissionMenu
+        allowedPermissionLevels={
+          Array [
+            "canViewOnly",
+          ]
         }
-      }
-    />
+        canChangePermissionLevel={true}
+        changePermissionLevel={[Function]}
+        trackingProps={
+          Object {
+            "onChangeSharedLinkPermissionLevel": undefined,
+            "sharedLinkPermissionsMenuButtonProps": undefined,
+          }
+        }
+      />
+    </GuideTooltip>
   </div>
 </div>
 `;
@@ -298,17 +303,22 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
         }
       }
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={Array []}
-      canChangePermissionLevel={false}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
+    <GuideTooltip
+      isShown={false}
+      onDismiss={[Function]}
+    >
+      <SharedLinkPermissionMenu
+        allowedPermissionLevels={Array []}
+        canChangePermissionLevel={false}
+        changePermissionLevel={[Function]}
+        trackingProps={
+          Object {
+            "onChangeSharedLinkPermissionLevel": undefined,
+            "sharedLinkPermissionsMenuButtonProps": undefined,
+          }
         }
-      }
-    />
+      />
+    </GuideTooltip>
   </div>
 </div>
 `;
@@ -484,21 +494,26 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         }
       }
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={
-        Array [
-          "canViewOnly",
-        ]
-      }
-      canChangePermissionLevel={true}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
+    <GuideTooltip
+      isShown={false}
+      onDismiss={[Function]}
+    >
+      <SharedLinkPermissionMenu
+        allowedPermissionLevels={
+          Array [
+            "canViewOnly",
+          ]
         }
-      }
-    />
+        canChangePermissionLevel={true}
+        changePermissionLevel={[Function]}
+        trackingProps={
+          Object {
+            "onChangeSharedLinkPermissionLevel": undefined,
+            "sharedLinkPermissionsMenuButtonProps": undefined,
+          }
+        }
+      />
+    </GuideTooltip>
   </div>
 </div>
 `;
@@ -884,22 +899,27 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         }
       }
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={
-        Array [
-          "canViewDownload",
-          "canViewOnly",
-        ]
-      }
-      canChangePermissionLevel={true}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
+    <GuideTooltip
+      isShown={false}
+      onDismiss={[Function]}
+    >
+      <SharedLinkPermissionMenu
+        allowedPermissionLevels={
+          Array [
+            "canViewDownload",
+            "canViewOnly",
+          ]
         }
-      }
-    />
+        canChangePermissionLevel={true}
+        changePermissionLevel={[Function]}
+        trackingProps={
+          Object {
+            "onChangeSharedLinkPermissionLevel": undefined,
+            "sharedLinkPermissionsMenuButtonProps": undefined,
+          }
+        }
+      />
+    </GuideTooltip>
   </div>
 </div>
 `;
@@ -1022,21 +1042,26 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         }
       }
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={
-        Array [
-          "canViewOnly",
-        ]
-      }
-      canChangePermissionLevel={true}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
+    <GuideTooltip
+      isShown={false}
+      onDismiss={[Function]}
+    >
+      <SharedLinkPermissionMenu
+        allowedPermissionLevels={
+          Array [
+            "canViewOnly",
+          ]
         }
-      }
-    />
+        canChangePermissionLevel={true}
+        changePermissionLevel={[Function]}
+        trackingProps={
+          Object {
+            "onChangeSharedLinkPermissionLevel": undefined,
+            "sharedLinkPermissionsMenuButtonProps": undefined,
+          }
+        }
+      />
+    </GuideTooltip>
   </div>
 </div>
 `;
@@ -1159,21 +1184,26 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         }
       }
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={
-        Array [
-          "canViewOnly",
-        ]
-      }
-      canChangePermissionLevel={true}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
+    <GuideTooltip
+      isShown={false}
+      onDismiss={[Function]}
+    >
+      <SharedLinkPermissionMenu
+        allowedPermissionLevels={
+          Array [
+            "canViewOnly",
+          ]
         }
-      }
-    />
+        canChangePermissionLevel={true}
+        changePermissionLevel={[Function]}
+        trackingProps={
+          Object {
+            "onChangeSharedLinkPermissionLevel": undefined,
+            "sharedLinkPermissionsMenuButtonProps": undefined,
+          }
+        }
+      />
+    </GuideTooltip>
   </div>
 </div>
 `;
@@ -1296,21 +1326,26 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         }
       }
     />
-    <SharedLinkPermissionMenu
-      allowedPermissionLevels={
-        Array [
-          "canViewOnly",
-        ]
-      }
-      canChangePermissionLevel={true}
-      changePermissionLevel={[Function]}
-      trackingProps={
-        Object {
-          "onChangeSharedLinkPermissionLevel": undefined,
-          "sharedLinkPermissionsMenuButtonProps": undefined,
+    <GuideTooltip
+      isShown={false}
+      onDismiss={[Function]}
+    >
+      <SharedLinkPermissionMenu
+        allowedPermissionLevels={
+          Array [
+            "canViewOnly",
+          ]
         }
-      }
-    />
+        canChangePermissionLevel={true}
+        changePermissionLevel={[Function]}
+        trackingProps={
+          Object {
+            "onChangeSharedLinkPermissionLevel": undefined,
+            "sharedLinkPermissionsMenuButtonProps": undefined,
+          }
+        }
+      />
+    </GuideTooltip>
   </div>
 </div>
 `;

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -368,6 +368,8 @@ export type USMProps = BaseUnifiedShareProps & {
     onRequestClose?: Function,
     /** Whether the FTUX tag should be rendered for the Can Edit option */
     sharedLinkEditTagTargetingApi?: TargetingApi,
+    /** Whether the FTUX tooltip should be rendered for Editable Shared Links  */
+    sharedLinkEditTooltipTargetingApi?: TargetingApi,
 };
 
 // Prop types for the Unified Share Form, passed from the Unified Share Modal
@@ -382,6 +384,8 @@ export type USFProps = BaseUnifiedShareProps & {
     openConfirmModal: () => void,
     /** Whether the FTUX tag should be rendered for the Can Edit option */
     sharedLinkEditTagTargetingApi?: TargetingApi,
+    /** Whether the FTUX tooltip should be rendered for Editable Shared Links  */
+    sharedLinkEditTooltipTargetingApi?: TargetingApi,
     /** Whether the shared link has loaded */
     sharedLinkLoaded: boolean,
     /** Whether the FTUX tooltip should be rendered */

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -55,6 +55,18 @@ const messages = defineMessages({
         description: 'This is label for the button so a user understands the new interface',
         id: 'boxui.unifiedShare.ftuxConfirmLabel',
     },
+    ftuxEditPermissionTooltipBody: {
+        defaultMessage: 'Select the new edit option to easily share your file with people or groups.',
+        description:
+            'Text for the body of the tooltip for the ftux experience when the edit option is available for the user',
+        id: 'boxui.unifiedShare.ftuxEditPermissionTooltipBody',
+    },
+    ftuxEditPermissionTooltipTitle: {
+        defaultMessage: 'Collaboration made easy',
+        description:
+            'Text for the title of the tooltip for the ftux experience when the edit option is available for the user',
+        id: 'boxui.unifiedShare.ftuxEditPermissionTooltipTitle',
+    },
     collaboratorListTitle: {
         defaultMessage: 'People in ‘{itemName}’',
         description: 'Title for collaborator list modal',


### PR DESCRIPTION
**Changes in this PR:**
- [x] add GuideTooltip in SharedLinkSection that will show up if the targetingApi indicates that `canShow` is set to true
- [x] the tooltip will be hidden when the tooltip is dismissed

**Demo:**
<img width="570" alt="Screen Shot 2021-09-08 at 10 34 36 AM" src="https://user-images.githubusercontent.com/7213887/132557296-186e3dc1-d4ba-455b-aea3-f1f7fad5b3ff.png">

