### PR TITLE
fix(metadata): add ariaLabel to button

### DIFF
--- a/src/features/metadata-instance-editor/Instance.js
+++ b/src/features/metadata-instance-editor/Instance.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import isEqual from 'lodash/isEqual';
 import cloneDeep from 'lodash/cloneDeep';
@@ -51,6 +51,7 @@ type Props = {
     data: MetadataFields,
     hasError: boolean,
     id: string,
+    intl: Object,
     isCascadingPolicyApplicable?: boolean,
     isDirty: boolean,
     isOpen: boolean,
@@ -549,7 +550,7 @@ class Instance extends React.PureComponent<Props, State> {
     }
 
     renderEditButton = () => {
-        const { isDirty }: Props = this.props;
+        const { isDirty, intl }: Props = this.props;
         const { isBusy }: State = this.state;
         const canEdit = this.canEdit();
         const isEditing = this.isEditing();
@@ -558,13 +559,15 @@ class Instance extends React.PureComponent<Props, State> {
         });
 
         if (canEdit && !isDirty && !isBusy) {
+            const metadataLabelEditText = intl.formatMessage(messages.metadataEditTooltip);
             return (
-                <Tooltip position="top-left" text={<FormattedMessage {...messages.metadataEditTooltip} />}>
+                <Tooltip position="top-left" text={metadataLabelEditText}>
                     <PlainButton
                         className={editClassName}
                         data-resin-target="metadata-instanceedit"
                         onClick={this.toggleIsEditing}
                         type="button"
+                        aria-label={metadataLabelEditText}
                     >
                         <IconEdit />
                     </PlainButton>
@@ -667,4 +670,5 @@ class Instance extends React.PureComponent<Props, State> {
     }
 }
 
-export default Instance;
+export { Instance as InstanceBase };
+export default injectIntl(Instance);

--- a/src/features/metadata-instance-editor/Instance.js
+++ b/src/features/metadata-instance-editor/Instance.js
@@ -550,7 +550,7 @@ class Instance extends React.PureComponent<Props, State> {
     }
 
     renderEditButton = () => {
-        const { isDirty, intl }: Props = this.props;
+        const { intl, isDirty }: Props = this.props;
         const { isBusy }: State = this.state;
         const canEdit = this.canEdit();
         const isEditing = this.isEditing();
@@ -563,11 +563,11 @@ class Instance extends React.PureComponent<Props, State> {
             return (
                 <Tooltip position="top-left" text={metadataLabelEditText}>
                     <PlainButton
+                        aria-label={metadataLabelEditText}
                         className={editClassName}
                         data-resin-target="metadata-instanceedit"
                         onClick={this.toggleIsEditing}
                         type="button"
-                        aria-label={metadataLabelEditText}
                     >
                         <IconEdit />
                     </PlainButton>

--- a/src/features/metadata-instance-editor/__tests__/Instance.test.js
+++ b/src/features/metadata-instance-editor/__tests__/Instance.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import TEMPLATE_CUSTOM_PROPERTIES from '../constants';
-import Instance from '../Instance';
+import { InstanceBase as Instance } from '../Instance';
 import { isValidValue } from '../../metadata-instance-fields/validateMetadataField';
 
 jest.mock('../../metadata-instance-fields/validateMetadataField');

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance.test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance.test.js.snap
@@ -17,12 +17,6 @@ exports[`features/metadata-instance-editor/fields/Instance collapsible isOpen pr
         constrainToWindow={true}
         isDisabled={false}
         position="top-left"
-        text={
-          <FormattedMessage
-            defaultMessage="Edit Metadata"
-            id="boxui.metadataInstanceEditor.editTooltip"
-          />
-        }
         theme="default"
       >
         <PlainButton
@@ -749,12 +743,6 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         constrainToWindow={true}
         isDisabled={false}
         position="top-left"
-        text={
-          <FormattedMessage
-            defaultMessage="Edit Metadata"
-            id="boxui.metadataInstanceEditor.editTooltip"
-          />
-        }
         theme="default"
       >
         <PlainButton
@@ -949,12 +937,6 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         constrainToWindow={true}
         isDisabled={false}
         position="top-left"
-        text={
-          <FormattedMessage
-            defaultMessage="Edit Metadata"
-            id="boxui.metadataInstanceEditor.editTooltip"
-          />
-        }
         theme="default"
       >
         <PlainButton
@@ -1058,12 +1040,6 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         constrainToWindow={true}
         isDisabled={false}
         position="top-left"
-        text={
-          <FormattedMessage
-            defaultMessage="Edit Metadata"
-            id="boxui.metadataInstanceEditor.editTooltip"
-          />
-        }
         theme="default"
       >
         <PlainButton


### PR DESCRIPTION
The edit button should have an attribute aria-label instead an attribute area-describedby.
And the value of aria-label should be the same as the Tooltip which is wrapping the button.

![image](https://user-images.githubusercontent.com/19536369/132742872-dd18708d-3ecb-4c31-a8e7-8c4a0cebebac.png)

