### PR TITLE
chore(security-controls): Removing unused message

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1230,8 +1230,6 @@ boxui.securityControls.securityControlsLabel = Restrictions
 boxui.securityControls.sharingCollabAndCompanyOnly = Shared links cannot be made publicly accessible.
 # Bullet point that summarizes shared link restriction applied to classification
 boxui.securityControls.sharingCollabOnly = Shared links allowed for collaborators only.
-# Short summary displayed for items when sharing, download and app download restrictions are applied to them.
-boxui.securityControls.shortAllRestrictions = Sharing, download and app restrictions apply
 # Short summary displayed for classification when an application download restriction is applied to it
 boxui.securityControls.shortApp = Application restrictions apply
 # Short summary displayed for items when both app download and Sign restrictions are applied to them. Box Sign is a product name

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControls.test.js.snap
@@ -58,7 +58,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
       message={
         Object {
           "defaultMessage": "Sharing, download and app restrictions apply",
-          "id": "boxui.securityControls.shortAllRestrictions",
+          "id": "boxui.securityControls.shortSharingDownloadApp",
         }
       }
     />
@@ -124,7 +124,7 @@ exports[`features/classification/security-controls/SecurityControls should rende
       message={
         Object {
           "defaultMessage": "Sharing, download and app restrictions apply",
-          "id": "boxui.securityControls.shortAllRestrictions",
+          "id": "boxui.securityControls.shortSharingDownloadApp",
         }
       }
     />

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -96,17 +96,6 @@ const messages = defineMessages({
         defaultMessage: 'Sharing, download and app restrictions apply',
         description:
             'Short summary displayed for items when sharing, download and app download restrictions are applied to them.',
-        id: 'boxui.securityControls.shortAllRestrictions',
-    },
-    // TODO
-    // The shortSharingDownloadApp message above is using the old shortAllRestrictions id in order to avoid introducing
-    // a breaking change (since changing the id would cause us to lose existing translations temporarily).
-    // Once translations with the new id are available, we can keep a single shortSharingDownloadApp message
-    // (with the correct matching id) and remove the old one.
-    shortSharingDownloadAppRenameMe: {
-        defaultMessage: 'Sharing, download and app restrictions apply',
-        description:
-            'Short summary displayed for items when sharing, download and app download restrictions are applied to them.',
         id: 'boxui.securityControls.shortSharingDownloadApp',
     },
     // Short summary messages - 4 restrictions


### PR DESCRIPTION
In #2931, a message was renamed but the old one was kept in order to avoid breaking existing translations while new ones were being generated. This PR removes the old message now that translations are available for the new message id.