### PR TITLE
feat(security-controls): Add restriction summary copies for Sign

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1194,6 +1194,8 @@ boxui.securityControls.appDownloadRestricted = Download restricted for some appl
 boxui.securityControls.appDownloadWhitelist = Only select applications are allowed: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
 boxui.securityControls.appDownloadWhitelistOverflow = Only select applications are allowed: {appNames} +{remainingAppCount} more
+# Bullet point that summarizes Box Sign request restrictions applied to items. Box Sign is a product name
+boxui.securityControls.boxSignRequestRestricted = Sign restrictions apply.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners. Box Drive is a product name and not translated
 boxui.securityControls.desktopDownloadExternalOwners = Download restricted on Box Drive, except Owners/Co-Owners. Also restricted for external users.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners/Editors. Box Drive is a product name and not translated
@@ -1228,20 +1230,38 @@ boxui.securityControls.securityControlsLabel = Restrictions
 boxui.securityControls.sharingCollabAndCompanyOnly = Shared links cannot be made publicly accessible.
 # Bullet point that summarizes shared link restriction applied to classification
 boxui.securityControls.sharingCollabOnly = Shared links allowed for collaborators only.
-# Short summary displayed for classification when sharing, download and app download restrictions are applied to it
+# Short summary displayed for items when sharing, download and app download restrictions are applied to them.
 boxui.securityControls.shortAllRestrictions = Sharing, download and app restrictions apply
 # Short summary displayed for classification when an application download restriction is applied to it
 boxui.securityControls.shortApp = Application restrictions apply
+# Short summary displayed for items when both app download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortAppSign = App and Sign restrictions apply
 # Short summary displayed for classification when a download restriction is applied to it
 boxui.securityControls.shortDownload = Download restrictions apply
 # Short summary displayed for classification when both download and app download restrictions are applied to it
 boxui.securityControls.shortDownloadApp = Download and app restrictions apply
+# Short summary displayed for items when download, app download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortDownloadAppSign = Download, app and Sign restrictions apply
+# Short summary displayed for items when both download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortDownloadSign = Download and Sign restrictions apply
 # Short summary displayed for classification when a sharing restriction is applied to it
 boxui.securityControls.shortSharing = Sharing restriction applies
 # Short summary displayed for classification when both sharing and app download restrictions are applied to it
 boxui.securityControls.shortSharingApp = Sharing and app restrictions apply
+# Short summary displayed for items when sharing, app download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortSharingAppSign = Sharing, app and Sign restrictions apply
 # Short summary displayed for classification when both sharing and download restrictions are applied to it
 boxui.securityControls.shortSharingDownload = Sharing and download restrictions apply
+# Short summary displayed for items when sharing, download and app download restrictions are applied to them.
+boxui.securityControls.shortSharingDownloadApp = Sharing, download and app restrictions apply
+# Short summary displayed for items when sharing, download, app download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortSharingDownloadAppSign = Sharing, download, app and Sign restrictions apply
+# Short summary displayed for items when sharing, download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortSharingDownloadSign = Sharing, download and Sign restrictions apply
+# Short summary displayed for items when both sharing and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortSharingSign = Sharing and Sign restrictions apply
+# Short summary displayed for items when Sign restriction is applied to them. Box Sign is a product name
+boxui.securityControls.shortSign = Sign restrictions apply
 # Short summary displayed for classification when watermarking is applied to it
 boxui.securityControls.shortWatermarking = Watermarking applies
 # Button to display security controls modal

--- a/src/features/classification/constants.js
+++ b/src/features/classification/constants.js
@@ -13,17 +13,19 @@ const SECURITY_CONTROLS_FORMAT: {
 
 const ACCESS_POLICY_RESTRICTION: {
     APP: 'app',
+    BOX_SIGN_REQUEST: 'boxSignRequest',
     DOWNLOAD: 'download',
     EXTERNAL_COLLAB: 'externalCollab',
     FTP: 'ftp',
     SHARED_LINK: 'sharedLink',
     WATERMARK: 'watermark',
 } = {
-    SHARED_LINK: 'sharedLink',
+    APP: 'app',
+    BOX_SIGN_REQUEST: 'boxSignRequest',
     DOWNLOAD: 'download',
     EXTERNAL_COLLAB: 'externalCollab',
-    APP: 'app',
     FTP: 'ftp',
+    SHARED_LINK: 'sharedLink',
     WATERMARK: 'watermark',
 };
 

--- a/src/features/classification/flowTypes.js
+++ b/src/features/classification/flowTypes.js
@@ -30,6 +30,10 @@ type ApplicationRestriction = {
     apps: Array<App>,
 };
 
+type BoxSignRequestRestriction = {
+    enabled?: boolean,
+};
+
 type DownloadRestriction = {
     restrictExternalUsers?: boolean,
     restrictManagedUsers?: DownloadManagedUserAccessLevel,
@@ -45,16 +49,17 @@ type SharedLinkRestrictions = {
     accessLevel: SharedLinkAccessLevel,
 };
 
-type watermarkApplied = {
+type WatermarkControl = {
     enabled?: boolean,
 };
 
 type Controls = {
     app?: ApplicationRestriction,
+    boxSignRequest?: BoxSignRequestRestriction,
     download?: DownloadRestrictions,
     externalCollab?: ExternalCollabRestriction,
     sharedLink?: SharedLinkRestrictions,
-    watermark?: watermarkApplied,
+    watermark?: WatermarkControl,
 };
 
 type ControlsFormat = $Values<typeof SECURITY_CONTROLS_FORMAT>;

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -18,77 +18,54 @@ const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVE
 
 describe('features/classification/security-controls/utils', () => {
     let accessPolicy;
+    const allSecurityControls = {
+        sharedLink: {},
+        download: {},
+        externalCollab: {},
+        app: {},
+        watermark: {},
+        boxSignRequest: {},
+    };
 
     beforeEach(() => {
         accessPolicy = {};
     });
 
     describe('getShortSecurityControlsMessage()', () => {
-        test('should return null when there are no restrictions', () => {
-            expect(getShortSecurityControlsMessage({})).toEqual([]);
-        });
+        test.each`
+            securityControls                                            | expectedMessages                                                      | description
+            ${{}}                                                       | ${[]}                                                                 | ${'there are no restrictions'}
+            ${allSecurityControls}                                      | ${[messages.shortSharingDownloadAppSign, messages.shortWatermarking]} | ${'all restrictions are present'}
+            ${{ sharedLink: { accessLevel: PUBLIC } }}                  | ${[]}                                                                 | ${'shared link restriction has a "public" access level'}
+            ${{ sharedLink: {}, download: {}, app: {} }}                | ${[messages.shortSharingDownloadApp]}                                 | ${'download, app and shared link restrictions are present'}
+            ${{ externalCollab: {}, download: {}, app: {} }}            | ${[messages.shortSharingDownloadApp]}                                 | ${'download, app and external collab restrictions are present'}
+            ${{ download: {}, app: {}, boxSignRequest: {} }}            | ${[messages.shortDownloadAppSign]}                                    | ${'download, app and sign restrictions are present'}
+            ${{ app: {}, boxSignRequest: {}, sharedLink: {} }}          | ${[messages.shortSharingAppSign]}                                     | ${'app, sign and shared link restrictions are present'}
+            ${{ app: {}, boxSignRequest: {}, externalCollab: {} }}      | ${[messages.shortSharingAppSign]}                                     | ${'app, sign and external collab restrictions are present'}
+            ${{ download: {}, boxSignRequest: {}, sharedLink: {} }}     | ${[messages.shortSharingDownloadSign]}                                | ${'download, sign and shared link restrictions are present'}
+            ${{ download: {}, boxSignRequest: {}, externalCollab: {} }} | ${[messages.shortSharingDownloadSign]}                                | ${'download, sign and external collab restrictions are present'}
+            ${{ sharedLink: {}, boxSignRequest: {} }}                   | ${[messages.shortSharingSign]}                                        | ${'sign and shared link restrictions are present'}
+            ${{ externalCollab: {}, boxSignRequest: {} }}               | ${[messages.shortSharingSign]}                                        | ${'sign and external collab restrictions are present'}
+            ${{ download: {}, boxSignRequest: {} }}                     | ${[messages.shortDownloadSign]}                                       | ${'download and sign restrictions are present'}
+            ${{ app: {}, boxSignRequest: {} }}                          | ${[messages.shortAppSign]}                                            | ${'app and sign restrictions are present'}
+            ${{ sharedLink: {}, download: {} }}                         | ${[messages.shortSharingDownload]}                                    | ${'download and shared link restrictions are present'}
+            ${{ externalCollab: {}, download: {} }}                     | ${[messages.shortSharingDownload]}                                    | ${'download and external collab restrictions are present'}
+            ${{ sharedLink: {}, app: {} }}                              | ${[messages.shortSharingApp]}                                         | ${'app and shared link restrictions are present'}
+            ${{ externalCollab: {}, app: {} }}                          | ${[messages.shortSharingApp]}                                         | ${'app and external collab restrictions are present'}
+            ${{ download: {}, app: {} }}                                | ${[messages.shortDownloadApp]}                                        | ${'app and download restrictions are present'}
+            ${{ sharedLink: {}, externalCollab: {} }}                   | ${[messages.shortSharing]}                                            | ${'shared link and external collab restrictions are present'}
+            ${{ sharedLink: {} }}                                       | ${[messages.shortSharing]}                                            | ${'shared link restrictions are present'}
+            ${{ externalCollab: {} }}                                   | ${[messages.shortSharing]}                                            | ${'external collab restrictions are present'}
+            ${{ download: {} }}                                         | ${[messages.shortDownload]}                                           | ${'download restrictions are present'}
+            ${{ app: {} }}                                              | ${[messages.shortApp]}                                                | ${'app restrictions are present'}
+            ${{ watermark: {} }}                                        | ${[messages.shortWatermarking]}                                       | ${'watermark restrictions are present'}
+            ${{ boxSignRequest: {} }}                                   | ${[messages.shortSign]}                                               | ${'sign restrictions are present'}
+        `('should return correct messages when $description', ({ securityControls, expectedMessages }) => {
+            const expectedResult = expectedMessages.map(message => ({ message }));
 
-        test('should not return messages when shared link restriction has a "public" access level', () => {
-            accessPolicy = { sharedLink: { accessLevel: PUBLIC } };
-            expect(getShortSecurityControlsMessage(accessPolicy)).toEqual([]);
-        });
+            const result = getShortSecurityControlsMessage(securityControls);
 
-        test('should return correct message when all restrictions are present', () => {
-            accessPolicy = { sharedLink: {}, download: {}, externalCollab: {}, app: {}, watermark: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortAllRestrictions);
-            expect(getShortSecurityControlsMessage(accessPolicy)[1].message).toBe(messages.shortWatermarking);
-        });
-
-        test('should return all restrictions message when download, app and either shared link, or external collab restrictions are present', () => {
-            accessPolicy = { sharedLink: {}, download: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortAllRestrictions);
-            accessPolicy = { externalCollab: {}, download: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortAllRestrictions);
-        });
-
-        test('should return correct message when download and either shared link, or external collab restrictions are present', () => {
-            accessPolicy = { sharedLink: {}, download: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortSharingDownload);
-            accessPolicy = { externalCollab: {}, download: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortSharingDownload);
-        });
-
-        test('should return correct message when app and either shared link, or external collab restrictions are present', () => {
-            accessPolicy = { sharedLink: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortSharingApp);
-            accessPolicy = { externalCollab: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortSharingApp);
-        });
-
-        test('should return correct message when app and download restrictions are present', () => {
-            accessPolicy = { download: {}, app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortDownloadApp);
-        });
-
-        test('should return correct message when there are shared link or external collab restrictions', () => {
-            accessPolicy = { sharedLink: {}, externalCollab: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortSharing);
-
-            accessPolicy = { sharedLink: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortSharing);
-
-            accessPolicy = { externalCollab: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortSharing);
-        });
-
-        test('should return correct message when there is a download restriction', () => {
-            accessPolicy = { download: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortDownload);
-        });
-
-        test('should return correct message when there is a download restriction', () => {
-            accessPolicy = { app: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortApp);
-        });
-
-        test('should return correct message when there is a watermark restriction', () => {
-            accessPolicy = { watermark: {} };
-            expect(getShortSecurityControlsMessage(accessPolicy)[0].message).toBe(messages.shortWatermarking);
+            expect(result).toEqual(expectedResult);
         });
 
         test('should not return tooltipMessage', () => {
@@ -244,6 +221,18 @@ describe('features/classification/security-controls/utils', () => {
                 ]);
             },
         );
+
+        test('should include correct message when Box Sign requests are restricted', () => {
+            accessPolicy = {
+                boxSignRequest: {
+                    enabled: true,
+                },
+            };
+
+            expect(getFullSecurityControlsMessages(accessPolicy)).toEqual([
+                { message: messages.boxSignRequestRestricted },
+            ]);
+        });
 
         describe.each([DESKTOP, MOBILE, WEB])('%s download restriction', platform => {
             test.each([OWNERS_AND_COOWNERS, OWNERS_COOWNERS_AND_EDITORS])(

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -8,6 +8,7 @@ const messages = defineMessages({
             'Label displayed above the security restrictions on the file due to the classification label and associated policies.',
         id: 'boxui.securityControls.securityControlsLabel',
     },
+    // Short summary messages - 1 restriction
     shortSharing: {
         defaultMessage: 'Sharing restriction applies',
         description: 'Short summary displayed for classification when a sharing restriction is applied to it',
@@ -29,6 +30,13 @@ const messages = defineMessages({
         description: 'Short summary displayed for classification when watermarking is applied to it',
         id: 'boxui.securityControls.shortWatermarking',
     },
+    shortSign: {
+        defaultMessage: 'Sign restrictions apply',
+        description:
+            'Short summary displayed for items when Sign restriction is applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortSign',
+    },
+    // Short summary messages - 2 restrictions
     shortSharingDownload: {
         defaultMessage: 'Sharing and download restrictions apply',
         description:
@@ -47,12 +55,68 @@ const messages = defineMessages({
             'Short summary displayed for classification when both download and app download restrictions are applied to it',
         id: 'boxui.securityControls.shortDownloadApp',
     },
-    shortAllRestrictions: {
+    shortSharingSign: {
+        defaultMessage: 'Sharing and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when both sharing and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortSharingSign',
+    },
+    shortDownloadSign: {
+        defaultMessage: 'Download and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when both download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortDownloadSign',
+    },
+    shortAppSign: {
+        defaultMessage: 'App and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when both app download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortAppSign',
+    },
+    // Short summary messages - 3 restrictions
+    shortDownloadAppSign: {
+        defaultMessage: 'Download, app and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when download, app download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortDownloadAppSign',
+    },
+    shortSharingAppSign: {
+        defaultMessage: 'Sharing, app and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when sharing, app download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortSharingAppSign',
+    },
+    shortSharingDownloadSign: {
+        defaultMessage: 'Sharing, download and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when sharing, download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortSharingDownloadSign',
+    },
+    shortSharingDownloadApp: {
         defaultMessage: 'Sharing, download and app restrictions apply',
         description:
-            'Short summary displayed for classification when sharing, download and app download restrictions are applied to it',
+            'Short summary displayed for items when sharing, download and app download restrictions are applied to them.',
         id: 'boxui.securityControls.shortAllRestrictions',
     },
+    // TODO
+    // The shortSharingDownloadApp message above is using the old shortAllRestrictions id in order to avoid introducing
+    // a breaking change (since changing the id would cause us to lose existing translations temporarily).
+    // Once translations with the new id are available, we can keep a single shortSharingDownloadApp message
+    // (with the correct matching id) and remove the old one.
+    shortSharingDownloadAppRenameMe: {
+        defaultMessage: 'Sharing, download and app restrictions apply',
+        description:
+            'Short summary displayed for items when sharing, download and app download restrictions are applied to them.',
+        id: 'boxui.securityControls.shortSharingDownloadApp',
+    },
+    // Short summary messages - 4 restrictions
+    shortSharingDownloadAppSign: {
+        defaultMessage: 'Sharing, download, app and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when sharing, download, app download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortSharingDownloadAppSign',
+    },
+    // Full list individual restriction bullets
     sharingCollabOnly: {
         defaultMessage: 'Shared links allowed for collaborators only.',
         description: 'Bullet point that summarizes shared link restriction applied to classification',
@@ -138,6 +202,12 @@ const messages = defineMessages({
             'Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users',
         id: 'boxui.securityControls.webDownloadExternal',
     },
+    boxSignRequestRestricted: {
+        defaultMessage: 'Sign restrictions apply.',
+        description:
+            'Bullet point that summarizes Box Sign request restrictions applied to items. Box Sign is a product name',
+        id: 'boxui.securityControls.boxSignRequestRestricted',
+    },
     // Mobile Download Restrictions
     mobileDownloadOwners: {
         defaultMessage: 'Download restricted on mobile, except Owners/Co-Owners.',
@@ -203,7 +273,7 @@ const messages = defineMessages({
             'Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users. Box Drive is a product name and not translated',
         id: 'boxui.securityControls.downloadExternal',
     },
-    // Security Constrols Modal
+    // Security Controls Modal
     viewAll: {
         defaultMessage: 'View All',
         description: 'Button to display security controls modal',


### PR DESCRIPTION
Updates the `SecurityControls` copies and logic in order to be able to display Sign request restrictions. This update follows the existing pattern in which the short version of the summary is displayed as a single sentence that lists all restrictions. Changes are backwards compatible.

**Sidebar Classification:**

<img width="402" alt="Screen Shot 2022-06-13 at 6 39 08 PM" src="https://user-images.githubusercontent.com/1322503/173475213-bdc5027d-b3cb-4b3e-900a-2b2fe075b1df.png">

**Security Controls Summary Modal:** 

<img width="470" alt="Screen Shot 2022-06-13 at 6 39 18 PM" src="https://user-images.githubusercontent.com/1322503/173475224-7aff3486-879b-41ca-9e96-3992c0cce3ec.png">

