### PR TITLE
fix(classification): Classification colors in Shared Link Settings Modal

### DIFF
--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.js
@@ -8,7 +8,7 @@ import { Modal, ModalActions } from '../../components/modal';
 import InlineNotice from '../../components/inline-notice';
 import Link from '../../components/link/LinkBase';
 import commonMessages from '../../common/messages';
-import Classification from '../classification';
+import Classification, { getClassificationLabelColor } from '../classification';
 
 import VanityNameSection from './VanityNameSection';
 import PasswordSection from './PasswordSection';
@@ -363,15 +363,17 @@ class SharedLinkSettingsModal extends Component {
     renderModalTitle() {
         const { item } = this.props;
         const { bannerPolicy, classification } = item;
+        const classificationColor = getClassificationLabelColor(bannerPolicy);
 
         return (
             <span className="bdl-SharedLinkSettingsModal-title">
                 <FormattedMessage {...messages.modalTitle} />
                 <Classification
+                    className="bdl-SharedLinkSettingsModal-classification"
+                    color={classificationColor}
                     definition={bannerPolicy ? bannerPolicy.body : undefined}
                     messageStyle="tooltip"
                     name={classification}
-                    className="bdl-SharedLinkSettingsModal-classification"
                 />
             </span>
         );

--- a/src/features/shared-link-settings-modal/__tests__/SharedLinkSettingsModal.test.js
+++ b/src/features/shared-link-settings-modal/__tests__/SharedLinkSettingsModal.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import sinon from 'sinon';
 
+import classificationColorsMap from '../../classification/classificationColorsMap';
+
 import SharedLinkSettingsModal from '../SharedLinkSettingsModal';
 
 const sandbox = sinon.sandbox.create();
@@ -285,9 +287,26 @@ describe('features/shared-link-settings-modal/SharedLinkSettingsModal', () => {
     });
 
     describe('renderModalTitle()', () => {
-        const wrapper = getWrapper();
-        const title = shallow(wrapper.instance().renderModalTitle());
-        expect(title).toMatchSnapshot();
+        test('should render modal title and match snapshot', () => {
+            const wrapper = getWrapper();
+            const title = shallow(wrapper.instance().renderModalTitle());
+            expect(title).toMatchSnapshot();
+        });
+
+        test('should render classification label with fill and stroke colors that match the classification color id', () => {
+            const colorID = 3;
+            const { color } = classificationColorsMap[colorID];
+
+            const item = {
+                bannerPolicy: {
+                    colorID,
+                },
+            };
+
+            const wrapper = getWrapper({ item });
+            const title = shallow(wrapper.instance().renderModalTitle());
+            expect(title.find('Classification').props().color).toBe(color);
+        });
     });
 
     describe('render()', () => {

--- a/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal.test.js.snap
+++ b/src/features/shared-link-settings-modal/__tests__/__snapshots__/SharedLinkSettingsModal.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` 1`] = `
+exports[`features/shared-link-settings-modal/SharedLinkSettingsModal renderModalTitle() should render modal title and match snapshot 1`] = `
 <span
   className="bdl-SharedLinkSettingsModal-title"
 >
@@ -10,6 +10,7 @@ exports[` 1`] = `
   />
   <Classification
     className="bdl-SharedLinkSettingsModal-classification"
+    color="#ffeb7f"
     definition="test"
     messageStyle="tooltip"
     name="internal"


### PR DESCRIPTION
Fixes an issue where the Shared Link Settings modal would render all classification labels in the default color (yellow).

This is due to the fact that the color information stored in the label was not properly being passed to the Classification component as we do in other places.