### PR TITLE
fix(versionhistory): change minimum contrast color

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsGroup.scss
+++ b/src/elements/content-sidebar/versions/VersionsGroup.scss
@@ -5,7 +5,7 @@
     margin-bottom: 0;
     padding-top: 20px;
     padding-bottom: 10px;
-    color: $bdl-gray-50;
+    color: $bdl-gray-62;
     font-size: 14px;
     line-height: 1;
 }


### PR DESCRIPTION
Before
![Screen Shot 2021-09-15 at 4 55 31 PM](https://user-images.githubusercontent.com/380315/133516243-ab4b7e24-5231-49f3-8d4c-25bc3f6e4a1b.png)

After
![Screen Shot 2021-09-15 at 4 56 17 PM](https://user-images.githubusercontent.com/380315/133516266-18b03352-1a22-4a0a-bbcd-9c45b42ded84.png)
