### PR TITLE
feat: add responsive behavior to Modal component

### DIFF
--- a/src/components/media-query/__tests__/useViewportSize.test.js
+++ b/src/components/media-query/__tests__/useViewportSize.test.js
@@ -1,0 +1,47 @@
+// @flow
+
+import React from 'react';
+import { mount } from 'enzyme';
+import { useViewportSize } from '../useViewportSize';
+
+const mockWIDTH = 999;
+const mockHEIGHT = 998;
+
+jest.mock('../util', () => {
+    return {
+        getClientDimensions: jest.fn(() => ({
+            viewWidth: mockWIDTH,
+            viewHeight: mockHEIGHT,
+        })),
+    };
+});
+
+type Props = {
+    children?: React.node,
+};
+
+function FakeComponent(props: Props) {
+    const viewportProps = useViewportSize();
+
+    return <div>{props.children(viewportProps)}</div>;
+}
+
+describe('components/media-query/useViewportSize', () => {
+    test('returns correct viewport width and height', () => {
+        const mountedComponent = mount(
+            <FakeComponent>
+                {viewportProps => {
+                    return (
+                        <div>
+                            <div className="width">{viewportProps.viewWidth}</div>
+                            <div className="height">{viewportProps.viewHeight}</div>
+                        </div>
+                    );
+                }}
+            </FakeComponent>,
+        );
+
+        expect(mountedComponent.find('.width').text()).toBe(`${mockWIDTH}`);
+        expect(mountedComponent.find('.height').text()).toBe(`${mockHEIGHT}`);
+    });
+});

--- a/src/components/media-query/__tests__/withViewportSize.test.js
+++ b/src/components/media-query/__tests__/withViewportSize.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import withViewportSize from '../withViewportSize';
+
+import { useViewportSize, VIEWPORT_SIZE_DEFAULT_DEBOUNCE } from '../useViewportSize';
+
+jest.mock('../useViewportSize', () => ({
+    useViewportSize: jest.fn(() => {
+        return { viewWidth: 1200, viewHeight: 800 };
+    }),
+    VIEWPORT_SIZE_DEFAULT_DEBOUNCE: 200,
+}));
+
+describe('elements/common/media-query/withViewportSize', () => {
+    const WrappedComponent = () => <div />;
+    const WithViewportSizeComponent = withViewportSize(WrappedComponent);
+
+    const getWrapper = props => shallow(<WithViewportSizeComponent {...props} />);
+
+    test('wraps component with viewport props', () => {
+        const wrapper = getWrapper();
+        const wrappedComponent = wrapper.find(WrappedComponent);
+        const props = wrappedComponent.props();
+
+        expect(wrappedComponent.exists()).toBeTruthy();
+
+        expect(typeof props.viewWidth).toBe('number');
+        expect(typeof props.viewHeight).toBe('number');
+    });
+
+    test('should render inner component', () => {
+        const props = {};
+        const wrapper = getWrapper(props);
+
+        expect(wrapper.find(WrappedComponent)).toHaveLength(1);
+    });
+
+    test('should use default debounce value when no debounce value is provided', () => {
+        const props = {};
+        getWrapper(props);
+        expect(useViewportSize).toBeCalledWith(VIEWPORT_SIZE_DEFAULT_DEBOUNCE);
+    });
+
+    test('should set debounce value when debounce value is provided', () => {
+        const props = { debounce: VIEWPORT_SIZE_DEFAULT_DEBOUNCE + 10 };
+        getWrapper(props);
+        expect(useViewportSize).toBeCalledWith(VIEWPORT_SIZE_DEFAULT_DEBOUNCE + 10);
+    });
+});

--- a/src/components/media-query/stories/ViewportSize.stories.js
+++ b/src/components/media-query/stories/ViewportSize.stories.js
@@ -1,0 +1,51 @@
+// @flow
+
+import * as React from 'react';
+
+import notes from './ViewportSize.stories.md';
+import useViewportSize from '../useViewportSize';
+import withViewportSize from '../withViewportSize';
+
+export const CustomHook = () => {
+    const { viewWidth, viewHeight } = useViewportSize();
+
+    return (
+        <div>
+            <p>
+                <b>Viewport Dimensions:</b>
+                <span>{` ${viewWidth}px (w) x ${viewHeight}px (h)`}</span>
+            </p>
+        </div>
+    );
+};
+
+type Props = {
+    viewHeight: number,
+    viewWidth: number,
+};
+
+const DemoComponent = (props: Props) => {
+    const { viewWidth, viewHeight } = props;
+
+    return (
+        <div>
+            <p>
+                <b>Viewport Dimensions:</b>
+                <span>{` ${viewWidth}px (w) x ${viewHeight}px (h)`}</span>
+            </p>
+        </div>
+    );
+};
+
+export const HigherOrderComponent = withViewportSize(DemoComponent);
+
+export default {
+    title: 'Components|ViewportSize',
+    component: useViewportSize,
+    parameters: {
+        notes,
+        viewport: {
+            defaultViewport: 'tablet',
+        },
+    },
+};

--- a/src/components/media-query/stories/ViewportSize.stories.md
+++ b/src/components/media-query/stories/ViewportSize.stories.md
@@ -1,0 +1,21 @@
+`import useViewportSize from 'box-ui-elements/es/components/media-query/useViewportSize';`
+
+The `useViewportSize` hook returns the current viewport dimensions. Dimensions are updated upon resize.
+These properties can be used to implement custom functionality based on viewport size.
+
+## Arguments
+
+| Property           | Description                                                      |
+| ------------------ | ---------------------------------------------------------------- |
+| `debounceInterval` | (Optional) argument to set debounce interval. Defaults to 200 ms |
+
+## Return props
+
+| Property     | Description                   |
+| ------------ | ----------------------------- |
+| `viewHeight` | current viewport height in px |
+| `viewWidth`  | current viewport width in px  |
+
+## Demo
+
+Change the window or viewport size in "Canvas", by resizing, or in browser developer tools

--- a/src/components/media-query/useViewportSize.js
+++ b/src/components/media-query/useViewportSize.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import debounce from 'lodash/debounce';
+import { getClientDimensions } from './util';
+
+const VIEWPORT_SIZE_DEFAULT_DEBOUNCE = 200;
+
+function useViewportSize(debounceInterval = VIEWPORT_SIZE_DEFAULT_DEBOUNCE) {
+    const [viewportSize, setViewportSize] = useState(getClientDimensions());
+    useEffect(() => {
+        function handleResize() {
+            setViewportSize(getClientDimensions());
+        }
+        window.addEventListener('resize', debounce(handleResize, debounceInterval));
+        handleResize();
+        return () => window.removeEventListener('resize', handleResize);
+    }, [debounceInterval]);
+    return viewportSize;
+}
+
+export { useViewportSize, VIEWPORT_SIZE_DEFAULT_DEBOUNCE, getClientDimensions };

--- a/src/components/media-query/util.js
+++ b/src/components/media-query/util.js
@@ -1,0 +1,5 @@
+export function getClientDimensions() {
+    return { viewWidth: document.documentElement.clientWidth, viewHeight: document.documentElement.clientHeight };
+}
+
+export default { getClientDimensions };

--- a/src/components/media-query/withViewportSize.js
+++ b/src/components/media-query/withViewportSize.js
@@ -1,0 +1,27 @@
+// @flow
+
+import * as React from 'react';
+import { useViewportSize, VIEWPORT_SIZE_DEFAULT_DEBOUNCE } from './useViewportSize';
+
+type PropsShape = {
+    children: React.Node,
+    debounce?: number,
+};
+
+function withViewportSize<Props: PropsShape>(WrappedComponent: React.ComponentType<any>): React.ComponentType<any> {
+    function ComponentWithViewportSize({ debounce = VIEWPORT_SIZE_DEFAULT_DEBOUNCE, children, ...rest }: Props) {
+        const viewportProps = useViewportSize(debounce);
+        return (
+            <WrappedComponent {...rest} {...viewportProps}>
+                {children}
+            </WrappedComponent>
+        );
+    }
+
+    const wrappedName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+    ComponentWithViewportSize.displayName = wrappedName;
+
+    return ComponentWithViewportSize;
+}
+
+export default withViewportSize;

--- a/src/components/modal/Modal.md
+++ b/src/components/modal/Modal.md
@@ -94,3 +94,45 @@ confirmBackdropClose = () => {
     </PrimaryButton>
 </div>
 ```
+
+**Responsive Modal**
+
+This modal will expand to fullscreen mode when the viewport is too small - making it more user-friendly for small device sizes and viewports.
+
+```
+const AllDeviceModal = ({ isOpen, onRequestClose }) => (
+    <ResponsiveModal
+        title="Box: Sharing is simple"
+        onRequestClose={ onRequestClose }
+        isOpen={ isOpen }
+        focusElementSelector="input"
+    >
+        <p>
+            Elements can be auto-focused by implementing transition logic in componentDidUpdate. Focus is trapped inside the modal while it is open, so pressing tab will cycle through the elements inside.
+        </p>
+        <p><input type="text" /></p>
+        <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum congue, lacus ut scelerisque porttitor, libero diam luctus ante, non porta lectus dolor eu lectus. Suspendisse sagittis ut orci eget placerat.
+        </p>
+        <ModalActions>
+            <Button onClick={ onRequestClose }>Cancel</Button>
+            <PrimaryButton onClick={ onRequestClose }>Okay</PrimaryButton>
+        </ModalActions>
+    </ResponsiveModal>
+);
+openModal = () =>
+    setState({
+        isModalOpen: true,
+    });
+closeModal = () => setState({ isModalOpen: false });
+
+<div>
+    <AllDeviceModal
+        onRequestClose={ closeModal }
+        isOpen={ state.isModalOpen }
+    />
+    <PrimaryButton onClick={ openModal }>
+        Launch standard modal
+    </PrimaryButton>
+</div>
+```

--- a/src/components/modal/Modal.scss
+++ b/src/components/modal/Modal.scss
@@ -1,5 +1,6 @@
 @import '../../styles/variables';
 @import '../../styles/mixins/buttons';
+@import '../../styles/constants/media-queries';
 
 /**************************************
  * Modal
@@ -30,6 +31,10 @@
     overflow: auto;
     outline: 0;
 
+    @include breakpoint($large-screen) {
+        padding: 0;
+    }
+
     .modal-dialog {
         border: none;
         box-shadow: none;
@@ -48,6 +53,7 @@
 }
 
 .modal-dialog-container {
+    min-width: 100%;
     margin: auto;
 }
 
@@ -62,6 +68,18 @@
     background-clip: padding-box;
     border-radius: $bdl-border-radius-size-xlarge;
     box-shadow: 0 1px 1px 1px fade-out($black, .95);
+}
+
+.modal-dialog-container-fullscreen {
+    height: 100%;
+
+    .modal-dialog {
+        min-width: 100%;
+        max-width: 100%;
+        min-height: 100%;
+        padding: 22px 16px 12px 16px;
+        border-radius: 0;
+    }
 }
 
 .modal-title {
@@ -92,6 +110,10 @@
     background: none;
     border: 0;
     cursor: pointer;
+
+    .fullscreen {
+        right: 10px;
+    }
 }
 
 .modal-backdrop {

--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -22,6 +22,7 @@ type Props = {
     children: React.Node,
     className?: string,
     closeButtonProps: Object,
+    fullscreen?: Boolean,
     intl: Object,
     modalRef?: Function,
     onRequestClose?: Function,
@@ -54,7 +55,7 @@ class ModalDialog extends React.Component<Props> {
      * @return {ReactElement|null} - Returns the button, or null if the button shouldn't be rendered
      */
     renderCloseButton() {
-        const { closeButtonProps, onRequestClose, intl } = this.props;
+        const { closeButtonProps, onRequestClose, intl, fullscreen } = this.props;
         const { formatMessage } = intl;
         if (!onRequestClose) {
             return null;
@@ -65,7 +66,7 @@ class ModalDialog extends React.Component<Props> {
             <button
                 {...closeButtonProps}
                 aria-label={formatMessage(messages.closeModalText)}
-                className="modal-close-button"
+                className={classNames('modal-close-button', fullscreen && 'fullscreen')}
                 onClick={this.onCloseButtonClick}
             >
                 <IconClose color="#909090" height={18} width={18} />

--- a/src/components/modal/__tests__/Modal.test.js
+++ b/src/components/modal/__tests__/Modal.test.js
@@ -154,6 +154,7 @@ describe('components/modal/Modal', () => {
         });
 
         test('should focus first element when opening', () => {
+            wrapper.setState({ initialWidth: 460, fullscreen: false });
             wrapper.setProps({ isOpen: true });
             clock.tick(1);
             expect(document.activeElement.id).toEqual('first');
@@ -166,6 +167,8 @@ describe('components/modal/Modal', () => {
                     <button id="last" />
                 </Modal>,
             );
+
+            wrapper.setState({ initialWidth: 460, fullscreen: false });
             wrapper.setProps({ isLoading: false });
             clock.tick(1);
             expect(document.activeElement.id).toEqual('first');
@@ -188,6 +191,7 @@ describe('components/modal/Modal', () => {
                     <button className="custom-element" />
                 </Modal>,
             );
+            wrapper.setState({ initialWidth: 460, fullscreen: false });
             wrapper.setProps({ isOpen: true });
             clock.tick(1);
             expect(document.activeElement.className).toContain('custom-element');
@@ -200,7 +204,7 @@ describe('components/modal/Modal', () => {
                     <button className="custom-element" />
                 </Modal>,
             );
-
+            wrapper.setState({ initialWidth: 460, fullscreen: false });
             wrapper.setProps({ isLoading: false });
             clock.tick(1);
             expect(document.activeElement.className).toContain('custom-element');
@@ -215,9 +219,30 @@ describe('components/modal/Modal', () => {
             );
 
             expect(() => {
+                wrapper.setState({ initialWidth: 460, fullscreen: false });
                 wrapper.setProps({ isOpen: true });
                 clock.tick(1);
             }).toThrow();
+        });
+
+        test('should render in fullscreen mode when viewport width is smaller than initial modal width', () => {
+            wrapper.setProps({
+                isOpen: true,
+                isLoading: false,
+                viewWidth: 375,
+            });
+            wrapper.setState({ initialWidth: 460 });
+            expect(wrapper.state('fullscreen')).toEqual(true);
+        });
+
+        test('should not render in fullscreen mode when viewport width is larger than initial modal width', () => {
+            wrapper.setProps({
+                isOpen: true,
+                isLoading: false,
+                viewWidth: 600,
+            });
+            wrapper.setState({ initialWidth: 460 });
+            expect(wrapper.state('fullscreen')).toEqual(false);
         });
     });
 });

--- a/src/components/modal/stories/Modal.stories.js
+++ b/src/components/modal/stories/Modal.stories.js
@@ -7,7 +7,7 @@ import Button from '../../button/Button';
 import ModalActions from '../ModalActions';
 import PrimaryButton from '../../primary-button/PrimaryButton';
 
-import Modal from '../Modal';
+import Modal, { ResponsiveModal } from '../Modal';
 import notes from './Modal.stories.md';
 
 export const basic = () => {
@@ -110,6 +110,55 @@ export const withCustomBackdropClickHandler = () => {
                             </ModalActions>
                         </Modal>
                         <PrimaryButton onClick={openModal}>Launch standard modal</PrimaryButton>
+                    </div>
+                </IntlProvider>
+            )}
+        </State>
+    );
+};
+
+export const responsiveModal = () => {
+    const componentStore = new Store({
+        isModalOpen: false,
+    });
+
+    const openModal = () =>
+        componentStore.set({
+            isModalOpen: true,
+        });
+
+    const closeModal = () => componentStore.set({ isModalOpen: false });
+
+    return (
+        <State store={componentStore}>
+            {state => (
+                <IntlProvider locale="en">
+                    <div>
+                        <ResponsiveModal
+                            title="Box: Responsive Modal"
+                            onRequestClose={closeModal}
+                            isOpen={state.isModalOpen}
+                            focusElementSelector="input"
+                        >
+                            <p>
+                                This modal supports responsiveness. Try changing the device type, resizing your browser
+                                window, or using developer tools to shrink the viewport width. The modal will expand to
+                                fullscreen mode when the viewport is too small.
+                            </p>
+                            <p>
+                                <input type="text" />
+                            </p>
+                            <p>
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum congue, lacus ut
+                                scelerisque porttitor, libero diam luctus ante, non porta lectus dolor eu lectus.
+                                Suspendisse sagittis ut orci eget placerat.
+                            </p>
+                            <ModalActions>
+                                <Button onClick={closeModal}>Cancel</Button>
+                                <PrimaryButton onClick={closeModal}>Okay</PrimaryButton>
+                            </ModalActions>
+                        </ResponsiveModal>
+                        <PrimaryButton onClick={openModal}>Launch responsive modal</PrimaryButton>
                     </div>
                 </IntlProvider>
             )}

--- a/src/elements/content-sidebar/__tests__/__snapshots__/TaskModal.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/TaskModal.test.js.snap
@@ -19,6 +19,8 @@ exports[`elements/content-sidebar/TaskModal render should render a default compo
       id="be.contentSidebar.addTask.approval.title"
     />
   }
+  viewHeight={null}
+  viewWidth={null}
 >
   <div
     className="be"
@@ -55,6 +57,8 @@ exports[`elements/content-sidebar/TaskModal render using type APPROVAL and mode 
       id="be.contentSidebar.addTask.approval.title"
     />
   }
+  viewHeight={null}
+  viewWidth={null}
 >
   <div
     className="be"
@@ -92,6 +96,8 @@ exports[`elements/content-sidebar/TaskModal render using type APPROVAL and mode 
       id="be.contentSidebar.editTask.approval.title"
     />
   }
+  viewHeight={null}
+  viewWidth={null}
 >
   <div
     className="be"
@@ -129,6 +135,8 @@ exports[`elements/content-sidebar/TaskModal render using type GENERAL and mode C
       id="be.contentSidebar.addTask.general.title"
     />
   }
+  viewHeight={null}
+  viewWidth={null}
 >
   <div
     className="be"
@@ -166,6 +174,8 @@ exports[`elements/content-sidebar/TaskModal render using type GENERAL and mode E
       id="be.contentSidebar.editTask.general.title"
     />
   }
+  viewHeight={null}
+  viewWidth={null}
 >
   <div
     className="be"

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
@@ -22,6 +22,8 @@ exports[`features/classification/security-controls/SecurityControlsModal should 
       }
     />
   }
+  viewHeight={null}
+  viewWidth={null}
 >
   <p>
     <FormattedMessage

--- a/src/features/content-explorer/content-explorer-modal/__tests__/__snapshots__/ContentExplorerModal.test.js.snap
+++ b/src/features/content-explorer/content-explorer-modal/__tests__/__snapshots__/ContentExplorerModal.test.js.snap
@@ -11,6 +11,8 @@ exports[`features/content-explorer/content-explorer-modal/ContentExplorerModal r
     }
   }
   title=""
+  viewHeight={null}
+  viewWidth={null}
 >
   <ContentExplorer
     actionButtonsProps={Object {}}

--- a/src/features/invite-collaborators-modal/__tests__/__snapshots__/InviteCollaboratorsModal.test.js.snap
+++ b/src/features/invite-collaborators-modal/__tests__/__snapshots__/InviteCollaboratorsModal.test.js.snap
@@ -28,6 +28,8 @@ exports[`features/invite-collaborators-modal/InviteCollaboratorsModal render() s
       }
     />
   }
+  viewHeight={null}
+  viewWidth={null}
 >
   <PillSelectorDropdown
     allowCustomPills={true}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
@@ -28,6 +28,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -123,6 +125,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -218,6 +222,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -316,6 +322,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -411,6 +419,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -505,6 +515,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -599,6 +611,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       canInvite={false}
@@ -694,6 +708,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       canInvite={false}
@@ -789,6 +805,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       canInvite={true}
@@ -884,6 +902,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       canInvite={true}
@@ -979,6 +999,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={true}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -1083,6 +1105,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -1182,6 +1206,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -1280,6 +1306,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       classification={
@@ -1374,6 +1402,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       canInvite={true}
@@ -1467,6 +1497,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       canInvite={true}
@@ -1567,6 +1599,8 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
         showCollaboratorList={false}
       />
     }
+    viewHeight={null}
+    viewWidth={null}
   >
     <UnifiedShareForm
       canInvite={true}


### PR DESCRIPTION
## Summary of Changes

- Updated Modal component to accept `viewWidth` and `viewHeight` props
- Added state to Modal to track fullscreen mode
- Added CSS to support fullscreen mode
- Added hook `useViewportSize` to provide viewport size. Updates on resize
- Added HOC `withViewportSize` to support class based components
- Updated Storybook documentation
- Updated tests

## Behavior
The modal will detect the regular width of the modal, and if the viewport is smaller, it will render in fullscreen. If we have 2 modals Modal460px and Modal620px.

The behavior would be as follows:

- Case 1: 1200 px - Modal460px & Modal620px both regular modals
- Case 2: 435 px - Modal460px & Modal620px both fullscreen
- Case 3: 520 px - Modal460px is a regular modal. Modal620px is fullscreen

#### Case 3 Example

![Responsive-Modal-Fullscreens](https://user-images.githubusercontent.com/6400298/154582992-dc0d24d2-ce26-4550-960d-8fcccd85de58.gif)



### EUA Example
![Responsive-Modal-EUA](https://user-images.githubusercontent.com/6400298/154547064-4fa1be18-df02-4de8-afad-5e592395f689.gif)

### Storybook Example
![Responsive-Modal-Storybook](https://user-images.githubusercontent.com/6400298/154547112-775df20b-f777-43c3-8abb-531f6ff2dc16.gif)

