### PR TITLE
fix(tooltip-icons): add title attribute

### DIFF
--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -63,7 +63,7 @@ const Select = ({
                         {infoTooltip && (
                             <Tooltip position="middle-right" text={infoTooltip}>
                                 <span className="tooltip-icon-container">
-                                    <IconInfo height={16} width={16} {...infoIconProps} />
+                                    <IconInfo height={16} width={16} {...infoIconProps} title={infoTooltip} />
                                 </span>
                             </Tooltip>
                         )}

--- a/src/components/select/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/components/select/__tests__/__snapshots__/Select.test.js.snap
@@ -111,7 +111,7 @@ exports[`components/select/Select should render infoTooltip when specified 1`] =
           >
             <IconInfo
               height={16}
-              title="hello"
+              title="hello!!!"
               width={16}
             />
           </span>


### PR DESCRIPTION
Icons for descriptive tooltips need to have title prop
ex. account-setting page, sharing tab

<img width="1584" alt="Screen Shot 2021-09-29 at 12 36 51 PM" src="https://user-images.githubusercontent.com/380315/135320230-2e2a85cc-57c2-4b00-bc94-db132fea6d2d.png">
