### PR TITLE
fix(datepicker): Add local timezone offset to display date

### DIFF
--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -490,7 +490,7 @@ class DatePicker extends React.Component<DatePickerProps> {
 
     formatDisplayDateType = (date?: Date | null): string => {
         // Input type "date" only accepts the format YYYY-MM-DD
-        return date ? date.toISOString().slice(0, 10) : '';
+        return date ? getFormattedDate(date, DateFormat.UTC_ISO_STRING_DATE_FORMAT).slice(0, 10) : '';
     };
 
     parseDisplayDateType = (dateString?: string | null): Date | null => {


### PR DESCRIPTION
The `toISOString()` method converts the date to UTC (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).

This adds a local timezone offset to the ISO string so that the date section is properly associated with the local time.

This was tested in Chrome, Firefox, and Safari and using system settings to mock different timezones.