### PR TITLE
fix(modal): Adjust modal header elements and enable scrolling action

### DIFF
--- a/src/components/modal/Modal.scss
+++ b/src/components/modal/Modal.scss
@@ -144,8 +144,23 @@
             padding: 0;
         }
 
+        .modal-header-container {
+            position: fixed;
+            top: 0;
+            left: 0;
+            z-index: 2;
+            display: flex;
+            width: 100%;
+            height: 64px;
+            background-color: $white;
+        }
+
+        .modal-header {
+            padding: 20px 16px;
+        }
+
         .modal-content {
-            padding-bottom: 60px;
+            margin: 60px 0;
         }
 
         .modal-dialog {
@@ -155,9 +170,9 @@
         }
 
         .modal-close-button {
-            top: initial;
+            top: 0;
             right: 10px;
-            line-height: 0;
+            padding: 20px 0;
         }
 
         .modal-actions {

--- a/src/components/modal/Modal.scss
+++ b/src/components/modal/Modal.scss
@@ -155,7 +155,9 @@
         }
 
         .modal-close-button {
+            top: initial;
             right: 10px;
+            line-height: 0;
         }
 
         .modal-actions {

--- a/src/components/modal/Modal.scss
+++ b/src/components/modal/Modal.scss
@@ -5,7 +5,6 @@
 /**************************************
  * Modal
  **************************************/
-
 @keyframes popup_bounce_in {
     0% {
         transform: scale3d(.1, .1, 1);
@@ -139,39 +138,49 @@
 //Responsive support - triggers fullscreen mode after reaching $small-medium-screen width
 .is-responsive-web {
     @include breakpoint($small-medium-screen) {
+        $responsive-modal-header-height: 64px;
+        $responsive-modal-actions-height: 60px;
+
         .modal {
             flex-direction: column;
             padding: 0;
         }
 
         .modal-header-container {
-            position: fixed;
+            position: absolute;
             top: 0;
             left: 0;
-            z-index: 2;
             display: flex;
+            align-items: center;
             width: 100%;
-            height: 64px;
-            background-color: $white;
+            height: $responsive-modal-header-height;
         }
 
         .modal-header {
-            padding: 20px 16px;
+            display: flex;
+            align-items: center;
+            padding: 0 16px;
         }
 
         .modal-content {
-            margin: 60px 0;
+            margin-top: $responsive-modal-header-height;
+            margin-bottom: $responsive-modal-actions-height;
+            padding: 24px 16px 12px 16px;
+            overflow: auto;
         }
 
         .modal-dialog {
-            min-height: 100%;
-            padding: 22px 16px 12px 16px;
+            height: 100%;
+            padding: 0;
             border-radius: 0;
         }
 
         .modal-close-button {
             top: 0;
             right: 10px;
+            display: flex;
+            align-items: center;
+            height: 100%;
             padding: 20px 0;
         }
 
@@ -180,6 +189,7 @@
             right: 0;
             bottom: 0;
             width: 100%;
+            height: $responsive-modal-actions-height;
             padding: 10px 16px;
             background-color: $white;
         }
@@ -188,5 +198,6 @@
     .modal-dialog-container {
         flex-basis: 100%;
         width: 100%;
+        overflow: hidden;
     }
 }

--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -112,11 +112,13 @@ class ModalDialog extends React.Component<Props> {
 
         return (
             <div ref={modalRef} className={classNames('modal-dialog', className)} {...divProps}>
-                <div className="modal-header">
-                    <h2 className="modal-title" id={`${this.modalID}-label`}>
-                        {title}
-                    </h2>
-                    <>{this.renderCloseButton()}</>
+                <div className="modal-header-container">
+                    <div className="modal-header">
+                        <h2 className="modal-title" id={`${this.modalID}-label`}>
+                            {title}
+                        </h2>
+                    </div>
+                    {this.renderCloseButton()}
                 </div>
                 {this.renderContent()}
             </div>

--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -116,8 +116,8 @@ class ModalDialog extends React.Component<Props> {
                     <h2 className="modal-title" id={`${this.modalID}-label`}>
                         {title}
                     </h2>
+                    <>{this.renderCloseButton()}</>
                 </div>
-                {this.renderCloseButton()}
                 {this.renderContent()}
             </div>
         );


### PR DESCRIPTION
### Overview
This is a continuation of this PR: https://github.com/box/box-ui-elements/pull/2910/files

The original author is unable to continue working on the PR, so I've taken over further development. This PR incorporates the author's prior commits.

### Summary
- Adjusted styles to remove `z-index` and `position: fixed`. 
- Adjusted header and footer margins
- Now internal content can be properly scrolled

### Demo
Shows margin, padding, content and then shows scrolling action.
![Modal-Header-Changes](https://user-images.githubusercontent.com/6400298/178119524-f826bd85-cb7a-428d-941c-3f91a5a72516.gif)

