### PR TITLE
feat(contentsidebar): Add instrumentation for data load time

### DIFF
--- a/src/elements/common/logger/Logger.js
+++ b/src/elements/common/logger/Logger.js
@@ -55,11 +55,13 @@ class Logger extends React.Component<Props> {
      * Creates an event name meant for use with an event which is unique and meant to be logged only once
      *
      * @param {string} name - The event name
-     * @returns {string} A string containing the component and event name
+     * @param {string} [uniqueId] - an optional unique id
+     * @returns {string} A string containing the component and event name and optional unique id
      */
-    createEventName(name: string): string {
+    createEventName(name: string, uniqueId?: string): string {
         const { source } = this.props;
-        return `${source}::${name}`;
+        const eventName = `${source}::${name}`;
+        return uniqueId ? `${eventName}::${uniqueId}` : eventName;
     }
 
     /**
@@ -100,9 +102,11 @@ class Logger extends React.Component<Props> {
      * @param {string} type - the type of the event
      * @param {string} name - the name of the event
      * @param {Object} data  - the event data
+     * @param {string} [uniqueId] - an optional unique id
+     * @returns {void}
      */
-    logUniqueMetric(type: MetricType, name: string, data: Object): void {
-        const eventName = this.createEventName(name);
+    logUniqueMetric(type: MetricType, name: string, data: Object, uniqueId?: string): void {
+        const eventName = this.createEventName(name, uniqueId);
         if (this.hasLoggedEvent(eventName)) {
             return;
         }
@@ -131,12 +135,12 @@ class Logger extends React.Component<Props> {
      * @param {Object} data - the metric data
      * @returns {void}
      */
-    handleDataReadyMetric = (data: ElementsLoadMetricData) => {
+    handleDataReadyMetric = (data: ElementsLoadMetricData, uniqueId?: string) => {
         if (!isMarkSupported) {
             return;
         }
 
-        this.logUniqueMetric(METRIC_TYPE_ELEMENTS_LOAD_METRIC, EVENT_DATA_READY, data);
+        this.logUniqueMetric(METRIC_TYPE_ELEMENTS_LOAD_METRIC, EVENT_DATA_READY, data, uniqueId);
     };
 
     /**

--- a/src/elements/common/logger/Logger.js
+++ b/src/elements/common/logger/Logger.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import noop from 'lodash/noop';
 import uuidv4 from 'uuid/v4';
 import { isMarkSupported } from '../../../utils/performance';
-import { EVENT_JS_READY } from './constants';
+import { EVENT_DATA_READY, EVENT_JS_READY } from './constants';
 import { METRIC_TYPE_PREVIEW, METRIC_TYPE_ELEMENTS_LOAD_METRIC } from '../../../constants';
 import type { ElementOrigin } from '../flowTypes';
 import type { MetricType, ElementsLoadMetricData, LoggerProps } from '../../../common/types/logging';
@@ -35,6 +35,7 @@ class Logger extends React.Component<Props> {
     constructor(props: Props) {
         super(props);
         this.loggerProps = {
+            onDataReadyMetric: this.handleDataReadyMetric,
             onPreviewMetric: this.handlePreviewMetric,
             onReadyMetric: this.handleReadyMetric,
         };
@@ -122,6 +123,20 @@ class Logger extends React.Component<Props> {
             ...data,
             type: METRIC_TYPE_PREVIEW,
         });
+    };
+
+    /**
+     * Data ready metric handler
+     *
+     * @param {Object} data - the metric data
+     * @returns {void}
+     */
+    handleDataReadyMetric = (data: ElementsLoadMetricData) => {
+        if (!isMarkSupported) {
+            return;
+        }
+
+        this.logUniqueMetric(METRIC_TYPE_ELEMENTS_LOAD_METRIC, EVENT_DATA_READY, data);
     };
 
     /**

--- a/src/elements/common/logger/__tests__/Logger.test.js
+++ b/src/elements/common/logger/__tests__/Logger.test.js
@@ -27,6 +27,12 @@ describe('elements/common/logger/Logger', () => {
             const { source } = instance.props;
             expect(eventName).toBe(`${source}::${name}`);
         });
+        test('should create an event name with optional uniqueId', () => {
+            const name = 'bar';
+            const eventName = instance.createEventName(name, '123');
+            const { source } = instance.props;
+            expect(eventName).toBe(`${source}::${name}::123`);
+        });
     });
 
     describe('logMetric()', () => {
@@ -139,6 +145,17 @@ describe('elements/common/logger/Logger', () => {
                 METRIC_TYPE_ELEMENTS_LOAD_METRIC,
                 EVENT_DATA_READY,
                 data,
+                undefined,
+            );
+        });
+
+        test('should log a unique metric with uniqueId', () => {
+            instance.handleDataReadyMetric(data, '123');
+            expect(instance.logUniqueMetric).toHaveBeenCalledWith(
+                METRIC_TYPE_ELEMENTS_LOAD_METRIC,
+                EVENT_DATA_READY,
+                data,
+                '123',
             );
         });
     });

--- a/src/elements/common/logger/__tests__/Logger.test.js
+++ b/src/elements/common/logger/__tests__/Logger.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import Logger from '../Logger';
 import { METRIC_TYPE_PREVIEW, METRIC_TYPE_ELEMENTS_LOAD_METRIC } from '../../../../constants';
-import { EVENT_JS_READY } from '../constants';
+import { EVENT_DATA_READY, EVENT_JS_READY } from '../constants';
 
 jest.mock('../../../../utils/performance');
 
@@ -115,6 +115,31 @@ describe('elements/common/logger/Logger', () => {
                 ...data,
                 type: METRIC_TYPE_PREVIEW,
             });
+        });
+    });
+
+    describe('handleDataReadyMetric()', () => {
+        const END = 'end';
+        const START = 'start';
+        const data = {
+            foo: 'bar',
+            endMarkName: END,
+            startMarkName: START,
+        };
+        let instance;
+        beforeEach(() => {
+            const wrapper = getWrapper();
+            instance = wrapper.instance();
+            instance.logUniqueMetric = jest.fn();
+        });
+
+        test('should log a unique metric', () => {
+            instance.handleDataReadyMetric(data);
+            expect(instance.logUniqueMetric).toHaveBeenCalledWith(
+                METRIC_TYPE_ELEMENTS_LOAD_METRIC,
+                EVENT_DATA_READY,
+                data,
+            );
         });
     });
 

--- a/src/elements/common/logger/__tests__/__snapshots__/Logger.test.js.snap
+++ b/src/elements/common/logger/__tests__/__snapshots__/Logger.test.js.snap
@@ -5,6 +5,7 @@ exports[`elements/common/logger/Logger render() should decorate with logger prop
   fileId="123"
   logger={
     Object {
+      "onDataReadyMetric": [Function],
       "onPreviewMetric": [Function],
       "onReadyMetric": [Function],
     }

--- a/src/elements/common/logger/constants.js
+++ b/src/elements/common/logger/constants.js
@@ -1,5 +1,6 @@
 // @flow
-const EVENT_JS_READY = 'js_ready';
+const EVENT_DATA_READY = 'data_ready';
 const EVENT_INITIALIZED = 'component_initialized';
+const EVENT_JS_READY = 'js_ready';
 
-export { EVENT_INITIALIZED, EVENT_JS_READY };
+export { EVENT_DATA_READY, EVENT_INITIALIZED, EVENT_JS_READY };

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -460,15 +460,22 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
      * @return {void}
      */
     fetchFeedItemsSuccessCallback = (feedItems: FeedItems): void => {
-        const { logger } = this.props;
+        const {
+            file: { id: fileId },
+            logger,
+        } = this.props;
+
+        mark(MARK_NAME_DATA_READY);
 
         // Only emit metric if has >1 activity feed items (there should always at least be the current version)
         if (feedItems.length > 1) {
-            mark(MARK_NAME_DATA_READY);
-            logger.onDataReadyMetric({
-                endMarkName: MARK_NAME_DATA_READY,
-                startMarkName: MARK_NAME_DATA_LOADING,
-            });
+            logger.onDataReadyMetric(
+                {
+                    endMarkName: MARK_NAME_DATA_READY,
+                    startMarkName: MARK_NAME_DATA_LOADING,
+                },
+                fileId,
+            );
         }
 
         this.setState({ feedItems, activityFeedError: undefined });

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -129,6 +129,8 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         // eslint-disable-next-line react/prop-types
         const { logger } = this.props;
 
+        mark(MARK_NAME_DATA_LOADING);
+
         logger.onReadyMetric({
             endMarkName: MARK_NAME_JS_READY,
         });
@@ -138,7 +140,6 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     componentDidMount() {
         const { currentUser } = this.props;
 
-        mark(MARK_NAME_DATA_LOADING);
         this.fetchFeedItems(true);
         this.fetchCurrentUser(currentUser);
     }

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -419,10 +419,13 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
 
         test('should call onDataReadyMetric if feedItems is > 1', () => {
             instance.fetchFeedItemsSuccessCallback(['foo', 'bar']);
-            expect(logger.onDataReadyMetric).toHaveBeenCalledWith({
-                endMarkName: 'activity_sidebar_data_ready',
-                startMarkName: 'activity_sidebar_data_loading',
-            });
+            expect(logger.onDataReadyMetric).toHaveBeenCalledWith(
+                {
+                    endMarkName: 'activity_sidebar_data_ready',
+                    startMarkName: 'activity_sidebar_data_loading',
+                },
+                file.id,
+            );
         });
     });
 

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -392,12 +392,14 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
     });
 
     describe('fetchFeedItemsSuccessCallback()', () => {
+        const feedItems = ['foo'];
         let instance;
+        let logger;
         let wrapper;
-        const feedItems = 'foo';
 
         beforeEach(() => {
-            wrapper = getWrapper();
+            logger = { onDataReadyMetric: jest.fn(), onReadyMetric: jest.fn() };
+            wrapper = getWrapper({ logger });
             instance = wrapper.instance();
             instance.setState = jest.fn();
         });
@@ -407,6 +409,19 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             expect(instance.setState).toBeCalledWith({
                 feedItems,
                 activityFeedError: undefined,
+            });
+        });
+
+        test('should not call onDataReadyMetric if feedItems is <= 1', () => {
+            instance.fetchFeedItemsSuccessCallback(feedItems);
+            expect(logger.onDataReadyMetric).not.toHaveBeenCalled();
+        });
+
+        test('should call onDataReadyMetric if feedItems is > 1', () => {
+            instance.fetchFeedItemsSuccessCallback(['foo', 'bar']);
+            expect(logger.onDataReadyMetric).toHaveBeenCalledWith({
+                endMarkName: 'activity_sidebar_data_ready',
+                startMarkName: 'activity_sidebar_data_loading',
             });
         });
     });


### PR DESCRIPTION
Introduces instrumentation to measure the time taken to load the data needed for a sidebar in the `ContentSidebar`. In this case, the PR is applying this instrumentation to the `ActivitySidebar` to measure the time taken to load the initial feed items from component mount time to `Feed` api returning successfully.

Subsequent data fetch times are not logged as a metric.