### PR TITLE
fix(preview): update more apps icon in Preview sidebar/drawer

### DIFF
--- a/src/elements/content-sidebar/additional-tabs/AdditionalTab.js
+++ b/src/elements/content-sidebar/additional-tabs/AdditionalTab.js
@@ -10,9 +10,9 @@ import { FormattedMessage } from 'react-intl';
 
 import { bdlGray50 } from '../../../styles/variables';
 import PlainButton from '../../../components/plain-button/PlainButton';
-import IconEllipsis from '../../../icons/general/IconEllipsis';
 import AdditionalTabTooltip from './AdditionalTabTooltip';
 import AdditionalTabPlaceholder from './AdditionalTabPlaceholder';
+import Apps16 from '../../../icon/fill/Apps16';
 import messages from './messages';
 import type { AdditionalSidebarTab, AdditionalSidebarTabFtuxData } from '../flowTypes';
 
@@ -78,7 +78,7 @@ class AdditionalTab extends React.PureComponent<Props, State> {
                 />
             );
         } else {
-            TabIcon = <IconEllipsis color={bdlGray50} />;
+            TabIcon = <Apps16 color={bdlGray50} width={20} height={20} />;
         }
 
         return TabIcon;

--- a/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
+++ b/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
@@ -41,8 +41,10 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render th
     onClick={[Function]}
     type="button"
   >
-    <IconEllipsis
+    <Apps16
       color="#909090"
+      height={20}
+      width={20}
     />
   </PlainButton>
 </AdditionalTabTooltip>


### PR DESCRIPTION
Updated more apps icon on Preview sidebar to App Center icon

### Before 
![Screen Shot 2022-08-05 at 6 43 31 PM](https://user-images.githubusercontent.com/6400298/183228768-beaeb539-c37e-486b-a5e3-736eb6655b57.png)
![Screen Shot 2022-08-05 at 6 43 09 PM](https://user-images.githubusercontent.com/6400298/183228771-f49adb28-417a-48e7-825a-8892310bad8a.png)

### After
![Screen Shot 2022-08-05 at 6 39 54 PM](https://user-images.githubusercontent.com/6400298/183228776-bbbd57b8-2ab0-4521-9d6f-3d2743eb09b3.png)
![Screen Shot 2022-08-05 at 6 40 55 PM](https://user-images.githubusercontent.com/6400298/183228773-9dcf6339-0973-494e-9bab-8ead9025baf7.png)


