### PR TITLE
feat(threaded-replies): add ThrededComments API to support threaded replies

### DIFF
--- a/src/api/ThreadedComments.js
+++ b/src/api/ThreadedComments.js
@@ -1,0 +1,340 @@
+/**
+ * @flow
+ * @file Helper for the box threadedComments API
+ * @author Box
+ */
+
+import type { ThreadedCommentPermission, ThreadedCommentStatus } from '../common/types/threadedComments';
+import MarkerBasedApi from './MarkerBasedAPI';
+import {
+    PERMISSION_CAN_COMMENT,
+    PERMISSION_CAN_DELETE,
+    PERMISSION_CAN_EDIT,
+    ERROR_CODE_CREATE_COMMENT,
+    ERROR_CODE_UPDATE_COMMENT,
+    ERROR_CODE_DELETE_COMMENT,
+    ERROR_CODE_FETCH_COMMENTS,
+    PERMISSION_CAN_RESOLVE,
+    ERROR_CODE_FETCH_REPLIES,
+    ERROR_CODE_CREATE_REPLY,
+} from '../constants';
+import type { ElementsXhrError, ElementsErrorCallback } from '../common/types/api';
+import type { BoxItem, BoxItemPermission } from '../common/types/core';
+
+class ThreadedComments extends MarkerBasedApi {
+    /**
+     * API URL for comments
+     *
+     * @return {string} base url for comments
+     */
+    getUrl(): string {
+        return `${this.getBaseApiUrl()}/undoc/comments`;
+    }
+
+    /**
+     * API URL for specific comment
+     *
+     * @param {string} [commentId]
+     * @return {string} base url for specific comment
+     */
+    getUrlForId(commentId: string): string {
+        return `${this.getUrl()}/${commentId}`;
+    }
+
+    /**
+     * API URL for specific comment
+     *
+     * @param {string} [commentId]
+     * @return {string}  base url for specific comment replies
+     */
+    getUrlWithRepliesForId(commentId: string): string {
+        return `${this.getUrlForId(commentId)}/replies`;
+    }
+
+    /**
+     * API for creating a comment on a file
+     *
+     * @param {BoxItem} file - File object for which we are creating a comment
+     * @param {string} message - Comment message
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @return {void}
+     */
+    create({
+        file,
+        message,
+        successCallback,
+        errorCallback,
+    }: {
+        errorCallback: ElementsErrorCallback,
+        file: BoxItem,
+        message?: string,
+        successCallback: Function,
+    }): void {
+        this.errorCode = ERROR_CODE_CREATE_COMMENT;
+        const { id = '', permissions, type } = file;
+
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, id);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        const requestData = {
+            data: {
+                item: {
+                    id,
+                    type,
+                },
+                message,
+            },
+        };
+
+        this.post({
+            id,
+            url: this.getUrl(),
+            data: requestData,
+            successCallback,
+            errorCallback,
+        });
+    }
+
+    /**
+     * API for updating a comment
+     *
+     * @param {string} fileId - File id for which we are updating a comment
+     * @param {string} commentId - Comment to be edited
+     * @param {ThreadedCommentStatus} status - Comment status
+     * @param {string} message - Comment message
+     * @param {BoxItemPermission} permissions - The known permissions of the comment we're updating
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @return {void}
+     */
+    updateComment({
+        fileId,
+        commentId,
+        status,
+        message,
+        permissions,
+        successCallback,
+        errorCallback,
+    }: {
+        commentId: string,
+        errorCallback: ElementsErrorCallback,
+        fileId: string,
+        message?: string,
+        permissions: ThreadedCommentPermission,
+        status?: ThreadedCommentStatus,
+        successCallback: Function,
+    }): void {
+        this.errorCode = ERROR_CODE_UPDATE_COMMENT;
+
+        if (message) {
+            try {
+                this.checkApiCallValidity(PERMISSION_CAN_EDIT, permissions, fileId);
+            } catch (e) {
+                errorCallback(e, this.errorCode);
+                return;
+            }
+        }
+
+        if (status) {
+            try {
+                this.checkApiCallValidity(PERMISSION_CAN_RESOLVE, permissions, fileId);
+            } catch (e) {
+                errorCallback(e, this.errorCode);
+                return;
+            }
+        }
+
+        const requestData = {
+            data: { status, message },
+        };
+
+        this.put({
+            id: fileId,
+            url: this.getUrlForId(commentId),
+            data: requestData,
+            successCallback,
+            errorCallback,
+        });
+    }
+
+    /**
+     * API for deleting a comment or reply
+     *
+     * @param {string} fileId - Id of an object for which we are deleting a comment
+     * @param {string} commentId - Id of the comment we are deleting
+     * @param {ThreadedCommentPermission} permissions - The known permissions of the comment we're deleting
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @return {void}
+     */
+    deleteComment({
+        fileId,
+        commentId,
+        permissions,
+        successCallback,
+        errorCallback,
+    }: {
+        commentId: string,
+        errorCallback: ElementsErrorCallback,
+        fileId: string,
+        permissions: ThreadedCommentPermission,
+        successCallback: Function,
+    }): void {
+        this.errorCode = ERROR_CODE_DELETE_COMMENT;
+
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_DELETE, permissions, fileId);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        this.delete({
+            id: fileId,
+            url: this.getUrlForId(commentId),
+            successCallback,
+            errorCallback,
+        });
+    }
+
+    /**
+     * API for fetching comments
+     *
+     * @param {string} fileId - the file id
+     * @param {BoxItemPermission} permissions - the permissions for the file
+     * @param {Function} successCallback - the success callback
+     * @param {Function} errorCallback - the error callback
+     * @param {array} fields - the fields to fetch
+     * @param {string} marker the marker from the start to start fetching at
+     * @param {number} limit - the number of items to fetch
+     * @param {boolean} shouldFetchAll - true if should get all the pages before calling the sucessCallback
+     * @param {number} repliesCount - number of replies to return, by deafult all replies all returned
+     *  @returns {void}
+     */
+    getComments({
+        fileId,
+        permissions,
+        successCallback,
+        errorCallback,
+        marker,
+        limit,
+        shouldFetchAll,
+        repliesCount,
+    }: {
+        errorCallback: (e: ElementsXhrError, code: string) => void,
+        fileId: string,
+        limit?: number,
+        marker?: string,
+        permissions: BoxItemPermission,
+        repliesCount?: number,
+        shouldFetchAll?: boolean,
+        successCallback: Function,
+    }): void {
+        this.errorCode = ERROR_CODE_FETCH_COMMENTS;
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileId);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        this.markerGet({
+            id: fileId,
+            successCallback,
+            errorCallback,
+            marker,
+            limit,
+            requestData: {
+                file_id: fileId,
+                ...(repliesCount ? { replies_count: repliesCount } : null),
+            },
+            shouldFetchAll,
+        });
+    }
+
+    /**
+     * @param {string} fileId - the file id
+     * @param {string} commentId - id of a Comment
+     * @param {BoxItemPermission} permissions - The known permissions of the comment
+     * @param {Function} successCallback - the success callback
+     * @param {Function} errorCallback - the error callback
+     */
+    getCommentReplies({
+        fileId,
+        commentId,
+        permissions,
+        successCallback,
+        errorCallback,
+    }: {
+        commentId: string,
+        errorCallback: (e: ElementsXhrError, code: string) => void,
+        fileId: string,
+        permissions: BoxItemPermission,
+        successCallback: Function,
+    }): void {
+        this.errorCode = ERROR_CODE_FETCH_REPLIES;
+
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileId);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        this.get({
+            id: fileId,
+            errorCallback,
+            successCallback,
+            url: this.getUrlWithRepliesForId(commentId),
+        });
+    }
+
+    /**
+     * @param {string} fileId - the file id
+     * @param {string} commentId - id of a Comment for which we createing Reply
+     * @param {BoxItemPermission} permissions - The known permissions of the comment
+     * @param {Function} successCallback - the success callback
+     * @param {Function} errorCallback - the error callback
+     * @param {string} message - message of the Reply
+     */
+    createCommentReply({
+        fileId,
+        commentId,
+        permissions,
+        successCallback,
+        errorCallback,
+        message,
+    }: {
+        commentId: string,
+        errorCallback: (e: ElementsXhrError, code: string) => void,
+        fileId: string,
+        message: string,
+        permissions: BoxItemPermission,
+        shouldFetchReplies?: boolean,
+        successCallback: Function,
+    }): void {
+        this.errorCode = ERROR_CODE_CREATE_REPLY;
+
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileId);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        this.post({
+            id: fileId,
+            data: { data: { message } },
+            errorCallback,
+            successCallback,
+            url: this.getUrlWithRepliesForId(commentId),
+        });
+    }
+}
+
+export default ThreadedComments;

--- a/src/api/ThreadedComments.js
+++ b/src/api/ThreadedComments.js
@@ -4,7 +4,6 @@
  * @author Box
  */
 
-import type { ThreadedCommentPermission, ThreadedCommentStatus } from '../common/types/threadedComments';
 import MarkerBasedApi from './MarkerBasedAPI';
 import {
     PERMISSION_CAN_COMMENT,
@@ -18,6 +17,8 @@ import {
     ERROR_CODE_FETCH_REPLIES,
     ERROR_CODE_CREATE_REPLY,
 } from '../constants';
+
+import type { ThreadedCommentPermission, ThreadedCommentStatus } from '../common/types/threadedComments';
 import type { ElementsXhrError, ElementsErrorCallback } from '../common/types/api';
 import type { BoxItem, BoxItemPermission } from '../common/types/core';
 
@@ -60,7 +61,7 @@ class ThreadedComments extends MarkerBasedApi {
      * @param {Function} errorCallback - Error callback
      * @return {void}
      */
-    create({
+    createComment({
         file,
         message,
         successCallback,
@@ -72,7 +73,7 @@ class ThreadedComments extends MarkerBasedApi {
         successCallback: Function,
     }): void {
         this.errorCode = ERROR_CODE_CREATE_COMMENT;
-        const { id = '', permissions, type } = file;
+        const { id, permissions, type } = file;
 
         try {
             this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, id);
@@ -81,20 +82,18 @@ class ThreadedComments extends MarkerBasedApi {
             return;
         }
 
-        const requestData = {
-            data: {
-                item: {
-                    id,
-                    type,
-                },
-                message,
-            },
-        };
-
         this.post({
             id,
             url: this.getUrl(),
-            data: requestData,
+            data: {
+                data: {
+                    item: {
+                        id,
+                        type,
+                    },
+                    message,
+                },
+            },
             successCallback,
             errorCallback,
         });

--- a/src/api/__tests__/ThreadedComments.test.js
+++ b/src/api/__tests__/ThreadedComments.test.js
@@ -1,0 +1,313 @@
+import ThreadedComments from '../ThreadedComments';
+import {
+    ERROR_CODE_CREATE_COMMENT,
+    ERROR_CODE_UPDATE_COMMENT,
+    ERROR_CODE_DELETE_COMMENT,
+    ERROR_CODE_FETCH_COMMENTS,
+    ERROR_CODE_FETCH_REPLIES,
+    ERROR_CODE_CREATE_REPLY,
+} from '../../constants';
+
+describe('api/ThreadedComments', () => {
+    let threadedComments;
+
+    beforeEach(() => {
+        threadedComments = new ThreadedComments({});
+        threadedComments.delete = jest.fn();
+        threadedComments.get = jest.fn();
+        threadedComments.markerGet = jest.fn();
+        threadedComments.post = jest.fn();
+        threadedComments.put = jest.fn();
+    });
+
+    afterEach(() => {
+        threadedComments.destroy();
+        threadedComments = null;
+    });
+
+    describe('getUrl()', () => {
+        test('should return correct url for threaded comments', () => {
+            expect(threadedComments.getUrl()).toBe('https://api.box.com/2.0/undoc/comments');
+        });
+    });
+
+    describe('getUrlForId()', () => {
+        test('should return the correct url for a given threaded comment id', () => {
+            expect(threadedComments.getUrlForId('test')).toBe('https://api.box.com/2.0/undoc/comments/test');
+        });
+    });
+
+    describe('getUrlWithRepliesForId()', () => {
+        test('should return the correct replies url for a given threaded comment id', () => {
+            expect(threadedComments.getUrlWithRepliesForId('test')).toBe(
+                'https://api.box.com/2.0/undoc/comments/test/replies',
+            );
+        });
+    });
+
+    describe('create()', () => {
+        const file = {
+            id: 'foo',
+            permissions: {},
+            type: 'file',
+        };
+        const message = 'Test message';
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+
+        test('should format its parameters and call the post method', () => {
+            const permissions = {
+                can_comment: true,
+            };
+
+            threadedComments.create({
+                file: { ...file, permissions },
+                message,
+                errorCallback,
+                successCallback,
+            });
+
+            expect(threadedComments.post).toBeCalledWith({
+                id: 'foo',
+                data: {
+                    data: {
+                        item: {
+                            id: 'foo',
+                            type: 'file',
+                        },
+                        message,
+                    },
+                },
+                errorCallback,
+                successCallback,
+                url: 'https://api.box.com/2.0/undoc/comments',
+            });
+        });
+
+        test('should reject with an error code for calls with invalid permission ', () => {
+            threadedComments.create({ file: { ...file, can_comment: false }, message, errorCallback, successCallback });
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_CREATE_COMMENT);
+            expect(threadedComments.post).not.toBeCalled();
+        });
+    });
+
+    describe('updateComment()', () => {
+        const status = 'resolved';
+        const message = 'hello';
+        test('should format its parameters and call the update method for a given id', () => {
+            const errorCallback = jest.fn();
+            const successCallback = jest.fn();
+            threadedComments.updateComment({
+                fileId: '12345',
+                commentId: 'abc',
+                permissions: {
+                    can_resolve: true,
+                    can_edit: true,
+                },
+                status,
+                message,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(threadedComments.put).toBeCalledWith({
+                id: '12345',
+                data: { data: { status, message } },
+                errorCallback,
+                successCallback,
+                url: 'https://api.box.com/2.0/undoc/comments/abc',
+            });
+        });
+
+        test.each([
+            { can_edit: true, can_resolve: false },
+            { can_edit: false, can_resolve: true },
+            { can_edit: false, can_resolve: false },
+        ])('should reject with an error code for calls with invalid permissions %s', permissions => {
+            const errorCallback = jest.fn();
+            const successCallback = jest.fn();
+            threadedComments.updateComment({
+                fileId: '12345',
+                commentId: 'abc',
+                permissions,
+                status,
+                message,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_UPDATE_COMMENT);
+            expect(threadedComments.put).not.toBeCalled();
+        });
+    });
+
+    describe('deleteComment()', () => {
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+
+        test('should format its parameters and call the delete method for a given id', () => {
+            threadedComments.deleteComment({
+                fileId: '12345',
+                commentId: 'abc',
+                permissions: { can_delete: true },
+                successCallback,
+                errorCallback,
+            });
+
+            expect(threadedComments.delete).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                successCallback,
+                url: 'https://api.box.com/2.0/undoc/comments/abc',
+            });
+        });
+
+        test('should reject with an error code for calls with invalid permissions', () => {
+            threadedComments.deleteComment({
+                fileId: '12345',
+                commentId: '67890',
+                permissions: { can_delete: false },
+                successCallback,
+                errorCallback,
+            });
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_DELETE_COMMENT);
+            expect(threadedComments.delete).not.toBeCalled();
+        });
+    });
+
+    describe('getComments()', () => {
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+
+        test('should format its parameters and call the get method', () => {
+            const permissions = {
+                can_comment: true,
+            };
+
+            threadedComments.getComments({
+                fileId: '12345',
+                permissions,
+                successCallback,
+                errorCallback,
+                repliesCount: 1,
+            });
+
+            expect(threadedComments.markerGet).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                requestData: {
+                    file_id: '12345',
+                    replies_count: 1,
+                },
+                successCallback,
+            });
+        });
+
+        test('should reject with an error code for calls with invalid permissions', () => {
+            const permissions = {
+                can_comment: false,
+            };
+            threadedComments.getComments({
+                fileId: '12345',
+                permissions,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_FETCH_COMMENTS);
+            expect(threadedComments.get).not.toBeCalled();
+        });
+    });
+
+    describe('getCommentReplies()', () => {
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+
+        test('should format its parameters and call get method', () => {
+            const permissions = {
+                can_comment: true,
+            };
+
+            threadedComments.getCommentReplies({
+                fileId: '12345',
+                commentId: '67890',
+                permissions,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(threadedComments.get).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                url: 'https://api.box.com/2.0/undoc/comments/67890/replies',
+                successCallback,
+            });
+        });
+
+        test('should reject with an error code for calls with invalid permissions', () => {
+            const permissions = {
+                can_comment: false,
+            };
+
+            threadedComments.getCommentReplies({
+                fileId: '12345',
+                commentId: '67890',
+                permissions,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_FETCH_REPLIES);
+            expect(threadedComments.get).not.toBeCalled();
+        });
+    });
+
+    describe('createCommentReply()', () => {
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+        const message = 'Hello';
+
+        test('should format its parameters and call post method', () => {
+            const permissions = {
+                can_comment: true,
+            };
+
+            threadedComments.createCommentReply({
+                fileId: '12345',
+                commentId: '67890',
+                permissions,
+                successCallback,
+                errorCallback,
+                message,
+            });
+
+            expect(threadedComments.post).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                url: 'https://api.box.com/2.0/undoc/comments/67890/replies',
+                data: { data: { message } },
+                successCallback,
+            });
+        });
+
+        test('should reject with an error code for calls with invalid permissions', () => {
+            const permissions = {
+                can_comment: false,
+            };
+
+            threadedComments.createCommentReply({
+                fileId: '12345',
+                commentId: '67890',
+                permissions,
+                successCallback,
+                errorCallback,
+                message,
+            });
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_CREATE_REPLY);
+            expect(threadedComments.get).not.toBeCalled();
+        });
+    });
+});

--- a/src/api/__tests__/ThreadedComments.test.js
+++ b/src/api/__tests__/ThreadedComments.test.js
@@ -45,7 +45,7 @@ describe('api/ThreadedComments', () => {
         });
     });
 
-    describe('create()', () => {
+    describe('createComment()', () => {
         const file = {
             id: 'foo',
             permissions: {},
@@ -60,7 +60,7 @@ describe('api/ThreadedComments', () => {
                 can_comment: true,
             };
 
-            threadedComments.create({
+            threadedComments.createComment({
                 file: { ...file, permissions },
                 message,
                 errorCallback,
@@ -85,7 +85,12 @@ describe('api/ThreadedComments', () => {
         });
 
         test('should reject with an error code for calls with invalid permission ', () => {
-            threadedComments.create({ file: { ...file, can_comment: false }, message, errorCallback, successCallback });
+            threadedComments.createComment({
+                file: { ...file, can_comment: false },
+                message,
+                errorCallback,
+                successCallback,
+            });
 
             expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_CREATE_COMMENT);
             expect(threadedComments.post).not.toBeCalled();

--- a/src/common/types/threadedComments.js
+++ b/src/common/types/threadedComments.js
@@ -1,0 +1,9 @@
+// @flow
+
+export type ThreadedCommentStatus = 'open' | 'resolved';
+
+export type ThreadedCommentPermission = {
+    can_delete?: boolean,
+    can_edit?: boolean,
+    can_resolve?: boolean,
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -156,11 +156,11 @@ export const PERMISSION_CAN_DOWNLOAD = 'can_download';
 export const PERMISSION_CAN_EDIT = 'can_edit';
 export const PERMISSION_CAN_PREVIEW = 'can_preview';
 export const PERMISSION_CAN_RENAME = 'can_rename';
+export const PERMISSION_CAN_RESOLVE = 'can_resolve';
 export const PERMISSION_CAN_SET_SHARE_ACCESS = 'can_set_share_access';
 export const PERMISSION_CAN_SHARE = 'can_share';
 export const PERMISSION_CAN_UPLOAD = 'can_upload';
 export const PERMISSION_CAN_VIEW_ANNOTATIONS = 'can_view_annotations';
-export const PERMISSION_CAN_RESOLVE = 'can_resolve';
 
 /* --------------------- Invitee roles --------------------------- */
 export const INVITEE_ROLE_EDITOR: 'editor' = 'editor';

--- a/src/constants.js
+++ b/src/constants.js
@@ -160,6 +160,7 @@ export const PERMISSION_CAN_SET_SHARE_ACCESS = 'can_set_share_access';
 export const PERMISSION_CAN_SHARE = 'can_share';
 export const PERMISSION_CAN_UPLOAD = 'can_upload';
 export const PERMISSION_CAN_VIEW_ANNOTATIONS = 'can_view_annotations';
+export const PERMISSION_CAN_RESOLVE = 'can_resolve';
 
 /* --------------------- Invitee roles --------------------------- */
 export const INVITEE_ROLE_EDITOR: 'editor' = 'editor';
@@ -243,6 +244,7 @@ export const ERROR_CODE_FETCH_FOLDER = 'fetch_folder_error';
 export const ERROR_CODE_FETCH_WEBLINK = 'fetch_weblink_error';
 export const ERROR_CODE_FETCH_CLASSIFICATION = 'fetch_classification_error';
 export const ERROR_CODE_FETCH_COMMENTS = 'fetch_comments_error';
+export const ERROR_CODE_FETCH_REPLIES = 'fetch_replies_error';
 export const ERROR_CODE_FETCH_VERSION = 'fetch_version_error';
 export const ERROR_CODE_FETCH_VERSIONS = 'fetch_versions_error';
 export const ERROR_CODE_FETCH_TASKS = 'fetch_tasks_error';
@@ -260,6 +262,7 @@ export const ERROR_CODE_FETCH_RECENTS = 'fetch_recents_error';
 export const ERROR_CODE_EXECUTE_INTEGRATION = 'execute_integrations_error';
 export const ERROR_CODE_CREATE_ANNOTATION = 'create_annotation_error';
 export const ERROR_CODE_CREATE_COMMENT = 'create_comment_error';
+export const ERROR_CODE_CREATE_REPLY = 'create_reply_error';
 export const ERROR_CODE_CREATE_TASK = 'create_task_error';
 export const ERROR_CODE_CREATE_TASK_LINK = 'create_task_link_error';
 export const ERROR_CODE_CREATE_TASK_ASSIGNMENT = 'create_task_assignment_error';


### PR DESCRIPTION
Create src/api/ThreadedComments.js  to implement Threaded Replies requirements

- Include new api v2 url in the implementation getUrl function
- Include logic to support all required actions
  - Creating Comment / reply
  - Getting Comments for fileId
  - Updating Comment (status and message)
  - Deleting Comment
  - Getting replies to Comment

