### PR TITLE
feat(icons): Update IWorkIcon to latests assets

### DIFF
--- a/src/icons/iwork/IWorkDesktopIcon.md
+++ b/src/icons/iwork/IWorkDesktopIcon.md
@@ -1,7 +1,7 @@
 ```
 <div className="icon-wrapper">
-    <IWorkDesktopIcon extension="numbers" />
     <IWorkDesktopIcon extension="pages" />
+    <IWorkDesktopIcon extension="numbers" />
     <IWorkDesktopIcon extension="key" />
 </div>
 ```

--- a/src/icons/iwork/IWorkIcon.md
+++ b/src/icons/iwork/IWorkIcon.md
@@ -1,7 +1,7 @@
 ```
 <div className="icon-wrapper">
-    <IWorkIcon extension="key" />
-    <IWorkIcon extension="numbers" />
     <IWorkIcon extension="pages" />
+    <IWorkIcon extension="numbers" />
+    <IWorkIcon extension="key" />
 </div>
 ```

--- a/src/icons/iwork/IWorkIcon.tsx
+++ b/src/icons/iwork/IWorkIcon.tsx
@@ -1,21 +1,22 @@
 import * as React from 'react';
 
-import IconIWorkKeynote from './IconIWorkKeynote';
-import IconIWorkNumbers from './IconIWorkNumbers';
-import IconIWorkPages from './IconIWorkPages';
+import KeynoteForMac32 from '../../icon/logo/KeynoteForMac32';
+import NumbersForMac32 from '../../icon/logo/NumbersForMac32';
+import PagesForMac32 from '../../icon/logo/PagesForMac32';
+
 import { FileIcon } from '../iconTypes';
 
-const IWorkIcon = ({ className, dimension = 30, extension, title }: FileIcon) => {
+const IWorkIcon = ({ className, dimension = 32, extension, title }: FileIcon) => {
     let Component = null;
     switch (extension) {
         case 'pages':
-            Component = IconIWorkPages;
+            Component = PagesForMac32;
             break;
         case 'numbers':
-            Component = IconIWorkNumbers;
+            Component = NumbersForMac32;
             break;
         case 'key':
-            Component = IconIWorkKeynote;
+            Component = KeynoteForMac32;
             break;
         // no default
     }

--- a/src/icons/iwork/__tests__/IWorkIcon.test.tsx
+++ b/src/icons/iwork/__tests__/IWorkIcon.test.tsx
@@ -7,23 +7,23 @@ describe('icons/iwork/IWorkIcon', () => {
     [
         {
             extension: 'pages',
-            component: 'IconIWorkPages',
+            component: 'PagesForMac32',
         },
         {
             extension: 'numbers',
-            component: 'IconIWorkNumbers',
+            component: 'NumbersForMac32',
         },
         {
             extension: 'key',
-            component: 'IconIWorkKeynote',
+            component: 'KeynoteForMac32',
         },
     ].forEach(({ extension, component }) => {
         test('should correctly render default icon', () => {
             const wrapper = getWrapper({ extension });
 
             expect(wrapper.is(component)).toBe(true);
-            expect(wrapper.prop('height')).toEqual(30);
-            expect(wrapper.prop('width')).toEqual(30);
+            expect(wrapper.prop('height')).toEqual(32);
+            expect(wrapper.prop('width')).toEqual(32);
         });
 
         test('should set class when specified', () => {


### PR DESCRIPTION
Updated `IWorkIcon` component to use new iWork icons. Following this PR: https://github.com/box/box-ui-elements/pull/2433

Reordered icons in README for consistent ordering (also aligns with ordering of `IconIWorkTrio`).

### Before
![Screen Shot 2022-07-05 at 5 22 01 PM](https://user-images.githubusercontent.com/7311041/177437478-a28dfbb6-6108-4c94-96f0-361419701c0d.png)

---

### After
![Screen Shot 2022-07-05 at 5 19 56 PM](https://user-images.githubusercontent.com/7311041/177437331-9c69d018-1e13-4e8d-83d3-d404eabafff0.png)
