### PR TITLE
fix(shared-link-section): fix reposition esl ftux tooltip

### DIFF
--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -373,6 +373,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                                     onClose();
                                 }
                             }}
+                            position="bottom-center"
                         >
                             <SharedLinkPermissionMenu
                                 allowedPermissionLevels={allowedPermissionLevels}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -149,6 +149,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
     <GuideTooltip
       isShown={false}
       onDismiss={[Function]}
+      position="bottom-center"
     >
       <SharedLinkPermissionMenu
         allowedPermissionLevels={
@@ -307,6 +308,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
     <GuideTooltip
       isShown={false}
       onDismiss={[Function]}
+      position="bottom-center"
     >
       <SharedLinkPermissionMenu
         allowedPermissionLevels={Array []}
@@ -499,6 +501,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
     <GuideTooltip
       isShown={false}
       onDismiss={[Function]}
+      position="bottom-center"
     >
       <SharedLinkPermissionMenu
         allowedPermissionLevels={
@@ -905,6 +908,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <GuideTooltip
       isShown={false}
       onDismiss={[Function]}
+      position="bottom-center"
     >
       <SharedLinkPermissionMenu
         allowedPermissionLevels={
@@ -1049,6 +1053,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <GuideTooltip
       isShown={false}
       onDismiss={[Function]}
+      position="bottom-center"
     >
       <SharedLinkPermissionMenu
         allowedPermissionLevels={
@@ -1192,6 +1197,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <GuideTooltip
       isShown={false}
       onDismiss={[Function]}
+      position="bottom-center"
     >
       <SharedLinkPermissionMenu
         allowedPermissionLevels={
@@ -1335,6 +1341,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     <GuideTooltip
       isShown={false}
       onDismiss={[Function]}
+      position="bottom-center"
     >
       <SharedLinkPermissionMenu
         allowedPermissionLevels={


### PR DESCRIPTION
**Changes in this PR:**
- [x] add position: 'bottom-center' to reposition tooltip below the permission level dropdown

**Demo:**
<img width="546" alt="Screen Shot 2021-09-21 at 11 01 23 AM" src="https://user-images.githubusercontent.com/7213887/134225007-d0d5de04-7faa-4203-a5a6-d3817d912079.png">
