### PR TITLE
fix(activity-sidebar): delete and cancel button misalignment

### DIFF
--- a/src/elements/content-sidebar/activity-feed/common/delete-confirmation/DeleteConfirmation.scss
+++ b/src/elements/content-sidebar/activity-feed/common/delete-confirmation/DeleteConfirmation.scss
@@ -16,11 +16,11 @@
 }
 
 // overrides for confirm/cancel button spacing
-.bcs-DeleteConfirmation-delete,
-.bcs-DeleteConfirmation-cancel {
+.btn.bcs-DeleteConfirmation-delete,
+.btn.bcs-DeleteConfirmation-cancel {
     margin-left: 0;
 }
 
-.bcs-DeleteConfirmation-cancel {
+.btn.bcs-DeleteConfirmation-cancel {
     margin-right: 10px;
 }


### PR DESCRIPTION
Bug fix for incorrect vertical stacking of the delete and cancel buttons on the confirmation modal that pops up when the user tries to delete a comment. Now the buttons are aligned horizontally.

### Before
![COXP-9313](https://user-images.githubusercontent.com/95440409/145487521-06b6755e-3980-4430-b4cd-ac4357a3f0ba.jpg)


### After
**Example of Fix on Chrome:**
<img width="1678" alt="Screen Shot 2021-12-09 at 2 33 50 PM" src="https://user-images.githubusercontent.com/95440409/145487292-be28a2cc-e351-41a8-8cdc-bd877af79936.png">

**Example of Fix on IE11:**
<img width="566" alt="Screen Shot 2021-12-09 at 11 23 43 AM" src="https://user-images.githubusercontent.com/95440409/145487330-bb76d264-fda2-433f-a6a0-2867f76efecd.png">
Fix on IE11
