### PR TITLE
fix(sidebar): Add data-testid to preview sidebar

### DIFF
--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -235,7 +235,7 @@ class Sidebar extends React.Component<Props, State> {
         });
 
         return (
-            <aside id={this.id} className={styleClassName}>
+            <aside id={this.id} className={styleClassName} data-testid="preview-sidebar">
                 {isLoading ? (
                     <div className="bcs-loading">
                         <LoadingIndicator />


### PR DESCRIPTION
I create this PR because we need to add the parameter `data-testid` to the sidebar in order to access to this property for testing purposes.