### PR TITLE
feat(content-explorer): Expose item row renderer

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -113,6 +113,8 @@ class ContentExplorer extends Component {
         itemNameLinkRenderer: PropTypes.func,
         /** Used to render item buttons in the list. Overrides the default buttons. */
         itemButtonRenderer: PropTypes.func,
+        /** Used to render the row element for items on the list. Allows row customizations such as adding tooltips, etc. */
+        itemRowRenderer: PropTypes.func,
         /** Width of the item list */
         listWidth: PropTypes.number.isRequired,
         /** Height of the item list */
@@ -409,6 +411,7 @@ class ContentExplorer extends Component {
             itemIconRenderer,
             itemNameLinkRenderer,
             itemButtonRenderer,
+            itemRowRenderer,
             listWidth,
             listHeight,
             searchInputProps,
@@ -490,6 +493,7 @@ class ContentExplorer extends Component {
                     itemIconRenderer={itemIconRenderer}
                     itemNameLinkRenderer={itemNameLinkRenderer}
                     items={items}
+                    itemRowRenderer={itemRowRenderer}
                     noItemsRenderer={this.renderItemListEmptyState}
                     numItemsPerPage={numItemsPerPage}
                     numTotalItems={numTotalItems}

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -122,6 +122,7 @@ const ItemList = ({
     itemIconRenderer,
     itemNameLinkRenderer,
     itemButtonRenderer,
+    itemRowRenderer = defaultTableRowRenderer,
     noItemsRenderer,
     width,
     height,
@@ -167,7 +168,7 @@ const ItemList = ({
             );
         }
 
-        const defaultRow = defaultTableRowRenderer({
+        const defaultRow = itemRowRenderer({
             ...rendererParams,
             className: itemRowClassname,
         });
@@ -258,6 +259,7 @@ ItemList.propTypes = {
     itemIconRenderer: PropTypes.func,
     itemNameLinkRenderer: PropTypes.func,
     itemButtonRenderer: PropTypes.func,
+    itemRowRenderer: PropTypes.func,
     noItemsRenderer: PropTypes.func,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,

--- a/src/features/content-explorer/item-list/__tests__/ItemList.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemList.test.js
@@ -227,6 +227,34 @@ describe('features/content-explorer/item-list/ItemList', () => {
         });
     });
 
+    describe('itemRowRenderer', () => {
+        test('should use defaultTableRowRenderer when itemRowRenderer is not provided', () => {
+            const items = [
+                { id: '1', name: 'item1' },
+                { id: '2', name: 'item2' },
+            ];
+            const wrapper = renderComponent({
+                items,
+            });
+
+            expect(wrapper.find('Grid [role="row"].ReactVirtualized__Table__row').length).toBe(items.length);
+        });
+
+        test('should use itemRowRenderer when specified', () => {
+            const items = [
+                { id: '1', name: 'item1' },
+                { id: '2', name: 'item2' },
+            ];
+            const itemRowRenderer = params => <div key={params.index} className="row-test" />;
+            const wrapper = renderComponent({
+                items,
+                itemRowRenderer,
+            });
+
+            expect(wrapper.find('Grid .row-test').length).toBe(items.length);
+        });
+    });
+
     describe('noItemsRenderer', () => {
         test('should use noItemsRenderer when no items are specified', () => {
             const emptyText = 'Empty';


### PR DESCRIPTION
Adding a new `itemRowRenderer` prop which exposes the row renderer of the virtualized table in `ItemList`. The main purpose of this change is to allow customization of the rows so that a tooltip can be displayed in some cases.
<img width="671" alt="Screen Shot 2022-06-27 at 6 21 33 PM" src="https://user-images.githubusercontent.com/1322503/176066567-b0ce03a7-d468-474e-bc09-2428094250f5.png">

