### PR TITLE
fix(metadata): added aria-expanded to collapsible buttons

### DIFF
--- a/src/components/collapsible/Collapsible.tsx
+++ b/src/components/collapsible/Collapsible.tsx
@@ -115,9 +115,9 @@ class Collapsible extends React.PureComponent<CollapsibleProps, CollapsibleState
                 <div className={buttonClassName}>
                     <PlainButton
                         {...modifiedButtonProps}
+                        aria-expanded={isOpen}
                         className="collapsible-card-title"
                         onClick={this.toggleVisibility}
-                        aria-expanded={isOpen ? 'true' : 'false'}
                         type={ButtonType.BUTTON}
                     >
                         {title}

--- a/src/components/collapsible/Collapsible.tsx
+++ b/src/components/collapsible/Collapsible.tsx
@@ -102,7 +102,6 @@ class Collapsible extends React.PureComponent<CollapsibleProps, CollapsibleState
         const resinTagTarget: string = RESIN_TAG_TARGET;
         const modifiedButtonProps: { [index: string]: string } = omit(buttonProps, [resinTagTarget]);
         const interactionTarget = buttonProps[resinTagTarget];
-        const ariaExpanded = isOpen ? 'true' : 'false';
         const buttonClassName = hasStickyHeader
             ? 'collapsible-card-header has-sticky-header'
             : 'collapsible-card-header';
@@ -118,7 +117,7 @@ class Collapsible extends React.PureComponent<CollapsibleProps, CollapsibleState
                         {...modifiedButtonProps}
                         className="collapsible-card-title"
                         onClick={this.toggleVisibility}
-                        aria-expanded={ariaExpanded}
+                        aria-expanded={isOpen ? 'true' : 'false'}
                         type={ButtonType.BUTTON}
                     >
                         {title}

--- a/src/components/collapsible/Collapsible.tsx
+++ b/src/components/collapsible/Collapsible.tsx
@@ -102,6 +102,7 @@ class Collapsible extends React.PureComponent<CollapsibleProps, CollapsibleState
         const resinTagTarget: string = RESIN_TAG_TARGET;
         const modifiedButtonProps: { [index: string]: string } = omit(buttonProps, [resinTagTarget]);
         const interactionTarget = buttonProps[resinTagTarget];
+        const ariaExpanded = isOpen ? 'true' : 'false';
         const buttonClassName = hasStickyHeader
             ? 'collapsible-card-header has-sticky-header'
             : 'collapsible-card-header';
@@ -117,6 +118,7 @@ class Collapsible extends React.PureComponent<CollapsibleProps, CollapsibleState
                         {...modifiedButtonProps}
                         className="collapsible-card-title"
                         onClick={this.toggleVisibility}
+                        aria-expanded={ariaExpanded}
                         type={ButtonType.BUTTON}
                     >
                         {title}

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`components/collapsible/Collapsible should apply buttonProps correctly 1
   >
     <PlainButton
       a={1}
-      aria-expanded="true"
+      aria-expanded={true}
       b={2}
       className="collapsible-card-title"
       onClick={[Function]}
@@ -65,7 +65,7 @@ exports[`components/collapsible/Collapsible should apply correct border class 1`
     className="collapsible-card-header"
   >
     <PlainButton
-      aria-expanded="true"
+      aria-expanded={true}
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -120,7 +120,7 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
     className="collapsible-card-header"
   >
     <PlainButton
-      aria-expanded="false"
+      aria-expanded={false}
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -175,7 +175,7 @@ exports[`components/collapsible/Collapsible should not render a PlainButton if a
     className="collapsible-card-header"
   >
     <PlainButton
-      aria-expanded="true"
+      aria-expanded={true}
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -230,7 +230,7 @@ exports[`components/collapsible/Collapsible should render a PlainButton if a but
     className="collapsible-card-header"
   >
     <PlainButton
-      aria-expanded="true"
+      aria-expanded={true}
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -285,7 +285,7 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
     className="collapsible-card-header"
   >
     <PlainButton
-      aria-expanded="true"
+      aria-expanded={true}
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -342,7 +342,7 @@ exports[`components/collapsible/Collapsible should render with headerActionItems
     className="collapsible-card-header"
   >
     <PlainButton
-      aria-expanded="false"
+      aria-expanded={false}
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`components/collapsible/Collapsible should apply buttonProps correctly 1
   >
     <PlainButton
       a={1}
+      aria-expanded="true"
       b={2}
       className="collapsible-card-title"
       onClick={[Function]}
@@ -64,6 +65,7 @@ exports[`components/collapsible/Collapsible should apply correct border class 1`
     className="collapsible-card-header"
   >
     <PlainButton
+      aria-expanded="true"
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -118,6 +120,7 @@ exports[`components/collapsible/Collapsible should apply correct isOpen state 1`
     className="collapsible-card-header"
   >
     <PlainButton
+      aria-expanded="false"
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -172,6 +175,7 @@ exports[`components/collapsible/Collapsible should not render a PlainButton if a
     className="collapsible-card-header"
   >
     <PlainButton
+      aria-expanded="true"
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -226,6 +230,7 @@ exports[`components/collapsible/Collapsible should render a PlainButton if a but
     className="collapsible-card-header"
   >
     <PlainButton
+      aria-expanded="true"
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -280,6 +285,7 @@ exports[`components/collapsible/Collapsible should render component correctly 1`
     className="collapsible-card-header"
   >
     <PlainButton
+      aria-expanded="true"
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"
@@ -336,6 +342,7 @@ exports[`components/collapsible/Collapsible should render with headerActionItems
     className="collapsible-card-header"
   >
     <PlainButton
+      aria-expanded="false"
       className="collapsible-card-title"
       onClick={[Function]}
       type="button"


### PR DESCRIPTION
Hi guys! 

One of the current issues we have is that some collapsible buttons doesn't give enough information to the users while they are being expanded or not.
<img width="884" alt="Screen Shot 2021-09-21 at 9 44 26" src="https://user-images.githubusercontent.com/81333063/134198494-3d56eb94-705e-4611-abf2-ac6fbc693f21.png">

Added the aria-expanded attribute so screen readers can inform the users while the buttons are open or not
<img width="886" alt="Screen Shot 2021-09-21 at 9 45 01" src="https://user-images.githubusercontent.com/81333063/134199054-3e0f698a-ad8c-4692-a09d-4638185932d9.png">

