### PR TITLE
feat(icons): add user settings icon

### DIFF
--- a/src/icon/fill/UserSettings16.js.flow
+++ b/src/icon/fill/UserSettings16.js.flow
@@ -1,0 +1,38 @@
+// @flow
+/* eslint-disable react/jsx-sort-props */
+import * as React from 'react';
+import * as vars from '../../styles/variables';
+import AccessibleSVG from '../../icons/accessible-svg';
+import type { Icon } from '../../icons/flowTypes';
+
+/**
+ * This is an auto-generated component and should not be edited
+ * manually in contributor pull requests.
+ *
+ * If you have problems with this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Bug_report.md
+ *
+ * If there are missing features in this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Feature_request.md
+ */
+
+const UserSettings16 = (props: Icon) => (
+    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...props}>
+        <path
+            d="M7 8c.55 0 1.05-.135 1.504-.404.453-.27.816-.633 1.088-1.09C9.864 6.047 10 5.566 10 5a2.94 2.94 0 00-.408-1.527A3.074 3.074 0 008.5 2.4 2.915 2.915 0 007 2a2.91 2.91 0 00-1.508.404c-.456.27-.82.628-1.092 1.076A2.86 2.86 0 004 5c0 .563.135 1.048.404 1.505.27.458.631.822 1.084 1.091C5.942 7.866 6.446 8 7 8z"
+            fill={vars.bdlGray50}
+        />
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M12.574 9c.177 0 .33.128.352.3l.091.62c.111.052.217.112.32.181l.612-.24a.358.358 0 01.43.155l.575.968a.352.352 0 01-.091.454l-.508.386c.005.061.005.29 0 .352l.508.387c.14.107.177.3.088.457l-.57.96a.356.356 0 01-.44.156l-.606-.237a2.3 2.3 0 01-.318.18l-.09.617a.352.352 0 01-.353.304h-1.146a.352.352 0 01-.352-.3l-.091-.62a2.31 2.31 0 01-.32-.181l-.611.24a.358.358 0 01-.43-.155l-.576-.968a.352.352 0 01.091-.454l.508-.386a4.006 4.006 0 010-.352l-.508-.387a.348.348 0 01-.089-.457l.57-.96a.357.357 0 01.44-.156l.606.237c.105-.07.21-.13.318-.18l.091-.617A.353.353 0 0111.428 9h1.146zM12 10.714A1.287 1.287 0 1013.286 12c0-.709-.577-1.286-1.286-1.286z"
+            fill={vars.bdlGray50}
+        />
+        <path
+            d="M9 9.31A7.308 7.308 0 006.813 9c-.886 0-1.686.126-2.401.378-.715.253-1.326.58-1.834.983s-.898.835-1.17 1.295c-.272.46-.408.904-.408 1.33 0 .32.117.568.35.747.234.178.649.267 1.246.267h6.056l-.672-.676-.005-.008A.994.994 0 018.232 12c-.416-.324-.536-.888-.243-1.339l.728-1.05c.075-.12.172-.22.283-.301z"
+            fill={vars.bdlGray50}
+        />
+    </AccessibleSVG>
+);
+
+export default UserSettings16;

--- a/src/icon/fill/UserSettings16.stories.tsx
+++ b/src/icon/fill/UserSettings16.stories.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import UserSettings16 from './UserSettings16';
+
+export const userSettings16 = () => <UserSettings16 />;
+
+export default {
+    title: 'Icon|Fill|UserSettings16',
+    component: UserSettings16,
+    parameters: {
+        notes: "`import UserSettings16 from 'box-ui-elements/es/icon/fill/UserSettings16';`",
+    },
+};

--- a/src/icon/fill/UserSettings16.tsx
+++ b/src/icon/fill/UserSettings16.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable react/jsx-sort-props */
+import * as React from 'react';
+import * as vars from '../../styles/variables';
+import AccessibleSVG, { SVGProps } from '../../components/accessible-svg/AccessibleSVG';
+
+/**
+ * This is an auto-generated component and should not be edited
+ * manually in contributor pull requests.
+ *
+ * If you have problems with this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Bug_report.md
+ *
+ * If there are missing features in this component:
+ * - https://github.com/box/box-ui-elements/issues/new?template=Feature_request.md
+ */
+
+const UserSettings16 = (props: SVGProps) => (
+    <AccessibleSVG width={16} height={16} viewBox="0 0 16 16" {...props}>
+        <path
+            d="M7 8c.55 0 1.05-.135 1.504-.404.453-.27.816-.633 1.088-1.09C9.864 6.047 10 5.566 10 5a2.94 2.94 0 00-.408-1.527A3.074 3.074 0 008.5 2.4 2.915 2.915 0 007 2a2.91 2.91 0 00-1.508.404c-.456.27-.82.628-1.092 1.076A2.86 2.86 0 004 5c0 .563.135 1.048.404 1.505.27.458.631.822 1.084 1.091C5.942 7.866 6.446 8 7 8z"
+            fill={vars.bdlGray50}
+        />
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M12.574 9c.177 0 .33.128.352.3l.091.62c.111.052.217.112.32.181l.612-.24a.358.358 0 01.43.155l.575.968a.352.352 0 01-.091.454l-.508.386c.005.061.005.29 0 .352l.508.387c.14.107.177.3.088.457l-.57.96a.356.356 0 01-.44.156l-.606-.237a2.3 2.3 0 01-.318.18l-.09.617a.352.352 0 01-.353.304h-1.146a.352.352 0 01-.352-.3l-.091-.62a2.31 2.31 0 01-.32-.181l-.611.24a.358.358 0 01-.43-.155l-.576-.968a.352.352 0 01.091-.454l.508-.386a4.006 4.006 0 010-.352l-.508-.387a.348.348 0 01-.089-.457l.57-.96a.357.357 0 01.44-.156l.606.237c.105-.07.21-.13.318-.18l.091-.617A.353.353 0 0111.428 9h1.146zM12 10.714A1.287 1.287 0 1013.286 12c0-.709-.577-1.286-1.286-1.286z"
+            fill={vars.bdlGray50}
+        />
+        <path
+            d="M9 9.31A7.308 7.308 0 006.813 9c-.886 0-1.686.126-2.401.378-.715.253-1.326.58-1.834.983s-.898.835-1.17 1.295c-.272.46-.408.904-.408 1.33 0 .32.117.568.35.747.234.178.649.267 1.246.267h6.056l-.672-.676-.005-.008A.994.994 0 018.232 12c-.416-.324-.536-.888-.243-1.339l.728-1.05c.075-.12.172-.22.283-.301z"
+            fill={vars.bdlGray50}
+        />
+    </AccessibleSVG>
+);
+
+export default UserSettings16;


### PR DESCRIPTION
This PR is a result of me running `yarn build:assets -r git@git.dev.box.net/Box/design-assets` then ignoring every change apart of the icon I'm interested in and committing. 

![image](https://user-images.githubusercontent.com/3791384/186483017-7e5f9786-957a-47a9-8b4a-bc2c0993bbae.png)
