### PR TITLE
fix: Fix className property passed to ImageTooltip component

### DIFF
--- a/src/components/image-tooltip/ImageTooltip.tsx
+++ b/src/components/image-tooltip/ImageTooltip.tsx
@@ -31,8 +31,7 @@ const ImageTooltip = ({ children, className, content, image, title, ...otherTool
         </ImageTooltipContent>
     );
 
-    const imageTooltipClasses = classNames('bdl-ImageTooltip', {
-        className,
+    const imageTooltipClasses = classNames('bdl-ImageTooltip', className, {
         'bdl-is-image-loaded': isImageLoaded,
     });
 


### PR DESCRIPTION
I noticed ImageTooltip component did not pass className property.
Instead of provided value component render 'className' string. 

Change has been tested and providing expected result.