### PR TITLE
fix(datepicker): Update input value after date is converted

### DIFF
--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -125,6 +125,8 @@ export interface DatePickerProps extends WrappedComponentProps {
     hideOptionalLabel?: boolean;
     /** Props that will be applied on the input element */
     inputProps?: Object;
+    /** Does the date input meet accessibility standards */
+    isAccessible?: boolean;
     /** Is the calendar always visible */
     isAlwaysVisible?: boolean;
     /** Is input clearable */
@@ -155,8 +157,6 @@ export interface DatePickerProps extends WrappedComponentProps {
     placeholder?: string;
     /** Resin tag */
     resinTarget?: string;
-    /** Does the date input meet accessibility standards */
-    isAccessible?: boolean;
     /** Date to set the input */
     value?: Date | null;
     /** Number of years, or an array containing an upper and lower range */
@@ -191,6 +191,7 @@ class DatePicker extends React.Component<DatePickerProps> {
             isTextInputAllowed,
             maxDate,
             minDate,
+            onChange,
             value,
             yearRange,
         } = this.props;
@@ -206,6 +207,11 @@ class DatePicker extends React.Component<DatePickerProps> {
         // relative to browser timezone
         if (dateFormat === DateFormat.UTC_TIME_DATE_FORMAT && value) {
             defaultValue = convertUTCToLocal(value);
+
+            if (onChange) {
+                const formattedDate = this.formatValue(defaultValue);
+                onChange(defaultValue, formattedDate);
+            }
         }
         // Make sure the DST detection algorithm in browsers is up-to-date
         const year = new Date().getFullYear();


### PR DESCRIPTION
When `dateFormat` is `DateFormat.UTC_TIME_DATE_FORMAT`, the date value is converted from being relative to UTC to relative to local time.

The input element is not updated to reflect the converted date, so the date value on initial rendering is wrong.

This change updates the form state after conversion which re-renders the input value with the correct date.

Before (initial render)
<img width="320" alt="Screen Shot 2021-12-21 at 10 46 14 AM" src="https://user-images.githubusercontent.com/7311041/146984248-3f3bd123-9167-4700-a764-ef2b3db2b124.png">

After (initial render)
<img width="320" alt="Screen Shot 2021-12-21 at 11 02 09 AM" src="https://user-images.githubusercontent.com/7311041/146984265-8bea36b2-8968-4477-b73a-bfef29336a31.png">
