### PR TITLE
fix(content-sharing): save enterprise name after removing link

### DIFF
--- a/src/elements/content-sharing/SharingNotification.js
+++ b/src/elements/content-sharing/SharingNotification.js
@@ -151,9 +151,9 @@ function SharingNotification({
     /**
      * Handle a successful shared link removal request.
      *
-     * Most of the data for the shared link will be removed, with the exception of the "canInvite" and "serverURL"
-     * properties, both of which are still necessary for rendering the form-only version of ContentSharing.
-     * We retain "serverURL" from the previous shared link, to avoid having to make another call to the Users API.
+     * Most of the data for the shared link will be removed, with the exception of the "canInvite", "enterpriseName",
+     * and "serverURL" properties, which are still necessary for rendering the form-only version of ContentSharing.
+     * We retain "serverURL" and "enterpriseName" from the previous shared link, to avoid having to make another call to the Users API.
      *
      * @param {ContentSharingItemAPIResponse} itemData
      */
@@ -164,6 +164,7 @@ function SharingNotification({
             return {
                 ...updatedSharedLink,
                 serverURL: prevSharedLink ? prevSharedLink.serverURL : '',
+                enterpriseName: prevSharedLink?.enterpriseName ? prevSharedLink.enterpriseName : '',
             };
         });
     };


### PR DESCRIPTION
Enterprise name should be saved after a shared link is removed so that a new call to Users API isn't needed. Currently the enterprise name is undefined if a shared link is removed then added.