### PR TITLE
fix(tab-view): focus outline

### DIFF
--- a/src/components/tab-view/Tabs.scss
+++ b/src/components/tab-view/Tabs.scss
@@ -107,10 +107,6 @@
         }
     }
 
-    .tab:focus {
-        outline: 1px dotted $primary-color;
-    }
-
     .tab:hover,
     .tab:focus {
         .tab-title {


### PR DESCRIPTION
Before
<img width="1657" alt="Screen Shot 2022-02-15 at 4 56 49 PM" src="https://user-images.githubusercontent.com/3284947/154176172-40bda4bf-479c-434f-82dc-f53f0dceeebb.png">

After
<img width="1650" alt="Screen Shot 2022-02-15 at 4 55 01 PM" src="https://user-images.githubusercontent.com/3284947/154176175-bc57961e-95dd-4832-8728-ce824d3d8a84.png">
