### PR TITLE
fix(itemicon): Hide preview thumbnail for screen readers

### DIFF
--- a/src/icons/item-icon/ItemIcon.tsx
+++ b/src/icons/item-icon/ItemIcon.tsx
@@ -81,7 +81,16 @@ export interface ItemIconProps {
 
 const ItemIcon = ({ className, dimension = 32, iconType, title }: ItemIconProps) => {
     const IconComponent = (itemIconTable as { [key: string]: React.FC<SVGProps> })[iconType] || IconFileDefault;
-    return <IconComponent className={className} height={dimension} title={title} width={dimension} />;
+    return (
+        <IconComponent
+            className={className}
+            height={dimension}
+            title={title}
+            width={dimension}
+            aria-hidden="true"
+            role="presentation"
+        />
+    );
 };
 
 export default ItemIcon;

--- a/src/icons/item-icon/__tests__/__snapshots__/ItemIcon.test.tsx.snap
+++ b/src/icons/item-icon/__tests__/__snapshots__/ItemIcon.test.tsx.snap
@@ -2,8 +2,10 @@
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 1`] = `
 <FileAudio32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -11,8 +13,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 2`] = `
 <FileBookmark32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -20,8 +24,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 3`] = `
 <FileBoxNote32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -29,8 +35,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 4`] = `
 <FileCode32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -38,8 +46,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 5`] = `
 <FileDefault32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -47,8 +57,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 6`] = `
 <FileText32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -56,8 +68,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 7`] = `
 <FileDwg32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -65,8 +79,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 8`] = `
 <FileExcel32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -74,8 +90,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 9`] = `
 <FolderShared32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -83,8 +101,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 10`] = `
 <FolderExternal32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -92,8 +112,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 11`] = `
 <FolderPersonal32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -101,8 +123,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 12`] = `
 <FileDocs32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -110,8 +134,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 13`] = `
 <FileSheets32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -119,8 +145,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 14`] = `
 <FileSlides32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -128,8 +156,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 15`] = `
 <FileIllustrator32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -137,8 +167,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 16`] = `
 <FileImage32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -146,8 +178,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 17`] = `
 <FileIndesign32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -155,8 +189,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 18`] = `
 <FileKeynote32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -164,8 +200,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 19`] = `
 <FileNumbers32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -173,8 +211,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 20`] = `
 <FilePages32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -182,8 +222,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 21`] = `
 <FilePdf32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -191,8 +233,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 22`] = `
 <FilePhotoshop32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -200,8 +244,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 23`] = `
 <FilePowerpoint32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -209,8 +255,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 24`] = `
 <FilePresentation32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -218,8 +266,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 25`] = `
 <FileSpreadsheet32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -227,8 +277,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 26`] = `
 <FileText32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -236,8 +288,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 27`] = `
 <FileThreeD32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -245,8 +299,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 28`] = `
 <FolderPersonal32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -254,8 +310,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 29`] = `
 <FileVector32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -263,8 +321,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 30`] = `
 <FileVideo32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -272,8 +332,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 31`] = `
 <FileWord32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -281,8 +343,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 32`] = `
 <FileZip32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -290,8 +354,10 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render component with additional props 33`] = `
 <FileDefault32
+  aria-hidden="true"
   className="test"
   height={10}
+  role="presentation"
   title="title"
   width={10}
 />
@@ -299,231 +365,297 @@ exports[`icons/item-icon/ItemIcon render() should render component with addition
 
 exports[`icons/item-icon/ItemIcon render() should render default component 1`] = `
 <FileAudio32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 2`] = `
 <FileBookmark32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 3`] = `
 <FileBoxNote32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 4`] = `
 <FileCode32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 5`] = `
 <FileDefault32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 6`] = `
 <FileText32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 7`] = `
 <FileDwg32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 8`] = `
 <FileExcel32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 9`] = `
 <FolderShared32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 10`] = `
 <FolderExternal32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 11`] = `
 <FolderPersonal32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 12`] = `
 <FileDocs32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 13`] = `
 <FileSheets32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 14`] = `
 <FileSlides32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 15`] = `
 <FileIllustrator32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 16`] = `
 <FileImage32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 17`] = `
 <FileIndesign32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 18`] = `
 <FileKeynote32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 19`] = `
 <FileNumbers32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 20`] = `
 <FilePages32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 21`] = `
 <FilePdf32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 22`] = `
 <FilePhotoshop32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 23`] = `
 <FilePowerpoint32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 24`] = `
 <FilePresentation32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 25`] = `
 <FileSpreadsheet32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 26`] = `
 <FileText32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 27`] = `
 <FileThreeD32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 28`] = `
 <FolderPersonal32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 29`] = `
 <FileVector32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 30`] = `
 <FileVideo32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 31`] = `
 <FileWord32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 32`] = `
 <FileZip32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;
 
 exports[`icons/item-icon/ItemIcon render() should render default component 33`] = `
 <FileDefault32
+  aria-hidden="true"
   height={32}
+  role="presentation"
   width={32}
 />
 `;


### PR DESCRIPTION
The image links in each entry lack any alternative text or text content, making it very difficult for screen reader users to determine the purpose of the link.

for that reason we are making them `presentation` icons and not focusable (since do not have any content to read out)

![Screen Shot 2021-09-10 at 5 33 02 PM](https://user-images.githubusercontent.com/380315/132924456-6b792163-db2f-453d-b2f3-cf9197ea6e69.png)
