### PR TITLE
fix(versions): improved contrast on highlighted version button

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsItemButton.scss
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.scss
@@ -44,7 +44,7 @@
         border-color: $bdl-box-blue;
 
         .bcs-VersionsItem-info {
-            color: $bdl-gray;
+            color: inherit;
         }
     }
 }

--- a/src/elements/content-sidebar/versions/VersionsItemButton.scss
+++ b/src/elements/content-sidebar/versions/VersionsItemButton.scss
@@ -42,5 +42,9 @@
     &.bcs-is-selected {
         background-color: $hover-blue-background;
         border-color: $bdl-box-blue;
+
+        .bcs-VersionsItem-info {
+            color: $bdl-gray;
+        }
     }
 }


### PR DESCRIPTION
Currently, the version history uses #767676 for the modified date text, which has no contrast issues on white background, but the selected state, has a light blue BG (#F5FAFD) and the contrast ratio is not enough.

<img width="352" alt="Screen Shot 2021-09-14 at 12 09 52" src="https://user-images.githubusercontent.com/81333063/133304997-81714671-7d0d-45ab-a04a-05ced3e7eff4.png">

So, for the selected class, the text is now #222 and the contrast ratio is now fixed.

Before:
<img width="889" alt="Screen Shot 2021-09-14 at 11 40 46" src="https://user-images.githubusercontent.com/81333063/133305252-0ffba191-0c05-4443-a874-d9832cd9954e.png">

After:
<img width="880" alt="Screen Shot 2021-09-14 at 12 08 05" src="https://user-images.githubusercontent.com/81333063/133305269-7e879d32-2a35-45de-a7c1-465fd806c62a.png">

