### PR TITLE
fix(content-explorer): disable item name click if item disabled

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -309,6 +309,10 @@ class ContentExplorer extends Component {
         const { items } = this.props;
         const item = items[index];
 
+        if (item.isDisabled || item.isLoading) {
+            return;
+        }
+
         if (item.type !== ItemTypes.FOLDER) {
             return;
         }

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
@@ -295,7 +295,7 @@ describe('features/content-explorer/content-explorer/ContentExplorer', () => {
             expect(onEnterFolderSpy.withArgs(clickedFolder, newFoldersPath).calledOnce).toBe(true);
         });
 
-        test('should not call onEnterFolder when clicking a disabled folder name', () => {
+        test('should not call onEnterFolder when clicking disabled folder name', () => {
             const disabledItems = [{ id: '123', name: 'item1', type: 'folder', isDisabled: true }];
             wrapper = renderComponent(
                 {

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
@@ -294,6 +294,29 @@ describe('features/content-explorer/content-explorer/ContentExplorer', () => {
 
             expect(onEnterFolderSpy.withArgs(clickedFolder, newFoldersPath).calledOnce).toBe(true);
         });
+
+        test('should not call onEnterFolder when clicking a disabled folder name', () => {
+            const disabledItems = [{ id: '123', name: 'item1', type: 'folder', isDisabled: true }];
+            wrapper = renderComponent(
+                {
+                    items: disabledItems,
+                    initialFoldersPath,
+                    onEnterFolder: onEnterFolderSpy,
+                },
+                true,
+            );
+
+            const clickedFolderIndex = 0;
+            const clickedFolder = items[clickedFolderIndex];
+            const newFoldersPath = initialFoldersPath.concat([clickedFolder]);
+
+            wrapper
+                .find('.item-list-name')
+                .first()
+                .simulate('click');
+
+            expect(onEnterFolderSpy.withArgs(clickedFolder, newFoldersPath).calledOnce).toBe(false);
+        });
     });
 
     describe('onSelectItem', () => {


### PR DESCRIPTION
Adds guard clause to handleItemNameClick if item is disabled. Similar to the other click handlers above (handleItemDoubleClick and handleItemClick).

It seems to me the the existence of this guard clause in handleItemDoubleClick implies that we should not be able to enter a folder if it is disabled. https://github.com/box/box-ui-elements/blob/master/src/features/content-explorer/content-explorer/ContentExplorer.js#L296-L304


Also open to separating this into a separate prop to disable navigation on click.