### PR TITLE
feat(button): add responsive behavior to button

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -21,6 +21,8 @@ export interface ButtonProps {
     isDisabled?: boolean;
     /** whether the button is loading or not */
     isLoading: boolean;
+    /** toggles responsive behavior */
+    isResponsive?: boolean;
     /** whether the button is selected or not */
     isSelected?: boolean;
     /** onClick handler for the button */
@@ -29,6 +31,8 @@ export interface ButtonProps {
     setRef?: Function;
     /** size of the button */
     size?: 'large';
+    /** whether to show icon when the button is not responsive or on large screens */
+    showIcon?: boolean;
     /** whether to show a radar */
     showRadar: boolean;
     /** type for the button */
@@ -41,6 +45,8 @@ class Button extends React.Component<ButtonProps> {
     static defaultProps = {
         className: '',
         isLoading: false,
+        isResponsive: false,
+        showIcon: true,
         showRadar: false,
         type: ButtonType.SUBMIT,
     };
@@ -64,10 +70,12 @@ class Button extends React.Component<ButtonProps> {
             icon,
             isDisabled,
             isLoading,
+            isResponsive,
             isSelected,
             setRef,
             size,
             type,
+            showIcon,
             showRadar,
             ...rest
         } = this.props;
@@ -83,7 +91,8 @@ class Button extends React.Component<ButtonProps> {
                 'is-loading': isLoading,
                 'is-selected': isSelected,
                 'bdl-btn--large': size === 'large',
-                'bdl-has-icon': !!icon,
+                'bdl-show-icon': !!icon && showIcon,
+                'bdl-Button--responsive': isResponsive && !!icon,
             },
             className,
         );

--- a/src/components/button/__tests__/Button.test.tsx
+++ b/src/components/button/__tests__/Button.test.tsx
@@ -84,7 +84,7 @@ describe('components/button/Button', () => {
         const wrapper = shallow(<Button icon={<FakeIcon />} />);
         const iconContainer = wrapper.find('.bdl-btn-icon');
         const { width, height } = iconContainer.find('FakeIcon').props();
-        expect(wrapper.props().className).toEqual('btn bdl-has-icon');
+        expect(wrapper.props().className).toEqual('btn bdl-show-icon');
         expect(iconContainer.length).toBe(1);
         expect(width).toEqual(height);
         expect(width).toEqual(20);
@@ -118,5 +118,20 @@ describe('components/button/Button', () => {
     test('should render a RadarAnimation if showRadar is true', () => {
         const wrapper = shallow(<Button showRadar>Test</Button>);
         expect(wrapper.find('RadarAnimation')).toMatchSnapshot();
+    });
+
+    test.each`
+        isResponsive | icon                          | showIcon
+        ${false}     | ${null}                       | ${false}
+        ${false}     | ${(<span>fakeContent</span>)} | ${false}
+        ${true}      | ${null}                       | ${true}
+        ${true}      | ${(<span>fakeContent</span>)} | ${true}
+    `('should render responsive behavior correctly', ({ icon, isResponsive, showIcon }) => {
+        const wrapper = shallow(
+            <Button icon={icon} isResponsive={isResponsive} showIcon={showIcon}>
+                Test
+            </Button>,
+        );
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`components/button/Button should render a RadarAnimation if showRadar is
 
 exports[`components/button/Button should render icon next to text if icon and children props are both set 1`] = `
 <button
-  className="btn bdl-has-icon"
+  className="btn bdl-show-icon"
   onClick={[Function]}
   type="submit"
 >
@@ -41,6 +41,82 @@ exports[`components/button/Button should render icon next to text if icon and ch
       height={16}
       width={16}
     />
+  </span>
+</button>
+`;
+
+exports[`components/button/Button should render responsive behavior correctly 1`] = `
+<button
+  className="btn"
+  onClick={[Function]}
+  type="submit"
+>
+  <span
+    className="btn-content"
+  >
+    Test
+  </span>
+</button>
+`;
+
+exports[`components/button/Button should render responsive behavior correctly 2`] = `
+<button
+  className="btn"
+  onClick={[Function]}
+  type="submit"
+>
+  <span
+    className="btn-content"
+  >
+    Test
+  </span>
+  <span
+    className="bdl-btn-icon"
+  >
+    <span
+      height={16}
+      width={16}
+    >
+      fakeContent
+    </span>
+  </span>
+</button>
+`;
+
+exports[`components/button/Button should render responsive behavior correctly 3`] = `
+<button
+  className="btn"
+  onClick={[Function]}
+  type="submit"
+>
+  <span
+    className="btn-content"
+  >
+    Test
+  </span>
+</button>
+`;
+
+exports[`components/button/Button should render responsive behavior correctly 4`] = `
+<button
+  className="btn bdl-show-icon bdl-Button--responsive"
+  onClick={[Function]}
+  type="submit"
+>
+  <span
+    className="btn-content"
+  >
+    Test
+  </span>
+  <span
+    className="bdl-btn-icon"
+  >
+    <span
+      height={16}
+      width={16}
+    >
+      fakeContent
+    </span>
   </span>
 </button>
 `;

--- a/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
+++ b/src/components/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
@@ -360,6 +360,8 @@ exports[`components/collapsible/Collapsible should render with headerActionItems
       <Button
         className=""
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="submit"
       >

--- a/src/components/nudge/__tests__/__snapshots__/Nudge.test.tsx.snap
+++ b/src/components/nudge/__tests__/__snapshots__/Nudge.test.tsx.snap
@@ -9,7 +9,9 @@ exports[`components/nudge/Nudge should correctly render Nudge 1`] = `
     aria-label="close-nudge"
     className="bdl-Nudge-closeButton"
     isLoading={false}
+    isResponsive={false}
     onClick={[MockFunction]}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >

--- a/src/components/pill-cloud/__tests__/__snapshots__/PillCloud.test.js.snap
+++ b/src/components/pill-cloud/__tests__/__snapshots__/PillCloud.test.js.snap
@@ -8,7 +8,9 @@ exports[`components/pill-cloud/PillCloud should render pills 1`] = `
     className="bdl-Pill bdl-PillCloud-button pill pill-cloud-button"
     data-resin-target={1}
     isLoading={false}
+    isResponsive={false}
     key="1"
+    showIcon={true}
     showRadar={false}
     type="submit"
   >
@@ -18,7 +20,9 @@ exports[`components/pill-cloud/PillCloud should render pills 1`] = `
     className="bdl-Pill bdl-PillCloud-button pill pill-cloud-button"
     data-resin-target={2}
     isLoading={false}
+    isResponsive={false}
     key="2"
+    showIcon={true}
     showRadar={false}
     type="submit"
   >
@@ -28,7 +32,9 @@ exports[`components/pill-cloud/PillCloud should render pills 1`] = `
     className="bdl-Pill bdl-PillCloud-button pill pill-cloud-button"
     data-resin-target={3}
     isLoading={false}
+    isResponsive={false}
     key="3"
+    showIcon={true}
     showRadar={false}
     type="submit"
   >

--- a/src/elements/content-open-with/__tests__/__snapshots__/MultipleIntegrationsOpenWithButton.test.js.snap
+++ b/src/elements/content-open-with/__tests__/__snapshots__/MultipleIntegrationsOpenWithButton.test.js.snap
@@ -14,6 +14,8 @@ exports[`elements/content-open-with/MultipleIntegrationsOpenWithButton should pa
     className=""
     data-testid="multipleintegrationsbutton"
     isLoading={false}
+    isResponsive={false}
+    showIcon={true}
     showRadar={false}
     type="submit"
     width={50}
@@ -46,6 +48,8 @@ exports[`elements/content-open-with/MultipleIntegrationsOpenWithButton should re
     className=""
     data-testid="multipleintegrationsbutton"
     isLoading={false}
+    isResponsive={false}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >

--- a/src/elements/content-open-with/__tests__/__snapshots__/OpenWithButton.test.js.snap
+++ b/src/elements/content-open-with/__tests__/__snapshots__/OpenWithButton.test.js.snap
@@ -13,7 +13,9 @@ exports[`elements/content-open-with/OpenWithButton should force the tooltip open
     data-testid="singleintegrationbutton"
     isDisabled={true}
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >
@@ -45,7 +47,9 @@ exports[`elements/content-open-with/OpenWithButton should render as disabled if 
     data-testid="singleintegrationbutton"
     isDisabled={true}
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >
@@ -77,7 +81,9 @@ exports[`elements/content-open-with/OpenWithButton should render as disabled if 
     data-testid="singleintegrationbutton"
     isDisabled={true}
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >
@@ -109,7 +115,9 @@ exports[`elements/content-open-with/OpenWithButton should render with the correc
     data-testid="singleintegrationbutton"
     isDisabled={false}
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >

--- a/src/elements/content-preview/__tests__/__snapshots__/ReloadNotification.test.js.snap
+++ b/src/elements/content-preview/__tests__/__snapshots__/ReloadNotification.test.js.snap
@@ -14,6 +14,8 @@ exports[`elements/content-preview/ReloadNotification render() should render corr
     <Button
       className=""
       isLoading={false}
+      isResponsive={false}
+      showIcon={true}
       showRadar={false}
       type="submit"
     >

--- a/src/elements/content-sidebar/__tests__/__snapshots__/AddTaskMenu.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/AddTaskMenu.test.js.snap
@@ -10,6 +10,8 @@ exports[`elements/content-sidebar/AddTaskMenu render should render a default com
   <Button
     className=""
     isLoading={false}
+    isResponsive={false}
+    showIcon={true}
     showRadar={false}
     type="button"
   >

--- a/src/elements/content-sidebar/skills/faces/__tests__/__snapshots__/Faces.test.js.snap
+++ b/src/elements/content-sidebar/skills/faces/__tests__/__snapshots__/Faces.test.js.snap
@@ -164,7 +164,9 @@ exports[`elements/content-sidebar/Skills/Faces/Faces should correctly render sav
       className=""
       data-resin-target="skill-faceeditcancel"
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/EditableKeywords.test.js.snap
+++ b/src/elements/content-sidebar/skills/keywords/__tests__/__snapshots__/EditableKeywords.test.js.snap
@@ -39,7 +39,9 @@ exports[`elements/content-sidebar/Skills/Keywords/EditableKeywords should correc
       className=""
       data-resin-target="skill-keywordeditcancel"
       isLoading={false}
+      isResponsive={false}
       onClick={[MockFunction]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/elements/content-sidebar/skills/transcript/__tests__/__snapshots__/EditingTranscriptRow.test.js.snap
+++ b/src/elements/content-sidebar/skills/transcript/__tests__/__snapshots__/EditingTranscriptRow.test.js.snap
@@ -27,6 +27,8 @@ exports[`elements/content-sidebar/Skills/Transcript/TranscriptRow should correct
         className=""
         data-resin-target="skill-transcripteditcancel"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -71,6 +73,8 @@ exports[`elements/content-sidebar/Skills/Transcript/TranscriptRow should correct
         className=""
         data-resin-target="skill-transcripteditcancel"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >

--- a/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/SecurityControlsModal.test.js.snap
@@ -73,7 +73,9 @@ exports[`features/classification/security-controls/SecurityControlsModal should 
     <Button
       className=""
       isLoading={false}
+      isResponsive={false}
       onClick={[MockFunction]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorList.test.js.snap
+++ b/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorList.test.js.snap
@@ -93,6 +93,8 @@ exports[`features/collaborator-avatars/CollaboratorList render() should render d
     <Button
       className="btn-done"
       isLoading={false}
+      isResponsive={false}
+      showIcon={true}
       showRadar={false}
       type="submit"
     >
@@ -199,6 +201,8 @@ exports[`features/collaborator-avatars/CollaboratorList render() should render e
     <Button
       className="btn-done"
       isLoading={false}
+      isResponsive={false}
+      showIcon={true}
       showRadar={false}
       type="submit"
     >

--- a/src/features/invite-collaborators-modal/__tests__/__snapshots__/InviteCollaboratorsModal.test.js.snap
+++ b/src/features/invite-collaborators-modal/__tests__/__snapshots__/InviteCollaboratorsModal.test.js.snap
@@ -61,7 +61,9 @@ exports[`features/invite-collaborators-modal/InviteCollaboratorsModal render() s
       className=""
       data-resin-target="cancel"
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/features/metadata-based-view/__tests__/__snapshots__/IconWithTooltip.test.js.snap
+++ b/src/features/metadata-based-view/__tests__/__snapshots__/IconWithTooltip.test.js.snap
@@ -70,7 +70,9 @@ exports[`features/metadata-based-view/IconWithTooltip should get IconSave with T
   <Button
     className="bdl-MetadataBasedItemList-cell--saveIcon"
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="button"
   >

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/Footer.test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/Footer.test.js.snap
@@ -24,6 +24,8 @@ exports[`features/metadata-instance-editor/fields/Footer should correctly render
       className=""
       data-resin-target="metadata-instancecancel"
       isLoading={false}
+      isResponsive={false}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/MetadataInstanceConfirmDialog.test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/MetadataInstanceConfirmDialog.test.js.snap
@@ -18,7 +18,9 @@ exports[`features/metadata-instance-editor/MetadataInstanceConfirmDialog should 
         className=""
         data-resin-target="metadata-confirmcancel"
         isLoading={false}
+        isResponsive={false}
         onClick={[Function]}
+        showIcon={true}
         showRadar={false}
         type="button"
       >

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/TemplateDropdown.test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/TemplateDropdown.test.js.snap
@@ -21,6 +21,8 @@ exports[`features/metadata-instance-editor/fields/ should correctly render butto
   <Button
     className=""
     isLoading={false}
+    isResponsive={false}
+    showIcon={true}
     showRadar={false}
     type="submit"
   />

--- a/src/features/metadata-instance-fields/__tests__/__snapshots__/CustomMetadataField.test.js.snap
+++ b/src/features/metadata-instance-fields/__tests__/__snapshots__/CustomMetadataField.test.js.snap
@@ -29,7 +29,9 @@ exports[`features/metadata-instance-editor/fields/CustomMetadataField should cor
       className=""
       data-resin-target="metadata-customfieldremove"
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/features/pagination/__tests__/__snapshots__/MarkerBasedPagination.test.js.snap
+++ b/src/features/pagination/__tests__/__snapshots__/MarkerBasedPagination.test.js.snap
@@ -73,12 +73,14 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -144,7 +146,9 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
               className=""
               isDisabled={true}
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -231,7 +235,9 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
               className=""
               isDisabled={true}
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -320,12 +326,14 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -449,12 +457,14 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -550,12 +560,14 @@ exports[`elements/Pagination/MarkerBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"

--- a/src/features/pagination/__tests__/__snapshots__/OffsetBasedPagination.test.js.snap
+++ b/src/features/pagination/__tests__/__snapshots__/OffsetBasedPagination.test.js.snap
@@ -59,9 +59,11 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                 className="bdl-Pagination-toggle"
                 id="menubutton2"
                 isLoading={false}
+                isResponsive={false}
                 key=".$menubutton2"
                 onClick={[Function]}
                 onKeyDown={[Function]}
+                showIcon={true}
                 showRadar={false}
                 type="submit"
               >
@@ -115,7 +117,9 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
               className=""
               isDisabled={true}
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -204,12 +208,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -327,9 +333,11 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                 className="bdl-Pagination-toggle"
                 id="menubutton7"
                 isLoading={false}
+                isResponsive={false}
                 key=".$menubutton7"
                 onClick={[Function]}
                 onKeyDown={[Function]}
+                showIcon={true}
                 showRadar={false}
                 type="submit"
               >
@@ -383,7 +391,9 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
               className=""
               isDisabled={true}
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -472,12 +482,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -595,9 +607,11 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                 className="bdl-Pagination-toggle"
                 id="menubutton12"
                 isLoading={false}
+                isResponsive={false}
                 key=".$menubutton12"
                 onClick={[Function]}
                 onKeyDown={[Function]}
+                showIcon={true}
                 showRadar={false}
                 type="submit"
               >
@@ -651,7 +665,9 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
               className=""
               isDisabled={true}
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -740,12 +756,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -863,9 +881,11 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                 className="bdl-Pagination-toggle"
                 id="menubutton17"
                 isLoading={false}
+                isResponsive={false}
                 key=".$menubutton17"
                 onClick={[Function]}
                 onKeyDown={[Function]}
+                showIcon={true}
                 showRadar={false}
                 type="submit"
               >
@@ -949,12 +969,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -1050,12 +1072,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -1173,9 +1197,11 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                 className="bdl-Pagination-toggle"
                 id="menubutton23"
                 isLoading={false}
+                isResponsive={false}
                 key=".$menubutton23"
                 onClick={[Function]}
                 onKeyDown={[Function]}
+                showIcon={true}
                 showRadar={false}
                 type="submit"
               >
@@ -1259,12 +1285,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -1360,12 +1388,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -1483,9 +1513,11 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                 className="bdl-Pagination-toggle"
                 id="menubutton29"
                 isLoading={false}
+                isResponsive={false}
                 key=".$menubutton29"
                 onClick={[Function]}
                 onKeyDown={[Function]}
+                showIcon={true}
                 showRadar={false}
                 type="submit"
               >
@@ -1569,12 +1601,14 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
                   className=""
                   isDisabled={false}
                   isLoading={false}
+                  isResponsive={false}
                   key=".0"
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
+                  showIcon={true}
                   showRadar={false}
                   tabIndex="0"
                   type="submit"
@@ -1640,7 +1674,9 @@ exports[`elements/Pagination/OffsetBasedPagination should render properly with o
               className=""
               isDisabled={true}
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >

--- a/src/features/pagination/__tests__/__snapshots__/PaginationControls.test.js.snap
+++ b/src/features/pagination/__tests__/__snapshots__/PaginationControls.test.js.snap
@@ -29,7 +29,9 @@ exports[`elements/Pagination/PaginationControls should render properly for offse
         className=""
         isDisabled={false}
         isLoading={false}
+        isResponsive={false}
         onClick={[MockFunction]}
+        showIcon={true}
         showRadar={false}
         type="submit"
       >
@@ -52,7 +54,9 @@ exports[`elements/Pagination/PaginationControls should render properly for offse
         className=""
         isDisabled={true}
         isLoading={false}
+        isResponsive={false}
         onClick={[MockFunction]}
+        showIcon={true}
         showRadar={false}
         type="submit"
       >
@@ -86,7 +90,9 @@ exports[`elements/Pagination/PaginationControls should render properly for offse
         className=""
         isDisabled={false}
         isLoading={false}
+        isResponsive={false}
         onClick={[MockFunction]}
+        showIcon={true}
         showRadar={false}
         type="submit"
       >
@@ -109,7 +115,9 @@ exports[`elements/Pagination/PaginationControls should render properly for offse
         className=""
         isDisabled={true}
         isLoading={false}
+        isResponsive={false}
         onClick={[MockFunction]}
+        showIcon={true}
         showRadar={false}
         type="submit"
       >

--- a/src/features/pagination/__tests__/__snapshots__/PaginationMenu.test.js.snap
+++ b/src/features/pagination/__tests__/__snapshots__/PaginationMenu.test.js.snap
@@ -11,6 +11,8 @@ exports[`elements/Pagination/PaginationMenu should render a button and menu with
   <Button
     className="bdl-Pagination-toggle"
     isLoading={false}
+    isResponsive={false}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >
@@ -52,6 +54,8 @@ exports[`elements/Pagination/PaginationMenu should render a button and menu with
   <Button
     className="bdl-Pagination-toggle"
     isLoading={false}
+    isResponsive={false}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >
@@ -121,6 +125,8 @@ exports[`elements/Pagination/PaginationMenu should render a button and menu with
   <Button
     className="bdl-Pagination-toggle"
     isLoading={false}
+    isResponsive={false}
+    showIcon={true}
     showRadar={false}
     type="submit"
   >

--- a/src/features/presence/__tests__/__snapshots__/Presence.test.js.snap
+++ b/src/features/presence/__tests__/__snapshots__/Presence.test.js.snap
@@ -508,7 +508,9 @@ exports[`features/presence/Presence render() Tests for presence autofly - GROWTH
     <Button
       className="btn-primary"
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="submit"
     >

--- a/src/features/query-bar/__tests__/__snapshots__/ColumnButton.test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/ColumnButton.test.js.snap
@@ -21,7 +21,9 @@ exports[`features/query-bar/components/ColumnButton render should render ColumnB
     className="query-bar-button"
     isDisabled={true}
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="button"
   >
@@ -64,7 +66,9 @@ exports[`features/query-bar/components/ColumnButton render should render ColumnB
     className="query-bar-button"
     isDisabled={true}
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="button"
   >
@@ -129,7 +133,9 @@ exports[`features/query-bar/components/ColumnButton render should render ColumnB
     className="query-bar-button"
     isDisabled={false}
     isLoading={false}
+    isResponsive={false}
     onClick={[Function]}
+    showIcon={true}
     showRadar={false}
     type="button"
   >

--- a/src/features/query-bar/__tests__/__snapshots__/TemplateButton.test.js.snap
+++ b/src/features/query-bar/__tests__/__snapshots__/TemplateButton.test.js.snap
@@ -18,7 +18,9 @@ exports[`feature/query-bar/components/TemplateButton render() should render Temp
       className="query-bar-button"
       isDisabled={true}
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/EmailForm.test.js.snap
@@ -217,7 +217,9 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className=""
       isDisabled={false}
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >
@@ -302,7 +304,9 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className=""
       isDisabled={false}
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >
@@ -439,7 +443,9 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className=""
       isDisabled={false}
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >
@@ -529,7 +535,9 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className=""
       isDisabled={false}
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >
@@ -630,7 +638,9 @@ exports[`features/unified-share-modal/EmailForm render() should render default c
       className=""
       isDisabled={false}
       isLoading={false}
+      isResponsive={false}
       onClick={[Function]}
+      showIcon={true}
       showRadar={false}
       type="button"
     >

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -120,6 +120,8 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -280,6 +282,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -474,6 +478,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -739,6 +745,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -883,6 +891,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -1029,6 +1039,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -1174,6 +1186,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -1319,6 +1333,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >
@@ -1490,6 +1506,8 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
       <Button
         className="email-shared-link-btn"
         isLoading={false}
+        isResponsive={false}
+        showIcon={true}
         showRadar={false}
         type="button"
       >

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
@@ -49,7 +49,9 @@ exports[`features/unified-share-modal/UnifiedShareForm closeEmailSharedLinkForm(
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -248,7 +250,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -411,7 +415,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -574,7 +580,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -742,7 +750,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -906,7 +916,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -1071,7 +1083,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -1205,7 +1219,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -1370,7 +1386,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -1535,7 +1553,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -1701,7 +1721,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -1877,7 +1899,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -2041,7 +2065,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -2209,7 +2235,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -2374,7 +2402,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >
@@ -2538,7 +2568,9 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
             <Button
               className="ftux-tooltip-button"
               isLoading={false}
+              isResponsive={false}
               onClick={[Function]}
+              showIcon={true}
               showRadar={false}
               type="submit"
             >

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -41,7 +41,7 @@
         @include bdl-Button--large;
     }
 
-    &.bdl-has-icon {
+    &.bdl-show-icon {
         // Buttons with icons use flexbox to align content instead of line-height/padding
         display: inline-flex;
         align-items: center;
@@ -74,6 +74,10 @@
                 margin: ($bdl-btn-height-large - $bdl-btn-icon-size) / 2 - $bdl-btn-border-width;
             }
         }
+    }
+
+    &:not(.bdl-show-icon) .bdl-btn-icon {
+        display: none;
     }
 
     &:active,
@@ -195,6 +199,18 @@ button svg {
         .btn-content,
         .bdl-btn-icon {
             background-color: $bdl-gray-30;
+        }
+    }
+}
+
+@include breakpoint($medium-screen) {
+    .btn.bdl-Button--responsive {
+        .btn-content {
+            display: none;
+        }
+
+        .bdl-btn-icon {
+            display: block;
         }
     }
 }


### PR DESCRIPTION
Allow parents that consume the Button component to configure the responsive behavior, so that for screen sizes less than 768px:

- If **isResponsive=false** OR **icon is undefined**, button content will not change (see share button below)
![nonresponsive_or_no_responsivecontent](https://user-images.githubusercontent.com/17888863/180296067-1f7faee1-c475-4280-a190-d91177fd83e8.gif)

- If **isResponsive=true** AND **icon is defined**, button content will change to the icon set (see share button below)
text + icon -> icon (**showIcon=true**)
![text_and_icon_to_icon](https://user-images.githubusercontent.com/17888863/180297674-5b1c101e-2bf6-42e9-a8ac-39f27ac3220f.gif)
text -> icon (**showIcon=false**)
![text_to_icon](https://user-images.githubusercontent.com/17888863/180297709-db956a10-d8fe-4617-bcd8-dd0455e97da4.gif)



