### PR TITLE
fix(headings): fixed headings hierarchy on version history

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsGroup.js
+++ b/src/elements/content-sidebar/versions/VersionsGroup.js
@@ -20,7 +20,7 @@ type Props = {
 const VersionsGroup = ({ heading, ...rest }: Props) => {
     return (
         <section className="bcs-VersionsGroup">
-            <h1 className="bcs-VersionsGroup-heading">{heading}</h1>
+            <h4 className="bcs-VersionsGroup-heading">{heading}</h4>
             <VersionsList {...rest} />
         </section>
     );


### PR DESCRIPTION
Currently, the time stamp heading is marked up with a H1 tag, which is semantically wrong (since there's one already)

<img width="887" alt="Screen Shot 2021-09-10 at 16 22 16" src="https://user-images.githubusercontent.com/81333063/132920092-85430427-374e-4c6b-abc8-873623655422.png">

This has been fixed and now its marked up with the H4 tag.
<img width="891" alt="Screen Shot 2021-09-10 at 16 21 57" src="https://user-images.githubusercontent.com/81333063/132920552-527eefe2-2c7a-4a4f-96d4-32b663297e94.png">

