### PR TITLE
feat(header-flyout): add responsive footer behavior and fix a few bugs

### DIFF
--- a/src/components/flyout/Flyout.scss
+++ b/src/components/flyout/Flyout.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables';
+@import './variables';
 
 .flyout-overlay {
     @include common-typography;
@@ -22,15 +23,11 @@
             @include bdl-openComponentAnimation($bdl-transitionDurationBase);
         }
     }
-
-    .bdl-OverlayHeader {
-        display: none;
-    }
 }
 
 @include breakpoint($medium-screen) {
-    .bdl-Flyout--responsive {
-        .flyout-overlay-enabled {
+    .flyout-overlay.bdl-Flyout--responsive {
+        &.flyout-overlay-enabled {
             // cancels out the tether inline styling without having to set enabled=false
             transform: none !important;
         }
@@ -48,9 +45,21 @@
             border-radius: 0;
             box-shadow: none;
         }
-    }
 
-    .bdl-OverlayHeader {
-        display: flex;
+        .bdl-OverlayHeader {
+            position: relative;
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: $bdl-OverlayHeader-height;
+            padding: ($bdl-grid-unit * 3) ($bdl-grid-unit * 4);
+            background-color: $white;
+            box-shadow: $bdl-header-box-shadow;
+
+            .bdl-CloseButton {
+                display: block;
+            }
+        }
     }
 }

--- a/src/components/flyout/OverlayHeader.scss
+++ b/src/components/flyout/OverlayHeader.scss
@@ -1,15 +1,7 @@
-@import '../../styles/variables';
-
 .bdl-OverlayHeader {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 64px;
-    padding: ($bdl-grid-unit * 3) ($bdl-grid-unit * 4);
-    background-color: $white;
-    box-shadow: $bdl-header-box-shadow;
+    .bdl-CloseButton {
+        display: none;
+    }
 }
 
 .bdl-OverlayHeader-content {

--- a/src/components/flyout/_variables.scss
+++ b/src/components/flyout/_variables.scss
@@ -1,0 +1,1 @@
+$bdl-OverlayHeader-height: 64px;

--- a/src/features/header-flyout/HeaderFlyout.js
+++ b/src/features/header-flyout/HeaderFlyout.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import classNames from 'classnames';
-import { Flyout, Overlay } from '../../components/flyout';
+import { Flyout, Overlay, OverlayHeader } from '../../components/flyout';
 import ScrollWrapper from '../../components/scroll-wrapper';
 import type { FlyoutProps } from '../../components/flyout/Flyout';
 
@@ -18,6 +18,8 @@ type Props = FlyoutProps & {
     footer?: React.Element<any>,
     /** What content to display in the header */
     header?: React.Element<any>,
+    /** Enable responsive behaviors of Flyout */
+    isResponsive?: boolean,
     /** Optional function to get the scrollRef in parent components */
     scrollRefFn?: any => any,
 };
@@ -27,27 +29,25 @@ class HeaderFlyout extends React.Component<Props> {
 
     static defaultProps = {
         position: 'bottom-left',
+        isResponsive: false,
     };
 
     render() {
-        const { header, footer, flyoutButton, children, scrollRefFn, className, ...rest } = this.props;
+        const { header, footer, flyoutButton, children, isResponsive, scrollRefFn, className, ...rest } = this.props;
 
         return (
             <Flyout
-                closeOnClick={false}
-                offset={HeaderFlyout.panelOffset}
                 className={classNames('header-flyout', className)}
+                closeOnClick={false}
                 constrainToWindow
+                isResponsive={isResponsive}
+                offset={HeaderFlyout.panelOffset}
                 {...rest}
             >
                 {flyoutButton}
                 <Overlay className="header-flyout-overlay">
+                    <OverlayHeader>{header && <h4 className="header-flyout-title">{header}</h4>}</OverlayHeader>
                     <div className="header-flyout-list-container">
-                        {header && (
-                            <div className="flyout-list-container-title">
-                                <h4 className="flyout-list-title">{header}</h4>
-                            </div>
-                        )}
                         <div
                             className={classNames('flyout-list-container-body', {
                                 'with-header': !!header,

--- a/src/features/header-flyout/__tests__/__snapshots__/HeaderFlyout.test.js.snap
+++ b/src/features/header-flyout/__tests__/__snapshots__/HeaderFlyout.test.js.snap
@@ -21,20 +21,18 @@ exports[`components/core/header/components/HeaderFlyout render() should include 
   <Overlay
     className="header-flyout-overlay"
   >
+    <OverlayHeader>
+      <h4
+        className="header-flyout-title"
+      >
+        <span>
+          test header
+        </span>
+      </h4>
+    </OverlayHeader>
     <div
       className="header-flyout-list-container"
     >
-      <div
-        className="flyout-list-container-title"
-      >
-        <h4
-          className="flyout-list-title"
-        >
-          <span>
-            test header
-          </span>
-        </h4>
-      </div>
       <div
         className="flyout-list-container-body with-header with-footer"
       >
@@ -80,6 +78,7 @@ exports[`components/core/header/components/HeaderFlyout render() should render d
   <Overlay
     className="header-flyout-overlay"
   >
+    <OverlayHeader />
     <div
       className="header-flyout-list-container"
     >
@@ -124,6 +123,7 @@ exports[`components/core/header/components/HeaderFlyout render() should render t
   <Overlay
     className="header-flyout-overlay"
   >
+    <OverlayHeader />
     <div
       className="header-flyout-list-container"
     >

--- a/src/features/header-flyout/styles/HeaderFlyout.scss
+++ b/src/features/header-flyout/styles/HeaderFlyout.scss
@@ -1,3 +1,4 @@
+@import '../../../components/flyout/variables';
 @import '../../../styles/variables';
 @import '../../../styles/mixins/overlay';
 @import './variables';
@@ -17,43 +18,35 @@
 
         padding: (2 * $flyout-header-spacer) $flyout-list-padding 0;
     }
-}
 
-.header-flyout-list-container {
-    padding: 0;
-
-    .flyout-list-container-title {
-        padding-bottom: $flyout-header-spacer;
-    }
-
-    .flyout-list-title {
+    .header-flyout-title {
         margin: 0;
+        padding-bottom: $flyout-header-spacer;
         font-size: $flyout-title-font-size;
         line-height: $flyout-title-line-height;
     }
+}
 
+.header-flyout-list-container {
     .flyout-list-container-body {
-        $title-height: $flyout-title-line-height + $flyout-header-spacer;
-        $footer-height: $flyout-title-line-height + 2 * $flyout-footer-spacer;
-
         // the overall height, minus the top and bottom padding
         height: $flyout-list-height - 2 * $flyout-list-padding;
         margin-bottom: $flyout-list-padding;
 
         &.with-header {
             // the overall height minus the padding, and header height
-            height: $flyout-list-height - (2 * $flyout-list-padding + $title-height);
+            height: $flyout-list-height - (2 * $flyout-list-padding + $flyout-title-height);
         }
 
         &.with-footer {
             // the overall height minus the padding, and the footer height
-            height: $flyout-list-height - ($flyout-list-padding + $footer-height);
+            height: $flyout-list-height - ($flyout-list-padding + $flyout-footer-height);
             margin-bottom: 0;
         }
 
         &.with-header.with-footer {
             // the overall height minus the padding, and both text hbdl-gray-50
-            height: $flyout-list-height - ($flyout-list-padding + $title-height + $footer-height);
+            height: $flyout-list-height - ($flyout-list-padding + $flyout-title-height + $flyout-footer-height);
             margin-bottom: 0;
         }
     }
@@ -66,6 +59,50 @@
 
         &.hidden {
             display: none;
+        }
+    }
+}
+
+@include breakpoint($medium-screen) {
+    .header-flyout-list-container {
+        .flyout-list-container-body {
+            $header-height: $bdl-OverlayHeader-height;
+
+            height: calc(100vh - #{$header-height});
+
+            &.with-header {
+                height: calc(100vh - #{$header-height});
+            }
+
+            &.with-footer {
+                height: calc(100vh - #{$flyout-footer-height});
+            }
+
+            &.with-header.with-footer {
+                height: calc(100vh - #{$header-height} - #{$flyout-footer-height});
+            }
+
+            .scroll-container {
+                overflow-y: auto;
+
+                .scroll-wrap-container {
+                    &::before,
+                    &::after {
+                        display: none;
+                    }
+                }
+            }
+        }
+
+        .flyout-list-container-footer {
+            height: $flyout-footer-height;
+            padding: $flyout-footer-spacer;
+        }
+    }
+
+    .header-flyout-overlay {
+        .header-flyout-title {
+            padding-bottom: 0;
         }
     }
 }

--- a/src/features/header-flyout/styles/_variables.scss
+++ b/src/features/header-flyout/styles/_variables.scss
@@ -11,6 +11,10 @@ $flyout-title-line-height: 16px;
 $flyout-footer-font-size: 13px;
 $flyout-footer-line-height: 16px;
 
+// Variables for title and footer height to help calculate component height
+$flyout-title-height: $flyout-title-line-height + $flyout-header-spacer;
+$flyout-footer-height: $flyout-title-line-height + 2 * $flyout-footer-spacer;
+
 // Consumable mixins - to use with the contents of a header flyout
 @mixin header-flyout-row-padding {
     padding: 12px 0;


### PR DESCRIPTION
Modified HeaderFlyout which implements Flyout to have responsive behaviors. Minimal changes to this component was made in order to limit the risk of changing HeaderFlyout and time spent on refactoring. HeaderFlyout is currently only used in two projects. Majority of the changes is in CSS

Consumers of HeaderFlyout can opt in to activate responsive behaviors by passing in the prop isResponsive=true

![responsive-header-flyouts](https://user-images.githubusercontent.com/1041516/167046646-5bda890d-827b-4fbf-8f80-cf67c85afc7c.gif)

