### PR TITLE
fix(content-sidebar): remove access stats from content sidebar

### DIFF
--- a/src/elements/content-sidebar/__tests__/__snapshots__/DetailsSidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/DetailsSidebar.test.js.snap
@@ -1,28 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`elements/content-sidebar/DetailsSidebar render() should render DetailsSidebar with access stats 1`] = `
-<SidebarContent
-  className="bcs-details"
-  elementId=""
-  sidebarView="details"
-  title={
-    <FormattedMessage
-      defaultMessage="Details"
-      id="be.sidebarDetailsTitle"
-    />
-  }
->
-  <SidebarAccessStats
-    file={
-      Object {
-        "description": "bar",
-        "id": "foo",
-      }
-    }
-  />
-</SidebarContent>
-`;
-
 exports[`elements/content-sidebar/DetailsSidebar render() should render DetailsSidebar with all components 1`] = `
 <SidebarContent
   className="bcs-details"
@@ -62,14 +39,6 @@ exports[`elements/content-sidebar/DetailsSidebar render() should render DetailsS
     }
     onEdit={[Function]}
   />
-  <SidebarAccessStats
-    file={
-      Object {
-        "description": "bar",
-        "id": "foo",
-      }
-    }
-  />
   <SidebarSection
     className=""
     interactionTarget="fileproperties"
@@ -97,7 +66,6 @@ exports[`elements/content-sidebar/DetailsSidebar render() should render DetailsS
         }
       }
       hasRetentionPolicy={true}
-      isLoading={false}
       onDescriptionChange={[Function]}
     />
   </SidebarSection>
@@ -162,7 +130,6 @@ exports[`elements/content-sidebar/DetailsSidebar render() should render DetailsS
         }
       }
       hasRetentionPolicy={false}
-      isLoading={false}
       onDescriptionChange={[Function]}
     />
   </SidebarSection>


### PR DESCRIPTION
**Before:**
<img width="1680" alt="content-analytics-sidebar-before" src="https://user-images.githubusercontent.com/95440409/152034904-fc33174d-84f7-4fe1-a5b8-f16728cce45a.png">

**After:**
<img width="1680" alt="content-analytics-sidebar-after" src="https://user-images.githubusercontent.com/95440409/152034917-4ba25c1a-4f37-44d3-abe2-7f537a474845.png">

