### PR TITLE
feat(contentsidebar): add blockedReason shieldsign

### DIFF
--- a/src/elements/content-sidebar/SidebarNavSign.tsx
+++ b/src/elements/content-sidebar/SidebarNavSign.tsx
@@ -36,6 +36,7 @@ export function SidebarNavSign({ blockedReason, intl, status, targetingApi, ...r
     switch (blockedReason) {
         case 'shield-download':
         case 'shared-link':
+        case 'shield-sign':
             tooltipMessage = intl.formatMessage(messages.boxSignSecurityBlockedTooltip);
             break;
         case 'watermark':

--- a/src/elements/content-sidebar/__tests__/SidebarNavSign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/SidebarNavSign.test.tsx
@@ -43,6 +43,7 @@ describe('elements/content-sidebar/SidebarNavSign', () => {
         blockedReason        | isDisabled | tooltipMessage
         ${'shield-download'} | ${true}    | ${'This action is unavailable due to a security policy.'}
         ${'shared-link'}     | ${true}    | ${'This action is unavailable due to a security policy.'}
+        ${'shield-sign'}     | ${true}    | ${'This action is unavailable due to a security policy.'}
         ${'watermark'}       | ${true}    | ${'This action is unavailable, because the file is watermarked.'}
         ${''}                | ${false}   | ${'Request Signature'}
     `(


### PR DESCRIPTION
We need to include a new blocked reason for the new Sign shield policy restriction. The reason is: 'shield-sign'

Before:
<img width="259" alt="image" src="https://user-images.githubusercontent.com/50145747/172871511-e4efcf28-c1e5-4f9e-a1b2-fc02e1400bbb.png">

After:
<img width="304" alt="image" src="https://user-images.githubusercontent.com/50145747/172870509-370a62a5-134e-4d01-8159-65d72f9ce55d.png">

