### PR TITLE
feat(threaded-replies): create base of ActivityThread component

### DIFF
--- a/src/common/types/annotations.js
+++ b/src/common/types/annotations.js
@@ -53,6 +53,7 @@ export type Annotation = {
     repliesTotal?: number,
     status?: AnnotationStatus,
     target: Target,
+    total_reply_count?: number,
     type: 'annotation',
 };
 

--- a/src/common/types/annotations.js
+++ b/src/common/types/annotations.js
@@ -50,7 +50,6 @@ export type Annotation = {
     modified_by: User,
     permissions: AnnotationPermission,
     replies?: Array<Comment>,
-    repliesTotal?: number,
     status?: AnnotationStatus,
     target: Target,
     total_reply_count?: number,

--- a/src/common/types/annotations.js
+++ b/src/common/types/annotations.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { BoxItemVersionMini, Reply, User } from './core';
-import type { ActionItemError } from './feed';
+import type { ActionItemError, Comment } from './feed';
 
 export type Page = {
     type: 'page',
@@ -49,7 +49,8 @@ export type Annotation = {
     modified_at: string,
     modified_by: User,
     permissions: AnnotationPermission,
-    replies?: Array<Reply>,
+    replies?: Array<Comment>,
+    repliesTotal?: number,
     status?: AnnotationStatus,
     target: Target,
     type: 'annotation',

--- a/src/common/types/feed.js
+++ b/src/common/types/feed.js
@@ -39,10 +39,14 @@ type Comment = {
     is_reply_comment?: boolean,
     message?: string,
     modified_at: string,
+    parent?: {
+        id: string,
+        type: 'comment' | 'annotation',
+    },
     permissions: BoxCommentPermission,
     replies?: Array<Comment>,
-    repliesTotal?: number,
     tagged_message: string,
+    total_reply_count?: number,
     type: 'comment',
 };
 

--- a/src/common/types/feed.js
+++ b/src/common/types/feed.js
@@ -40,6 +40,8 @@ type Comment = {
     message?: string,
     modified_at: string,
     permissions: BoxCommentPermission,
+    replies?: Array<Comment>,
+    repliesTotal?: number,
     tagged_message: string,
     type: 'comment',
 };

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -94,11 +94,11 @@ const ActiveState = ({
                         return (
                             <ActivityItem
                                 key={item.type + item.id}
-                                data-testid={hasReplies ? 'activity-thread' : 'comment'}
+                                data-testid="comment"
                                 isFocused={isFocused}
                                 ref={refValue}
                             >
-                                <ActivityThread hasReplies={hasReplies}>
+                                <ActivityThread hasReplies={hasReplies} data-testid="activity-thread">
                                     <Comment
                                         {...item}
                                         currentUser={currentUser}
@@ -169,12 +169,12 @@ const ActiveState = ({
                         return (
                             <ActivityItem
                                 key={item.type + item.id}
-                                className={!hasReplies && 'bcs-activity-feed-annotation-activity'}
-                                data-testid={hasReplies ? 'activity-thread' : 'annotation-activity'}
+                                className="bcs-activity-feed-annotation-activity"
+                                data-testid="annotation-activity"
                                 isFocused={isFocused}
                                 ref={refValue}
                             >
-                                <ActivityThread hasReplies={hasReplies}>
+                                <ActivityThread hasReplies={hasReplies} data-testid="activity-thread">
                                     <AnnotationActivity
                                         currentUser={currentUser}
                                         getAvatarUrl={getAvatarUrl}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -4,6 +4,7 @@
  */
 import * as React from 'react';
 import getProp from 'lodash/get';
+import ActivityThread from './ActivityThread';
 import ActivityItem from './ActivityItem';
 import AppActivity from '../app-activity';
 import AnnotationActivity from '../annotations';
@@ -33,6 +34,7 @@ type Props = {
     getAvatarUrl: GetAvatarUrlCallback,
     getMentionWithQuery?: Function,
     getUserProfileUrl?: GetProfileUrlCallback,
+    hasReplies?: boolean,
     items: FeedItems,
     mentionSelectorContacts?: SelectorItems<>,
     onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => void,
@@ -57,6 +59,7 @@ const ActiveState = ({
     approverSelectorContacts,
     currentFileVersionId,
     currentUser,
+    hasReplies = false,
     items,
     mentionSelectorContacts,
     getMentionWithQuery,
@@ -85,6 +88,35 @@ const ActiveState = ({
                 const isFocused = item === activeEntry;
                 const refValue = isFocused ? activeFeedItemRef : undefined;
                 const itemFileVersionId = getProp(item, 'file_version.id');
+                const isCurrentVersion = currentFileVersionId === itemFileVersionId;
+
+                if (hasReplies && (item.type === 'comment' || item.type === 'annotation')) {
+                    return (
+                        <ActivityItem
+                            key={item.type + item.id}
+                            className="bcs-activity-thread"
+                            data-testid="activity-thread"
+                            isFocused={isFocused}
+                            ref={refValue}
+                        >
+                            <ActivityThread
+                                currentFileVersionId={currentFileVersionId}
+                                getAvatarUrl={getAvatarUrl}
+                                isCurrentVersion={isCurrentVersion}
+                                item={item}
+                                onAnnotationDelete={onAnnotationDelete}
+                                onAnnotationEdit={onAnnotationEdit}
+                                onAnnotationSelect={onAnnotationSelect}
+                                // onAnnotationReplyCreate={() => {}} // TODO will be implemented in next PR
+                                // onCommentReplyCreate={() => {}} // TODO will be implemented in next PR
+                                onCommentDelete={onCommentDelete}
+                                onCommentEdit={onCommentEdit}
+                                // onGetAnnotationReplies={() => {}} // TODO will be implemented in next PR
+                                // onGetCommentReplies={() => {}} // TODO will be implemented in next PR
+                            />
+                        </ActivityItem>
+                    );
+                }
 
                 switch (item.type) {
                     case 'comment':

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -94,7 +94,6 @@ const ActiveState = ({
                         return (
                             <ActivityItem
                                 key={item.type + item.id}
-                                className={hasReplies ? 'bcs-activity-thread' : 'bcs-activity-feed-comment'}
                                 data-testid={hasReplies ? 'activity-thread' : 'comment'}
                                 isFocused={isFocused}
                                 ref={refValue}
@@ -170,7 +169,7 @@ const ActiveState = ({
                         return (
                             <ActivityItem
                                 key={item.type + item.id}
-                                className={hasReplies ? 'bcs-activity-thread' : 'bcs-activity-feed-annotation-activity'}
+                                className={!hasReplies && 'bcs-activity-feed-annotation-activity'}
                                 data-testid={hasReplies ? 'activity-thread' : 'annotation-activity'}
                                 isFocused={isFocused}
                                 ref={refValue}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -91,60 +91,34 @@ const ActiveState = ({
 
                 switch (item.type) {
                     case 'comment':
-                        if (hasReplies) {
-                            return (
-                                <ActivityItem
-                                    key={item.type + item.id}
-                                    className="bcs-activity-thread"
-                                    data-testid="activity-thread"
-                                    isFocused={isFocused}
-                                    ref={refValue}
-                                >
-                                    <ActivityThread>
-                                        <Comment
-                                            {...item}
-                                            currentUser={currentUser}
-                                            getAvatarUrl={getAvatarUrl}
-                                            getMentionWithQuery={getMentionWithQuery}
-                                            getUserProfileUrl={getUserProfileUrl}
-                                            mentionSelectorContacts={mentionSelectorContacts}
-                                            onDelete={onCommentDelete}
-                                            onEdit={onCommentEdit}
-                                            permissions={{
-                                                can_delete: getProp(item.permissions, 'can_delete', false),
-                                                can_edit: getProp(item.permissions, 'can_edit', false),
-                                            }}
-                                            translations={translations}
-                                        />
-                                    </ActivityThread>
-                                </ActivityItem>
-                            );
-                        }
                         return (
                             <ActivityItem
                                 key={item.type + item.id}
-                                className="bcs-activity-feed-comment"
-                                data-testid="comment"
+                                className={hasReplies ? 'bcs-activity-thread' : 'bcs-activity-feed-comment'}
+                                data-testid={hasReplies ? 'activity-thread' : 'comment'}
                                 isFocused={isFocused}
                                 ref={refValue}
                             >
-                                <Comment
-                                    {...item}
-                                    currentUser={currentUser}
-                                    getAvatarUrl={getAvatarUrl}
-                                    getMentionWithQuery={getMentionWithQuery}
-                                    getUserProfileUrl={getUserProfileUrl}
-                                    mentionSelectorContacts={mentionSelectorContacts}
-                                    onDelete={onCommentDelete}
-                                    onEdit={onCommentEdit}
-                                    permissions={{
-                                        can_delete: getProp(item.permissions, 'can_delete', false),
-                                        can_edit: getProp(item.permissions, 'can_edit', false),
-                                    }}
-                                    translations={translations}
-                                />
+                                <ActivityThread hasReplies={hasReplies}>
+                                    <Comment
+                                        {...item}
+                                        currentUser={currentUser}
+                                        getAvatarUrl={getAvatarUrl}
+                                        getMentionWithQuery={getMentionWithQuery}
+                                        getUserProfileUrl={getUserProfileUrl}
+                                        mentionSelectorContacts={mentionSelectorContacts}
+                                        onDelete={onCommentDelete}
+                                        onEdit={onCommentEdit}
+                                        permissions={{
+                                            can_delete: getProp(item.permissions, 'can_delete', false),
+                                            can_edit: getProp(item.permissions, 'can_edit', false),
+                                        }}
+                                        translations={translations}
+                                    />
+                                </ActivityThread>
                             </ActivityItem>
                         );
+
                     case 'task':
                         return (
                             <ActivityItem
@@ -193,54 +167,31 @@ const ActiveState = ({
                             </ActivityItem>
                         );
                     case 'annotation':
-                        if (hasReplies) {
-                            return (
-                                <ActivityItem
-                                    key={item.type + item.id}
-                                    className="bcs-activity-thread"
-                                    data-testid="activity-thread"
-                                    isFocused={isFocused}
-                                    ref={refValue}
-                                >
-                                    <ActivityThread>
-                                        <AnnotationActivity
-                                            currentUser={currentUser}
-                                            getAvatarUrl={getAvatarUrl}
-                                            getUserProfileUrl={getUserProfileUrl}
-                                            getMentionWithQuery={getMentionWithQuery}
-                                            isCurrentVersion={currentFileVersionId === itemFileVersionId}
-                                            item={item}
-                                            mentionSelectorContacts={mentionSelectorContacts}
-                                            onEdit={onAnnotationEdit}
-                                            onDelete={onAnnotationDelete}
-                                            onSelect={onAnnotationSelect}
-                                        />
-                                    </ActivityThread>
-                                </ActivityItem>
-                            );
-                        }
                         return (
                             <ActivityItem
                                 key={item.type + item.id}
-                                className="bcs-activity-feed-annotation-activity"
-                                data-testid="annotation-activity"
+                                className={hasReplies ? 'bcs-activity-thread' : 'bcs-activity-feed-annotation-activity'}
+                                data-testid={hasReplies ? 'activity-thread' : 'annotation-activity'}
                                 isFocused={isFocused}
                                 ref={refValue}
                             >
-                                <AnnotationActivity
-                                    currentUser={currentUser}
-                                    getAvatarUrl={getAvatarUrl}
-                                    getUserProfileUrl={getUserProfileUrl}
-                                    getMentionWithQuery={getMentionWithQuery}
-                                    isCurrentVersion={currentFileVersionId === itemFileVersionId}
-                                    item={item}
-                                    mentionSelectorContacts={mentionSelectorContacts}
-                                    onEdit={onAnnotationEdit}
-                                    onDelete={onAnnotationDelete}
-                                    onSelect={onAnnotationSelect}
-                                />
+                                <ActivityThread hasReplies={hasReplies}>
+                                    <AnnotationActivity
+                                        currentUser={currentUser}
+                                        getAvatarUrl={getAvatarUrl}
+                                        getUserProfileUrl={getUserProfileUrl}
+                                        getMentionWithQuery={getMentionWithQuery}
+                                        isCurrentVersion={currentFileVersionId === itemFileVersionId}
+                                        item={item}
+                                        mentionSelectorContacts={mentionSelectorContacts}
+                                        onEdit={onAnnotationEdit}
+                                        onDelete={onAnnotationDelete}
+                                        onSelect={onAnnotationSelect}
+                                    />
+                                </ActivityThread>
                             </ActivityItem>
                         );
+
                     default:
                         return null;
                 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -88,38 +88,38 @@ const ActiveState = ({
                 const isFocused = item === activeEntry;
                 const refValue = isFocused ? activeFeedItemRef : undefined;
                 const itemFileVersionId = getProp(item, 'file_version.id');
-                const isCurrentVersion = currentFileVersionId === itemFileVersionId;
-
-                if (hasReplies && (item.type === 'comment' || item.type === 'annotation')) {
-                    return (
-                        <ActivityItem
-                            key={item.type + item.id}
-                            className="bcs-activity-thread"
-                            data-testid="activity-thread"
-                            isFocused={isFocused}
-                            ref={refValue}
-                        >
-                            <ActivityThread
-                                currentFileVersionId={currentFileVersionId}
-                                getAvatarUrl={getAvatarUrl}
-                                isCurrentVersion={isCurrentVersion}
-                                item={item}
-                                onAnnotationDelete={onAnnotationDelete}
-                                onAnnotationEdit={onAnnotationEdit}
-                                onAnnotationSelect={onAnnotationSelect}
-                                // onAnnotationReplyCreate={() => {}} // TODO will be implemented in next PR
-                                // onCommentReplyCreate={() => {}} // TODO will be implemented in next PR
-                                onCommentDelete={onCommentDelete}
-                                onCommentEdit={onCommentEdit}
-                                // onGetAnnotationReplies={() => {}} // TODO will be implemented in next PR
-                                // onGetCommentReplies={() => {}} // TODO will be implemented in next PR
-                            />
-                        </ActivityItem>
-                    );
-                }
 
                 switch (item.type) {
                     case 'comment':
+                        if (hasReplies) {
+                            return (
+                                <ActivityItem
+                                    key={item.type + item.id}
+                                    className="bcs-activity-thread"
+                                    data-testid="activity-thread"
+                                    isFocused={isFocused}
+                                    ref={refValue}
+                                >
+                                    <ActivityThread>
+                                        <Comment
+                                            {...item}
+                                            currentUser={currentUser}
+                                            getAvatarUrl={getAvatarUrl}
+                                            getMentionWithQuery={getMentionWithQuery}
+                                            getUserProfileUrl={getUserProfileUrl}
+                                            mentionSelectorContacts={mentionSelectorContacts}
+                                            onDelete={onCommentDelete}
+                                            onEdit={onCommentEdit}
+                                            permissions={{
+                                                can_delete: getProp(item.permissions, 'can_delete', false),
+                                                can_edit: getProp(item.permissions, 'can_edit', false),
+                                            }}
+                                            translations={translations}
+                                        />
+                                    </ActivityThread>
+                                </ActivityItem>
+                            );
+                        }
                         return (
                             <ActivityItem
                                 key={item.type + item.id}
@@ -193,6 +193,32 @@ const ActiveState = ({
                             </ActivityItem>
                         );
                     case 'annotation':
+                        if (hasReplies) {
+                            return (
+                                <ActivityItem
+                                    key={item.type + item.id}
+                                    className="bcs-activity-thread"
+                                    data-testid="activity-thread"
+                                    isFocused={isFocused}
+                                    ref={refValue}
+                                >
+                                    <ActivityThread>
+                                        <AnnotationActivity
+                                            currentUser={currentUser}
+                                            getAvatarUrl={getAvatarUrl}
+                                            getUserProfileUrl={getUserProfileUrl}
+                                            getMentionWithQuery={getMentionWithQuery}
+                                            isCurrentVersion={currentFileVersionId === itemFileVersionId}
+                                            item={item}
+                                            mentionSelectorContacts={mentionSelectorContacts}
+                                            onEdit={onAnnotationEdit}
+                                            onDelete={onAnnotationDelete}
+                                            onSelect={onAnnotationSelect}
+                                        />
+                                    </ActivityThread>
+                                </ActivityItem>
+                            );
+                        }
                         return (
                             <ActivityItem
                                 key={item.type + item.id}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -4,10 +4,14 @@ import ActivityCard from '../ActivityCard';
 
 type Props = {
     children: React.Node,
+    hasReplies: boolean,
 };
 
-const ActivityThread = ({ children }: Props) => {
-    return <ActivityCard className="bcs-ActivityThread">{children}</ActivityCard>;
+const ActivityThread = ({ children, hasReplies }: Props) => {
+    if (hasReplies) {
+        return <ActivityCard className="bcs-ActivityThread">{children}</ActivityCard>;
+    }
+    return children;
 };
 
 export default ActivityThread;

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -1,0 +1,101 @@
+// @flow
+import * as React from 'react';
+import noop from 'lodash/noop';
+import getProp from 'lodash/get';
+import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
+import type { Translations } from '../../flowTypes';
+import type {
+    Annotation,
+    AnnotationPermission,
+    BoxCommentPermission,
+    Comment as CommentType,
+} from '../../../../common/types/feed';
+import type { SelectorItems, User } from '../../../../common/types/core';
+import AnnotationActivity from '../annotations/AnnotationActivity';
+import Comment from '../comment/Comment';
+import ActivityCard from '../ActivityCard';
+
+type Props = {
+    currentFileVersionId: string,
+    currentUser?: User,
+    getAvatarUrl: GetAvatarUrlCallback,
+    getMentionWithQuery?: (searchStr: string) => void,
+    getUserProfileUrl?: GetProfileUrlCallback,
+    isCurrentVersion: boolean,
+    item: Annotation | CommentType,
+    mentionSelectorContacts?: SelectorItems<User>,
+    onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => any,
+    onAnnotationEdit?: (id: string, text: string, permissions: AnnotationPermission) => any,
+    onAnnotationReplyCreate?: ({ annotationId: string, message: string }) => any,
+    onAnnotationSelect?: (annotation: Annotation) => void,
+    onCommentDelete?: ({ id: string, permissions?: BoxCommentPermission }) => any,
+    onCommentEdit?: (id: string, text: string, hasMention: boolean, permissions?: BoxCommentPermission) => any,
+    onCommentReplyCreate?: ({ commentId: string, message: string }) => any,
+    onGetAnnotationReplies?: ({ annotationId: string }) => void,
+    onGetCommentReplies?: ({ commentId: string }) => void,
+    translations?: Translations,
+};
+
+const ActivityThread = ({
+    currentUser,
+    getAvatarUrl,
+    getMentionWithQuery,
+    getUserProfileUrl,
+    isCurrentVersion,
+    item,
+    mentionSelectorContacts,
+    // eslint-disable-next-line no-unused-vars
+    onAnnotationReplyCreate = noop,
+    // eslint-disable-next-line no-unused-vars
+    onCommentReplyCreate = noop,
+    onCommentDelete = noop,
+    onCommentEdit = noop,
+    onAnnotationSelect = noop,
+    onAnnotationDelete = noop,
+    onAnnotationEdit = noop,
+    // eslint-disable-next-line no-unused-vars
+    onGetAnnotationReplies = noop,
+    // eslint-disable-next-line no-unused-vars
+    onGetCommentReplies = noop,
+    translations,
+}: Props) => {
+    return (
+        <ActivityCard className="bcs-ActivityThread">
+            {item.type === 'comment' && (
+                <Comment
+                    {...item}
+                    currentUser={currentUser}
+                    getAvatarUrl={getAvatarUrl}
+                    getMentionWithQuery={getMentionWithQuery}
+                    getUserProfileUrl={getUserProfileUrl}
+                    mentionSelectorContacts={mentionSelectorContacts}
+                    onDelete={onCommentDelete}
+                    onEdit={onCommentEdit}
+                    permissions={{
+                        can_delete: getProp(item.permissions, 'can_delete', false),
+                        can_edit: getProp(item.permissions, 'can_edit', false),
+                        can_resolve: getProp(item.permissions, 'can_resolve', false),
+                    }}
+                    translations={translations}
+                />
+            )}
+
+            {item.type === 'annotation' && (
+                <AnnotationActivity
+                    currentUser={currentUser}
+                    getAvatarUrl={getAvatarUrl}
+                    getUserProfileUrl={getUserProfileUrl}
+                    getMentionWithQuery={getMentionWithQuery}
+                    isCurrentVersion={isCurrentVersion}
+                    item={item}
+                    mentionSelectorContacts={mentionSelectorContacts}
+                    onEdit={onAnnotationEdit}
+                    onDelete={onAnnotationDelete}
+                    onSelect={onAnnotationSelect}
+                />
+            )}
+        </ActivityCard>
+    );
+};
+
+export default ActivityThread;

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -9,7 +9,11 @@ type Props = {
 
 const ActivityThread = ({ children, hasReplies }: Props) => {
     if (hasReplies) {
-        return <ActivityCard className="bcs-ActivityThread">{children}</ActivityCard>;
+        return (
+            <ActivityCard className="bcs-ActivityThread" data-testid="activity-thread">
+                {children}
+            </ActivityCard>
+        );
     }
     return children;
 };

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import ActivityCard from '../ActivityCard';
 
 type Props = {
     children: React.Node,
@@ -9,11 +8,7 @@ type Props = {
 
 const ActivityThread = ({ children, hasReplies }: Props) => {
     if (hasReplies) {
-        return (
-            <ActivityCard className="bcs-ActivityThread" data-testid="activity-thread">
-                {children}
-            </ActivityCard>
-        );
+        return <div className="bcs-ActivityThread">{children}</div>;
     }
     return children;
 };

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -1,101 +1,13 @@
 // @flow
 import * as React from 'react';
-import noop from 'lodash/noop';
-import getProp from 'lodash/get';
-import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
-import type { Translations } from '../../flowTypes';
-import type {
-    Annotation,
-    AnnotationPermission,
-    BoxCommentPermission,
-    Comment as CommentType,
-} from '../../../../common/types/feed';
-import type { SelectorItems, User } from '../../../../common/types/core';
-import AnnotationActivity from '../annotations/AnnotationActivity';
-import Comment from '../comment/Comment';
 import ActivityCard from '../ActivityCard';
 
 type Props = {
-    currentFileVersionId: string,
-    currentUser?: User,
-    getAvatarUrl: GetAvatarUrlCallback,
-    getMentionWithQuery?: (searchStr: string) => void,
-    getUserProfileUrl?: GetProfileUrlCallback,
-    isCurrentVersion: boolean,
-    item: Annotation | CommentType,
-    mentionSelectorContacts?: SelectorItems<User>,
-    onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => any,
-    onAnnotationEdit?: (id: string, text: string, permissions: AnnotationPermission) => any,
-    onAnnotationReplyCreate?: ({ annotationId: string, message: string }) => any,
-    onAnnotationSelect?: (annotation: Annotation) => void,
-    onCommentDelete?: ({ id: string, permissions?: BoxCommentPermission }) => any,
-    onCommentEdit?: (id: string, text: string, hasMention: boolean, permissions?: BoxCommentPermission) => any,
-    onCommentReplyCreate?: ({ commentId: string, message: string }) => any,
-    onGetAnnotationReplies?: ({ annotationId: string }) => void,
-    onGetCommentReplies?: ({ commentId: string }) => void,
-    translations?: Translations,
+    children: React.Node,
 };
 
-const ActivityThread = ({
-    currentUser,
-    getAvatarUrl,
-    getMentionWithQuery,
-    getUserProfileUrl,
-    isCurrentVersion,
-    item,
-    mentionSelectorContacts,
-    // eslint-disable-next-line no-unused-vars
-    onAnnotationReplyCreate = noop,
-    // eslint-disable-next-line no-unused-vars
-    onCommentReplyCreate = noop,
-    onCommentDelete = noop,
-    onCommentEdit = noop,
-    onAnnotationSelect = noop,
-    onAnnotationDelete = noop,
-    onAnnotationEdit = noop,
-    // eslint-disable-next-line no-unused-vars
-    onGetAnnotationReplies = noop,
-    // eslint-disable-next-line no-unused-vars
-    onGetCommentReplies = noop,
-    translations,
-}: Props) => {
-    return (
-        <ActivityCard className="bcs-ActivityThread">
-            {item.type === 'comment' && (
-                <Comment
-                    {...item}
-                    currentUser={currentUser}
-                    getAvatarUrl={getAvatarUrl}
-                    getMentionWithQuery={getMentionWithQuery}
-                    getUserProfileUrl={getUserProfileUrl}
-                    mentionSelectorContacts={mentionSelectorContacts}
-                    onDelete={onCommentDelete}
-                    onEdit={onCommentEdit}
-                    permissions={{
-                        can_delete: getProp(item.permissions, 'can_delete', false),
-                        can_edit: getProp(item.permissions, 'can_edit', false),
-                        can_resolve: getProp(item.permissions, 'can_resolve', false),
-                    }}
-                    translations={translations}
-                />
-            )}
-
-            {item.type === 'annotation' && (
-                <AnnotationActivity
-                    currentUser={currentUser}
-                    getAvatarUrl={getAvatarUrl}
-                    getUserProfileUrl={getUserProfileUrl}
-                    getMentionWithQuery={getMentionWithQuery}
-                    isCurrentVersion={isCurrentVersion}
-                    item={item}
-                    mentionSelectorContacts={mentionSelectorContacts}
-                    onEdit={onAnnotationEdit}
-                    onDelete={onAnnotationDelete}
-                    onSelect={onAnnotationSelect}
-                />
-            )}
-        </ActivityCard>
-    );
+const ActivityThread = ({ children }: Props) => {
+    return <ActivityCard className="bcs-ActivityThread">{children}</ActivityCard>;
 };
 
 export default ActivityThread;

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
@@ -144,6 +144,13 @@ describe('elements/content-sidebar/ActiveState/activity-feed/ActiveState', () =>
         expect(wrapper.find('[data-testid="annotation-activity"]')).toHaveLength(1);
     });
 
+    test('should correctly render ActivityThread for annotations and comments if has replies', () => {
+        const wrapper = getShallowWrapper({
+            hasReplies: true,
+        }).dive();
+        expect(wrapper.find('[data-testid="activity-thread"]')).toHaveLength(2);
+    });
+
     test('should correctly render with an inline error if some feed items fail to fetch', () => {
         const wrapper = getShallowWrapper({ inlineError: activityFeedError, items: [] });
         expect(wrapper).toMatchSnapshot();

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -1,29 +1,17 @@
+// @flow
 import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
-import Comment from '../../comment/Comment';
-import AnnotationActivity from '../../annotations/AnnotationActivity';
+
 import ActivityThread from '../ActivityThread.js';
 import ActivityCard from '../../ActivityCard';
 
 describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread', () => {
-    // eslint-disable-next-line flowtype/no-types-missing-file-annotation
-    const getWrapper = (props = {}): ShallowWrapper => shallow(<ActivityThread {...props} />);
+    const getWrapper = (props = {}): ShallowWrapper => shallow(<ActivityThread {...props}>Test</ActivityThread>);
 
-    test('should render Comment component if item.type is comment', () => {
-        const item = { type: 'comment' };
-        const wrapper = getWrapper({ item });
+    test('should render children component wrapped in ActivityCard', () => {
+        const wrapper = getWrapper();
 
         expect(wrapper.find(ActivityCard)).toHaveLength(1);
-        expect(wrapper.find(Comment)).toHaveLength(1);
-        expect(wrapper.find(AnnotationActivity)).toHaveLength(0);
-    });
-
-    test('should render AnnotationActivity component if item.type is annotation', () => {
-        const item = { type: 'annotation' };
-        const wrapper = getWrapper({ item });
-
-        expect(wrapper.find(ActivityCard)).toHaveLength(1);
-        expect(wrapper.find(AnnotationActivity)).toHaveLength(1);
-        expect(wrapper.find(Comment)).toHaveLength(0);
+        expect(wrapper.text()).toEqual('Test');
     });
 });

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 
 import ActivityThread from '../ActivityThread.js';
-import ActivityCard from '../../ActivityCard';
 
 describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread', () => {
     const getWrapper = (props = {}): ShallowWrapper => shallow(<ActivityThread {...props}>Test</ActivityThread>);
@@ -11,13 +10,13 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
     test('should render children component wrapped in ActivityCard if hasReplies is true', () => {
         const wrapper = getWrapper({ hasReplies: true });
 
-        expect(wrapper.find(ActivityCard)).toHaveLength(1);
+        expect(wrapper.find('.bcs-ActivityThread')).toHaveLength(1);
         expect(wrapper.text()).toEqual('Test');
     });
     test('should render children component if hasReplies if false', () => {
         const wrapper = getWrapper({ hasReplies: false });
 
-        expect(wrapper.find(ActivityCard)).toHaveLength(0);
+        expect(wrapper.find('bcs-ActivityThread')).toHaveLength(0);
         expect(wrapper.text()).toEqual('Test');
     });
 });

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import Comment from '../../comment/Comment';
+import AnnotationActivity from '../../annotations/AnnotationActivity';
+import ActivityThread from '../ActivityThread.js';
+import ActivityCard from '../../ActivityCard';
+
+describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread', () => {
+    // eslint-disable-next-line flowtype/no-types-missing-file-annotation
+    const getWrapper = (props = {}): ShallowWrapper => shallow(<ActivityThread {...props} />);
+
+    test('should render Comment component if item.type is comment', () => {
+        const item = { type: 'comment' };
+        const wrapper = getWrapper({ item });
+
+        expect(wrapper.find(ActivityCard)).toHaveLength(1);
+        expect(wrapper.find(Comment)).toHaveLength(1);
+        expect(wrapper.find(AnnotationActivity)).toHaveLength(0);
+    });
+
+    test('should render AnnotationActivity component if item.type is annotation', () => {
+        const item = { type: 'annotation' };
+        const wrapper = getWrapper({ item });
+
+        expect(wrapper.find(ActivityCard)).toHaveLength(1);
+        expect(wrapper.find(AnnotationActivity)).toHaveLength(1);
+        expect(wrapper.find(Comment)).toHaveLength(0);
+    });
+});

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -8,10 +8,16 @@ import ActivityCard from '../../ActivityCard';
 describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread', () => {
     const getWrapper = (props = {}): ShallowWrapper => shallow(<ActivityThread {...props}>Test</ActivityThread>);
 
-    test('should render children component wrapped in ActivityCard', () => {
-        const wrapper = getWrapper();
+    test('should render children component wrapped in ActivityCard if hasReplies is true', () => {
+        const wrapper = getWrapper({ hasReplies: true });
 
         expect(wrapper.find(ActivityCard)).toHaveLength(1);
+        expect(wrapper.text()).toEqual('Test');
+    });
+    test('should render children component if hasReplies if false', () => {
+        const wrapper = getWrapper({ hasReplies: false });
+
+        expect(wrapper.find(ActivityCard)).toHaveLength(0);
         expect(wrapper.text()).toEqual('Test');
     });
 });

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
@@ -50,6 +50,7 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
     key="annotationanno_123"
   >
     <ActivityThread
+      data-testid="activity-thread"
       hasReplies={false}
     >
       <AnnotationActivity
@@ -93,6 +94,7 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
     key="commentc_123"
   >
     <ActivityThread
+      data-testid="activity-thread"
       hasReplies={false}
     >
       <Comment

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
@@ -49,39 +49,43 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
     isFocused={false}
     key="annotationanno_123"
   >
-    <AnnotationActivity
-      currentUser={
-        Object {
-          "id": "user_123445",
-          "name": "Rihanna",
-        }
-      }
-      isCurrentVersion={true}
-      item={
-        Object {
-          "created_at": "2018-07-03T14:43:52-07:00",
-          "created_by": Object {
+    <ActivityThread
+      hasReplies={false}
+    >
+      <AnnotationActivity
+        currentUser={
+          Object {
             "id": "user_123445",
             "name": "Rihanna",
-          },
-          "description": Object {
-            "message": "This is an annotation",
-          },
-          "file_version": Object {
-            "id": "123",
-          },
-          "id": "anno_123",
-          "target": Object {
-            "location": Object {
-              "type": "page",
-              "value": 1,
-            },
-            "type": "region",
-          },
-          "type": "annotation",
+          }
         }
-      }
-    />
+        isCurrentVersion={true}
+        item={
+          Object {
+            "created_at": "2018-07-03T14:43:52-07:00",
+            "created_by": Object {
+              "id": "user_123445",
+              "name": "Rihanna",
+            },
+            "description": Object {
+              "message": "This is an annotation",
+            },
+            "file_version": Object {
+              "id": "123",
+            },
+            "id": "anno_123",
+            "target": Object {
+              "location": Object {
+                "type": "page",
+                "value": 1,
+              },
+              "type": "region",
+            },
+            "type": "annotation",
+          }
+        }
+      />
+    </ActivityThread>
   </ForwardRef(ActivityItem)>
   <ForwardRef(ActivityItem)
     className="bcs-activity-feed-comment"
@@ -89,32 +93,36 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
     isFocused={false}
     key="commentc_123"
   >
-    <Comment
-      created_at="2018-07-03T14:43:52-07:00"
-      created_by={
-        Object {
-          "id": 11,
-          "name": "Akon",
+    <ActivityThread
+      hasReplies={false}
+    >
+      <Comment
+        created_at="2018-07-03T14:43:52-07:00"
+        created_by={
+          Object {
+            "id": 11,
+            "name": "Akon",
+          }
         }
-      }
-      currentUser={
-        Object {
-          "id": "user_123445",
-          "name": "Rihanna",
+        currentUser={
+          Object {
+            "id": "user_123445",
+            "name": "Rihanna",
+          }
         }
-      }
-      id="c_123"
-      onDelete={[Function]}
-      onEdit={[Function]}
-      permissions={
-        Object {
-          "can_delete": false,
-          "can_edit": false,
+        id="c_123"
+        onDelete={[Function]}
+        onEdit={[Function]}
+        permissions={
+          Object {
+            "can_delete": false,
+            "can_edit": false,
+          }
         }
-      }
-      tagged_message="test @[123:Jeezy] @[10:Kanye West]"
-      type="comment"
-    />
+        tagged_message="test @[123:Jeezy] @[10:Kanye West]"
+        type="comment"
+      />
+    </ActivityThread>
   </ForwardRef(ActivityItem)>
   <ForwardRef(ActivityItem)
     className="bcs-version-item"

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
@@ -88,7 +88,6 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
     </ActivityThread>
   </ForwardRef(ActivityItem)>
   <ForwardRef(ActivityItem)
-    className="bcs-activity-feed-comment"
     data-testid="comment"
     isFocused={false}
     key="commentc_123"


### PR DESCRIPTION
create base of ActivityThread component to support threads for Comments and Annotation. 

The role of this component is to group an activity (Comment or Annotation) with it’s replies

Props:
- replies?: Comment[]
- repliesTotal: number
- onReplyCreate?: Function
- onGetReplies?: Function


UI should be wrapped with ActivityCard component so that the entire thread is treated as a card
UI will render the main item based on it’s type using Comment or AnnotationActivity