### PR TITLE
fix(content-explorer): Pass id into custom name renderer

### DIFF
--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -57,6 +57,7 @@ const itemNameCellRenderer = rendererParams => {
         name && (
             <div className={TABLE_CELL_CLASS}>
                 <ItemListName
+                    itemId={id}
                     type={type}
                     name={name}
                     label={label}

--- a/src/features/content-explorer/item-list/ItemListName.js
+++ b/src/features/content-explorer/item-list/ItemListName.js
@@ -9,7 +9,7 @@ import { ItemTypePropType } from '../prop-types';
 
 const ITEM_LIST_NAME_CLASS = 'item-list-name';
 
-const ItemListName = ({ type, name, label = '', isSelected = false, onClick, linkRenderer }) => {
+const ItemListName = ({ itemId = '', type, name, label = '', isSelected = false, onClick, linkRenderer }) => {
     const isFolder = type === ItemTypes.FOLDER;
 
     const linkProps = {
@@ -26,7 +26,7 @@ const ItemListName = ({ type, name, label = '', isSelected = false, onClick, lin
             />,
         ],
     };
-    const renderLink = () => (linkRenderer ? linkRenderer(linkProps) : <PlainButton {...linkProps} />);
+    const renderLink = () => (linkRenderer ? linkRenderer({ ...linkProps, itemId }) : <PlainButton {...linkProps} />);
 
     return (
         <div className="item-list-name-container">
@@ -37,6 +37,7 @@ const ItemListName = ({ type, name, label = '', isSelected = false, onClick, lin
 };
 
 ItemListName.propTypes = {
+    itemId: PropTypes.string,
     type: ItemTypePropType,
     name: PropTypes.string.isRequired,
     label: PropTypes.string,

--- a/src/features/content-explorer/item-list/__tests__/ItemListName.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemListName.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import sinon from 'sinon';
 
 import ItemListName from '../ItemListName';
@@ -53,15 +54,28 @@ describe('features/content-explorer/item-list/ItemListName', () => {
 
     describe('linkRenderer', () => {
         test('should use linkRenderer when specified', () => {
+            const itemId = '1';
             const name = 'item';
-            const linkRenderer = () => <button type="button" className="name-test" />;
+            const linkRenderer = props => <button type="button" className={`name-${props.itemId}`} />;
+            linkRenderer.propTypes = { itemId: PropTypes.string };
             const wrapper = renderComponent({
+                itemId,
                 name,
                 type: 'folder',
                 linkRenderer,
             });
+            expect(wrapper.find(`button.name-${itemId}`)).toHaveLength(1);
+        });
 
-            expect(wrapper.find('button.name-test').length).toBe(1);
+        test('should not pass id to PlainButton', () => {
+            const itemId = 'abc'; // Must be a valid html ID for this test. wrapper.find('#1') will crash.
+            const name = 'item';
+            const wrapper = renderComponent({
+                itemId,
+                name,
+                type: 'folder',
+            });
+            expect(wrapper.find(`#${itemId}`)).toHaveLength(0);
         });
     });
 });


### PR DESCRIPTION
Without the id of the item being passed into the callback function you have no idea which row this is suppose to be rendered for. 