### PR TITLE
fix(tooltips): support hover state for WCAG 1.4.13

### DIFF
--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -340,6 +340,8 @@ class Tooltip extends React.Component<TooltipProps, State> {
                 onClick={this.handleTooltipEvent}
                 onContextMenu={this.handleTooltipEvent}
                 onKeyPress={this.handleTooltipEvent}
+                onMouseEnter={this.handleMouseEnter}
+                onMouseLeave={this.handleMouseLeave}
             >
                 <div
                     role={theme === TooltipTheme.ERROR ? undefined : 'tooltip'}
@@ -358,6 +360,8 @@ class Tooltip extends React.Component<TooltipProps, State> {
                 aria-live="polite"
                 aria-hidden={isLabelMatchingTooltipText}
                 role={theme === TooltipTheme.ERROR ? undefined : 'tooltip'}
+                onMouseEnter={this.handleMouseEnter}
+                onMouseLeave={this.handleMouseLeave}
             >
                 {tooltipInner}
             </div>

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -336,12 +336,12 @@ class Tooltip extends React.Component<TooltipProps, State> {
             <div
                 className={classes}
                 id={this.tooltipID}
-                role="presentation"
                 onClick={this.handleTooltipEvent}
                 onContextMenu={this.handleTooltipEvent}
                 onKeyPress={this.handleTooltipEvent}
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
+                role="presentation"
             >
                 <div
                     role={theme === TooltipTheme.ERROR ? undefined : 'tooltip'}
@@ -354,14 +354,14 @@ class Tooltip extends React.Component<TooltipProps, State> {
             </div>
         ) : (
             <div
+                aria-live="polite"
+                aria-hidden={isLabelMatchingTooltipText}
                 className={classes}
                 data-testid="bdl-Tooltip"
                 id={this.tooltipID}
-                aria-live="polite"
-                aria-hidden={isLabelMatchingTooltipText}
-                role={theme === TooltipTheme.ERROR ? undefined : 'tooltip'}
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
+                role={theme === TooltipTheme.ERROR ? undefined : 'tooltip'}
             >
                 {tooltipInner}
             </div>

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`components/tooltip/Tooltip render() should match snapshot when stopBubb
   onClick={[Function]}
   onContextMenu={[Function]}
   onKeyPress={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   role="presentation"
 >
   <div
@@ -97,6 +99,8 @@ exports[`components/tooltip/Tooltip render() should not render with close button
     className="tooltip bdl-Tooltip"
     data-testid="bdl-Tooltip"
     id="tooltip3"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     role="tooltip"
   >
     hi
@@ -170,6 +174,8 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
     className="tooltip bdl-Tooltip is-callout"
     data-testid="bdl-Tooltip"
     id="tooltip5"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     role="tooltip"
   >
     hi
@@ -238,6 +244,8 @@ exports[`components/tooltip/Tooltip render() should render with close button if 
     className="tooltip bdl-Tooltip with-close-button"
     data-testid="bdl-Tooltip"
     id="tooltip1"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     role="tooltip"
   >
     hi


### PR DESCRIPTION
These changes should get us more aligned with the recommended approach of having the tooltip persist when the user is hovered over it. Sample of a desired path forward: https://dequeuniversity.com/library/aria/tooltip

## Specification Request

https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus

## Before
![Tooltips-Hover-Before](https://user-images.githubusercontent.com/918979/145303576-518c229d-0c19-4e43-a4d4-5567c77e7a74.gif)


## After
![Tooltips-Hover-After](https://user-images.githubusercontent.com/918979/145303557-11dd9dca-131a-4427-a1af-fd2a34448ced.gif)
