### PR TITLE
fix(tooltip): Fix Tooltip selectors specificity

### DIFF
--- a/src/components/guide-tooltip/GuideTooltip.scss
+++ b/src/components/guide-tooltip/GuideTooltip.scss
@@ -4,9 +4,6 @@ $bdl-guide-tooltip-max-width: 408px;
 
 .bdl-GuideTooltip {
     display: flex;
-}
-
-.bdl-GuideTooltip.bdl-Tooltip {
     max-width: $bdl-guide-tooltip-max-width;
     padding: ($bdl-grid-unit * 6) ($bdl-grid-unit * 12) ($bdl-grid-unit * 6) ($bdl-grid-unit * 6);
 }


### PR DESCRIPTION
## Description

There is a bug in EndUserApp with improper `padding-right` value applied on `<GuideTooltip>`. It's caused by accidental change of order of CSS styles from `<GuideTooltip>` and `<Tooltip>` components.

Currently right padding on a `<GuideTooltip>` with close button has 28px (visible below):

![Screenshot 2022-05-07 at 19-35-46 All Files Powered by Box](https://user-images.githubusercontent.com/12070821/167265489-a761f87c-f3fd-4f90-81b6-606231fa6736.png)

The intended value from how the styles are written should be 48px (visible below):

![Screenshot 2022-05-07 at 19-34-44 All Files Powered by Box](https://user-images.githubusercontent.com/12070821/167265497-e9fe315c-bf39-447d-a1c5-dd32333958b6.png)

The current value is different than intended because `box-content-preview` imports `<Tooltip>` component (more details below).

It's not clear to me if it should be fixed in `box-ui-elements` or in `EndUserApp`, nor what the padding's value should be. For now I'm posting a Draft PR here with intention of having discussion about it.

## Nitty-gritty

`padding-right` value is declared in 2 places:

```scss
// Tooltip.scss (imported first)
.bdlTooltip.with-close-button {
    padding-right: 28px;
}

```

```scss
// GuideTooltip.scss (imported later)
.bdl-GuideTooltip.bdl-Tooltip {
    padding: ($bdl-grid-unit * 6) ($bdl-grid-unit * 12) ($bdl-grid-unit * 6) ($bdl-grid-unit * 6);
}
```

### Intended flow

-  `.bdl-GuideTooltip.bdl-Tooltip` and `.bdl-Tooltip.with-close-button` match the same element for Guide Tooltip with close button: ![Screenshot 2022-05-07 at 18 36 04](https://user-images.githubusercontent.com/12070821/167265757-45904620-8e30-4ee9-bba1-fcebf66b080c.png)
- Both selectors have the same specificity (2 classes)
- `GuideTooltip.scss` is imported later than `Tooltip.scss` (as `<GuideTooltip>` imports `<Tooltip>`), so it takes precedence

**The result is that the padding should have 48px.**

### Current flow in EUA

EndUserApp imports `box-content-preview` and it's styles in `preview.css`. As `box-content-preview` imports `<Tooltip>` (but not `<GuideTooltip>`) component from `box-ui-elements`, `preview.css` stylesheet has it's styles duplicated. As `preview.css` comes later in EUA's `<head>` than main EUA's styles, `Tooltip.scss` styles are effectively later in declaration order than `GuideTooltip.css`, even though they should be earlier.

```
<!-- EndUserApp -->
<head>
  <link href="src_mainAfterPolyfill_js.css" />
    * includes Tooltip.scss
    * includes GuideTooltip.scss
  <link href="preview.css" />
    * includes Tooltip.scss again
 </head>
```

**The result is that the padding has 28px.**

I noticed the bug, when I imported `<GuideTooltip>` in `box-content-preview` and the padding on tooltips changed for no obvious reason. Took me quite a while to identify the problem.

## Which padding value is intended?

First I guess we should answer which padding value is the intended one? It looks like it should be 48px, but it has been 28px for a while now (a year it seems) and maybe that's what we actually prefer... 🤔 

## Possible solutions

Below I propose 2 different solutions to fix this problem. I assumed 48px is intended value, but they can be modified to use 28px instead.

### 1. Include `preview.css` earlier in EndUserApp

One solution is changing the order of CSS declarations in EndUserApp's `<head>` so that `preview.css` comes before main EndUserApp's styles. That would fix the problem both for those tooltip components and any other similar problems that likely already exist or would appear in the future.

But it could bring a new array of problems, as we would change order of quite a lot of rules. Different rules might start getting applied to what was applied before in different places of the app.

### 2. Use `!important`

Using `!important` is definitely not a good CSS practice, but it would solve the problem here and be safe to not break other things. It would make further extensions of `<GuideTooltip>` harder though.

```scss
// Tooltip.scss (imported first)
.bdlTooltip.with-close-button {
    padding-right: 28px;
}

```

```scss
// GuideTooltip.scss (imported later)
.bdl-GuideTooltip {
    padding: ($bdl-grid-unit * 6) ($bdl-grid-unit * 12) ($bdl-grid-unit * 6) ($bdl-grid-unit * 6) !important;
}
```

## Specificity of `.bdl-GuideTooltip.bdl-Tooltip` selector

There is one more thing worth to talk about: It's not a good practice that `.bdl-GuideTooltip.bdl-Tooltip` selector uses 2 classes to target an element instead of 1. Those 2 classes will be always applied together (`.bdl-GuideTooltip` is passed as `className` property to `<Tooltip>`, which applies it on the same element as has `.bdl-Tooltip` class). So `.bdl-GuideTooltip.bdl-Tooltip` and `.bdl-GuideTooltip` selectors target exactly the same set of elements. There is a good reason why methodologies like BEM exist and recommend always using single class selectors (other than when you have modifiers) and we break that good practice here.

I understand it was probably done to equal the specificity of `.bdlTooltip.with-close-button` selector, but there is another solution we could use - re-declaring `.with-close-button` again in `GuideTooltip.scss`:

```scss
// Tooltip.scss (imported first)
.bdlTooltip.with-close-button {
    padding-right: 28px;
}
```

```scss
// GuideTooltip.scss (imported later)
.bdl-GuideTooltip {
    padding: ($bdl-grid-unit * 6) ($bdl-grid-unit * 12) ($bdl-grid-unit * 6) ($bdl-grid-unit * 6);

    &.with-close-button {
        padding-right: ($bdl-grid-unit * 12);
    }
}
```