### PR TITLE
fix(unified-share-modal): filter out collaborated users and groups

### DIFF
--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -259,7 +259,7 @@ function SharingNotification({
             closeComponent();
         },
         setIsLoading,
-        transformRequest: data => convertCollabsRequest(data),
+        transformRequest: data => convertCollabsRequest(data, collaboratorsList),
     });
     if (sendInvitesFn && !sendInvites) {
         setSendInvites(() => sendInvitesFn);

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -171,7 +171,7 @@ export type sharedLinkType = {
 
 export type collaboratorType = {
     collabID: number,
-    email: string,
+    email?: string,
     expiration?: {
         executeAt: string,
     },

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -171,6 +171,7 @@ export type sharedLinkType = {
 
 export type collaboratorType = {
     collabID: number,
+    email: string,
     expiration?: {
         executeAt: string,
     },

--- a/src/features/unified-share-modal/stories/UnifiedShareModal.stories.js
+++ b/src/features/unified-share-modal/stories/UnifiedShareModal.stories.js
@@ -199,6 +199,7 @@ export const basic = () => {
                     // convert the existing contact entries to compatible collaborator entries in this example
                     const collaborator: collaboratorType = {
                         collabID: 1234,
+                        email: contact.email,
                         id: contact.id,
                         name: contact.name || '',
                         type: contact.type !== 'group' ? constants.COLLAB_USER_TYPE : constants.COLLAB_GROUP_TYPE,

--- a/src/features/unified-share-modal/utils/__mocks__/USMMocks.js
+++ b/src/features/unified-share-modal/utils/__mocks__/USMMocks.js
@@ -787,6 +787,17 @@ const MOCK_COLLABS_REQUEST_USERS_AND_GROUPS = {
     permission: 'Editor',
 };
 
+const MOCK_COLLABS_LIST = {
+    collaborators: [
+        { email: 'narwhal@box.com', type: 'user' },
+        { email: 'armadillo@box.com', type: 'user' },
+        { email: 'turtle@box.com', type: 'user' },
+        { userID: 12345, type: 'group' },
+        { userID: 67891, type: 'group' },
+        { userID: 13141, type: 'group' },
+    ],
+};
+
 const MOCK_COLLABS_CONVERTED_USERS = [
     {
         accessible_by: {
@@ -854,6 +865,27 @@ const MOCK_COLLABS_CONVERTED_REQUEST = {
     users: MOCK_COLLABS_CONVERTED_USERS,
 };
 
+const MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER = {
+    groups: [
+        {
+            accessible_by: {
+                id: '01112',
+                type: 'group',
+            },
+            role: 'editor',
+        },
+    ],
+    users: [
+        {
+            accessible_by: {
+                login: 'hedgehog@box.com',
+                type: 'user',
+            },
+            role: 'editor',
+        },
+    ],
+};
+
 const MOCK_DISABLED_REASONS_FROM_API = {
     company: DISABLED_REASON_ACCESS_POLICY,
     open: DISABLED_REASON_MALICIOUS_CONTENT,
@@ -874,7 +906,9 @@ export {
     MOCK_COLLABS_CONVERTED_GROUPS,
     MOCK_COLLABS_CONVERTED_RESPONSE,
     MOCK_COLLABS_CONVERTED_REQUEST,
+    MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER,
     MOCK_COLLABS_CONVERTED_USERS,
+    MOCK_COLLABS_LIST,
     MOCK_COLLABS_REQUEST_GROUPS_ONLY,
     MOCK_COLLABS_REQUEST_USERS_ONLY,
     MOCK_COLLABS_REQUEST_USERS_AND_GROUPS,

--- a/src/features/unified-share-modal/utils/__mocks__/USMMocks.js
+++ b/src/features/unified-share-modal/utils/__mocks__/USMMocks.js
@@ -787,7 +787,7 @@ const MOCK_COLLABS_REQUEST_USERS_AND_GROUPS = {
     permission: 'Editor',
 };
 
-const MOCK_COLLABS_LIST = {
+const MOCK_COLLABS_EXISTING_LIST = {
     collaborators: [
         { email: 'narwhal@box.com', type: 'user' },
         { email: 'armadillo@box.com', type: 'user' },
@@ -908,7 +908,7 @@ export {
     MOCK_COLLABS_CONVERTED_REQUEST,
     MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER,
     MOCK_COLLABS_CONVERTED_USERS,
-    MOCK_COLLABS_LIST,
+    MOCK_COLLABS_EXISTING_LIST,
     MOCK_COLLABS_REQUEST_GROUPS_ONLY,
     MOCK_COLLABS_REQUEST_USERS_ONLY,
     MOCK_COLLABS_REQUEST_USERS_AND_GROUPS,

--- a/src/features/unified-share-modal/utils/__tests__/convertData.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/convertData.test.js
@@ -55,6 +55,8 @@ import {
     MOCK_COLLABS_CONVERTED_USERS,
     MOCK_COLLABS_REQUEST_USERS_ONLY,
     MOCK_COLLABS_REQUEST_USERS_AND_GROUPS,
+    MOCK_COLLABS_LIST,
+    MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER,
     MOCK_CONVERTED_DISABLED_REASONS,
     MOCK_DISABLED_REASONS_FROM_API,
     MOCK_GROUP_CONTACTS_API_RESPONSE,
@@ -820,12 +822,13 @@ describe('convertGroupContactsResponse()', () => {
 
 describe('convertCollabsRequest()', () => {
     test.each`
-        requestFromUSM                                      | convertedResponse                                       | description
-        ${MOCK_COLLABS_REQUEST_USERS_ONLY}                  | ${{ groups: [], users: MOCK_COLLABS_CONVERTED_USERS }}  | ${'users only'}
-        ${MOCK_COLLABS_REQUEST_GROUPS_ONLY}                 | ${{ groups: MOCK_COLLABS_CONVERTED_GROUPS, users: [] }} | ${'groups only'}
-        ${MOCK_COLLABS_REQUEST_USERS_AND_GROUPS}            | ${MOCK_COLLABS_CONVERTED_REQUEST}                       | ${'users and groups'}
-        ${{ emails: '', groups: '', permission: 'Editor' }} | ${{ groups: [], users: [] }}                            | ${'no users or groups'}
-    `('should convert a request with $description', ({ requestFromUSM, convertedResponse }) => {
-        expect(convertCollabsRequest(requestFromUSM)).toEqual(convertedResponse);
+        requestFromUSM                                      | collaboratorsList    | convertedResponse                                       | description
+        ${MOCK_COLLABS_REQUEST_USERS_ONLY}                  | ${null}              | ${{ groups: [], users: MOCK_COLLABS_CONVERTED_USERS }}  | ${'users only'}
+        ${MOCK_COLLABS_REQUEST_GROUPS_ONLY}                 | ${null}              | ${{ groups: MOCK_COLLABS_CONVERTED_GROUPS, users: [] }} | ${'groups only'}
+        ${MOCK_COLLABS_REQUEST_USERS_AND_GROUPS}            | ${null}              | ${MOCK_COLLABS_CONVERTED_REQUEST}                       | ${'users and groups'}
+        ${{ emails: '', groups: '', permission: 'Editor' }} | ${null}              | ${{ groups: [], users: [] }}                            | ${'no users or groups'}
+        ${MOCK_COLLABS_REQUEST_USERS_AND_GROUPS}            | ${MOCK_COLLABS_LIST} | ${MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER}           | ${'filtered users and groups'}
+    `('should convert a request with $description', ({ requestFromUSM, collaboratorsList, convertedResponse }) => {
+        expect(convertCollabsRequest(requestFromUSM, collaboratorsList)).toEqual(convertedResponse);
     });
 });

--- a/src/features/unified-share-modal/utils/__tests__/convertData.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/convertData.test.js
@@ -55,7 +55,7 @@ import {
     MOCK_COLLABS_CONVERTED_USERS,
     MOCK_COLLABS_REQUEST_USERS_ONLY,
     MOCK_COLLABS_REQUEST_USERS_AND_GROUPS,
-    MOCK_COLLABS_LIST,
+    MOCK_COLLABS_EXISTING_LIST,
     MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER,
     MOCK_CONVERTED_DISABLED_REASONS,
     MOCK_DISABLED_REASONS_FROM_API,
@@ -822,13 +822,16 @@ describe('convertGroupContactsResponse()', () => {
 
 describe('convertCollabsRequest()', () => {
     test.each`
-        requestFromUSM                                      | collaboratorsList    | convertedResponse                                       | description
-        ${MOCK_COLLABS_REQUEST_USERS_ONLY}                  | ${null}              | ${{ groups: [], users: MOCK_COLLABS_CONVERTED_USERS }}  | ${'users only'}
-        ${MOCK_COLLABS_REQUEST_GROUPS_ONLY}                 | ${null}              | ${{ groups: MOCK_COLLABS_CONVERTED_GROUPS, users: [] }} | ${'groups only'}
-        ${MOCK_COLLABS_REQUEST_USERS_AND_GROUPS}            | ${null}              | ${MOCK_COLLABS_CONVERTED_REQUEST}                       | ${'users and groups'}
-        ${{ emails: '', groups: '', permission: 'Editor' }} | ${null}              | ${{ groups: [], users: [] }}                            | ${'no users or groups'}
-        ${MOCK_COLLABS_REQUEST_USERS_AND_GROUPS}            | ${MOCK_COLLABS_LIST} | ${MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER}           | ${'filtered users and groups'}
-    `('should convert a request with $description', ({ requestFromUSM, collaboratorsList, convertedResponse }) => {
-        expect(convertCollabsRequest(requestFromUSM, collaboratorsList)).toEqual(convertedResponse);
-    });
+        requestFromUSM                                      | existingCollaboratorsList     | convertedResponse                                       | description
+        ${MOCK_COLLABS_REQUEST_USERS_ONLY}                  | ${null}                       | ${{ groups: [], users: MOCK_COLLABS_CONVERTED_USERS }}  | ${'users only'}
+        ${MOCK_COLLABS_REQUEST_GROUPS_ONLY}                 | ${null}                       | ${{ groups: MOCK_COLLABS_CONVERTED_GROUPS, users: [] }} | ${'groups only'}
+        ${MOCK_COLLABS_REQUEST_USERS_AND_GROUPS}            | ${null}                       | ${MOCK_COLLABS_CONVERTED_REQUEST}                       | ${'users and groups'}
+        ${{ emails: '', groups: '', permission: 'Editor' }} | ${null}                       | ${{ groups: [], users: [] }}                            | ${'no users or groups'}
+        ${MOCK_COLLABS_REQUEST_USERS_AND_GROUPS}            | ${MOCK_COLLABS_EXISTING_LIST} | ${MOCK_COLLABS_CONVERTED_REQUEST_WITH_FILTER}           | ${'filtered users and groups'}
+    `(
+        'should convert a request with $description',
+        ({ requestFromUSM, existingCollaboratorsList, convertedResponse }) => {
+            expect(convertCollabsRequest(requestFromUSM, existingCollaboratorsList)).toEqual(convertedResponse);
+        },
+    );
 });

--- a/src/features/unified-share-modal/utils/convertData.js
+++ b/src/features/unified-share-modal/utils/convertData.js
@@ -458,15 +458,15 @@ export const convertCollabsResponse = (
  */
 export const convertCollabsRequest = (
     collabRequest: InviteCollaboratorsRequest,
-    collaboratorsList: collaboratorsListType | null,
+    existingCollaboratorsList: collaboratorsListType | null,
 ): ContentSharingCollaborationsRequest => {
     const { emails, groupIDs, permission } = collabRequest;
     const emailArray = emails ? emails.split(',') : [];
     const groupIDArray = groupIDs ? groupIDs.split(',') : [];
     const collabSet = new Set();
-    if (collaboratorsList) {
-        collaboratorsList.collaborators.forEach(collab => {
-            if (collab.type === COLLAB_USER_TYPE) {
+    if (existingCollaboratorsList) {
+        existingCollaboratorsList.collaborators.forEach(collab => {
+            if (collab.type === COLLAB_USER_TYPE && !!collab.email) {
                 collabSet.add(collab.email);
             } else if (collab.type === COLLAB_GROUP_TYPE && !!collab.userID) {
                 collabSet.add(collab.userID.toString());


### PR DESCRIPTION
Filter out users and groups who has already collaborated on the file when sending requests.