### PR TITLE
feat(icons): add Google and Microsoft Office icons

### DIFF
--- a/src/icons/google-docs/IconGoogle.js.flow
+++ b/src/icons/google-docs/IconGoogle.js.flow
@@ -1,0 +1,57 @@
+// @flow
+import * as React from 'react';
+import uniqueId from 'lodash/uniqueId';
+
+import AccessibleSVG from '../accessible-svg';
+
+const ICON_CLASS = 'icon-google';
+
+type Props = {
+    className: string,
+    height?: number,
+    /** A text-only string describing the icon if it's not purely decorative for accessibility */
+    title?: string | React.Element<any>,
+    width?: number,
+};
+
+class IconGoogleDefault extends React.Component<Props> {
+    static defaultProps = {
+        className: '',
+        height: 30,
+        width: 30,
+    };
+
+    idPrefix = `${uniqueId(ICON_CLASS)}-`;
+
+    render() {
+        const { className, height, title, width } = this.props;
+        return (
+            <AccessibleSVG
+                className={`${ICON_CLASS} ${className}`}
+                height={height}
+                title={title}
+                viewBox="0 0 14 14"
+                width={width}
+            >
+                <path
+                    d="M13.3684 7.12062C13.3684 6.59531 13.3258 6.21198 13.2336 5.81445H7.23511V8.18542H10.7561C10.6851 8.77463 10.3018 9.66198 9.44991 10.2582L9.43797 10.3376L11.3346 11.8069L11.466 11.82C12.6727 10.7055 13.3684 9.06567 13.3684 7.12062Z"
+                    fill="#4285F4"
+                />
+                <path
+                    d="M7.23502 13.3675C8.95999 13.3675 10.4081 12.7996 11.4659 11.82L9.44982 10.2582C8.91032 10.6344 8.18623 10.8971 7.23502 10.8971C5.54552 10.8971 4.11158 9.78262 3.60042 8.24219L3.52549 8.24855L1.55338 9.77479L1.52759 9.84648C2.5782 11.9335 4.73623 13.3675 7.23502 13.3675Z"
+                    fill="#34A853"
+                />
+                <path
+                    d="M3.60049 8.24224C3.46561 7.84472 3.38756 7.41876 3.38756 6.97866C3.38756 6.53851 3.46561 6.1126 3.59339 5.71507L3.58982 5.63041L1.59299 4.07965L1.52766 4.11073C1.09465 4.97679 0.846191 5.94934 0.846191 6.97866C0.846191 8.00798 1.09465 8.98048 1.52766 9.84654L3.60049 8.24224Z"
+                    fill="#FBBC05"
+                />
+                <path
+                    d="M7.23502 3.06008C8.43469 3.06008 9.24394 3.57829 9.70537 4.01134L11.5085 2.25083C10.4011 1.22152 8.96 0.589722 7.23502 0.589722C4.73623 0.589722 2.5782 2.02366 1.52759 4.11069L3.59332 5.71503C4.11158 4.1746 5.54552 3.06008 7.23502 3.06008Z"
+                    fill="#EB4335"
+                />
+            </AccessibleSVG>
+        );
+    }
+}
+
+export default IconGoogleDefault;

--- a/src/icons/google-docs/IconGoogle.tsx
+++ b/src/icons/google-docs/IconGoogle.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import uniqueId from 'lodash/uniqueId';
+
+import AccessibleSVG from '../accessible-svg';
+
+import { TwoTonedIcon } from '../iconTypes';
+
+const ICON_CLASS = 'icon-google';
+
+class IconGoogle extends React.Component<TwoTonedIcon> {
+    static defaultProps = {
+        className: '',
+        height: 30,
+        width: 30,
+    };
+
+    idPrefix = `${uniqueId(ICON_CLASS)}-`;
+
+    render() {
+        const { className, height, title, width } = this.props;
+        return (
+            <AccessibleSVG
+                className={`${ICON_CLASS} ${className}`}
+                height={height}
+                title={title}
+                viewBox="0 0 14 14"
+                width={width}
+            >
+                <path
+                    d="M13.3684 7.12062C13.3684 6.59531 13.3258 6.21198 13.2336 5.81445H7.23511V8.18542H10.7561C10.6851 8.77463 10.3018 9.66198 9.44991 10.2582L9.43797 10.3376L11.3346 11.8069L11.466 11.82C12.6727 10.7055 13.3684 9.06567 13.3684 7.12062Z"
+                    fill="#4285F4"
+                />
+                <path
+                    d="M7.23502 13.3675C8.95999 13.3675 10.4081 12.7996 11.4659 11.82L9.44982 10.2582C8.91032 10.6344 8.18623 10.8971 7.23502 10.8971C5.54552 10.8971 4.11158 9.78262 3.60042 8.24219L3.52549 8.24855L1.55338 9.77479L1.52759 9.84648C2.5782 11.9335 4.73623 13.3675 7.23502 13.3675Z"
+                    fill="#34A853"
+                />
+                <path
+                    d="M3.60049 8.24224C3.46561 7.84472 3.38756 7.41876 3.38756 6.97866C3.38756 6.53851 3.46561 6.1126 3.59339 5.71507L3.58982 5.63041L1.59299 4.07965L1.52766 4.11073C1.09465 4.97679 0.846191 5.94934 0.846191 6.97866C0.846191 8.00798 1.09465 8.98048 1.52766 9.84654L3.60049 8.24224Z"
+                    fill="#FBBC05"
+                />
+                <path
+                    d="M7.23502 3.06008C8.43469 3.06008 9.24394 3.57829 9.70537 4.01134L11.5085 2.25083C10.4011 1.22152 8.96 0.589722 7.23502 0.589722C4.73623 0.589722 2.5782 2.02366 1.52759 4.11069L3.59332 5.71503C4.11158 4.1746 5.54552 3.06008 7.23502 3.06008Z"
+                    fill="#EB4335"
+                />
+            </AccessibleSVG>
+        );
+    }
+}
+
+export default IconGoogle;

--- a/src/icons/google-docs/__tests__/IconGoogle.test.tsx
+++ b/src/icons/google-docs/__tests__/IconGoogle.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import IconGoogle from '../IconGoogle';
+
+describe('icons/google-docs/IconGoogle', () => {
+    const getWrapper = (props = {}) => shallow(<IconGoogle {...props} />);
+
+    test('should correctly render default icon', () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.is('AccessibleSVG')).toBe(true);
+        expect(wrapper.hasClass('icon-google')).toBe(true);
+        expect(wrapper.prop('height')).toEqual(30);
+        expect(wrapper.prop('width')).toEqual(30);
+    });
+
+    test('should correctly render icon with specified class', () => {
+        const className = 'test';
+        const wrapper = getWrapper({ className });
+
+        expect(wrapper.hasClass(className)).toBe(true);
+    });
+
+    test('should correctly render icon with specified height', () => {
+        const height = 17;
+        const wrapper = getWrapper({ height });
+
+        expect(wrapper.prop('height')).toEqual(height);
+    });
+
+    test('should correctly render icon with specified title', () => {
+        const title = 'fool';
+        const wrapper = getWrapper({ title });
+
+        expect(wrapper.prop('title')).toEqual(title);
+    });
+
+    test('should correctly render icon with specified width', () => {
+        const width = 17;
+        const wrapper = getWrapper({ width });
+
+        expect(wrapper.prop('width')).toEqual(width);
+    });
+});

--- a/src/icons/microsoft-office/IconOffice.js.flow
+++ b/src/icons/microsoft-office/IconOffice.js.flow
@@ -1,0 +1,45 @@
+// @flow
+import * as React from 'react';
+import uniqueId from 'lodash/uniqueId';
+
+import AccessibleSVG from '../accessible-svg';
+
+const ICON_CLASS = 'icon-office';
+
+type Props = {
+    className: string,
+    height?: number,
+    /** A text-only string describing the icon if it's not purely decorative for accessibility */
+    title?: string | React.Element<any>,
+    width?: number,
+};
+
+class IconOfficeDefault extends React.Component<Props> {
+    static defaultProps = {
+        className: '',
+        height: 30,
+        width: 30,
+    };
+
+    idPrefix = `${uniqueId(ICON_CLASS)}-`;
+
+    render() {
+        const { className, height, title, width } = this.props;
+        return (
+            <AccessibleSVG
+                className={`${ICON_CLASS} ${className}`}
+                height={height}
+                title={title}
+                viewBox="0 0 64 77"
+                width={width}
+            >
+                <path
+                    d="M 0 62.113281 L 0 15.304688 L 41.464844 0.00390625 L 64 7.199219 L 64 70.214844 L 41.464844 77 L 0 62.113281 L 41.464844 67.097656 L 41.464844 12.605469 L 14.421875 18.90625 L 14.421875 55.816406 Z M 0 62.113281 "
+                    fill="#d83b01"
+                />
+            </AccessibleSVG>
+        );
+    }
+}
+
+export default IconOfficeDefault;

--- a/src/icons/microsoft-office/IconOffice.tsx
+++ b/src/icons/microsoft-office/IconOffice.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import uniqueId from 'lodash/uniqueId';
+
+import AccessibleSVG from '../accessible-svg';
+
+import { TwoTonedIcon } from '../iconTypes';
+
+const ICON_CLASS = 'icon-office';
+
+class IconOffice extends React.Component<TwoTonedIcon> {
+    static defaultProps = {
+        className: '',
+        height: 30,
+        width: 30,
+    };
+
+    idPrefix = `${uniqueId(ICON_CLASS)}-`;
+
+    render() {
+        const { className, height, title, width } = this.props;
+        return (
+            <AccessibleSVG
+                className={`${ICON_CLASS} ${className}`}
+                height={height}
+                title={title}
+                viewBox="0 0 64 77"
+                width={width}
+            >
+                <path
+                    d="M 0 62.113281 L 0 15.304688 L 41.464844 0.00390625 L 64 7.199219 L 64 70.214844 L 41.464844 77 L 0 62.113281 L 41.464844 67.097656 L 41.464844 12.605469 L 14.421875 18.90625 L 14.421875 55.816406 Z M 0 62.113281 "
+                    fill="#d83b01"
+                />
+            </AccessibleSVG>
+        );
+    }
+}
+
+export default IconOffice;

--- a/src/icons/microsoft-office/__tests__/IconOffice.test.tsx
+++ b/src/icons/microsoft-office/__tests__/IconOffice.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import IconOffice from '../IconOffice';
+
+describe('icons/microsoft-office/IconOffice', () => {
+    const getWrapper = (props = {}) => shallow(<IconOffice {...props} />);
+
+    test('should correctly render default icon', () => {
+        const wrapper = getWrapper();
+
+        expect(wrapper.is('AccessibleSVG')).toBe(true);
+        expect(wrapper.hasClass('icon-office')).toBe(true);
+        expect(wrapper.prop('height')).toEqual(30);
+        expect(wrapper.prop('width')).toEqual(30);
+    });
+
+    test('should correctly render icon with specified class', () => {
+        const className = 'test';
+        const wrapper = getWrapper({ className });
+
+        expect(wrapper.hasClass(className)).toBe(true);
+    });
+
+    test('should correctly render icon with specified height', () => {
+        const height = 17;
+        const wrapper = getWrapper({ height });
+
+        expect(wrapper.prop('height')).toEqual(height);
+    });
+
+    test('should correctly render icon with specified title', () => {
+        const title = 'fool';
+        const wrapper = getWrapper({ title });
+
+        expect(wrapper.prop('title')).toEqual(title);
+    });
+
+    test('should correctly render icon with specified width', () => {
+        const width = 17;
+        const wrapper = getWrapper({ width });
+
+        expect(wrapper.prop('width')).toEqual(width);
+    });
+});


### PR DESCRIPTION
Add Google and Microsoft Office generic icons:
![image](https://user-images.githubusercontent.com/29651042/148236450-2b495d3c-3068-43ea-8319-387b19eeddc2.png)
![Screenshot 2022-01-13 at 12 26 11](https://user-images.githubusercontent.com/29651042/149321974-ca861c4b-00cb-40d4-87f6-763bd7572ee6.png)

