### PR TITLE
feat(preview): Extend previewExperiences

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -56,7 +56,7 @@ import {
     ERROR_CODE_UNKNOWN,
 } from '../../constants';
 import type { Annotation } from '../../common/types/feed';
-import type { TargetingApi } from '../../features/targeting/types';
+import type { PersistentOnboardingTargetingApi, TargetingApi } from '../../features/targeting/types';
 import type { ErrorType, AdditionalVersionInfo } from '../common/flowTypes';
 import type { WithLoggerProps } from '../../common/types/logging';
 import type { RequestOptions, ErrorContextProps, ElementsXhrError } from '../../common/types/api';
@@ -105,7 +105,8 @@ type Props = {
     onNavigate: Function,
     onVersionChange: VersionChangeCallback,
     previewExperiences?: {
-        [name: string]: TargetingApi,
+        persistentOnboardingBoxEditAnnotations: PersistentOnboardingTargetingApi,
+        tooltipFlowAnnotations: TargetingApi,
     },
     previewLibraryVersion: string,
     requestInterceptor?: Function,
@@ -790,11 +791,11 @@ class ContentPreview extends React.PureComponent<Props, State> {
 
         const previewOptions = {
             container: `#${this.id} .bcpr-content`,
+            experiences: previewExperiences,
             enableThumbnailsSidebar,
             fileOptions: fileOpts,
             header: 'none',
             headerElement: `#${this.id} .bcpr-PreviewHeader`,
-            experiences: previewExperiences,
             showAnnotations: this.canViewAnnotations(),
             showAnnotationsControls,
             showDownload: this.canDownload(),

--- a/src/features/targeting/types.js
+++ b/src/features/targeting/types.js
@@ -30,6 +30,10 @@ export type TargetingApi = $ReadOnly<{
     onShow: () => void,
 }>;
 
+export type PersistentOnboardingTargetingApi = TargetingApi & {
+    onPrevious: () => void,
+};
+
 export type UseTargetingApi = () => TargetingApi;
 
 export type TargetedComponentProps = {


### PR DESCRIPTION
## Description

Extend `<ContentPreview>` component, so that Persistent Onboarding Box Edit tooltip can be displayed on `<AnnotationsControls>` in  `box-content-preview`:
- ~Rename `previewExperiences` property to `previewDependencies`~
- ~In addition to `experiences` add 2 new properties in `previewDependencies`:~
  * ~`isLocaleLanguageEnglish`~
  * ~`onPersistentOnboardingTooltipBack`~
- Add `onPrevious()` callback to Persistent Onboarding experience