### PR TITLE
chore(deps): upgrade @hapi/address 2.1.2 to @sideway/address 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,8 +146,8 @@
         "@formatjs/intl-pluralrules": "^1.5.2",
         "@formatjs/intl-relativetimeformat": "^4.5.9",
         "@formatjs/intl-unified-numberformat": "^3.2.0",
-        "@hapi/address": "2.1.1",
         "@sambego/storybook-state": "^2.0.1",
+        "@sideway/address": "^4.1.3",
         "@storybook/addon-actions": "^5.3.9",
         "@storybook/addon-docs": "^5.3.9",
         "@storybook/addon-info": "^5.3.9",
@@ -327,7 +327,6 @@
     "peerDependencies": {
         "@box/cldr-data": "^34.2.0",
         "@box/react-virtualized": "9.22.3-rc-box.2",
-        "@hapi/address": ">=2.0.0 <2.1.2",
         "axios": "^0.18.1",
         "classnames": "^2.2.5",
         "color": "^3.1.2",
@@ -369,7 +368,6 @@
     },
     "comments": {
         "dependencies": {
-            "@hapi/address": "Version 2.1.2+ requires a polyfill for TextEncoder. Pinning to version 2.1.1 prevents IE11 from breaking.",
             "react-tether": "Version 2.x has too many breaking changes and requires forwardRef on all components"
         }
     }

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,5 +1,5 @@
 // @flow
-import Address from '@hapi/address';
+import Address from '@sideway/address';
 
 function hostnameValidator(value: string): boolean {
     // @see https://github.com/hapijs/joi/blame/3516cf0b995c9fe415634c4612c0ac2f8792f0b4/lib/types/string/index.js#L530

--- a/yarn.lock
+++ b/yarn.lock
@@ -3562,11 +3562,6 @@
   resolved "https://registry.yarnpkg.com/@formatjs/macro/-/macro-0.2.6.tgz#eb173658d803416a43210778b2f5c04c5a240bb6"
   integrity sha512-DfdnLJf8+PwLHzJECZ1Xfa8+sI9akQnUuLN2UdkaExTQmlY0Vs36rMzEP0JoVDBMk+KdQbJNt72rPeZkBNcKWg==
 
-"@hapi/address@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.1.tgz#61395b5ed94c4cb19c2dc4c85969cff3d40d583f"
-  integrity sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA==
-
 "@hapi/address@2.x.x", "@hapi/address@^2.1.2":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -3586,6 +3581,11 @@
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.0.tgz#2f9ce301c8898e1c3248b0a8564696b24d1a9a5a"
   integrity sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==
+
+"@hapi/hoek@^9.0.0":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
+  integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
 
 "@hapi/joi@^15.0.3":
   version "15.1.1"
@@ -4181,6 +4181,13 @@
     import-from "^2.1.0"
     into-stream "^4.0.0"
     lodash "^4.17.4"
+
+"@sideway/address@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
+  integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"


### PR DESCRIPTION
Tested on dev vm. Apparently does not need TextEncoder polyfill at this stage.
@hapi/address 2.1.2 is still in node_modules via @hapi/joi, a fact which probably insulates against unforseeable risks.

No longer seeing "invalid email" error for .cpa top-level domain:
![Screen Shot 2022-01-28 at 1 12 45 PM](https://user-images.githubusercontent.com/5461045/151601149-518dc248-40af-450d-af95-41e4926082c7.png)
![Screen Shot 2022-01-28 at 1 12 50 PM](https://user-images.githubusercontent.com/5461045/151601504-ff5e247c-5c58-4618-800f-cbf171778fb8.png)


