### PR TITLE
fix(content-explorer): disable item name click if item disabled

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -309,6 +309,10 @@ class ContentExplorer extends Component {
         const { items } = this.props;
         const item = items[index];
 
+        if (item.isDisabled || item.isLoading) {
+            return;
+        }
+
         if (item.type !== ItemTypes.FOLDER) {
             return;
         }


### PR DESCRIPTION
Adds guard clause to `handleItemNameClick` if item is disabled. Similar to the other click handlers above (`handleItemDoubleClick` and `handleItemClick`)