### PR TITLE
fix(metadata): added aria-pressed to edit metadata button

### DIFF
--- a/src/elements/content-sidebar/activity-feed/version/Version.scss
+++ b/src/elements/content-sidebar/activity-feed/version/Version.scss
@@ -7,8 +7,8 @@
         justify-content: space-between;
         margin: 0 $sidebarActivityFeedSpacingHorizontal;
         padding: 9px;
-        color: $bdl-green-light;
-        background-color: fade-out($bdl-green-light, .9);
+        color: $bdl-gray;
+        background-color: $bdl-box-blue-05;
         border-radius: 4px;
     }
 
@@ -23,7 +23,7 @@
         height: 16px;
 
         path {
-            fill: $bdl-green-light;
+            fill: $bdl-box-blue;
         }
     }
 

--- a/src/features/metadata-instance-editor/Instance.js
+++ b/src/features/metadata-instance-editor/Instance.js
@@ -563,6 +563,7 @@ class Instance extends React.PureComponent<Props, State> {
             return (
                 <Tooltip position="top-left" text={metadataLabelEditText}>
                     <PlainButton
+                        aria-pressed={isEditing ? 'true' : 'false'}
                         aria-label={metadataLabelEditText}
                         className={editClassName}
                         data-resin-target="metadata-instanceedit"

--- a/src/features/metadata-instance-editor/Instance.js
+++ b/src/features/metadata-instance-editor/Instance.js
@@ -563,8 +563,8 @@ class Instance extends React.PureComponent<Props, State> {
             return (
                 <Tooltip position="top-left" text={metadataLabelEditText}>
                     <PlainButton
-                        aria-pressed={isEditing ? 'true' : 'false'}
                         aria-label={metadataLabelEditText}
+                        aria-pressed={isEditing}
                         className={editClassName}
                         data-resin-target="metadata-instanceedit"
                         onClick={this.toggleIsEditing}

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance.test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance.test.js.snap
@@ -20,7 +20,7 @@ exports[`features/metadata-instance-editor/fields/Instance collapsible isOpen pr
         theme="default"
       >
         <PlainButton
-          aria-pressed="false"
+          aria-pressed={false}
           className="metadata-instance-editor-instance-edit"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}
@@ -747,7 +747,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         theme="default"
       >
         <PlainButton
-          aria-pressed="true"
+          aria-pressed={true}
           className="metadata-instance-editor-instance-edit metadata-instance-editor-instance-is-editing"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}
@@ -942,7 +942,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         theme="default"
       >
         <PlainButton
-          aria-pressed="true"
+          aria-pressed={true}
           className="metadata-instance-editor-instance-edit metadata-instance-editor-instance-is-editing"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}
@@ -1046,7 +1046,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         theme="default"
       >
         <PlainButton
-          aria-pressed="true"
+          aria-pressed={true}
           className="metadata-instance-editor-instance-edit metadata-instance-editor-instance-is-editing"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance.test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/Instance.test.js.snap
@@ -20,6 +20,7 @@ exports[`features/metadata-instance-editor/fields/Instance collapsible isOpen pr
         theme="default"
       >
         <PlainButton
+          aria-pressed="false"
           className="metadata-instance-editor-instance-edit"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}
@@ -746,6 +747,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         theme="default"
       >
         <PlainButton
+          aria-pressed="true"
           className="metadata-instance-editor-instance-edit metadata-instance-editor-instance-is-editing"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}
@@ -940,6 +942,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         theme="default"
       >
         <PlainButton
+          aria-pressed="true"
           className="metadata-instance-editor-instance-edit metadata-instance-editor-instance-is-editing"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}
@@ -1043,6 +1046,7 @@ exports[`features/metadata-instance-editor/fields/Instance should correctly rend
         theme="default"
       >
         <PlainButton
+          aria-pressed="true"
           className="metadata-instance-editor-instance-edit metadata-instance-editor-instance-is-editing"
           data-resin-target="metadata-instanceedit"
           onClick={[Function]}


### PR DESCRIPTION
In order to improve accessibility, the Edit metadata button required some tweaking to inform the SR users that is in use
<img width="889" alt="Screen Shot 2021-09-21 at 10 53 57" src="https://user-images.githubusercontent.com/81333063/134208090-0a7f8d16-4c6e-49da-9fb8-be5bec558464.png">

The aria-pressed attribute helps telling users the button they are interacting with
<img width="887" alt="Screen Shot 2021-09-21 at 10 57 38" src="https://user-images.githubusercontent.com/81333063/134208307-0e6cf79a-778a-4264-953b-371b7d109385.png">

