### PR TITLE
fix(alerts): Improved Color Contrast for accessibility

### DIFF
--- a/src/components/notification/Notification.js
+++ b/src/components/notification/Notification.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import classNames from 'classnames';
+import { bdlGray } from '../../styles/variables';
 
 import IconAlertCircle from '../../icons/general/IconAlertCircle';
 import IconBell from '../../icons/general/IconBell';
@@ -107,7 +108,7 @@ class Notification extends React.Component<Props> {
         return (
             <div className={classes}>
                 {React.cloneElement(ICON_RENDERER[type](), {
-                    color: '#fff',
+                    color: bdlGray,
                     height: 20,
                     width: 20,
                 })}
@@ -118,7 +119,7 @@ class Notification extends React.Component<Props> {
                     onClick={this.onClose}
                     type="button"
                 >
-                    <IconClose color="#FFF" height={18} width={18} />
+                    <IconClose color={bdlGray} height={18} width={18} />
                 </button>
             </div>
         );

--- a/src/components/notification/Notification.scss
+++ b/src/components/notification/Notification.scss
@@ -21,24 +21,24 @@
     margin: 10px auto;
     padding: 10px 10px 10px 20px;
     overflow: hidden;
-    color: $white;
+    color: $bdl-gray;
     font-weight: bold;
-    background-color: $bdl-gray-80;
+    background-color: $bdl-gray-40;
     border-radius: 4px;
     box-shadow: 0 2px 6px fade-out($black, .85);
     opacity: .9;
     transition: opacity .1s ease-out;
 
     &.info {
-        background-color: $bdl-green-light;
+        background-color: $bdl-green-light-50;
     }
 
     &.warn {
-        background-color: $bdl-yellorange;
+        background-color: $bdl-yellorange-50;
     }
 
     &.error {
-        background-color: $bdl-watermelon-red;
+        background-color: $bdl-watermelon-red-50;
     }
 
     &.is-hidden {
@@ -71,14 +71,15 @@
     button,
     a {
         flex: none;
-        color: $white;
+        color: $bdl-gray;
+        border-color: $bdl-gray;
 
         &.btn.is-disabled,
         &.btn:not(.is-disabled) {
             margin: 0 5px;
             padding: 7px 13px;
             background-color: transparent;
-            border-color: $bdl-gray-10;
+            border-color: inherit;
         }
 
         &.close-btn {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/81333063/137557503-30a7dcde-6e38-442c-8476-860bb5201769.png)

Alerts used to have low contrast ratio with a colored BG and white text. In order to fix this, the color combination was changed and the BG is lighter now.