### PR TITLE
feat(persistent-onboarding): Add renderAvatar property to ContentPreview

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -61,6 +61,7 @@ type ExternalProps = {
     onTaskDelete: (id: string) => any,
     onTaskUpdate: () => any,
     onTaskView: (id: string, isCreator: boolean) => any,
+    renderCommentFormAvatar?: Function,
 } & ErrorContextProps &
     WithAnnotatorContextProps;
 
@@ -719,6 +720,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             activeFeedEntryId,
             activeFeedEntryType,
             onTaskView,
+            renderCommentFormAvatar,
         } = this.props;
         const {
             currentUser,
@@ -768,6 +770,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     onTaskUpdate={this.updateTask}
                     onTaskView={onTaskView}
                     onVersionHistoryClick={onVersionHistoryClick}
+                    renderCommentFormAvatar={renderCommentFormAvatar}
                 />
             </SidebarContent>
         );

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -52,6 +52,7 @@ type Props = {
     onTaskUpdate?: Function,
     onTaskView?: Function,
     onVersionHistoryClick?: Function,
+    renderCommentFormAvatar?: Function,
     translations?: Translations,
 };
 
@@ -222,6 +223,7 @@ class ActivityFeed extends React.Component<Props, State> {
             onTaskUpdate,
             onTaskView,
             onVersionHistoryClick,
+            renderCommentFormAvatar,
             translations,
         } = this.props;
         const { isInputOpen } = this.state;
@@ -327,6 +329,7 @@ class ActivityFeed extends React.Component<Props, State> {
                         user={currentUser}
                         onCancel={this.commentFormCancelHandler}
                         onFocus={this.commentFormFocusHandler}
+                        renderCommentFormAvatar={renderCommentFormAvatar}
                         getAvatarUrl={getAvatarUrl}
                     />
                 ) : null}

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -36,6 +36,7 @@ type Props = {
     onCancel: Function,
     onFocus?: Function,
     onSubmit?: Function,
+    renderCommentFormAvatar?: Function,
     showTip?: boolean,
     tagged_message?: string,
     updateComment?: Function,
@@ -49,6 +50,7 @@ type State = {
 class CommentForm extends React.Component<Props, State> {
     static defaultProps = {
         isOpen: false,
+        renderCommentFormAvatar: avatar => avatar,
     };
 
     state = {
@@ -119,6 +121,7 @@ class CommentForm extends React.Component<Props, State> {
             tagged_message,
             getAvatarUrl,
             showTip = true,
+            renderCommentFormAvatar,
         } = this.props;
         const { commentEditorState } = this.state;
         const inputContainerClassNames = classNames('bcs-CommentForm', className, {
@@ -129,7 +132,7 @@ class CommentForm extends React.Component<Props, State> {
             <Media className={inputContainerClassNames}>
                 {!isEditing && (
                     <Media.Figure className="bcs-CommentForm-avatar">
-                        <Avatar getAvatarUrl={getAvatarUrl} user={user} />
+                        {renderCommentFormAvatar(<Avatar getAvatarUrl={getAvatarUrl} user={user} />)}
                     </Media.Figure>
                 )}
 


### PR DESCRIPTION
In Persistent Onboarding project I need to add a tooltip over `Avatar` component inside Preview. For that to work I defined `renderAvatar` property, which can be passed down in EUA and wrap this component in a tooltip. If `renderAvatar` is not defined `Avatar` will render normally, so the old code will still work as it used to.