### PR TITLE
fix(dropdown-menu): fix menu header close btn and text positioning

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.scss
+++ b/src/components/dropdown-menu/DropdownMenu.scss
@@ -49,7 +49,7 @@
                 left: 0;
                 display: flex;
                 height: $bdl-header-height;
-                padding: ($bdl-grid-unit * 3) ($bdl-grid-unit * 4);
+                padding: ($bdl-grid-unit * 3) ($bdl-grid-unit * 3);
                 background-color: $white;
                 box-shadow: $bdl-header-box-shadow;
             }

--- a/src/components/menu/MenuHeader.scss
+++ b/src/components/menu/MenuHeader.scss
@@ -3,8 +3,29 @@
 .bdl-MenuHeader {
     display: flex;
     align-items: center;
+    justify-content: flex-end;
+    max-width: 100%;
 }
 
 .bdl-MenuHeader-content {
-    flex-grow: 1;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
+    padding-right: 5px;
+}
+
+.bdl-MenuHeader-title {
+    margin: 0;
+    overflow: hidden;
+    color: $bdl-gray;
+    font-weight: bold;
+    font-size: 16px;
+    text-overflow: ellipsis;
+}
+
+.bdl-MenuHeader-subtitle {
+    margin: 0;
+    color: $bdl-gray-62;
+    font-size: 12px;
 }

--- a/src/components/menu/MenuHeader.tsx
+++ b/src/components/menu/MenuHeader.tsx
@@ -7,13 +7,15 @@ import MenuContext from './MenuContext';
 import './MenuHeader.scss';
 
 export interface MenuHeaderProps {
-    /** children - menu section header content */
-    children?: Array<React.ReactChild> | React.ReactChild;
     /** className - CSS class name for the menu section header */
     className?: string;
+    /** subtitle - Secondary title of header below Title */
+    subtitle?: React.ReactChild;
+    /** title - Title of header */
+    title?: React.ReactChild;
 }
 
-const MenuHeader = ({ children, className, ...rest }: MenuHeaderProps) => {
+const MenuHeader = ({ className, subtitle, title, ...rest }: MenuHeaderProps) => {
     const { closeMenu } = React.useContext(MenuContext);
 
     return (
@@ -23,8 +25,11 @@ const MenuHeader = ({ children, className, ...rest }: MenuHeaderProps) => {
             role="presentation"
             {...rest}
         >
-            <div className="bdl-MenuHeader-content">{children}</div>
-            <CloseButton onClick={closeMenu} />
+            <div className="bdl-MenuHeader-content">
+                <div className="bdl-MenuHeader-title">{title}</div>
+                <div className="bdl-MenuHeader-subtitle">{subtitle}</div>
+            </div>
+            <CloseButton className="bdl-MenuHeader-close-button" onClick={closeMenu} />
         </div>
     );
 };

--- a/src/components/menu/__tests__/MenuHeader.test.tsx
+++ b/src/components/menu/__tests__/MenuHeader.test.tsx
@@ -10,9 +10,7 @@ describe('components/menu/MenuHeader', () => {
             const classNameCustom = 'oh-class';
             const classNameChild = 'child-class';
             const { container } = render(
-                <MenuHeader className={classNameCustom}>
-                    <div className={classNameChild} />
-                </MenuHeader>,
+                <MenuHeader title={<div className={classNameChild} />} className={classNameCustom} />,
             );
 
             expect(container.firstChild).toHaveClass('bdl-MenuHeader');
@@ -27,9 +25,7 @@ describe('components/menu/MenuHeader', () => {
             const closeMenu = jest.fn();
             render(
                 <MenuContext.Provider value={{ closeMenu }}>
-                    <MenuHeader>
-                        <p>Hi</p>
-                    </MenuHeader>
+                    <MenuHeader />
                 </MenuContext.Provider>,
             );
 


### PR DESCRIPTION
* CloseButton is now properly anchored to the top right as opposed it being pushed off screen with a long title
* MenuHeader now takes in title and subtitle props
