### PR TITLE
feat(icons): Add color attribute to AvatarPlusBadge16

### DIFF
--- a/src/icon/line/AvatarPlusBadge16.js.flow
+++ b/src/icon/line/AvatarPlusBadge16.js.flow
@@ -2,8 +2,7 @@
 /* eslint-disable react/jsx-sort-props */
 import * as React from 'react';
 import * as vars from '../../styles/variables';
-import AccessibleSVG from '../../icons/accessible-svg';
-import type { Icon } from '../../icons/flowTypes';
+import AccessibleSVG, { SVGProps } from '../../components/accessible-svg/AccessibleSVG';
 
 /**
  * This is an auto-generated component and should not be edited
@@ -16,10 +15,14 @@ import type { Icon } from '../../icons/flowTypes';
  * - https://github.com/box/box-ui-elements/issues/new?template=Feature_request.md
  */
 
-const AvatarPlusBadge16 = (props: Icon) => (
-    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...props}>
+type Props = SVGProps & {
+    color?: string;
+};
+
+const AvatarPlusBadge16 = ({ color = vars.bdlGray, ...svgProps }: Props) => (
+    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...svgProps}>
         <path
-            fill={vars.bdlGray}
+            fill={color}
             fillRule="evenodd"
             d="M8 0c1.117 0 2.18.229 3.146.642-.28.22-.52.49-.707.795a7 7 0 104.124 4.123c.305-.185.575-.425.795-.705A8 8 0 118 0zm0 9.5c1.21 0 2.293.413 3.232 1.096.56.407.953.817 1.168 1.104a.5.5 0 01-.8.6 3.29 3.29 0 00-.234-.267 5.406 5.406 0 00-.722-.629C9.864 10.837 8.979 10.5 8 10.5c-.979 0-1.865.337-2.644.904-.275.2-.517.415-.722.63a3.29 3.29 0 00-.234.266.5.5 0 01-.8-.6c.215-.287.607-.697 1.168-1.104C5.707 9.913 6.79 9.5 8 9.5zm0-6a2.5 2.5 0 110 5 2.5 2.5 0 010-5zm0 1a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM13.004 1a.5.5 0 01.5.5v1h.996a.5.5 0 010 1h-.996v1a.5.5 0 01-1 0v-1H11.5a.5.5 0 010-1h1.004v-1a.5.5 0 01.5-.5z"
         />

--- a/src/icon/line/AvatarPlusBadge16.stories.tsx
+++ b/src/icon/line/AvatarPlusBadge16.stories.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
 import AvatarPlusBadge16 from './AvatarPlusBadge16';
+import { bdlYellow } from '../../styles/variables';
 
 export const avatarPlusBadge16 = () => <AvatarPlusBadge16 />;
+
+export const avatarPlusBadge16CustomColor = () => <AvatarPlusBadge16 color={bdlYellow} />;
 
 export default {
     title: 'Icon|Line|AvatarPlusBadge16',

--- a/src/icon/line/AvatarPlusBadge16.tsx
+++ b/src/icon/line/AvatarPlusBadge16.tsx
@@ -14,10 +14,14 @@ import AccessibleSVG, { SVGProps } from '../../components/accessible-svg/Accessi
  * - https://github.com/box/box-ui-elements/issues/new?template=Feature_request.md
  */
 
-const AvatarPlusBadge16 = (props: SVGProps) => (
-    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...props}>
+type Props = SVGProps & {
+    color?: string;
+};
+
+const AvatarPlusBadge16 = ({ color = vars.bdlGray, ...svgProps }: Props) => (
+    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...svgProps}>
         <path
-            fill={vars.bdlGray}
+            fill={color}
             fillRule="evenodd"
             d="M8 0c1.117 0 2.18.229 3.146.642-.28.22-.52.49-.707.795a7 7 0 104.124 4.123c.305-.185.575-.425.795-.705A8 8 0 118 0zm0 9.5c1.21 0 2.293.413 3.232 1.096.56.407.953.817 1.168 1.104a.5.5 0 01-.8.6 3.29 3.29 0 00-.234-.267 5.406 5.406 0 00-.722-.629C9.864 10.837 8.979 10.5 8 10.5c-.979 0-1.865.337-2.644.904-.275.2-.517.415-.722.63a3.29 3.29 0 00-.234.266.5.5 0 01-.8-.6c.215-.287.607-.697 1.168-1.104C5.707 9.913 6.79 9.5 8 9.5zm0-6a2.5 2.5 0 110 5 2.5 2.5 0 010-5zm0 1a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM13.004 1a.5.5 0 01.5.5v1h.996a.5.5 0 010 1h-.996v1a.5.5 0 01-1 0v-1H11.5a.5.5 0 010-1h1.004v-1a.5.5 0 01.5-.5z"
         />


### PR DESCRIPTION
Hi,
Piotr Laskowski from Box Poland here.
I need this icon in white color to use it in a GuidedTooltip.