### PR TITLE
feat(replies): Update Annotations API to support threaded replies

### DIFF
--- a/src/api/Annotations.js
+++ b/src/api/Annotations.js
@@ -2,20 +2,25 @@
 import merge from 'lodash/merge';
 import {
     ERROR_CODE_CREATE_ANNOTATION,
+    ERROR_CODE_CREATE_REPLY,
     ERROR_CODE_DELETE_ANNOTATION,
     ERROR_CODE_EDIT_ANNOTATION,
     ERROR_CODE_FETCH_ANNOTATION,
     ERROR_CODE_FETCH_ANNOTATIONS,
+    ERROR_CODE_FETCH_REPLIES,
     PERMISSION_CAN_CREATE_ANNOTATIONS,
     PERMISSION_CAN_DELETE,
     PERMISSION_CAN_EDIT,
     PERMISSION_CAN_VIEW_ANNOTATIONS,
+    PERMISSION_CAN_RESOLVE,
 } from '../constants';
 import MarkerBasedApi from './MarkerBasedAPI';
+
 import type {
     Annotation,
     AnnotationPermission,
     Annotations as AnnotationsType,
+    AnnotationStatus,
     NewAnnotation,
 } from '../common/types/annotations';
 import type { BoxItemPermission } from '../common/types/core';
@@ -28,6 +33,10 @@ export default class Annotations extends MarkerBasedApi {
 
     getUrlForId(annotationId: string) {
         return `${this.getUrl()}/${annotationId}`;
+    }
+
+    getUrlWithRepliesForId(annotationId: string) {
+        return `${this.getUrlForId(annotationId)}/replies`;
     }
 
     createAnnotation(
@@ -74,24 +83,39 @@ export default class Annotations extends MarkerBasedApi {
         fileId: string,
         annotationId: string,
         permissions: AnnotationPermission,
-        message: string,
+        payload: { message?: string, status?: AnnotationStatus },
         successCallback: (annotation: Annotation) => void,
         errorCallback: (e: ElementsXhrError, code: string) => void,
     ): void {
         this.errorCode = ERROR_CODE_EDIT_ANNOTATION;
+        const { message, status } = payload;
 
-        try {
-            this.checkApiCallValidity(PERMISSION_CAN_EDIT, permissions, fileId);
-        } catch (e) {
-            errorCallback(e, this.errorCode);
-            return;
+        if (message) {
+            try {
+                this.checkApiCallValidity(PERMISSION_CAN_EDIT, permissions, fileId);
+            } catch (e) {
+                errorCallback(e, this.errorCode);
+                return;
+            }
         }
 
-        const requestData = { data: { description: { message } } };
+        if (status) {
+            try {
+                this.checkApiCallValidity(PERMISSION_CAN_RESOLVE, permissions, fileId);
+            } catch (e) {
+                errorCallback(e, this.errorCode);
+                return;
+            }
+        }
 
         this.put({
             id: fileId,
-            data: requestData,
+            data: {
+                data: {
+                    description: message ? { message } : undefined,
+                    status,
+                },
+            },
             errorCallback,
             successCallback,
             url: this.getUrlForId(annotationId),
@@ -128,8 +152,71 @@ export default class Annotations extends MarkerBasedApi {
         permissions: BoxItemPermission,
         successCallback: (annotation: Annotation) => void,
         errorCallback: (e: ElementsXhrError, code: string) => void,
+        shouldFetchReplies?: boolean,
     ): void {
         this.errorCode = ERROR_CODE_FETCH_ANNOTATION;
+
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_VIEW_ANNOTATIONS, permissions, fileId);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        const requestData = shouldFetchReplies ? { params: { fields: 'replies' } } : undefined;
+
+        this.get({
+            id: fileId,
+            errorCallback,
+            successCallback,
+            url: this.getUrlForId(annotationId),
+            requestData,
+        });
+    }
+
+    getAnnotations(
+        fileId: string,
+        fileVersionId?: string,
+        permissions: BoxItemPermission,
+        successCallback: (annotations: AnnotationsType) => void,
+        errorCallback: (e: ElementsXhrError, code: string) => void,
+        limit?: number,
+        shouldFetchAll?: boolean,
+        shouldFetchReplies?: boolean,
+    ): void {
+        this.errorCode = ERROR_CODE_FETCH_ANNOTATIONS;
+
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_VIEW_ANNOTATIONS, permissions, fileId);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        const requestData = {
+            file_id: fileId,
+            file_version_id: fileVersionId,
+            ...(shouldFetchReplies ? { fields: 'replies' } : null),
+        };
+
+        this.markerGet({
+            id: fileId,
+            errorCallback,
+            limit,
+            requestData,
+            shouldFetchAll,
+            successCallback,
+        });
+    }
+
+    getAnnotationReplies(
+        fileId: string,
+        annotationId: string,
+        permissions: BoxItemPermission,
+        successCallback: (annotation: Annotation) => void,
+        errorCallback: (e: ElementsXhrError, code: string) => void,
+    ): void {
+        this.errorCode = ERROR_CODE_FETCH_REPLIES;
 
         try {
             this.checkApiCallValidity(PERMISSION_CAN_VIEW_ANNOTATIONS, permissions, fileId);
@@ -142,38 +229,33 @@ export default class Annotations extends MarkerBasedApi {
             id: fileId,
             errorCallback,
             successCallback,
-            url: this.getUrlForId(annotationId),
+            url: this.getUrlWithRepliesForId(annotationId),
         });
     }
 
-    getAnnotations(
+    createAnnotationReply(
         fileId: string,
-        fileVersionId?: string,
+        annotationId: string,
         permissions: BoxItemPermission,
-        successCallback: (annotations: AnnotationsType) => void,
+        message: string,
+        successCallback: (annotation: Annotation) => void,
         errorCallback: (e: ElementsXhrError, code: string) => void,
-        limit?: number,
-        shouldFetchAll?: boolean,
     ): void {
-        this.errorCode = ERROR_CODE_FETCH_ANNOTATIONS;
+        this.errorCode = ERROR_CODE_CREATE_REPLY;
 
         try {
-            this.checkApiCallValidity(PERMISSION_CAN_VIEW_ANNOTATIONS, permissions, fileId);
+            this.checkApiCallValidity(PERMISSION_CAN_CREATE_ANNOTATIONS, permissions, fileId);
         } catch (e) {
             errorCallback(e, this.errorCode);
             return;
         }
 
-        this.markerGet({
+        this.post({
             id: fileId,
+            data: { data: { message } },
             errorCallback,
-            limit,
-            requestData: {
-                file_id: fileId,
-                file_version_id: fileVersionId,
-            },
-            shouldFetchAll,
             successCallback,
+            url: this.getUrlWithRepliesForId(annotationId),
         });
     }
 }

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -185,7 +185,7 @@ class Feed extends Base {
             this.file.id,
             annotationId,
             permissions,
-            text,
+            { message: text },
             (annotation: Annotation) => {
                 this.updateFeedItem(
                     {

--- a/src/api/__tests__/Annotations.test.js
+++ b/src/api/__tests__/Annotations.test.js
@@ -1,6 +1,8 @@
 import Annotations from '../Annotations';
 import {
     ERROR_CODE_CREATE_ANNOTATION,
+    ERROR_CODE_CREATE_REPLY,
+    ERROR_CODE_FETCH_REPLIES,
     ERROR_CODE_DELETE_ANNOTATION,
     ERROR_CODE_EDIT_ANNOTATION,
     ERROR_CODE_FETCH_ANNOTATION,
@@ -33,6 +35,14 @@ describe('api/Annotations', () => {
     describe('getUrlForId()', () => {
         test('should return the correct url for a given annotation id', () => {
             expect(annotations.getUrlForId('test')).toBe('https://api.box.com/2.0/undoc/annotations/test');
+        });
+    });
+
+    describe('getUrlWithRepliesForId()', () => {
+        test('should return the correct url for replies for given annotation id', () => {
+            expect(annotations.getUrlWithRepliesForId('test')).toBe(
+                'https://api.box.com/2.0/undoc/annotations/test/replies',
+            );
         });
     });
 
@@ -102,33 +112,56 @@ describe('api/Annotations', () => {
     });
 
     describe('updateAnnotation()', () => {
-        const message = 'hello';
-
-        test('should format its parameters and call the update method for a given id', () => {
+        test('should format its parameters and call the update method for a given id and mesaage', () => {
             const errorCallback = jest.fn();
             const successCallback = jest.fn();
-            annotations.updateAnnotation('12345', 'abc', { can_edit: true }, message, successCallback, errorCallback);
+            const payload = { message: 'hello' };
+            annotations.updateAnnotation('12345', 'abc', { can_edit: true }, payload, successCallback, errorCallback);
 
             expect(annotations.put).toBeCalledWith({
                 id: '12345',
-                data: { data: { description: { message } } },
+                data: { data: { description: { message: 'hello' } } },
                 errorCallback,
                 successCallback,
                 url: 'https://api.box.com/2.0/undoc/annotations/abc',
             });
         });
 
-        test('should reject with an error code for calls with invalid permissions', () => {
+        test('should format its parameters and call the update method for a given id and status', () => {
             const errorCallback = jest.fn();
             const successCallback = jest.fn();
+            const payload = { status: 'resolved' };
             annotations.updateAnnotation(
                 '12345',
-                '67890',
-                { can_edit: false },
-                message,
+                'abc',
+                { can_resolve: true },
+                payload,
                 successCallback,
                 errorCallback,
             );
+
+            expect(annotations.put).toBeCalledWith({
+                id: '12345',
+                data: {
+                    data: {
+                        description: undefined,
+                        status: 'resolved',
+                    },
+                },
+                errorCallback,
+                successCallback,
+                url: 'https://api.box.com/2.0/undoc/annotations/abc',
+            });
+        });
+
+        test.each([
+            { can_resolve: true, can_edit: false },
+            { can_resolve: false, can_edit: true },
+        ])('should reject with an error code for calls with invalid permissions %s', permissions => {
+            const errorCallback = jest.fn();
+            const successCallback = jest.fn();
+            const payload = { message: 'hello', status: 'resolved' };
+            annotations.updateAnnotation('12345', '67890', permissions, payload, successCallback, errorCallback);
 
             expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_EDIT_ANNOTATION);
             expect(annotations.put).not.toBeCalled();
@@ -175,6 +208,24 @@ describe('api/Annotations', () => {
                 errorCallback,
                 successCallback,
                 url: 'https://api.box.com/2.0/undoc/annotations/abc',
+                requestData: undefined,
+            });
+        });
+
+        test('should format its parameters and call the get method with replies', () => {
+            const permissions = {
+                can_create_annotations: true,
+                can_view_annotations: true,
+            };
+
+            annotations.getAnnotation('12345', 'abc', permissions, successCallback, errorCallback, true);
+
+            expect(annotations.get).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                successCallback,
+                url: 'https://api.box.com/2.0/undoc/annotations/abc',
+                requestData: { params: { fields: 'replies' } },
             });
         });
 
@@ -212,6 +263,28 @@ describe('api/Annotations', () => {
             });
         });
 
+        test('should format its parameters and call the underlying markerGet with additional requestData', () => {
+            const permissions = {
+                can_create_annotations: true,
+                can_view_annotations: true,
+            };
+
+            annotations.getAnnotations('12345', '67890', permissions, successCallback, errorCallback, 100, false, true);
+
+            expect(annotations.markerGet).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                successCallback,
+                limit: 100,
+                shouldFetchAll: false,
+                requestData: {
+                    file_id: '12345',
+                    file_version_id: '67890',
+                    fields: 'replies',
+                },
+            });
+        });
+
         test.each([
             { can_create_annotations: true, can_view_annotations: false },
             { can_create_annotations: false, can_view_annotations: false },
@@ -219,7 +292,66 @@ describe('api/Annotations', () => {
             annotations.getAnnotations('12345', '67890', permissions, successCallback, errorCallback);
 
             expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_FETCH_ANNOTATIONS);
+            expect(annotations.markerGet).not.toBeCalled();
+        });
+    });
+
+    describe('getAnnotationReplies()', () => {
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+
+        test('should format its parameters and call the get method', () => {
+            const permissions = {
+                can_create_annotations: true,
+                can_view_annotations: true,
+            };
+
+            annotations.getAnnotationReplies('12345', '67890', permissions, successCallback, errorCallback);
+
+            expect(annotations.get).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                successCallback,
+                url: 'https://api.box.com/2.0/undoc/annotations/67890/replies',
+            });
+        });
+
+        test.each([
+            { can_create_annotations: true, can_view_annotations: false },
+            { can_create_annotations: false, can_view_annotations: false },
+        ])('should reject with an error code for calls with invalid permissions %s', permissions => {
+            annotations.getAnnotationReplies('12345', '67890', permissions, successCallback, errorCallback);
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_FETCH_REPLIES);
             expect(annotations.get).not.toBeCalled();
+        });
+    });
+
+    describe('createAnnotationReply()', () => {
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+        const message = 'Hello';
+
+        test('should format its parameters and call the post method', () => {
+            const permissions = {
+                can_create_annotations: true,
+            };
+            annotations.createAnnotationReply('12345', '67890', permissions, message, successCallback, errorCallback);
+            expect(annotations.post).toBeCalledWith({
+                id: '12345',
+                data: { data: { message } },
+                errorCallback,
+                successCallback,
+                url: 'https://api.box.com/2.0/undoc/annotations/67890/replies',
+            });
+        });
+        test.each([
+            { can_create_annotations: false, can_view_annotations: false },
+            { can_create_annotations: false, can_view_annotations: true },
+        ])('should reject with an error code for calls with invalid permissions %s', permissions => {
+            annotations.createAnnotationReply('12345', '67890', permissions, message, successCallback, errorCallback);
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_CREATE_REPLY);
+            expect(annotations.post).not.toBeCalled();
         });
     });
 });

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -251,7 +251,7 @@ jest.mock('../Annotations', () =>
         deleteAnnotation: jest.fn().mockImplementation((file, id, permissions, successCallback) => {
             successCallback();
         }),
-        updateAnnotation: jest.fn().mockImplementation((file, id, text, permissions, successCallback) => {
+        updateAnnotation: jest.fn().mockImplementation((file, id, payload, permissions, successCallback) => {
             successCallback();
         }),
         getAnnotations: jest.fn(),

--- a/src/common/types/annotations.js
+++ b/src/common/types/annotations.js
@@ -36,6 +36,8 @@ export type AnnotationPermission = {
     can_edit?: boolean,
 };
 
+export type AnnotationStatus = 'open' | 'deleted' | 'resolved';
+
 export type Annotation = {
     created_at: string,
     created_by: User,
@@ -48,7 +50,7 @@ export type Annotation = {
     modified_by: User,
     permissions: AnnotationPermission,
     replies?: Array<Reply>,
-    status?: 'deleted' | 'open' | 'resolved',
+    status?: AnnotationStatus,
     target: Target,
     type: 'annotation',
 };


### PR DESCRIPTION
Modify Annotations (src/api/Annotations.js) to implement Threaded Replies requirements

- modify getAnnotations function
New param: `shouldFetchReplies?: boolean`
if true add url param `fields=replies` 

- modify getAnnotation function
New param: `shouldFetchReplies?: boolean`
if true add url param `fields=replies` 

- modify updateAnnotation function
New param status?: OPEN|RESOLVED|DELETED
Include status field in PUT request

- create getAnnotationReplies function
Returns an array of replies for a given annotation id.
 
- create createAnnotationReply function
Creates a reply for an annotation
Request body:
```
{ message: “reply message” }
```
