### PR TITLE
fix(menu-item): fix menu item disabled tabbing

### DIFF
--- a/src/components/menu/Menu.scss
+++ b/src/components/menu/Menu.scss
@@ -50,7 +50,7 @@
         font-size: 10px;
     }
 
-    &[aria-disabled] {
+    &[aria-readonly] {
         cursor: default;
         opacity: .4;
     }

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -7,8 +7,8 @@ import RadarAnimation from '../radar';
 export interface MenuItemProps {
     /** 'aria-checked' - ARIA attribute for checkbox elements */
     'aria-checked'?: boolean;
-    /** 'aria-disabled' - ARIA attribute describing whether the menu item is disabled */
-    'aria-disabled'?: boolean | 'true' | 'false';
+    /** 'aria-readonly' - ARIA attribute describing whether the menu item is readonly */
+    'aria-readonly'?: boolean | 'true' | 'false';
     /** children - menu item content */
     children?: Array<React.ReactChild> | React.ReactChild;
     /** className - CSS class name for the menu item */
@@ -63,7 +63,8 @@ class MenuItem extends React.Component<MenuItemProps> {
         }
 
         if (isDisabled) {
-            menuItemProps['aria-disabled'] = 'true';
+            // Using aria-readonly to preserve tabbing behavior
+            menuItemProps['aria-readonly'] = 'true';
         }
 
         let menuItem = <li {...menuItemProps}>{children}</li>;

--- a/src/components/menu/__tests__/MenuItem.test.tsx
+++ b/src/components/menu/__tests__/MenuItem.test.tsx
@@ -45,6 +45,12 @@ describe('components/menu/MenuItem', () => {
             expect(wrapper.prop('aria-checked')).toBe(true);
         });
 
+        test('should add correct aria attribute when item has isDisabled prop', () => {
+            const wrapper = shallow(<MenuItem isDisabled>Test</MenuItem>);
+
+            expect(wrapper.prop('aria-readonly')).toBe('true');
+        });
+
         test('should not render a RadarAnimation if showRadar is false', () => {
             const wrapper = shallow(<MenuItem showRadar={false}>Test</MenuItem>);
             expect(wrapper.find('RadarAnimation')).toMatchSnapshot();


### PR DESCRIPTION
Fix disabled menu item by making it reachable via tabbing

![2022-08-03 17 14 05](https://user-images.githubusercontent.com/95440409/182743093-a2b9383e-9ff1-4690-b4d7-6350f483f7b9.gif)

**Text read by the voiceover:**
> “Download PDF, menu item”
> “Download PDF is not supported by this file”
