### PR TITLE
revert(content-explorer) Revert "feat(content-explorer): Add responsive behavior"

### DIFF
--- a/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
+++ b/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
@@ -13,7 +13,6 @@ type Props = {
     customInput?: React.ComponentType<any>,
     description?: string,
     isOpen?: boolean,
-    isResponsive?: boolean,
     onRequestClose?: Function,
     onSelectItem?: (item: Object, index: number) => void,
     onSelectedClick?: () => void,
@@ -26,7 +25,6 @@ const ContentExplorerModal = ({
     title = '',
     description = '',
     isOpen = false,
-    isResponsive = false,
     onRequestClose,
     onSelectedClick,
     onSelectItem,
@@ -34,16 +32,13 @@ const ContentExplorerModal = ({
 }: Props) => (
     <Modal
         title={title}
-        className={classNames('content-explorer-modal', className, {
-            'bdl-ContentExplorerModal--responsive': isResponsive,
-        })}
+        className={classNames('content-explorer-modal', className)}
         isOpen={isOpen}
         onRequestClose={onRequestClose}
     >
         {description}
         <ContentExplorer
             customInput={customInput}
-            isResponsive={isResponsive}
             onCancelButtonClick={onRequestClose}
             onSelectedClick={onSelectedClick}
             onSelectItem={onSelectItem}

--- a/src/features/content-explorer/content-explorer-modal/__tests__/__snapshots__/ContentExplorerModal.test.js.snap
+++ b/src/features/content-explorer/content-explorer-modal/__tests__/__snapshots__/ContentExplorerModal.test.js.snap
@@ -21,7 +21,6 @@ exports[`features/content-explorer/content-explorer-modal/ContentExplorerModal r
     customInput={[Function]}
     formatMessage={[Function]}
     initialFoldersPath={Array []}
-    isResponsive={false}
     items={Array []}
     listHeight={285}
     listWidth={560}

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -37,8 +37,6 @@ class ContentExplorer extends Component {
         initialFoldersPath: FoldersPathPropType.isRequired,
         /** Initial items that will show up as selected */
         initialSelectedItems: PropTypes.object,
-        /** Whether to use the responsive version */
-        isResponsive: PropTypes.bool,
         /**
          * Called when the current folder changes
          *
@@ -405,7 +403,6 @@ class ContentExplorer extends Component {
             isCopyButtonLoading,
             isCreateNewFolderAllowed,
             isMoveButtonLoading,
-            isResponsive = false,
             isSelectAllAllowed,
             items,
             numItemsPerPage,
@@ -459,9 +456,7 @@ class ContentExplorer extends Component {
         return (
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
             <div
-                className={classNames('content-explorer', className, {
-                    'bdl-ContentExplorer--responsive': isResponsive,
-                })}
+                className={classNames('content-explorer', className)}
                 data-testid="content-explorer"
                 onClick={this.handleContentExplorerClick}
                 ref={ref => {
@@ -494,7 +489,6 @@ class ContentExplorer extends Component {
                 <ItemList
                     contentExplorerMode={contentExplorerMode}
                     height={listHeight}
-                    isResponsive={isResponsive}
                     itemButtonRenderer={itemButtonRenderer}
                     itemIconRenderer={itemIconRenderer}
                     itemNameLinkRenderer={itemNameLinkRenderer}
@@ -521,7 +515,6 @@ class ContentExplorer extends Component {
                     isChooseButtonLoading={isChooseButtonLoading}
                     isCopyButtonLoading={isCopyButtonLoading}
                     isMoveButtonLoading={isMoveButtonLoading}
-                    isResponsive={isResponsive}
                     onCancelClick={onCancelButtonClick}
                     onChooseClick={onChooseItems}
                     onCopyClick={onCopyItem}

--- a/src/features/content-explorer/content-explorer/ContentExplorer.scss
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.scss
@@ -102,14 +102,3 @@
         }
     }
 }
-
-.content-explorer .modal-actions .status-message {
-    margin-right: auto;
-}
-
-.bdl-ContentExplorerModal--responsive .modal-content,
-.bdl-ContentExplorer--responsive {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-}

--- a/src/features/content-explorer/content-explorer/ContentExplorerActionButtons.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorerActionButtons.js
@@ -31,7 +31,6 @@ const ContentExplorerActionButtons = ({
     isChooseButtonLoading = false,
     isCopyButtonLoading = false,
     isMoveButtonLoading = false,
-    isResponsive = false,
     onCancelClick,
     onChooseClick,
     onCopyClick,
@@ -87,12 +86,9 @@ const ContentExplorerActionButtons = ({
 
         return contentExplorerMode === ContentExplorerModes.MULTI_SELECT && statusElement;
     };
-    const contentExplorerActionButtonsStyle = isResponsive
-        ? 'modal-actions'
-        : 'content-explorer-action-buttons-container';
 
     return (
-        <div className={contentExplorerActionButtonsStyle} {...actionButtonsProps}>
+        <div className="content-explorer-action-buttons-container" {...actionButtonsProps}>
             {renderStatus()}
             <Button
                 className="content-explorer-cancel-button"
@@ -157,7 +153,6 @@ ContentExplorerActionButtons.propTypes = {
     isChooseButtonLoading: PropTypes.bool,
     isCopyButtonLoading: PropTypes.bool,
     isMoveButtonLoading: PropTypes.bool,
-    isResponsive: PropTypes.bool,
     onCancelClick: PropTypes.func,
     onChooseClick: PropTypes.func,
     onCopyClick: PropTypes.func,

--- a/src/features/content-explorer/content-explorer/__tests__/__snapshots__/ContentExplorer.test.js.snap
+++ b/src/features/content-explorer/content-explorer/__tests__/__snapshots__/ContentExplorer.test.js.snap
@@ -26,7 +26,6 @@ exports[`features/content-explorer/content-explorer/ContentExplorer render() cus
   <ItemList
     contentExplorerMode="selectFile"
     height={500}
-    isResponsive={false}
     items={Array []}
     noItemsRenderer={[Function]}
     numItemsPerPage={100}
@@ -50,7 +49,6 @@ exports[`features/content-explorer/content-explorer/ContentExplorer render() cus
         "name": "folder",
       }
     }
-    isResponsive={false}
     selectedItems={Object {}}
   />
 </div>

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import getProp from 'lodash/get';
-import AutoSizer from '@box/react-virtualized/dist/commonjs/AutoSizer';
+
 import Column from '@box/react-virtualized/dist/commonjs/Table/Column';
 import Table from '@box/react-virtualized/dist/commonjs/Table';
 import defaultTableRowRenderer from '@box/react-virtualized/dist/commonjs/Table/defaultRowRenderer';
@@ -111,7 +111,6 @@ const itemLoadingPlaceholderRenderer = rendererParams => {
 const ItemList = ({
     contentExplorerMode,
     className = '',
-    isResponsive = false,
     items,
     numItemsPerPage,
     numTotalItems,
@@ -190,28 +189,8 @@ const ItemList = ({
         };
     }
 
-    const withAutoSizer = WrappedComponent => {
-        return props => {
-            return isResponsive ? (
-                <div style={{ flex: 1 }}>
-                    <AutoSizer>
-                        {({ width: w, height: h }) => <WrappedComponent {...props} width={w} height={h} />}
-                    </AutoSizer>
-                </div>
-            ) : (
-                <WrappedComponent {...props} />
-            );
-        };
-    };
-
-    TableComponent = withAutoSizer(TableComponent);
-
     return (
-        <div
-            className={classNames('content-explorer-item-list table', className, {
-                'bdl-ContentExplorerItemList--responsive': isResponsive,
-            })}
-        >
+        <div className={classNames('content-explorer-item-list table', className)}>
             <TableComponent
                 gridClassName="table-body"
                 headerClassName="table-header-item"
@@ -269,7 +248,6 @@ ItemList.displayName = 'ItemList';
 ItemList.propTypes = {
     className: PropTypes.string,
     contentExplorerMode: ContentExplorerModePropType.isRequired,
-    isResponsive: PropTypes.bool,
     items: ItemsPropType.isRequired,
     numItemsPerPage: PropTypes.number,
     numTotalItems: PropTypes.number,

--- a/src/features/content-explorer/item-list/ItemList.scss
+++ b/src/features/content-explorer/item-list/ItemList.scss
@@ -1,12 +1,5 @@
 @import '../../../styles/variables';
 
-.bdl-ContentExplorerItemList--responsive {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    min-height: 285px;
-}
-
 .content-explorer-item-list {
     .table-header-item {
         color: $bdl-gray-62;


### PR DESCRIPTION
Reverts box/box-ui-elements#2932

Seems to result in a bug when there are many folders. If an item is selected, and the user scrolls down past the initial selection and makes another selection, the file explorer "jumps" back to the top. Selection remains unaffected.