### PR TITLE
fix(datepicker): Add error styling for invalid date inputs

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -882,6 +882,12 @@ boxui.core.send = Send
 boxui.datePicker.chooseDate = Choose Date
 # Button for clearing date picker
 boxui.datePicker.dateClearButton = Clear Date
+# Error message when date is later than the maximum date
+boxui.datePicker.dateInputMaxError = Please enter a date before {maxLocaleDate}
+# Error message when date is earlier than the minimum date
+boxui.datePicker.dateInputMinError = Please enter a date after {minLocaleDate}
+# Error message when date is out of the minimum and maximum range
+boxui.datePicker.dateInputRangeError = Please enter a date between {minLocaleDate} and {maxLocaleDate}
 # Date entered is invalid
 boxui.datePicker.iconAlertText = Invalid Date
 # Message for screenReader users when trying to tag a user but there are no matches

--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -51,6 +51,21 @@ const messages = defineMessages({
         description: 'Button for opening date picker',
         id: 'boxui.datePicker.chooseDate',
     },
+    dateInputRangeError: {
+        defaultMessage: 'Please enter a date between {minLocaleDate} and {maxLocaleDate}',
+        description: 'Error message when date is out of the minimum and maximum range',
+        id: 'boxui.datePicker.dateInputRangeError',
+    },
+    dateInputMaxError: {
+        defaultMessage: 'Please enter a date before {maxLocaleDate}',
+        description: 'Error message when date is later than the maximum date',
+        id: 'boxui.datePicker.dateInputMaxError',
+    },
+    dateInputMinError: {
+        defaultMessage: 'Please enter a date after {minLocaleDate}',
+        description: 'Error message when date is earlier than the minimum date',
+        id: 'boxui.datePicker.dateInputMinError',
+    },
 });
 
 const TOGGLE_DELAY_MS = 300;
@@ -58,8 +73,11 @@ const ENTER_KEY = 'Enter';
 const ESCAPE_KEY = 'Escape';
 const TAB_KEY = 'Tab';
 
+const ISO_DATE_FORMAT_PATTERN = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/;
+
 export enum DateFormat {
     ISO_STRING_DATE_FORMAT = 'isoString',
+    LOCALE_DATE_STRING_DATE_FORMAT = 'localeDateString',
     UTC_TIME_DATE_FORMAT = 'utcTime',
     UNIX_TIME_DATE_FORMAT = 'unixTime',
     UTC_ISO_STRING_DATE_FORMAT = 'utcISOString',
@@ -89,6 +107,8 @@ function getFormattedDate(date: Date | null, format: DateFormat) {
     switch (format) {
         case DateFormat.ISO_STRING_DATE_FORMAT:
             return date.toISOString();
+        case DateFormat.LOCALE_DATE_STRING_DATE_FORMAT:
+            return date.toLocaleDateString();
         case DateFormat.UTC_TIME_DATE_FORMAT:
             return convertDateToUnixMidnightTime(date);
         case DateFormat.UTC_ISO_STRING_DATE_FORMAT:
@@ -163,7 +183,14 @@ export interface DatePickerProps extends WrappedComponentProps {
     yearRange?: number | Array<number>;
 }
 
-class DatePicker extends React.Component<DatePickerProps> {
+interface DatePickerState {
+    /** Is the date input invalid */
+    isDateInputInvalid: boolean;
+    /** Shows error message tooltip for invalid date input */
+    showDateInputError: boolean;
+}
+
+class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
     static defaultProps = {
         className: '',
         dateFormat: DateFormat.UNIX_TIME_DATE_FORMAT,
@@ -175,6 +202,11 @@ class DatePicker extends React.Component<DatePickerProps> {
         isKeyboardInputAllowed: false,
         isTextInputAllowed: false,
         yearRange: 10,
+    };
+
+    state = {
+        isDateInputInvalid: false,
+        showDateInputError: false,
     };
 
     errorMessageID = uniqueId('errorMessage');
@@ -364,6 +396,28 @@ class DatePicker extends React.Component<DatePickerProps> {
         }
     };
 
+    getDateInputError = () => {
+        const { intl, maxDate = null, minDate = null } = this.props;
+        const { showDateInputError } = this.state;
+        const { formatMessage } = intl;
+
+        if (!showDateInputError) return '';
+
+        let dateInputError = '';
+        const maxLocaleDate = getFormattedDate(maxDate, DateFormat.LOCALE_DATE_STRING_DATE_FORMAT);
+        const minLocaleDate = getFormattedDate(minDate, DateFormat.LOCALE_DATE_STRING_DATE_FORMAT);
+
+        if (maxLocaleDate && minLocaleDate) {
+            dateInputError = formatMessage(messages.dateInputRangeError, { maxLocaleDate, minLocaleDate });
+        } else if (maxLocaleDate) {
+            dateInputError = formatMessage(messages.dateInputMaxError, { maxLocaleDate });
+        } else if (minLocaleDate) {
+            dateInputError = formatMessage(messages.dateInputMinError, { minLocaleDate });
+        }
+
+        return dateInputError;
+    };
+
     handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
         const { isKeyboardInputAllowed, isTextInputAllowed, isAccessible } = this.props;
 
@@ -394,7 +448,8 @@ class DatePicker extends React.Component<DatePickerProps> {
     };
 
     handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const { isAccessible, onChange } = this.props;
+        const { isAccessible, maxDate, minDate, onChange } = this.props;
+        const { isDateInputInvalid } = this.state;
 
         if (!isAccessible || !this.canUseDateInputType) {
             return;
@@ -404,9 +459,24 @@ class DatePicker extends React.Component<DatePickerProps> {
             event.stopPropagation();
         }
 
-        const date = event.target.value;
-        if (this.datePicker && date) {
-            const parsedDate = this.parseDisplayDateType(date);
+        const { value } = event.target;
+        if (this.datePicker && value) {
+            const parsedDate = this.parseDisplayDateType(value);
+
+            if (parsedDate) {
+                if ((minDate && parsedDate < minDate) || (maxDate && parsedDate > maxDate)) {
+                    this.datePicker.setDate(null, true);
+                    this.setState({ isDateInputInvalid: true });
+                    return;
+                }
+                // Reset the error styling on valid date input
+                if (isDateInputInvalid) {
+                    this.setState({ isDateInputInvalid: false, showDateInputError: false });
+                }
+            } else {
+                this.setState({ isDateInputInvalid: true });
+            }
+
             // Set date so Pikaday date picker value stays in sync with input
             this.datePicker.setDate(parsedDate, true);
 
@@ -414,11 +484,14 @@ class DatePicker extends React.Component<DatePickerProps> {
                 const formattedDate = this.formatValue(parsedDate);
                 onChange(parsedDate, formattedDate);
             }
+        } else if (isDateInputInvalid) {
+            this.setState({ isDateInputInvalid: false, showDateInputError: false });
         }
     };
 
     handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-        const { onBlur, isTextInputAllowed, isAccessible } = this.props;
+        const { isAccessible, isTextInputAllowed, onBlur } = this.props;
+        const { isDateInputInvalid } = this.state;
         const nextActiveElement = event.relatedTarget || document.activeElement;
 
         // This is mostly here to cancel out the pikaday hide() on blur
@@ -453,6 +526,8 @@ class DatePicker extends React.Component<DatePickerProps> {
         if ((isTextInputAllowed || (isAccessible && !this.canUseDateInputType)) && inputDate && inputDate.getDate()) {
             this.onSelectHandler(inputDate);
         }
+
+        if (isAccessible && isDateInputInvalid) this.setState({ showDateInputError: true });
     };
 
     handleButtonClick = (event: React.SyntheticEvent<HTMLButtonElement>) => {
@@ -500,7 +575,7 @@ class DatePicker extends React.Component<DatePickerProps> {
     };
 
     parseDisplayDateType = (dateString?: string | null): Date | null => {
-        if (dateString) {
+        if (dateString && ISO_DATE_FORMAT_PATTERN.test(dateString)) {
             // Calling new Date('YYYY-MM-DD') without 'T00:00:00' yields undesired results:
             // E.g. new Date('2017-06-01') => May 31 2017
             // E.g. new Date('2017-06-01T00:00:00') => June 01 2017
@@ -577,11 +652,11 @@ class DatePicker extends React.Component<DatePickerProps> {
             hideOptionalLabel,
             inputProps,
             intl,
+            isAccessible,
             isClearable,
             isDisabled,
             isRequired,
             isTextInputAllowed,
-            isAccessible,
             label,
             name,
             onFocus,
@@ -589,15 +664,17 @@ class DatePicker extends React.Component<DatePickerProps> {
             resinTarget,
             value,
         } = this.props;
-
+        const { isDateInputInvalid } = this.state;
         const { formatMessage } = intl;
+
+        const errorMessage = error || this.getDateInputError();
+        const hasError = !!errorMessage;
+
         const classes = classNames(className, 'date-picker-wrapper', {
             'is-accessible': isAccessible,
             'show-clear-btn': !!value,
-            'show-error': !!error,
+            'show-error': hasError,
         });
-
-        const hasError = !!error;
 
         const ariaAttrs = {
             'aria-invalid': hasError,
@@ -625,12 +702,13 @@ class DatePicker extends React.Component<DatePickerProps> {
             onChangeAttr = { onChange: noop };
         }
 
-        const fallbackPattern = '\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])';
         // "name" prop is required for pattern validation to be surfaced on form submit. See components/form-elements/form/Form.js
         // "title" prop is shown during constraint validation as a description of the pattern
         // See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#usability
         const additionalAttrs =
-            isAccessible && !this.canUseDateInputType ? { name, pattern: fallbackPattern, title: 'YYYY-MM-DD' } : {};
+            isAccessible && !this.canUseDateInputType
+                ? { name, pattern: ISO_DATE_FORMAT_PATTERN.source, title: 'YYYY-MM-DD' }
+                : {};
 
         /* fixes proptype error about readonly field (not adding readonly so constraint validation works) */
         return (
@@ -645,9 +723,9 @@ class DatePicker extends React.Component<DatePickerProps> {
                             )}
                             <Tooltip
                                 className="date-picker-error-tooltip"
-                                isShown={!!error}
+                                isShown={hasError}
                                 position={errorTooltipPosition}
-                                text={error || ''}
+                                text={errorMessage || ''}
                                 theme={TooltipTheme.ERROR}
                             >
                                 {customInput ? (
@@ -684,7 +762,7 @@ class DatePicker extends React.Component<DatePickerProps> {
                                 )}
                             </Tooltip>
                             <span id={this.errorMessageID} className="accessibility-hidden" role="alert">
-                                {error}
+                                {errorMessage}
                             </span>
                         </>
                     </Label>
@@ -700,7 +778,7 @@ class DatePicker extends React.Component<DatePickerProps> {
                             <ClearBadge16 />
                         </PlainButton>
                     ) : null}
-                    {error ? (
+                    {errorMessage || isDateInputInvalid ? (
                         <Alert16
                             className="date-picker-icon-alert"
                             title={<FormattedMessage {...messages.iconAlertText} />}


### PR DESCRIPTION
When a date is entered via keyboard and `isAccessible` is enabled with a min and/or max date, the user is potentially blocked from entering valid inputs.

For example, if the min date is set to 01/01/2020 and the user attempts to enter 01/01/2022, the user will be blocked from entering the year because DatePicker will calculate 01/01/0002 as an invalid year and will immediately reset the input to the min date.

The following changes occur when entering invalid input:
- The date input does not reset to the min/max date
- An alert icon appears on input change with an invalid date
- A tooltip error shows on input blur with an invalid date

**Before (Typing 2022)**
![Before Behavior](https://user-images.githubusercontent.com/7311041/148315078-1445f6db-44bc-4be2-9fae-fcad9429eefd.gif)

**After (Typing 2022)**
![After Behavior](https://user-images.githubusercontent.com/7311041/148319055-4cb9f66b-87ec-4216-a84d-ec208bef3800.gif)

**After (Tooltip on Blur Event)**
<img width="364" alt="Screen Shot 2022-01-05 at 6 33 34 PM" src="https://user-images.githubusercontent.com/7311041/148319072-a17515db-a543-4dd8-8ae9-a8be2f9bdf4c.png">
