### PR TITLE
fix(usm): supplement email validator with addtl valid tlds

### DIFF
--- a/src/features/unified-share-modal/__tests__/EmailForm.test.js
+++ b/src/features/unified-share-modal/__tests__/EmailForm.test.js
@@ -403,6 +403,15 @@ describe('features/unified-share-modal/EmailForm', () => {
                 email: 'test@@example.com',
                 expectedValue: false,
             },
+            // manually supplemented TLD:
+            {
+                email: 'test@@example.cpa',
+                expectedValue: true,
+            },
+            {
+                email: 'test@@example.badTLD',
+                expectedValue: true,
+            },
         ].forEach(({ email, expectedValue }) => {
             test('should show an error if it detects an invalid email address', () => {
                 const wrapper = getWrapper();


### PR DESCRIPTION
IE 11.379.17763.0
<img width="1231" alt="Screen Shot 2022-02-04 at 9 05 52 AM" src="https://user-images.githubusercontent.com/5461045/152543799-211b2867-b9c7-4586-8b78-8e3f79ea1d56.png">

Safari 15.2 (16612.3.6.1.8, 16612)
<img width="1231" alt="Screen Shot 2022-02-04 at 9 05 52 AM" src="https://user-images.githubusercontent.com/5461045/152544108-779f007d-4b3a-46f1-91ee-2d7e610b6571.png">

Firefox 96.0.3
<img width="1245" alt="Screen Shot 2022-02-04 at 9 09 09 AM" src="https://user-images.githubusercontent.com/5461045/152544332-07b66f78-7318-48a0-a7e7-d4d374edec25.png">

Chrome 97.0.4692.99
<img width="1244" alt="Screen Shot 2022-02-04 at 9 10 22 AM" src="https://user-images.githubusercontent.com/5461045/152544431-be71e992-f2c3-45d8-a083-91342679040b.png">

(pills overlapping text input in the pill selector input may be a tangentially-related ui bug)
