### PR TITLE
fix(metadata): added correct role for select button

### DIFF
--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -466,7 +466,7 @@ class BaseSelectField extends React.Component<Props, State> {
             onClick: this.handleButtonClick,
             onKeyDown: this.handleButtonKeyDown,
             // @NOTE: Technically, only text inputs should be combo-boxes but ARIA specs do not cover custom select dropdowns
-            role: 'combobox',
+            role: 'listbox',
             title: buttonText,
         };
 

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -97,7 +97,7 @@ describe('components/select-field/BaseSelectField', () => {
             expect(buttonWrapper.prop('aria-autocomplete')).toEqual('list');
             expect(buttonWrapper.prop('aria-expanded')).toBe(false);
             expect(buttonWrapper.prop('aria-owns')).toEqual(instance.selectFieldID);
-            expect(buttonWrapper.prop('role')).toEqual('combobox');
+            expect(buttonWrapper.prop('role')).toEqual('listbox');
             expect(buttonWrapper.prop('isDisabled')).toEqual(false);
         });
 

--- a/src/components/select-field/__tests__/__snapshots__/BaseSelectField.test.js.snap
+++ b/src/components/select-field/__tests__/__snapshots__/BaseSelectField.test.js.snap
@@ -10,7 +10,7 @@ exports[`components/select-field/BaseSelectField renderSelectButton() should sen
   isDisabled={false}
   onClick={[Function]}
   onKeyDown={[Function]}
-  role="combobox"
+  role="listbox"
   title=""
 />
 `;


### PR DESCRIPTION
Select Buttons used to have a combobox role 
<img width="945" alt="Screen Shot 2021-09-09 at 10 34 25" src="https://user-images.githubusercontent.com/81333063/132726603-b74561bb-a59b-43d9-bbea-da8f8b7fb476.png">

But according to WebAIM in order to be compliant with accessibility, the right role for the buttons is Listbox. So we updated the role accordingly :D 
<img width="1004" alt="Screen Shot 2021-09-09 at 10 34 01" src="https://user-images.githubusercontent.com/81333063/132726813-a43625e8-2408-44f5-97a5-b4d741e93b15.png">
