### PR TITLE
fix(datepicker): Toggle calendar with button only in accessible mode

### DIFF
--- a/src/components/date-picker/AccessiblePikaday.ts
+++ b/src/components/date-picker/AccessiblePikaday.ts
@@ -2,15 +2,19 @@ import Pikaday, { PikadayOptions } from 'pikaday';
 
 export interface AccessiblePikadayOptions extends PikadayOptions {
     accessibleField?: HTMLElement | null;
+    datePickerButtonEl?: HTMLElement | null;
 }
 
 // An extended version of Pikaday to work when `isAccessible` prop is `true`. https://jira.inside-box.net/browse/A11Y-213
 class AccessiblePikaday extends Pikaday {
     accessibleField: HTMLElement | null | undefined;
 
+    datePickerButtonEl: HTMLElement | null | undefined;
+
     constructor(options: AccessiblePikadayOptions) {
         super(options);
         this.accessibleField = options.accessibleField;
+        this.datePickerButtonEl = options.datePickerButtonEl;
 
         // Override behavior as if `options.field` and `options.bound` were set.
         // See https://github.com/Pikaday/Pikaday/blob/master/pikaday.js#L671
@@ -18,21 +22,11 @@ class AccessiblePikaday extends Pikaday {
         if (this.accessibleField) {
             document.body.appendChild(this.el);
 
-            this.accessibleField.addEventListener('click', this.handleClick);
-            this.accessibleField.addEventListener('focus', this.handleFocus);
             this.accessibleField.addEventListener('blur', this.handleBlur);
 
             this.hide();
         }
     }
-
-    handleClick = () => {
-        this.show();
-    };
-
-    handleFocus = () => {
-        this.show();
-    };
 
     handleBlur = () => {
         // TODO: Test in IE11
@@ -40,6 +34,10 @@ class AccessiblePikaday extends Pikaday {
     };
 
     handleClickOutside = (e: MouseEvent) => {
+        if (this.isVisible() && this.datePickerButtonEl && this.datePickerButtonEl.contains(e.target as HTMLElement)) {
+            return;
+        }
+
         if (this.isVisible() && !this.el.contains(e.target as HTMLElement)) {
             this.hide();
         }
@@ -63,8 +61,6 @@ class AccessiblePikaday extends Pikaday {
     destroy() {
         super.destroy();
         if (this.accessibleField) {
-            this.accessibleField.removeEventListener('click', this.handleClick);
-            this.accessibleField.removeEventListener('focus', this.handleFocus);
             this.accessibleField.removeEventListener('blur', this.handleBlur);
         }
     }

--- a/src/components/date-picker/DatePicker.scss
+++ b/src/components/date-picker/DatePicker.scss
@@ -116,4 +116,10 @@
             padding-right: 50px;
         }
     }
+
+    &.is-accessible {
+        .date-picker-input {
+            min-width: 135px;
+        }
+    }
 }

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -249,6 +249,7 @@ class DatePicker extends React.Component<DatePickerProps> {
                 delete datePickerConfig.field;
                 datePickerConfig.trigger = this.dateInputEl;
                 datePickerConfig.accessibleField = this.dateInputEl;
+                datePickerConfig.datePickerButtonEl = this.datePickerButtonEl;
             }
 
             datePickerConfig.parse = this.parseDisplayDateType;
@@ -460,15 +461,22 @@ class DatePicker extends React.Component<DatePickerProps> {
         }
     };
 
-    handleDivClick = () => {
+    handleDivClick = (event: React.SyntheticEvent<HTMLDivElement>) => {
         const { isDisabled } = this.props;
 
         if (isDisabled) {
             return;
         }
 
-        if (!this.shouldStayClosed) {
-            this.focusDatePicker();
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (this.datePicker) {
+            if (this.datePicker.isVisible()) {
+                this.datePicker.hide();
+            } else {
+                this.datePicker.show();
+            }
         }
     };
 
@@ -586,6 +594,7 @@ class DatePicker extends React.Component<DatePickerProps> {
 
         const { formatMessage } = intl;
         const classes = classNames(className, 'date-picker-wrapper', {
+            'is-accessible': isAccessible,
             'show-clear-btn': !!value,
             'show-error': !!error,
         });


### PR DESCRIPTION
- Keeps the calendar closed while user is typing, to account for controlled use cases
- Only the calendar icon button will open & close the calendar popout
- Also fixes input width which led to overlapped icons

Before
![Screen Shot 2021-11-10 at 10 17 07 AM](https://user-images.githubusercontent.com/14035562/141171943-b9759dbe-d2c4-4a4f-8ed8-90687c1e7ba4.png)

After
![Screen Shot 2021-11-10 at 10 17 15 AM](https://user-images.githubusercontent.com/14035562/141171969-6f292acc-a6c7-487c-9ac4-a921ff22d344.png)
