### PR TITLE
fix: fix collaborator access message copy for international translations

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1472,8 +1472,6 @@ boxui.timeInput.invalidTimeError = Invalid time format. Enter a time in the form
 boxui.unifiedShare.collaboration.groupCollabText = Group
 # Text to display for individual users who have accepted an invitation to collaborate
 boxui.unifiedShare.collaboration.userCollabText = User
-# Label for link to learn more about collaborator access
-boxui.unifiedShare.collaboratorAccessLink = collaborator access
 # Title for collaborator list modal
 boxui.unifiedShare.collaboratorListTitle = People in ‘{itemName}’
 # This string is displayed as tooltip on hovering over expire icon for collab
@@ -1634,8 +1632,6 @@ boxui.unifiedShare.sharedLinkSettings = Link Settings
 boxui.unifiedShare.sharedLinkSettingsCalloutText = Create a custom URL, enable password protection, enable link expiration, and much more
 # Title for suggested collaborators that can be added to the form
 boxui.unifiedShare.suggestedCollabsTitle = Suggested
-# Description for cta to upgrade to get collaborator access controls
-boxui.unifiedShare.upgradeCollaboratorAccessDescription = Set the level of {collaboratorAccessLink} and increase security through one of our paid plans. 
 # Description for cta to upgrade to get more access controls for inviting collaborators to an item
 boxui.unifiedShare.upgradeGetMoreAccessControlsDescription = 62% of customers on your plan {upgradeGetMoreAccessControlsLink} to manage collaborators’ access and permission settings
 # Label for link to upgrade to get more access controls for inviting collaborators to an item

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1635,7 +1635,7 @@ boxui.unifiedShare.sharedLinkSettingsCalloutText = Create a custom URL, enable p
 # Title for suggested collaborators that can be added to the form
 boxui.unifiedShare.suggestedCollabsTitle = Suggested
 # Description for cta to upgrade to get collaborator access controls
-boxui.unifiedShare.upgradeCollaboratorAccessDescription = Set the level of {collaboratorAccessLink} and increase security through one of our paid plans. {upgradeGetMoreAccessControlsLink}.
+boxui.unifiedShare.upgradeCollaboratorAccessDescription = Set the level of {collaboratorAccessLink} and increase security through one of our paid plans. 
 # Description for cta to upgrade to get more access controls for inviting collaborators to an item
 boxui.unifiedShare.upgradeGetMoreAccessControlsDescription = 62% of customers on your plan {upgradeGetMoreAccessControlsLink} to manage collaborators’ access and permission settings
 # Label for link to upgrade to get more access controls for inviting collaborators to an item

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -542,7 +542,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     }
 
     renderUpgradeLinkDescription() {
-        const { openUpgradePlanModal = () => {}, showNewUpgradeText = false, trackingProps = {} } = this.props;
+        const { intl, openUpgradePlanModal = () => {}, showNewUpgradeText = false, trackingProps = {} } = this.props;
         const { inviteCollabsEmailTracking = {} } = trackingProps;
         const { upgradeLinkProps = {} } = inviteCollabsEmailTracking;
 
@@ -550,30 +550,30 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             <div className="upgrade-description">
                 <UpgradeBadge />
                 {showNewUpgradeText ? (
-                    <FormattedMessage
-                        values={{
-                            upgradeGetMoreAccessControlsLink: (
-                                <PlainButton
-                                    className="upgrade-link"
-                                    data-resin-target="external_collab_newcopy_upgrade_cta"
-                                    onClick={openUpgradePlanModal}
-                                    type="button"
-                                >
-                                    <FormattedMessage {...messages.upgradeLink} />
-                                </PlainButton>
-                            ),
-                            collaboratorAccessLink: (
-                                <Link
-                                    className="upgrade-link"
-                                    href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
-                                    target="_blank"
-                                >
-                                    <FormattedMessage {...messages.collaboratorAccessLink} />
-                                </Link>
-                            ),
-                        }}
-                        {...messages.upgradeCollaboratorAccessDescription}
-                    />
+                    <>
+                        <FormattedMessage
+                            values={{
+                                collaboratorAccessLink: (
+                                    <Link
+                                        className="upgrade-link"
+                                        href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
+                                        target="_blank"
+                                    >
+                                        {intl.formatMessage(messages.collaboratorAccessLink)}
+                                    </Link>
+                                ),
+                            }}
+                            {...messages.upgradeCollaboratorAccessDescription}
+                        />
+                        <PlainButton
+                            className="upgrade-link"
+                            data-resin-target="external_collab_newcopy_upgrade_cta"
+                            onClick={openUpgradePlanModal}
+                            type="button"
+                        >
+                            <FormattedMessage {...messages.upgradeGetMoreAccessControlsLink} />
+                        </PlainButton>
+                    </>
                 ) : (
                     <FormattedMessage
                         values={{
@@ -596,33 +596,31 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     }
 
     renderUpgradeInlineNotice() {
-        const { openUpgradePlanModal = () => {} } = this.props;
+        const { intl, openUpgradePlanModal = () => {} } = this.props;
         return (
             <InlineNotice title={<FormattedMessage {...messages.upgradeInlineNoticeTitle} />} type="info">
                 <FormattedMessage
                     values={{
-                        upgradeGetMoreAccessControlsLink: (
-                            <PlainButton
-                                className="upgrade-link"
-                                data-resin-target="external_collab_top_message_upgrade_cta"
-                                onClick={openUpgradePlanModal}
-                                type="button"
-                            >
-                                <FormattedMessage {...messages.upgradeLink} />
-                            </PlainButton>
-                        ),
                         collaboratorAccessLink: (
                             <Link
                                 className="upgrade-link"
                                 href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
                                 target="_blank"
                             >
-                                <FormattedMessage {...messages.collaboratorAccessLink} />
+                                {intl.formatMessage(messages.collaboratorAccessLink)}
                             </Link>
                         ),
                     }}
                     {...messages.upgradeCollaboratorAccessDescription}
                 />
+                <PlainButton
+                    className="upgrade-link"
+                    data-resin-target="external_collab_newcopy_upgrade_cta"
+                    onClick={openUpgradePlanModal}
+                    type="button"
+                >
+                    <FormattedMessage {...messages.upgradeLink} />
+                </PlainButton>
             </InlineNotice>
         );
     }

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -5,6 +5,7 @@ import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
+import FormattedCompMessage from '../../components/i18n/FormattedCompMessage';
 import LoadingIndicatorWrapper from '../../components/loading-indicator/LoadingIndicatorWrapper';
 import { Link } from '../../components/link';
 import Button from '../../components/button';
@@ -542,7 +543,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     }
 
     renderUpgradeLinkDescription() {
-        const { intl, openUpgradePlanModal = () => {}, showNewUpgradeText = false, trackingProps = {} } = this.props;
+        const { openUpgradePlanModal = () => {}, showNewUpgradeText = false, trackingProps = {} } = this.props;
         const { inviteCollabsEmailTracking = {} } = trackingProps;
         const { upgradeLinkProps = {} } = inviteCollabsEmailTracking;
 
@@ -551,27 +552,27 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                 <UpgradeBadge />
                 {showNewUpgradeText ? (
                     <>
-                        <FormattedMessage
-                            values={{
-                                collaboratorAccessLink: (
-                                    <Link
-                                        className="upgrade-link"
-                                        href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
-                                        target="_blank"
-                                    >
-                                        {intl.formatMessage(messages.collaboratorAccessLink)}
-                                    </Link>
-                                ),
-                            }}
-                            {...messages.upgradeCollaboratorAccessDescription}
-                        />
+                        <FormattedCompMessage
+                            id="boxui.unifiedShare.upgradeCollaboratorAccessDescription"
+                            description="Description for cta to upgrade to get collaborator access controls"
+                        >
+                            Set the level of{' '}
+                            <Link
+                                className="upgrade-link"
+                                href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
+                                target="_blank"
+                            >
+                                collaborator access
+                            </Link>{' '}
+                            and increase security through one of our paid plans.{' '}
+                        </FormattedCompMessage>
                         <PlainButton
                             className="upgrade-link"
                             data-resin-target="external_collab_newcopy_upgrade_cta"
                             onClick={openUpgradePlanModal}
                             type="button"
                         >
-                            <FormattedMessage {...messages.upgradeGetMoreAccessControlsLink} />
+                            <FormattedMessage {...messages.upgradeLink} />
                         </PlainButton>
                     </>
                 ) : (
@@ -596,26 +597,26 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     }
 
     renderUpgradeInlineNotice() {
-        const { intl, openUpgradePlanModal = () => {} } = this.props;
+        const { openUpgradePlanModal = () => {} } = this.props;
         return (
             <InlineNotice title={<FormattedMessage {...messages.upgradeInlineNoticeTitle} />} type="info">
-                <FormattedMessage
-                    values={{
-                        collaboratorAccessLink: (
-                            <Link
-                                className="upgrade-link"
-                                href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
-                                target="_blank"
-                            >
-                                {intl.formatMessage(messages.collaboratorAccessLink)}
-                            </Link>
-                        ),
-                    }}
-                    {...messages.upgradeCollaboratorAccessDescription}
-                />
+                <FormattedCompMessage
+                    id="boxui.unifiedShare.upgradeCollaboratorAccessDescription"
+                    description="Description for cta to upgrade to get collaborator access controls"
+                >
+                    Set the level of{' '}
+                    <Link
+                        className="upgrade-link"
+                        href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
+                        target="_blank"
+                    >
+                        collaborator access
+                    </Link>{' '}
+                    and increase security through one of our paid plans.{' '}
+                </FormattedCompMessage>
                 <PlainButton
                     className="upgrade-link"
-                    data-resin-target="external_collab_newcopy_upgrade_cta"
+                    data-resin-target="external_collab_top_message_upgrade_cta"
                     onClick={openUpgradePlanModal}
                     type="button"
                 >

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -224,7 +224,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
                 showUpgradeOptions: true,
             });
             expect(wrapper.exists('UpgradeBadge')).toBe(true);
-            const msg = wrapper.find('FormattedMessage');
+            const msg = wrapper.find('FormattedMessage').first();
             expect(msg.prop('id')).toEqual(messages.upgradeCollaboratorAccessDescription.id);
         });
 

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { ITEM_TYPE_WEBLINK, ITEM_TYPE_FOLDER } from '../../../common/constants';
-import messages from '../messages';
 
 import { JUSTIFICATION_CHECKPOINT_EXTERNAL_COLLAB } from '../constants';
 
@@ -224,8 +223,8 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
                 showUpgradeOptions: true,
             });
             expect(wrapper.exists('UpgradeBadge')).toBe(true);
-            const msg = wrapper.find('FormattedMessage').first();
-            expect(msg.prop('id')).toEqual(messages.upgradeCollaboratorAccessDescription.id);
+            const msg = wrapper.find('FormattedCompMessage');
+            expect(msg.prop('id')).toEqual('boxui.unifiedShare.upgradeCollaboratorAccessDescription');
         });
 
         test('should render correct upgrade inline notice when showUpgradeInlineNotice and showUpgradeOptions is enabled', () => {

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -276,7 +276,7 @@ const messages = defineMessages({
     },
     upgradeCollaboratorAccessDescription: {
         defaultMessage:
-            'Set the level of {collaboratorAccessLink} and increase security through one of our paid plans. {upgradeGetMoreAccessControlsLink}.',
+            'Set the level of {collaboratorAccessLink} and increase security through one of our paid plans. ',
         description: 'Description for cta to upgrade to get collaborator access controls',
         id: 'boxui.unifiedShare.upgradeCollaboratorAccessDescription',
     },

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -274,12 +274,6 @@ const messages = defineMessages({
         description: 'Label for link to upgrade to get more access controls for inviting collaborators to an item',
         id: 'boxui.unifiedShare.upgradeGetMoreAccessControlsLink',
     },
-    upgradeCollaboratorAccessDescription: {
-        defaultMessage:
-            'Set the level of {collaboratorAccessLink} and increase security through one of our paid plans. ',
-        description: 'Description for cta to upgrade to get collaborator access controls',
-        id: 'boxui.unifiedShare.upgradeCollaboratorAccessDescription',
-    },
     upgradeLink: {
         defaultMessage: 'Upgrade now',
         description: 'Label for link to upgrade account',
@@ -289,11 +283,6 @@ const messages = defineMessages({
         defaultMessage: 'Upgrade Your Plan',
         description: 'Title for the upgrade inline notice for upgrade user plan',
         id: 'boxui.unifiedShare.upgradeInlineNoticeTitle',
-    },
-    collaboratorAccessLink: {
-        defaultMessage: 'collaborator access',
-        description: 'Label for link to learn more about collaborator access',
-        id: 'boxui.unifiedShare.collaboratorAccessLink',
     },
     sharedLinkSettings: {
         defaultMessage: 'Link Settings',


### PR DESCRIPTION
copies remain the same
![image](https://user-images.githubusercontent.com/21050234/148303806-8176c6cb-88d5-4ed8-b92b-7fbfe519b55b.png)
