### PR TITLE
fix(usm): Email addresses should not be marked as external due to case

### DIFF
--- a/src/features/unified-share-modal/utils/__tests__/mergeContacts.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/mergeContacts.test.js
@@ -39,4 +39,27 @@ describe('features/unified-share-modal/utils/mergeContacts', () => {
 
         expect(mergedContacts).toEqual(expectedMergedContacts);
     });
+
+    test('should return existing contact information if value matches but case does not match', () => {
+        const caseSensitiveEmail = 'DeV@Box.COM';
+        const fetchedContacts = { [email]: { email, id, isExternalUser, name, type } };
+        const existingContactWithCaseChanges = [
+            { displayText: caseSensitiveEmail, text: caseSensitiveEmail, value: caseSensitiveEmail },
+        ];
+
+        const expectedMergedContacts = [{ email, id, isExternalUser, text: name, name, type, value }];
+        const mergedContacts = mergeContacts(existingContactWithCaseChanges, fetchedContacts);
+
+        expect(mergedContacts).toEqual(expectedMergedContacts);
+    });
+
+    test('should return external user if not matched to internal user record', () => {
+        const newEmail = 'dev+test@box.com';
+        const newContact = [{ displayText: newEmail, text: newEmail, value: newEmail }];
+        const expected = [
+            { email: newEmail, id: newEmail, isExternalUser, text: newEmail, type: 'user', value: newEmail },
+        ];
+
+        expect(mergeContacts(newContact, {})).toEqual(expected);
+    });
 });

--- a/src/features/unified-share-modal/utils/mergeContacts.js
+++ b/src/features/unified-share-modal/utils/mergeContacts.js
@@ -5,7 +5,8 @@ import type { contactType as Contact } from '../flowTypes';
 const mergeContacts = (existingContacts: Array<Contact>, fetchedContacts: Object): Array<Contact> => {
     const contactsMap = Object.keys(fetchedContacts).reduce((map, email) => {
         const contact = fetchedContacts[email];
-        map[email] = { ...contact, text: contact.name, value: contact.email || contact.id };
+        // Since objects are case-sensitive, normalize the key to lowercase.
+        map[email.toLowerCase()] = { ...contact, text: contact.name, value: contact.email || contact.id };
         return map;
     }, {});
 
@@ -14,7 +15,8 @@ const mergeContacts = (existingContacts: Array<Contact>, fetchedContacts: Object
             return contact;
         }
         return (
-            (contact.value && contactsMap[contact.value]) || {
+            // Normalize the getter in contactsMap so that matching existing contacts will be case-insensitive
+            (contact.value && contactsMap[contact.value.toLowerCase()]) || {
                 email: String(contact.value),
                 id: String(contact.value),
                 isExternalUser: true,


### PR DESCRIPTION
* Add lowercase normalization to email when merging new contacts with existing contacts
* Add test for different case email
* Test when an entry does not match and does not contain an id

**Before**
![2022-03-10 17 57 23](https://user-images.githubusercontent.com/7842095/157769466-1aea09b2-718a-4c92-b9ac-7388d7ab7dfa.gif)
**After**
![2022-03-10 17 59 44](https://user-images.githubusercontent.com/7842095/157769518-ff09d083-753f-4f54-ad9c-2ffb13f3f2a1.gif)

