### PR TITLE
fix(datepicker): Fix input type date height

### DIFF
--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -23,6 +23,7 @@
     }
 
     .date-picker-input {
+        height: 32px;
         margin-top: 5px;
         margin-bottom: 0;
         padding-right: 30px;


### PR DESCRIPTION
### Issue Resolved
input type `date` height 18px
<img width="290" alt="Screen Shot 2021-10-26 at 10 14 25 AM" src="https://user-images.githubusercontent.com/3284947/139150738-041d9510-4ae3-4ce0-9ce0-41e4c333f8c2.png">

input type `text` height 16px
<img width="293" alt="Screen Shot 2021-10-26 at 10 14 28 AM" src="https://user-images.githubusercontent.com/3284947/139150737-0737fd5f-442b-4e31-ac15-8a12599e2f56.png">


### Resolution
To avoid any layout shifts with existing input type `text` date pickers, set default height for all `.date-picker-input` to fixed height.