### PR TITLE
fix(avatar): fix scale of unknown user avtar svg

### DIFF
--- a/src/components/avatar/UnknownUserAvatar.tsx
+++ b/src/components/avatar/UnknownUserAvatar.tsx
@@ -7,7 +7,7 @@ const UnknownUserAvatar = ({ className = '', height = 28, title, width = 28 }: S
         className={`unknown-user-avatar ${className}`}
         height={height}
         title={title}
-        viewBox="0 0 28 28"
+        viewBox="0 0 16 16"
         width={width}
     >
         <path

--- a/src/icons/avatars/UnknownUserAvatar.tsx
+++ b/src/icons/avatars/UnknownUserAvatar.tsx
@@ -21,7 +21,7 @@ class UnknownUserAvatar extends React.PureComponent<TwoTonedIcon> {
                 className={`${ICON_CLASS} ${className}`}
                 height={height}
                 title={title}
-                viewBox="0 0 28 28"
+                viewBox="0 0 16 16"
                 width={width}
             >
                 <path


### PR DESCRIPTION
* Fixes Unknown user avatar scale to use proper viewbox for path element so path content fills svg container.

Before:
![E0A2817A-B15E-49EA-821C-D498DDDEAB61_4_5005_c](https://user-images.githubusercontent.com/25064622/158909945-1f674f37-b685-4f2c-9d3f-23172f1fadb0.jpeg)
After:
![DE58E5C9-867B-4DCF-9D20-9E421CE9F922_4_5005_c](https://user-images.githubusercontent.com/25064622/158909964-d9ca55b0-dd22-41ce-8f50-dec58bef3647.jpeg)

