### PR TITLE
fix(checkbox): add description area note to checkbox

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -63,7 +63,7 @@ const Checkbox = ({
     const checkboxAndLabel = (
         <span className="checkbox-label">
             <input
-                aria-labelledby={description ? `description_${inputID}` : ''}
+                aria-describedby={description ? `description_${inputID}` : ''}
                 checked={isChecked}
                 disabled={isDisabled}
                 id={inputID}


### PR DESCRIPTION
Three checkboxes—"Disable commenting for this folder", "Hide collaborators and their activity from non-owners", and "Enable watermarking for this folder"—each have a note below them (e.g., "Note: This also hides any comments that are currently in this folder."). Each of these notes presents important information that needs to be associated to the corresponding form control with aria-describedby.