### PR TITLE
feat(radar-animation): add tetherElementClassName prop

### DIFF
--- a/src/components/radar/RadarAnimation.js.flow
+++ b/src/components/radar/RadarAnimation.js.flow
@@ -71,6 +71,8 @@ type Props = {
     offset?: string,
     /** Where to position the radar relative to the wrapped component */
     position: Position,
+    /** A CSS class for the tether element component */
+    tetherElementClassName?: string;
 };
 
 class RadarAnimation extends React.Component<Props> {

--- a/src/components/radar/RadarAnimation.tsx
+++ b/src/components/radar/RadarAnimation.tsx
@@ -70,6 +70,8 @@ export interface RadarAnimationProps {
     offset?: string;
     /** Where to position the radar relative to the wrapped component */
     position: RadarAnimationPosition;
+    /** A CSS class for the tether element component */
+    tetherElementClassName?: string;
 }
 
 class RadarAnimation extends React.Component<RadarAnimationProps> {
@@ -101,6 +103,7 @@ class RadarAnimation extends React.Component<RadarAnimationProps> {
             position,
             isShown,
             offset,
+            tetherElementClassName,
             ...rest
         } = this.props;
 
@@ -127,6 +130,7 @@ class RadarAnimation extends React.Component<RadarAnimationProps> {
         // Typescript defs seem busted for older versions of react-tether
         const tetherProps: {
             attachment: string;
+            className?: string;
             classPrefix: string;
             constraints: {};
             targetAttachment: string;
@@ -137,6 +141,10 @@ class RadarAnimation extends React.Component<RadarAnimationProps> {
             constraints,
             targetAttachment,
         };
+
+        if (tetherElementClassName) {
+            tetherProps.className = tetherElementClassName;
+        }
 
         if (offset) {
             tetherProps.offset = offset;

--- a/src/components/radar/__tests__/RadarAnimation.test.tsx
+++ b/src/components/radar/__tests__/RadarAnimation.test.tsx
@@ -73,6 +73,14 @@ describe('components/radar/RadarAnimation', () => {
         expect(wrapper.prop('offset')).toEqual(offset);
     });
 
+    test('should render correctly with tetherElementClassName', () => {
+        expect(
+            getWrapper({
+                tetherElementClassName: 'tether-element-class-name',
+            }),
+        ).toMatchSnapshot();
+    });
+
     describe('isShown', () => {
         test('should be shown when isShown is not provided', () => {
             expect(

--- a/src/components/radar/__tests__/__snapshots__/RadarAnimation.test.tsx.snap
+++ b/src/components/radar/__tests__/__snapshots__/RadarAnimation.test.tsx.snap
@@ -210,6 +210,42 @@ exports[`components/radar/RadarAnimation should render correctly with middle-rig
 </TetherComponent>
 `;
 
+exports[`components/radar/RadarAnimation should render correctly with tetherElementClassName 1`] = `
+<TetherComponent
+  attachment="middle left"
+  className="tether-element-class-name"
+  classPrefix="radar-animation"
+  constraints={
+    Array [
+      Object {
+        "attachment": "together",
+        "to": "window",
+      },
+    ]
+  }
+  renderElementTag="div"
+  renderElementTo={null}
+  targetAttachment="middle right"
+>
+  <div
+    aria-describedby="radarAnimation12"
+  >
+    Hello
+  </div>
+  <div
+    className="radar "
+    id="radarAnimation12"
+  >
+    <div
+      className="radar-dot"
+    />
+    <div
+      className="radar-circle"
+    />
+  </div>
+</TetherComponent>
+`;
+
 exports[`components/radar/RadarAnimation should render correctly with top-center positioning 1`] = `
 <TetherComponent
   attachment="bottom center"


### PR DESCRIPTION
Added `tetherElementClassName` prop to `RadarAnimation` component so that it's possible to add a custom class name to the tether element component, the same way it is now implemented in `Tooltip` component.