### PR TITLE
feat(datepicker): Option to enable pikaday's default keyboard input

### DIFF
--- a/src/components/date-picker/DatePicker.stories.tsx
+++ b/src/components/date-picker/DatePicker.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { IntlProvider } from 'react-intl';
 import { State, Store } from '@sambego/storybook-state';
-import { boolean } from '@storybook/addon-knobs';
 
 import { TooltipPosition } from '../tooltip';
 import DatePicker from './DatePicker';
@@ -29,7 +28,42 @@ export const basic = () => {
                             month: 'long',
                             year: 'numeric',
                         }}
-                        isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
+                        label="Date"
+                        name="datepicker"
+                        onChange={(date: Date) => {
+                            componentStore.set({ date });
+                        }}
+                        placeholder="Date"
+                        value={state.date}
+                        yearRange={yearRange}
+                    />
+                </IntlProvider>
+            )}
+        </State>
+    );
+};
+
+export const basicWithKeyboardInput = () => {
+    const MIN_TIME = new Date(0);
+    const TODAY = new Date('July 18, 2018');
+    const yearRange = [MIN_TIME.getFullYear(), TODAY.getFullYear()];
+    const componentStore = new Store({
+        date: new Date('July 9, 2018'),
+        fromDate: null,
+        toDate: null,
+    });
+    return (
+        <State store={componentStore}>
+            {state => (
+                <IntlProvider locale="en-US">
+                    <DatePicker
+                        className="date-picker-example"
+                        displayFormat={{
+                            day: 'numeric',
+                            month: 'long',
+                            year: 'numeric',
+                        }}
+                        isKeyboardInputAllowed
                         label="Date"
                         name="datepicker"
                         onChange={(date: Date) => {
@@ -47,24 +81,13 @@ export const basic = () => {
 
 export const withDescription = () => (
     <IntlProvider locale="en-US">
-        <DatePicker
-            placeholder="Date"
-            description="Date of your birth"
-            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
-            label="Date Picker"
-        />
+        <DatePicker placeholder="Date" description="Date of your birth" label="Date Picker" />
     </IntlProvider>
 );
 
 export const manuallyEditable = () => (
     <IntlProvider locale="en-US">
-        <DatePicker
-            isTextInputAllowed
-            placeholder="Date"
-            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
-            label="Date Picker"
-            value={new Date('September 27, 2019')}
-        />
+        <DatePicker isTextInputAllowed placeholder="Date" label="Date Picker" value={new Date('September 27, 2019')} />
     </IntlProvider>
 );
 
@@ -83,7 +106,6 @@ export const withLimitedDateRange = () => {
                 <IntlProvider locale="en-US">
                     <DatePicker
                         isTextInputAllowed
-                        isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
                         placeholder="Date"
                         label="Date Picker"
                         minDate={minDate}
@@ -133,7 +155,6 @@ export const alwaysVisibleWithCustomInputField = () => {
                                 hideLabel
                                 isAlwaysVisible
                                 isClearable={false}
-                                isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
                                 label="Date"
                                 name="datepicker"
                                 onChange={(date: Date) => {
@@ -200,7 +221,6 @@ export const disabledWithErrorMessage = () => (
         <DatePicker
             isDisabled
             error="Error Message"
-            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
             placeholder="Date"
             name="datepicker"
             label="Disabled Date Picker"
@@ -213,7 +233,6 @@ export const customErrorTooltipPosition = () => (
         <DatePicker
             error="Error Message"
             errorTooltipPosition={TooltipPosition.MIDDLE_RIGHT}
-            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
             placeholder="Date"
             name="datepicker"
             label="Disabled Date Picker"

--- a/src/components/date-picker/DatePicker.stories.tsx
+++ b/src/components/date-picker/DatePicker.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { IntlProvider } from 'react-intl';
 import { State, Store } from '@sambego/storybook-state';
+import { boolean } from '@storybook/addon-knobs';
 
 import { TooltipPosition } from '../tooltip';
 import DatePicker from './DatePicker';
@@ -28,6 +29,7 @@ export const basic = () => {
                             month: 'long',
                             year: 'numeric',
                         }}
+                        isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
                         label="Date"
                         name="datepicker"
                         onChange={(date: Date) => {
@@ -45,13 +47,24 @@ export const basic = () => {
 
 export const withDescription = () => (
     <IntlProvider locale="en-US">
-        <DatePicker placeholder="Date" description="Date of your birth" label="Date Picker" />
+        <DatePicker
+            placeholder="Date"
+            description="Date of your birth"
+            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
+            label="Date Picker"
+        />
     </IntlProvider>
 );
 
 export const manuallyEditable = () => (
     <IntlProvider locale="en-US">
-        <DatePicker isTextInputAllowed placeholder="Date" label="Date Picker" value={new Date('September 27, 2019')} />
+        <DatePicker
+            isTextInputAllowed
+            placeholder="Date"
+            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
+            label="Date Picker"
+            value={new Date('September 27, 2019')}
+        />
     </IntlProvider>
 );
 
@@ -70,6 +83,7 @@ export const withLimitedDateRange = () => {
                 <IntlProvider locale="en-US">
                     <DatePicker
                         isTextInputAllowed
+                        isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
                         placeholder="Date"
                         label="Date Picker"
                         minDate={minDate}
@@ -119,6 +133,7 @@ export const alwaysVisibleWithCustomInputField = () => {
                                 hideLabel
                                 isAlwaysVisible
                                 isClearable={false}
+                                isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
                                 label="Date"
                                 name="datepicker"
                                 onChange={(date: Date) => {
@@ -155,6 +170,7 @@ export const alwaysVisibleWithCustomInputField = () => {
                                         Start Date
                                     </label>
                                     <input
+                                        disabled
                                         name="date-picker-custom-input"
                                         style={{
                                             background: bdlGray10,
@@ -184,6 +200,7 @@ export const disabledWithErrorMessage = () => (
         <DatePicker
             isDisabled
             error="Error Message"
+            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
             placeholder="Date"
             name="datepicker"
             label="Disabled Date Picker"
@@ -196,6 +213,7 @@ export const customErrorTooltipPosition = () => (
         <DatePicker
             error="Error Message"
             errorTooltipPosition={TooltipPosition.MIDDLE_RIGHT}
+            isKeyboardInputAllowed={boolean('isKeyboardInputAllowed', false)}
             placeholder="Date"
             name="datepicker"
             label="Disabled Date Picker"
@@ -242,6 +260,64 @@ export const withRange = () => {
                                 year: 'numeric',
                             }}
                             hideOptionalLabel
+                            label="To Date"
+                            minDate={state.fromDate || MIN_TIME}
+                            maxDate={TODAY}
+                            name="datepicker-to"
+                            onChange={(date: Date) => {
+                                componentStore.set({ toDate: date });
+                            }}
+                            placeholder="Choose a Date"
+                            value={state.toDate}
+                        />
+                    </div>
+                </IntlProvider>
+            )}
+        </State>
+    );
+};
+
+export const withRangeAndKeyboardInput = () => {
+    const MAX_TIME = new Date('3000-01-01T00:00:00.000Z');
+    const MIN_TIME = new Date(0);
+    const TODAY = new Date();
+    const componentStore: Store<{ date: Date; fromDate: Date | null; toDate: Date | null }> = new Store({
+        date: new Date(),
+        fromDate: null,
+        toDate: null,
+    });
+    return (
+        <State store={componentStore}>
+            {state => (
+                <IntlProvider locale="en-US">
+                    <div>
+                        <DatePicker
+                            className="date-picker-example"
+                            displayFormat={{
+                                day: 'numeric',
+                                month: 'long',
+                                year: 'numeric',
+                            }}
+                            hideOptionalLabel
+                            isKeyboardInputAllowed
+                            label="From Date"
+                            maxDate={state.toDate || MAX_TIME}
+                            name="datepicker-from"
+                            onChange={(date: Date) => {
+                                componentStore.set({ fromDate: date });
+                            }}
+                            placeholder="Choose a Date"
+                            value={state.fromDate}
+                        />
+                        <DatePicker
+                            className="date-picker-example"
+                            displayFormat={{
+                                day: 'numeric',
+                                month: 'long',
+                                year: 'numeric',
+                            }}
+                            hideOptionalLabel
+                            isKeyboardInputAllowed
                             label="To Date"
                             minDate={state.fromDate || MIN_TIME}
                             maxDate={TODAY}

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -128,6 +128,8 @@ export interface DatePickerProps extends WrappedComponentProps {
     isDisabled?: boolean;
     /** Is input required */
     isRequired?: boolean;
+    /** Enables pikaday's default keyboard input support */
+    isKeyboardInputAllowed?: boolean;
     /** Is user allowed to manually input a value (WARNING: this doesn't work with internationalization) */
     isTextInputAllowed?: boolean;
     /** Label displayed for the text input */
@@ -314,9 +316,9 @@ class DatePicker extends React.Component<DatePickerProps> {
     };
 
     handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        const { isTextInputAllowed } = this.props;
+        const { isKeyboardInputAllowed, isTextInputAllowed } = this.props;
 
-        if (this.datePicker && this.datePicker.isVisible()) {
+        if (!isKeyboardInputAllowed && this.datePicker && this.datePicker.isVisible()) {
             event.stopPropagation();
         }
 

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -165,6 +165,7 @@ class DatePicker extends React.Component<DatePickerProps> {
         errorTooltipPosition: TooltipPosition.BOTTOM_LEFT,
         inputProps: {},
         isClearable: true,
+        isKeyboardInputAllowed: false,
         isTextInputAllowed: false,
         yearRange: 10,
     };

--- a/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -304,6 +304,22 @@ describe('components/date-picker/DatePicker', () => {
             expect(stopPropagationSpy).not.toHaveBeenCalled();
         });
 
+        test('should not stop propagation when isKeyboardInputAllowed is enabled', () => {
+            const wrapper = renderDatePicker({ isKeyboardInputAllowed: true });
+            const instance = wrapper.instance();
+            const inputEl = wrapper.find('input').at(0);
+            const stopPropagationSpy = jest.fn();
+            if (instance.datePicker) {
+                instance.datePicker.isVisible = jest.fn().mockReturnValue(true);
+            }
+            inputEl.simulate('keyDown', {
+                preventDefault: noop,
+                stopPropagation: stopPropagationSpy,
+                key: 'anything',
+            });
+            expect(stopPropagationSpy).not.toHaveBeenCalled();
+        });
+
         test('should prevent default on input when key pressed was not a Tab', () => {
             const wrapper = renderDatePicker();
             const inputEl = wrapper.find('input').at(0);

--- a/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
+++ b/src/elements/content-sidebar/activity-feed/task-form/TaskForm.js
@@ -448,6 +448,7 @@ class TaskForm extends React.Component<Props, State> {
                                 'data-testid': 'task-form-date-input',
                             }}
                             isDisabled={isForbiddenErrorOnEdit}
+                            isKeyboardInputAllowed
                             isRequired={false}
                             label={<FormattedMessage {...messages.tasksAddTaskFormDueDateLabel} />}
                             minDate={new Date()}


### PR DESCRIPTION
- Optional prop `isKeyboardInputAllowed` allows keyboard inputs to fall back to the default pikaday behavior, which means users can use keyboard arrow keys to navigate through the calendar popup.
- Adds isKeyboardInputAllowed prop to TaskForm for accessibility purposes
- Tested all DatePicker storybooks with & without isKeyboardInputAllowed to check for regressions
- Tested TaskForm change in:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11
- [x] Edge

![Screen Shot 2021-09-15 at 1 40 20 PM](https://user-images.githubusercontent.com/14035562/133526754-31f63417-8b1d-4ec4-9df8-1e3cddab3e01.png)
