### PR TITLE
docs(colors): fix color value rendering

### DIFF
--- a/examples/colors.md
+++ b/examples/colors.md
@@ -17,6 +17,7 @@ Object.keys(colors).forEach(colorKey => {
     colorKey.startsWith('bdl') &&
     !colorKey.includes('Neutral') &&
     colorKey !== 'bdlSecondaryBlue' &&
+    !Array.isArray(colors[colorKey]) &&
     colors[colorKey].startsWith('#')
   ) {
     const colorNameBreakDown = colorKey


### PR DESCRIPTION
Some color values stored in `_variables.scss` emit arrays when translated into JSON and TS equivalents. Add a filter to the colors documentation that prevents doing `.startsWith` on an `Array` instance.

Before & After:
![Screen Shot 2021-10-17 at 6 51 33 PM](https://user-images.githubusercontent.com/3056447/137830062-81cb1ea3-bd2a-4dac-bf31-bae62f39f755.png)
![Screen Shot 2021-10-17 at 6 51 16 PM](https://user-images.githubusercontent.com/3056447/137830069-26b33f8b-9b4d-4bcc-a33c-07510e1ae71e.png)

Re: #2336

