### PR TITLE
feat(modal): default ugrade inline notice to top of share modal

### DIFF
--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -575,32 +575,28 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     }
 
     renderUpgradeLinkDescription() {
-        const { openUpgradePlanModal = () => {}, showNewUpgradeText = false, trackingProps = {} } = this.props;
+        const { openUpgradePlanModal = () => {}, trackingProps = {} } = this.props;
         const { inviteCollabsEmailTracking = {} } = trackingProps;
         const { upgradeLinkProps = {} } = inviteCollabsEmailTracking;
 
         return (
             <div className="upgrade-description">
                 <UpgradeBadge />
-                {showNewUpgradeText ? (
-                    this.renderCollaboratorMessage('external_collab_newcopy_upgrade_cta')
-                ) : (
-                    <FormattedMessage
-                        values={{
-                            upgradeGetMoreAccessControlsLink: (
-                                <PlainButton
-                                    className="upgrade-link"
-                                    onClick={openUpgradePlanModal}
-                                    type="button"
-                                    {...upgradeLinkProps}
-                                >
-                                    <FormattedMessage {...messages.upgradeGetMoreAccessControlsLink} />
-                                </PlainButton>
-                            ),
-                        }}
-                        {...messages.upgradeGetMoreAccessControlsDescription}
-                    />
-                )}
+                <FormattedMessage
+                    values={{
+                        upgradeGetMoreAccessControlsLink: (
+                            <PlainButton
+                                className="upgrade-link"
+                                onClick={openUpgradePlanModal}
+                                type="button"
+                                {...upgradeLinkProps}
+                            >
+                                <FormattedMessage {...messages.upgradeGetMoreAccessControlsLink} />
+                            </PlainButton>
+                        ),
+                    }}
+                    {...messages.upgradeGetMoreAccessControlsDescription}
+                />
             </div>
         );
     }

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -215,18 +215,6 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
             expect(wrapper.exists('UpgradeBadge')).toBe(true);
         });
 
-        test('should render correct copy of upgrade CTA when showUpgradeOptions and showNewUpgradeText is enabled', () => {
-            const wrapper = getWrapper({
-                canInvite: true,
-                isFetching: false,
-                showNewUpgradeText: true,
-                showUpgradeOptions: true,
-            });
-            expect(wrapper.exists('UpgradeBadge')).toBe(true);
-            const msg = wrapper.find('FormattedCompMessage');
-            expect(msg.prop('id')).toEqual('boxui.unifiedShare.upgradeCollaboratorAccessDescription');
-        });
-
         test('should render correct upgrade inline notice when showUpgradeInlineNotice and showUpgradeOptions is enabled', () => {
             const wrapper = getWrapper({
                 canInvite: true,

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -393,8 +393,6 @@ export type USFProps = BaseUnifiedShareProps & {
     sharedLinkLoaded: boolean,
     /** Whether the FTUX tooltip should be rendered */
     shouldRenderFTUXTooltip: boolean,
-    /** Whether the new upgrade text should be rendered */
-    showNewUpgradeText?: boolean,
     /** Whether the upgrade inline notice should be rendered */
     showUpgradeInlineNotice?: boolean,
 };


### PR DESCRIPTION
remove treatment code updates we don't plan to release (remove visuals related to `showNewUpgradeText`; keep winning visuals related to `showUpgradeInlineNotice`)

upgrading user will see:
<img width="1455" alt="Screen Shot 2022-06-08 at 4 42 36 PM" src="https://user-images.githubusercontent.com/5000110/172736906-c797705e-5411-40a3-914a-af74748dbf6c.png">
