### PR TITLE
feat(usm): BREAKING CHANGE Clean up USM props used for compatibility

### DIFF
--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -2,8 +2,6 @@
 
 import * as React from 'react';
 import { injectIntl } from 'react-intl';
-import isNil from 'lodash/isNil';
-import isEmpty from 'lodash/isEmpty';
 
 import { Modal } from '../../components/modal';
 
@@ -130,33 +128,12 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
     };
 
     renderUSF = () => {
-        const {
-            onRemoveAllRestrictedCollabs,
-            // $FlowFixMe - For temporary backwards compatibility
-            onRemoveAllRestrictedExternalCollabs,
-            restrictedCollabEmails,
-            // $FlowFixMe - For temporary backwards compatibility
-            restrictedExternalCollabEmails,
-            sharedLinkEditTagTargetingApi,
-            sharedLinkEditTooltipTargetingApi,
-        } = this.props;
+        const { sharedLinkEditTagTargetingApi, sharedLinkEditTooltipTargetingApi } = this.props;
         const { isFetching, sharedLinkLoaded, shouldRenderFTUXTooltip } = this.state;
-
-        // TODO
-        // For temporary backwards compatibility. Remove legacy onRemoveAllRestrictedExternalCollabs
-        // and restrictedExternalCollabEmails props once EUA has been updated not to pass them
-        const onRemoveAllRestrictedCollabsValue = isNil(onRemoveAllRestrictedExternalCollabs)
-            ? onRemoveAllRestrictedCollabs
-            : onRemoveAllRestrictedExternalCollabs;
-        const restrictedCollabEmailsValue = isEmpty(restrictedExternalCollabEmails)
-            ? restrictedCollabEmails
-            : restrictedExternalCollabEmails;
 
         return (
             <UnifiedShareForm
                 {...this.props}
-                onRemoveAllRestrictedCollabs={onRemoveAllRestrictedCollabsValue}
-                restrictedCollabEmails={restrictedCollabEmailsValue}
                 handleFtuxCloseClick={this.handleFtuxCloseClick}
                 isFetching={isFetching}
                 openConfirmModal={this.openConfirmModal}


### PR DESCRIPTION
BREAKING CHANGE: onRemoveAllRestrictedExternalCollabs and restrictedExternalCollabEmails props have been removed

Now that EUA has been updated we no longer need to support the old props.