### PR TITLE
fix(tooltip): dismiss tooltip on ESC

### DIFF
--- a/src/components/sidebar-toggle-button/__tests__/__snapshots__/SidebarToggleButton.test.js.snap
+++ b/src/components/sidebar-toggle-button/__tests__/__snapshots__/SidebarToggleButton.test.js.snap
@@ -45,7 +45,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
           key=".0"
           onBlur={[Function]}
           onFocus={[Function]}
-          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           tabIndex="0"
@@ -56,7 +55,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
             className="btn-plain bdl-SidebarToggleButton bdl-is-collapsed"
             onBlur={[Function]}
             onFocus={[Function]}
-            onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             tabIndex="0"
@@ -144,7 +142,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
           key=".0"
           onBlur={[Function]}
           onFocus={[Function]}
-          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           tabIndex="0"
@@ -155,7 +152,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
             className="btn-plain bdl-SidebarToggleButton bdl-is-collapsed"
             onBlur={[Function]}
             onFocus={[Function]}
-            onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             tabIndex="0"
@@ -243,7 +239,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
           key=".0"
           onBlur={[Function]}
           onFocus={[Function]}
-          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           tabIndex="0"
@@ -254,7 +249,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
             className="btn-plain bdl-SidebarToggleButton"
             onBlur={[Function]}
             onFocus={[Function]}
-            onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             tabIndex="0"
@@ -340,7 +334,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
           key=".0"
           onBlur={[Function]}
           onFocus={[Function]}
-          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
           tabIndex="0"
@@ -351,7 +344,6 @@ exports[`components/sidebar-toggle-button/SidebarToggleButton should render corr
             className="btn-plain bdl-SidebarToggleButton"
             onBlur={[Function]}
             onFocus={[Function]}
-            onKeyDown={[Function]}
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
             tabIndex="0"

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -140,12 +140,18 @@ class Tooltip extends React.Component<TooltipProps, State> {
             }
         } else {
             if (!prevState.isShown && this.state.isShown) {
-                document.addEventListener('keydown', this.handleKeyDown);
+                // capture event so that tooltip closes before any other floating components that can be closed by
+                // "Escape" key(e.g. Modal, Menu, etc.)
+                document.addEventListener('keydown', this.handleKeyDown, true);
             }
             if (prevState.isShown && !this.state.isShown) {
-                document.removeEventListener('keydown', this.handleKeyDown);
+                document.removeEventListener('keydown', this.handleKeyDown, true);
             }
         }
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeyDown, true);
     }
 
     tooltipID = uniqueId('tooltip');
@@ -207,6 +213,7 @@ class Tooltip extends React.Component<TooltipProps, State> {
 
     handleKeyDown = (event: KeyboardEvent) => {
         if (event.key === 'Escape') {
+            event.stopPropagation();
             this.setState({ isShown: false });
         }
         this.fireChildEvent('onKeyDown', event);

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -130,11 +130,20 @@ class Tooltip extends React.Component<TooltipProps, State> {
         this.setState({ hasRendered: true });
     }
 
-    componentDidUpdate(prevProps: TooltipProps) {
+    componentDidUpdate(prevProps: TooltipProps, prevState: State) {
+        const isControlled = this.isControlled();
+
         // Reset wasClosedByUser state when isShown transitions from false to true
-        if (this.isControlled()) {
+        if (isControlled) {
             if (!prevProps.isShown && this.props.isShown) {
                 this.setState({ wasClosedByUser: false });
+            }
+        } else {
+            if (!prevState.isShown && this.state.isShown) {
+                document.addEventListener('keydown', this.handleKeyDown);
+            }
+            if (prevState.isShown && !this.state.isShown) {
+                document.removeEventListener('keydown', this.handleKeyDown);
             }
         }
     }
@@ -158,7 +167,7 @@ class Tooltip extends React.Component<TooltipProps, State> {
         }
     };
 
-    fireChildEvent = (type: string, event: React.SyntheticEvent<HTMLElement>) => {
+    fireChildEvent = (type: string, event: React.SyntheticEvent<HTMLElement> | Event) => {
         const { children } = this.props;
         const handler = (children as React.ReactElement).props[type];
         if (handler) {
@@ -196,7 +205,7 @@ class Tooltip extends React.Component<TooltipProps, State> {
         return typeof isShownProp !== 'undefined';
     };
 
-    handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    handleKeyDown = (event: KeyboardEvent) => {
         if (event.key === 'Escape') {
             this.setState({ isShown: false });
         }
@@ -278,7 +287,6 @@ class Tooltip extends React.Component<TooltipProps, State> {
         if (!isControlled) {
             componentProps.onBlur = this.handleBlur;
             componentProps.onFocus = this.handleFocus;
-            componentProps.onKeyDown = this.handleKeyDown;
             componentProps.onMouseEnter = this.handleMouseEnter;
             componentProps.onMouseLeave = this.handleMouseLeave;
 

--- a/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -89,7 +89,6 @@ describe('components/tooltip/Tooltip', () => {
             expect(component.is('button')).toBe(true);
             expect(component.prop('onBlur')).toBeTruthy();
             expect(component.prop('onFocus')).toBeTruthy();
-            expect(component.prop('onKeyDown')).toBeTruthy();
             expect(component.prop('onMouseEnter')).toBeTruthy();
             expect(component.prop('onMouseLeave')).toBeTruthy();
             expect(component.prop('tabIndex')).toEqual('0');
@@ -477,18 +476,26 @@ describe('components/tooltip/Tooltip', () => {
 
     describe('handleKeyDown()', () => {
         test('should update isShown state only when escape key is pressed', () => {
+            const map: { [key: string]: Function } = {};
+            document.addEventListener = jest.fn().mockImplementationOnce((event, cb) => {
+                map[event] = cb;
+            });
             const wrapper = shallow(
                 <Tooltip text="hi">
                     <button />
                 </Tooltip>,
             );
             wrapper.setState({ isShown: true });
-
-            wrapper.find('button').simulate('keydown', { key: 'Escape' });
+            map.keydown({ key: 'Escape' });
+            expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.anything());
             expect(wrapper.state('isShown')).toBe(false);
         });
 
         test('should not update isShown state only when some other key is pressed', () => {
+            const map: { [key: string]: Function } = {};
+            document.addEventListener = jest.fn().mockImplementationOnce((event, cb) => {
+                map[event] = cb;
+            });
             const wrapper = shallow(
                 <Tooltip text="hi">
                     <button />
@@ -496,7 +503,8 @@ describe('components/tooltip/Tooltip', () => {
             );
             wrapper.setState({ isShown: true });
 
-            wrapper.find('button').simulate('keydown', { key: 'Space' });
+            map.keydown({ key: 'Space' });
+            expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.anything());
             expect(wrapper.state('isShown')).toBe(true);
         });
 

--- a/src/components/tooltip/__tests__/Tooltip.test.tsx
+++ b/src/components/tooltip/__tests__/Tooltip.test.tsx
@@ -3,6 +3,8 @@
 import * as React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
+import noop from 'lodash/noop';
+
 import Tooltip, { TooltipPosition, TooltipTheme } from '../Tooltip';
 import TetherPosition from '../../../common/tether-positions';
 
@@ -486,8 +488,11 @@ describe('components/tooltip/Tooltip', () => {
                 </Tooltip>,
             );
             wrapper.setState({ isShown: true });
-            map.keydown({ key: 'Escape' });
-            expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.anything());
+            map.keydown({
+                key: 'Escape',
+                stopPropagation: noop,
+            });
+            expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.anything(), true);
             expect(wrapper.state('isShown')).toBe(false);
         });
 
@@ -504,7 +509,7 @@ describe('components/tooltip/Tooltip', () => {
             wrapper.setState({ isShown: true });
 
             map.keydown({ key: 'Space' });
-            expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.anything());
+            expect(document.addEventListener).toHaveBeenCalledWith('keydown', expect.anything(), true);
             expect(wrapper.state('isShown')).toBe(true);
         });
 

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -135,7 +135,6 @@ exports[`components/tooltip/Tooltip render() should render children wrapped in t
   <div
     onBlur={[Function]}
     onFocus={[Function]}
-    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     tabIndex="0"
@@ -205,7 +204,6 @@ exports[`components/tooltip/Tooltip render() should render correctly with tether
   <div
     onBlur={[Function]}
     onFocus={[Function]}
-    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     tabIndex="0"

--- a/src/features/pagination/__tests__/__snapshots__/MarkerBasedPagination.test.js.snap
+++ b/src/features/pagination/__tests__/__snapshots__/MarkerBasedPagination.test.js.snap
@@ -77,7 +77,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -89,7 +88,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -326,7 +324,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -338,7 +335,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -457,7 +453,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -469,7 +464,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -560,7 +554,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -572,7 +565,6 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"

--- a/src/features/pagination/__tests__/__snapshots__/OffsetBasedPagination.test.js.snap
+++ b/src/features/pagination/__tests__/__snapshots__/OffsetBasedPagination.test.js.snap
@@ -207,7 +207,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -219,7 +218,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -476,7 +474,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -488,7 +485,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -745,7 +741,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -757,7 +752,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -955,7 +949,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -967,7 +960,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -1058,7 +1050,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -1070,7 +1061,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -1268,7 +1258,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -1280,7 +1269,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -1371,7 +1359,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -1383,7 +1370,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"
@@ -1581,7 +1567,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   showRadar={false}
@@ -1593,7 +1578,6 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     tabIndex="0"


### PR DESCRIPTION
### Issue Resolved
To meet [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) requirement, Tooltip needs to be dismissed by pressing "Escape" key when hovered or focused.

### Resolution
- Handle "Escape" key at `document` level to handle hovering over either the wrapped component or the tooltip
- Capture event and stop propagation of the Escape key event to prevent dismissing other floating components (e.g. Modal, Menu, etc.) from closing  (Note that the requirement describes it should dismiss **additional content**)
> A [mechanism](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html#dfn-mechanism) is available to dismiss the **additional content** without moving pointer hover or keyboard focus, ...

#### Escape key on focused element
![tooltip-focus](https://user-images.githubusercontent.com/3284947/152255126-856e7dc3-566a-4b52-b9a3-64dad79574eb.gif)

#### Escape key on hovered element
![tooltip-hover](https://user-images.githubusercontent.com/3284947/152255337-8b52204c-1463-4620-93d2-d4a8eb62c902.gif)

#### Escape key on both focused and hovered elements
![tooltip-focus hover](https://user-images.githubusercontent.com/3284947/152255630-e0aff118-81d4-4b42-833c-88f6a7aa7936.gif)

#### Escape key only closing tooltip
Preview

![tooltip-previewStopPropagation](https://user-images.githubusercontent.com/3284947/152254878-7b8189b1-8182-4a52-b16b-0d3d0f75a6e3.gif)

Modal
![tooltip-modal](https://user-images.githubusercontent.com/3284947/152254925-88e26fd0-7286-4f24-ae3a-fa785747b94d.gif)


### Additional Consideration
- We have use cases where the tooltip is forced opened without hover or focus. In these cases, it doesn't fall under WCAG 1.4.13, and it's okay not to close by "Escape" key
-  Some controlled tooltips won't be closed with "Escape" key by this fix. (e.g. ViewSelector in EUA)
    - With the proposed fix, each controlled tooltips needs to handle key event at `document` since we do not expose proper "close" event for tooltip.
    - One idea to resolve this is by adding new event props (e.g. `onOpen`, `onClose`) so that controlled components can handle these cases without knowing the tooltip's open/close mechanism 
    - (extra consideration) We should also rethink of how `showCloseButton` and `onDismiss` props behave. Clicking on close button closes the tooltip even when tooltip is controlled. 