### PR TITLE
fix(mediaquery): change type of size to string

### DIFF
--- a/src/components/media-query/types.js
+++ b/src/components/media-query/types.js
@@ -21,7 +21,7 @@ export type MediaShape = {
     anyPointer: MediaPointerType,
     hover: MediaHoverType,
     pointer: MediaPointerType,
-    size: boolean,
+    size: string,
     viewHeight: number,
     viewWidth: number,
 };


### PR DESCRIPTION
BREAKING CHANGE: the previous type was boolean. This could break type
checkers