### PR TITLE
feat(icon-search-juicy): create IconSearchJuicy

### DIFF
--- a/src/icons/general/IconSearch.js.flow
+++ b/src/icons/general/IconSearch.js.flow
@@ -6,7 +6,7 @@ import { bdlGray40 } from '../../styles/variables';
 
 import type { Icon } from '../flowTypes';
 
-const IconSearch = ({ className = 'icon-search', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearch = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
         className={`icon-search ${className}`}
         height={height}

--- a/src/icons/general/IconSearch.js.flow
+++ b/src/icons/general/IconSearch.js.flow
@@ -6,7 +6,7 @@ import { bdlGray40 } from '../../styles/variables';
 
 import type { Icon } from '../flowTypes';
 
-const IconSearch = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearch = ({ className = '', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
         className={`icon-search ${className}`}
         height={height}

--- a/src/icons/general/IconSearch.tsx
+++ b/src/icons/general/IconSearch.tsx
@@ -5,7 +5,7 @@ import { bdlGray40 } from '../../styles/variables';
 
 import { Icon } from '../iconTypes';
 
-const IconSearch = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearch = ({ className = '', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
         className={`icon-search ${className}`}
         height={height}

--- a/src/icons/general/IconSearch.tsx
+++ b/src/icons/general/IconSearch.tsx
@@ -5,7 +5,7 @@ import { bdlGray40 } from '../../styles/variables';
 
 import { Icon } from '../iconTypes';
 
-const IconSearch = ({ className = 'icon-search', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearch = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
         className={`icon-search ${className}`}
         height={height}

--- a/src/icons/general/IconSearchJuicy.js.flow
+++ b/src/icons/general/IconSearchJuicy.js.flow
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+
+import AccessibleSVG from '../accessible-svg';
+import { bdlGray40 } from '../../styles/variables';
+
+import type { Icon } from '../flowTypes';
+
+const IconSearchJuicy = ({ className = 'icon-search', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+    <AccessibleSVG
+        className={`icon-search ${className}`}
+        height={height}
+        title={title}
+        viewBox="0 0 24 24"
+        width={width}
+    >
+        <path
+            className="fill-color"
+            d="M10.491 1.5a8.99 8.99 0 0 1 7.359 14.157l4.21 4.21a1.5 1.5 0 0 1 0 2.123l-.07.07a1.5 1.5 0 0 1-2.122 0l-4.211-4.21A8.99 8.99 0 1 1 10.491 1.5zm0 2.997a5.994 5.994 0 1 0 0 11.988 5.994 5.994 0 0 0 0-11.988z"
+            fill={color}
+            fillRule="evenodd"
+        />
+    </AccessibleSVG>
+);
+
+export default IconSearchJuicy;

--- a/src/icons/general/IconSearchJuicy.js.flow
+++ b/src/icons/general/IconSearchJuicy.js.flow
@@ -6,7 +6,7 @@ import { bdlGray40 } from '../../styles/variables';
 
 import type { Icon } from '../flowTypes';
 
-const IconSearchJuicy = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearchJuicy = ({ className = '', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
         className={`icon-search-juicy ${className}`}
         height={height}

--- a/src/icons/general/IconSearchJuicy.js.flow
+++ b/src/icons/general/IconSearchJuicy.js.flow
@@ -8,7 +8,7 @@ import type { Icon } from '../flowTypes';
 
 const IconSearchJuicy = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
-        className={`icon-search ${className}`}
+        className={`icon-search-juicy ${className}`}
         height={height}
         title={title}
         viewBox="0 0 24 24"

--- a/src/icons/general/IconSearchJuicy.js.flow
+++ b/src/icons/general/IconSearchJuicy.js.flow
@@ -6,7 +6,7 @@ import { bdlGray40 } from '../../styles/variables';
 
 import type { Icon } from '../flowTypes';
 
-const IconSearchJuicy = ({ className = 'icon-search', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearchJuicy = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
         className={`icon-search ${className}`}
         height={height}

--- a/src/icons/general/IconSearchJuicy.tsx
+++ b/src/icons/general/IconSearchJuicy.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import AccessibleSVG from '../accessible-svg';
+import { bdlGray40 } from '../../styles/variables';
+
+import { Icon } from '../iconTypes';
+
+const IconSearchJuicy = ({ className = 'icon-search', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+    <AccessibleSVG
+        className={`icon-search ${className}`}
+        height={height}
+        title={title}
+        viewBox="0 0 24 24"
+        width={width}
+    >
+        <path
+            className="fill-color"
+            d="M10.491 1.5a8.99 8.99 0 0 1 7.359 14.157l4.21 4.21a1.5 1.5 0 0 1 0 2.123l-.07.07a1.5 1.5 0 0 1-2.122 0l-4.211-4.21A8.99 8.99 0 1 1 10.491 1.5zm0 2.997a5.994 5.994 0 1 0 0 11.988 5.994 5.994 0 0 0 0-11.988z"
+            fill={color}
+            fillRule="evenodd"
+        />
+    </AccessibleSVG>
+);
+
+export default IconSearchJuicy;

--- a/src/icons/general/IconSearchJuicy.tsx
+++ b/src/icons/general/IconSearchJuicy.tsx
@@ -5,7 +5,7 @@ import { bdlGray40 } from '../../styles/variables';
 
 import { Icon } from '../iconTypes';
 
-const IconSearchJuicy = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearchJuicy = ({ className = '', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
         className={`icon-search-juicy ${className}`}
         height={height}

--- a/src/icons/general/IconSearchJuicy.tsx
+++ b/src/icons/general/IconSearchJuicy.tsx
@@ -5,9 +5,9 @@ import { bdlGray40 } from '../../styles/variables';
 
 import { Icon } from '../iconTypes';
 
-const IconSearchJuicy = ({ className = 'icon-search', color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
+const IconSearchJuicy = ({ className, color = bdlGray40, height = 14, title, width = 14 }: Icon) => (
     <AccessibleSVG
-        className={`icon-search ${className}`}
+        className={`icon-search-juicy ${className}`}
         height={height}
         title={title}
         viewBox="0 0 24 24"

--- a/src/icons/general/README.md
+++ b/src/icons/general/README.md
@@ -902,6 +902,11 @@ width?: number,
         propsDocumentation: iconPropsDocumentation,
     },
     {
+        name: 'IconSearchJuicy',
+        component: require('./IconSearchJuicy').default,
+        propsDocumentation: iconPropsDocumentation,
+    },
+    {
         name: 'IconSecurityClassification',
         component: require('./IconSecurityClassification').default,
         propsDocumentation: iconPropsDocumentation,

--- a/src/icons/general/__tests__/IconSearchJuicy.test.tsx
+++ b/src/icons/general/__tests__/IconSearchJuicy.test.tsx
@@ -8,7 +8,7 @@ describe('icons/general/IconSearchJuicy', () => {
         const dimension = 14;
         const wrapper = shallow(<IconSearchJuicy />);
 
-        expect(wrapper.hasClass('icon-search')).toEqual(true);
+        expect(wrapper.hasClass('icon-search-juicy')).toEqual(true);
         expect(wrapper.find('path').prop('fill')).toEqual(bdlGray40);
         expect(wrapper.find('AccessibleSVG').prop('width')).toEqual(dimension);
         expect(wrapper.find('AccessibleSVG').prop('height')).toEqual(dimension);

--- a/src/icons/general/__tests__/IconSearchJuicy.test.tsx
+++ b/src/icons/general/__tests__/IconSearchJuicy.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import IconSearchJuicy from '../IconSearchJuicy';
+import { bdlGray40 } from '../../../styles/variables';
+
+describe('icons/general/IconSearchJuicy', () => {
+    test('should correctly render default icon with default color', () => {
+        const dimension = 14;
+        const wrapper = shallow(<IconSearchJuicy />);
+
+        expect(wrapper.hasClass('icon-search')).toEqual(true);
+        expect(wrapper.find('path').prop('fill')).toEqual(bdlGray40);
+        expect(wrapper.find('AccessibleSVG').prop('width')).toEqual(dimension);
+        expect(wrapper.find('AccessibleSVG').prop('height')).toEqual(dimension);
+    });
+
+    test('should correctly render icon with specified color', () => {
+        const color = '#fcfcfc';
+        const wrapper = shallow(<IconSearchJuicy color={color} />);
+
+        expect(wrapper.find('path').prop('fill')).toEqual(color);
+    });
+
+    test('should correctly render icon with specified width and height', () => {
+        const dimension = 16;
+        const wrapper = shallow(<IconSearchJuicy height={dimension} width={dimension} />);
+
+        expect(wrapper.find('AccessibleSVG').prop('width')).toEqual(dimension);
+        expect(wrapper.find('AccessibleSVG').prop('height')).toEqual(dimension);
+    });
+
+    test('should correctly render icon with title', () => {
+        const title = 'abcde';
+        const wrapper = shallow(<IconSearchJuicy title={title} />);
+
+        expect(wrapper.find('AccessibleSVG').prop('title')).toEqual(title);
+    });
+});


### PR DESCRIPTION
Juicier version of IconSearch [found in Zeplin mockups](https://app.zeplin.io/project/614cb647d7f89ab694666261/screen/6228da594da800bd75b6f3f1) for header on mobile screen sizes. 

Unit tests are happy:
![Screen Shot 2022-04-05 at 12 12 17 PM](https://user-images.githubusercontent.com/5461045/161799387-2acd1ee3-91b6-4a24-8ae2-0b8f16274f26.png)

In action:
![Screen Shot 2022-04-05 at 12 17 57 PM](https://user-images.githubusercontent.com/5461045/161799769-48d0e13f-5b3a-4882-b90e-4adedb752b00.png)

