### PR TITLE
fix(search): focus outline

### DIFF
--- a/src/components/search-form/SearchForm.scss
+++ b/src/components/search-form/SearchForm.scss
@@ -17,11 +17,6 @@
         border: 0;
         cursor: pointer;
 
-        &:hover,
-        &:focus {
-            outline: none;
-        }
-
         path {
             transition: fill linear .1s;
         }


### PR DESCRIPTION

Before
<img width="221" alt="Screen Shot 2022-02-22 at 1 23 15 PM" src="https://user-images.githubusercontent.com/3284947/155221740-6f00edbc-0377-48f8-baaf-5d5c2b16a573.png">
After
<img width="131" alt="Screen Shot 2022-02-22 at 1 23 25 PM" src="https://user-images.githubusercontent.com/3284947/155221726-e9d37580-d318-4867-b866-600226bbf9c4.png">
