### PR TITLE
fix(alerts): alerts color contrast

### DIFF
--- a/src/components/notification/Notification.js
+++ b/src/components/notification/Notification.js
@@ -4,7 +4,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 
 import { bdlGray } from '../../styles/variables';
-import InfoBadge from '../../icons/badges/InfoBadge';
+import InfoBadge16 from '../../icon/line/InfoBadge16';
 import CircleCheck16 from '../../icon/line/CircleCheck16';
 import TriangleAlert16 from '../../icon/line/TriangleAlert16';
 import XBadge16 from '../../icon/line/XBadge16';
@@ -31,7 +31,7 @@ const DURATION_TIMES = {
 };
 
 const ICON_RENDERER: { [string]: Function } = {
-    [TYPE_DEFAULT]: () => <InfoBadge />,
+    [TYPE_DEFAULT]: () => <InfoBadge16 />,
     [TYPE_ERROR]: () => <XBadge16 />,
     [TYPE_INFO]: () => <CircleCheck16 />,
     [TYPE_WARN]: () => <TriangleAlert16 />,

--- a/src/components/notification/Notification.js
+++ b/src/components/notification/Notification.js
@@ -4,12 +4,11 @@ import { defineMessages, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 
 import { bdlGray } from '../../styles/variables';
-
-import IconAlertCircle from '../../icons/general/IconAlertCircle';
-import IconBell from '../../icons/general/IconBell';
+import InfoBadge from '../../icons/badges/InfoBadge';
+import CircleCheck16 from '../../icon/line/CircleCheck16';
+import TriangleAlert16 from '../../icon/line/TriangleAlert16';
+import XBadge16 from '../../icon/line/XBadge16';
 import IconClose from '../../icons/general/IconClose';
-import IconInfoThin from '../../icons/general/IconInfoThin';
-import IconSync from '../../icons/general/IconSync';
 
 import type { NotificationType } from '../../common/types/core';
 
@@ -32,10 +31,10 @@ const DURATION_TIMES = {
 };
 
 const ICON_RENDERER: { [string]: Function } = {
-    [TYPE_DEFAULT]: () => <IconBell />,
-    [TYPE_ERROR]: () => <IconAlertCircle />,
-    [TYPE_INFO]: () => <IconSync />,
-    [TYPE_WARN]: () => <IconInfoThin />,
+    [TYPE_DEFAULT]: () => <InfoBadge />,
+    [TYPE_ERROR]: () => <XBadge16 />,
+    [TYPE_INFO]: () => <CircleCheck16 />,
+    [TYPE_WARN]: () => <TriangleAlert16 />,
 };
 
 const messages = defineMessages({

--- a/src/components/notification/Notification.scss
+++ b/src/components/notification/Notification.scss
@@ -24,8 +24,8 @@
     color: $bdl-gray;
     font-weight: bold;
     background-color: $bdl-gray-10;
-    border: 2px solid;
-    border-radius: 8px;
+    border: 2px solid $bdl-gray;
+    border-radius: $bdl-border-radius-size * 2;
     box-shadow: 0 2px 6px fade-out($black, .85);
     opacity: .9;
     transition: opacity .1s ease-out;

--- a/src/components/notification/Notification.scss
+++ b/src/components/notification/Notification.scss
@@ -23,22 +23,26 @@
     overflow: hidden;
     color: $bdl-gray;
     font-weight: bold;
-    background-color: $bdl-gray-40;
-    border-radius: 4px;
+    background-color: $bdl-gray-10;
+    border: 2px solid;
+    border-radius: 8px;
     box-shadow: 0 2px 6px fade-out($black, .85);
     opacity: .9;
     transition: opacity .1s ease-out;
 
     &.info {
-        background-color: $bdl-green-light-50;
+        background-color: $bdl-green-light-20;
+        border-color: $bdl-green-light;
     }
 
     &.warn {
-        background-color: $bdl-yellorange-50;
+        background-color: $bdl-yellorange-20;
+        border-color: $bdl-yellorange;
     }
 
     &.error {
-        background-color: $bdl-watermelon-red-50;
+        background-color: $bdl-watermelon-red-20;
+        border-color: $bdl-watermelon-red;
     }
 
     &.is-hidden {
@@ -72,14 +76,13 @@
     a {
         flex: none;
         color: $bdl-gray;
-        border-color: $bdl-gray;
 
         &.btn.is-disabled,
         &.btn:not(.is-disabled) {
             margin: 0 5px;
             padding: 7px 13px;
             background-color: transparent;
-            border-color: inherit;
+            border-color: $bdl-gray;
         }
 
         &.close-btn {

--- a/src/components/notification/__tests__/Notification.test.js
+++ b/src/components/notification/__tests__/Notification.test.js
@@ -48,12 +48,12 @@ describe('components/notification/Notification', () => {
 
         test('should render a correct icon when initialized', () => {
             const component = mount(<Notification type={type}>test</Notification>);
-            const infoBadgeCount = type === TYPE_DEFAULT ? 1 : 0;
+            const infoBadge16Count = type === TYPE_DEFAULT ? 1 : 0;
             const CircleCheck16Count = type === TYPE_INFO ? 1 : 0;
             const XBadge16Count = type === TYPE_ERROR ? 1 : 0;
             const TriangleAlert16Count = type === TYPE_WARN ? 1 : 0;
 
-            expect(component.find('InfoBadge').length).toBe(infoBadgeCount);
+            expect(component.find('InfoBadge16').length).toBe(infoBadge16Count);
             expect(component.find('XBadge16').length).toBe(XBadge16Count);
             expect(component.find('CircleCheck16').length).toBe(CircleCheck16Count);
             expect(component.find('TriangleAlert16').length).toBe(TriangleAlert16Count);

--- a/src/components/notification/__tests__/Notification.test.js
+++ b/src/components/notification/__tests__/Notification.test.js
@@ -48,15 +48,15 @@ describe('components/notification/Notification', () => {
 
         test('should render a correct icon when initialized', () => {
             const component = mount(<Notification type={type}>test</Notification>);
-            const iconBellCount = type === TYPE_DEFAULT ? 1 : 0;
-            const iconSyncCount = type === TYPE_INFO ? 1 : 0;
-            const iconAlertCircleCount = type === TYPE_ERROR ? 1 : 0;
-            const iconInfoThinCount = type === TYPE_WARN ? 1 : 0;
+            const infoBadgeCount = type === TYPE_DEFAULT ? 1 : 0;
+            const CircleCheck16Count = type === TYPE_INFO ? 1 : 0;
+            const XBadge16Count = type === TYPE_ERROR ? 1 : 0;
+            const TriangleAlert16Count = type === TYPE_WARN ? 1 : 0;
 
-            expect(component.find('IconBell').length).toBe(iconBellCount);
-            expect(component.find('IconAlertCircle').length).toBe(iconAlertCircleCount);
-            expect(component.find('IconSync').length).toBe(iconSyncCount);
-            expect(component.find('IconInfoThin').length).toBe(iconInfoThinCount);
+            expect(component.find('InfoBadge').length).toBe(infoBadgeCount);
+            expect(component.find('XBadge16').length).toBe(XBadge16Count);
+            expect(component.find('CircleCheck16').length).toBe(CircleCheck16Count);
+            expect(component.find('TriangleAlert16').length).toBe(TriangleAlert16Count);
         });
     });
 


### PR DESCRIPTION
<img width="1419" alt="Screen Shot 2021-10-21 at 10 56 57" src="https://user-images.githubusercontent.com/81333063/138325188-fc60de53-fd27-4d09-94ae-66ccb8516f6c.png">

Alerts color contrast has been improved as the general look, proper image preview is below:

![image](https://user-images.githubusercontent.com/81333063/138325558-9eb3eb54-a4dc-451a-8ffc-5996ad7b57cd.png)
