### PR TITLE
feat(content-sidebar): updated annotations logic for threaded replies

### DIFF
--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -590,11 +590,11 @@ describe('api/Feed', () => {
             const annotationItems = feed.fetchAnnotations({ can_edit: true }, true);
             expect(annotationItems instanceof Promise).toBeTruthy();
             expect(feed.annotationsAPI.getAnnotations).toBeCalledWith(
-                expect.anything(),
+                feed.file.id,
                 undefined,
-                expect.anything(),
-                expect.anything(),
-                expect.anything(),
+                { can_edit: true },
+                expect.any(Function),
+                expect.any(Function),
                 undefined,
                 undefined,
                 true,
@@ -1425,11 +1425,11 @@ describe('api/Feed', () => {
 
         describe('should updateFeedItem with isPending set to true', () => {
             test.each`
-                testText     | testStatus   | expected                                                 | description
-                ${'hello'}   | ${undefined} | ${{ message: 'hello', isPending: true }}                 | ${'only text'}
-                ${undefined} | ${'open'}    | ${{ status: 'open', isPending: true }}                   | ${'only status'}
-                ${'hello'}   | ${'open'}    | ${{ message: 'hello', status: 'open', isPending: true }} | ${'text and status'}
-            `('given $description', ({ testText, testStatus, expected }) => {
+                testText     | testStatus   | expected
+                ${'hello'}   | ${undefined} | ${{ message: 'hello', isPending: true }}
+                ${undefined} | ${'open'}    | ${{ status: 'open', isPending: true }}
+                ${'hello'}   | ${'open'}    | ${{ message: 'hello', status: 'open', isPending: true }}
+            `('given text=$testText and status=$testStatus', ({ testText, testStatus, expected }) => {
                 feed.updateFeedItem = jest.fn();
                 feed.updateAnnotation(
                     file,
@@ -1447,11 +1447,11 @@ describe('api/Feed', () => {
 
         describe('should call the updateAnnotation API and call updateFeedItem on success', () => {
             test.each`
-                testText     | testStatus   | expected                                | description
-                ${'hello'}   | ${undefined} | ${{ message: 'hello' }}                 | ${'only text'}
-                ${undefined} | ${'open'}    | ${{ status: 'open' }}                   | ${'only status'}
-                ${'hello'}   | ${'open'}    | ${{ message: 'hello', status: 'open' }} | ${'text and status'}
-            `('given $description', ({ testText, testStatus, expected }) => {
+                testText     | testStatus   | expected
+                ${'hello'}   | ${undefined} | ${{ message: 'hello' }}
+                ${undefined} | ${'open'}    | ${{ status: 'open' }}
+                ${'hello'}   | ${'open'}    | ${{ message: 'hello', status: 'open' }}
+            `('given text=$testText and status=$testStatus', ({ testText, testStatus, expected }) => {
                 feed.updateFeedItem = jest.fn();
                 feed.updateAnnotation(
                     file,

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -488,6 +488,22 @@ describe('api/Feed', () => {
             });
         });
 
+        test.each`
+            shouldShowReplies | expected
+            ${undefined}      | ${false}
+            ${false}          | ${false}
+            ${true}           | ${true}
+        `(
+            'should pass $expected as shouldShowReplies when calling fetchAnnotations when $shouldShowReplies is given as shouldShowReplies',
+            ({ shouldShowReplies, expected }) => {
+                feed.feedItems(file, false, successCb, errorCb, errorCb, {
+                    shouldShowAnnotations: true,
+                    shouldShowReplies,
+                });
+                expect(feed.fetchAnnotations).toBeCalledWith(expect.anything(), expected);
+            },
+        );
+
         test('should not use the annotations api if shouldShowannotations is false', done => {
             feed.feedItems(file, false, successCb, errorCb, errorCb, { shouldShowAnnotations: false });
             setImmediate(() => {
@@ -568,6 +584,21 @@ describe('api/Feed', () => {
             const annotationItems = feed.fetchAnnotations();
             expect(annotationItems instanceof Promise).toBeTruthy();
             expect(feed.annotationsAPI.getAnnotations).toBeCalled();
+        });
+
+        test('when called with shouldFetchReplies = true, should return a promise and call the annotations api with shouldFetchReplies param as true', () => {
+            const annotationItems = feed.fetchAnnotations({ can_edit: true }, true);
+            expect(annotationItems instanceof Promise).toBeTruthy();
+            expect(feed.annotationsAPI.getAnnotations).toBeCalledWith(
+                expect.anything(),
+                undefined,
+                expect.anything(),
+                expect.anything(),
+                expect.anything(),
+                undefined,
+                undefined,
+                true,
+            );
         });
     });
 
@@ -1367,31 +1398,81 @@ describe('api/Feed', () => {
 
         test('should throw if file does not have an id', () => {
             expect(() =>
-                feed.updateAnnotation({}, annotationId, text, permissions, successCallback, errorCallback),
+                feed.updateAnnotation({}, annotationId, text, undefined, permissions, successCallback, errorCallback),
             ).toThrow(fileError);
         });
 
+        test('should throw if no text or status', () => {
+            expect(() =>
+                feed.updateAnnotation(
+                    file,
+                    annotationId,
+                    undefined,
+                    undefined,
+                    permissions,
+                    successCallback,
+                    errorCallback,
+                ),
+            ).toThrowError();
+        });
+
         test('should set error callback and file', () => {
-            feed.updateAnnotation(file, annotationId, text, permissions, successCallback, errorCallback);
+            feed.updateAnnotation(file, annotationId, text, undefined, permissions, successCallback, errorCallback);
 
             expect(feed.errorCallback).toEqual(errorCallback);
             expect(feed.file).toEqual(file);
         });
 
-        test('should updateFeedItem with isPending set to true', () => {
-            feed.updateFeedItem = jest.fn();
-            feed.updateAnnotation(file, annotationId, text, permissions, successCallback, errorCallback);
+        describe('should updateFeedItem with isPending set to true', () => {
+            test.each`
+                testText     | testStatus   | expected                                                 | description
+                ${'hello'}   | ${undefined} | ${{ message: 'hello', isPending: true }}                 | ${'only text'}
+                ${undefined} | ${'open'}    | ${{ status: 'open', isPending: true }}                   | ${'only status'}
+                ${'hello'}   | ${'open'}    | ${{ message: 'hello', status: 'open', isPending: true }} | ${'text and status'}
+            `('given $description', ({ testText, testStatus, expected }) => {
+                feed.updateFeedItem = jest.fn();
+                feed.updateAnnotation(
+                    file,
+                    annotationId,
+                    testText,
+                    testStatus,
+                    permissions,
+                    successCallback,
+                    errorCallback,
+                );
 
-            expect(feed.updateFeedItem).toBeCalledWith({ message: text, isPending: true }, annotationId);
+                expect(feed.updateFeedItem).toBeCalledWith(expected, annotationId);
+            });
         });
 
-        test('should call the updateAnnotation API and call updateFeedItem on success', () => {
-            feed.updateFeedItem = jest.fn();
-            feed.updateAnnotation(file, annotationId, permissions, text, successCallback, errorCallback);
-
-            expect(feed.annotationsAPI.updateAnnotation).toHaveBeenCalled();
-            expect(feed.updateFeedItem).toHaveBeenCalled();
-            expect(successCallback).toHaveBeenCalled();
+        describe('should call the updateAnnotation API and call updateFeedItem on success', () => {
+            test.each`
+                testText     | testStatus   | expected                                | description
+                ${'hello'}   | ${undefined} | ${{ message: 'hello' }}                 | ${'only text'}
+                ${undefined} | ${'open'}    | ${{ status: 'open' }}                   | ${'only status'}
+                ${'hello'}   | ${'open'}    | ${{ message: 'hello', status: 'open' }} | ${'text and status'}
+            `('given $description', ({ testText, testStatus, expected }) => {
+                feed.updateFeedItem = jest.fn();
+                feed.updateAnnotation(
+                    file,
+                    annotationId,
+                    testText,
+                    testStatus,
+                    permissions,
+                    successCallback,
+                    errorCallback,
+                );
+                expect(feed.annotationsAPI.updateAnnotation).toBeCalledWith(
+                    file.id,
+                    annotationId,
+                    permissions,
+                    expected,
+                    expect.any(Function),
+                    expect.any(Function),
+                );
+                expect(feed.updateFeedItem).toBeCalled();
+                expect(successCallback).toBeCalled();
+            });
         });
     });
 

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -179,6 +179,23 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             file,
             id,
             text,
+            undefined,
+            permissions,
+            this.feedSuccessCallback,
+            this.feedErrorCallback,
+        );
+
+        this.fetchFeedItems();
+    };
+
+    handleAnnotationStatusChange = (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => {
+        const { api, file } = this.props;
+
+        api.getFeedAPI(false).updateAnnotation(
+            file,
+            id,
+            undefined,
+            status,
             permissions,
             this.feedSuccessCallback,
             this.feedErrorCallback,
@@ -453,7 +470,14 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
      * @param {boolean} shouldDestroy true if the api factory should be destroyed
      */
     fetchFeedItems(shouldRefreshCache: boolean = false, shouldDestroy: boolean = false) {
-        const { file, api, features, hasTasks: shouldShowTasks, hasVersions: shouldShowVersions } = this.props;
+        const {
+            file,
+            api,
+            features,
+            hasReplies: shouldShowReplies,
+            hasTasks: shouldShowTasks,
+            hasVersions: shouldShowVersions,
+        } = this.props;
         const shouldShowAppActivity = isFeatureEnabled(features, 'activityFeed.appActivity.enabled');
         const shouldShowAnnotations = isFeatureEnabled(features, 'activityFeed.annotations.enabled');
 
@@ -463,7 +487,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             this.fetchFeedItemsSuccessCallback,
             this.fetchFeedItemsErrorCallback,
             this.errorCallback,
-            { shouldShowAnnotations, shouldShowAppActivity, shouldShowTasks, shouldShowVersions },
+            { shouldShowAnnotations, shouldShowAppActivity, shouldShowReplies, shouldShowTasks, shouldShowVersions },
         );
     }
 
@@ -826,6 +850,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     onAnnotationDelete={this.handleAnnotationDelete}
                     onAnnotationEdit={this.handleAnnotationEdit}
                     onAnnotationSelect={this.handleAnnotationSelect}
+                    onAnnotationStatusChange={this.handleAnnotationStatusChange}
                     onAppActivityDelete={this.deleteAppActivity}
                     onCommentCreate={this.createComment}
                     onCommentDelete={this.deleteComment}

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -360,37 +360,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         test.each`
             annotationsEnabled | appActivityEnabled | repliesEnabled | tasksEnabled | versionsEnabled | expectedAnnotations | expectedAppActivity | expectedReplies | expectedTasks | expectedVersions
             ${false}           | ${false}           | ${false}       | ${false}     | ${false}        | ${false}            | ${false}            | ${false}        | ${false}      | ${false}
-            ${false}           | ${true}            | ${false}       | ${false}     | ${false}        | ${false}            | ${true}             | ${false}        | ${false}      | ${false}
-            ${true}            | ${false}           | ${false}       | ${false}     | ${true}         | ${true}             | ${false}            | ${false}        | ${false}      | ${true}
-            ${true}            | ${true}            | ${false}       | ${false}     | ${true}         | ${true}             | ${true}             | ${false}        | ${false}      | ${true}
-            ${false}           | ${true}            | ${false}       | ${false}     | ${true}         | ${false}            | ${true}             | ${false}        | ${false}      | ${true}
-            ${false}           | ${false}           | ${false}       | ${false}     | ${true}         | ${false}            | ${false}            | ${false}        | ${false}      | ${true}
-            ${true}            | ${true}            | ${false}       | ${false}     | ${false}        | ${true}             | ${true}             | ${false}        | ${false}      | ${false}
-            ${true}            | ${false}           | ${false}       | ${false}     | ${false}        | ${true}             | ${false}            | ${false}        | ${false}      | ${false}
-            ${false}           | ${false}           | ${false}       | ${true}      | ${false}        | ${false}            | ${false}            | ${false}        | ${true}       | ${false}
-            ${false}           | ${true}            | ${false}       | ${true}      | ${false}        | ${false}            | ${true}             | ${false}        | ${true}       | ${false}
-            ${true}            | ${false}           | ${false}       | ${true}      | ${true}         | ${true}             | ${false}            | ${false}        | ${true}       | ${true}
-            ${true}            | ${true}            | ${false}       | ${true}      | ${true}         | ${true}             | ${true}             | ${false}        | ${true}       | ${true}
-            ${false}           | ${true}            | ${false}       | ${true}      | ${true}         | ${false}            | ${true}             | ${false}        | ${true}       | ${true}
-            ${false}           | ${false}           | ${false}       | ${true}      | ${true}         | ${false}            | ${false}            | ${false}        | ${true}       | ${true}
-            ${true}            | ${true}            | ${false}       | ${true}      | ${false}        | ${true}             | ${true}             | ${false}        | ${true}       | ${false}
-            ${true}            | ${false}           | ${false}       | ${true}      | ${false}        | ${true}             | ${false}            | ${false}        | ${true}       | ${false}
-            ${false}           | ${false}           | ${true}        | ${false}     | ${false}        | ${false}            | ${false}            | ${true}         | ${false}      | ${false}
-            ${false}           | ${true}            | ${true}        | ${false}     | ${false}        | ${false}            | ${true}             | ${true}         | ${false}      | ${false}
-            ${true}            | ${false}           | ${true}        | ${false}     | ${true}         | ${true}             | ${false}            | ${true}         | ${false}      | ${true}
-            ${true}            | ${true}            | ${true}        | ${false}     | ${true}         | ${true}             | ${true}             | ${true}         | ${false}      | ${true}
-            ${false}           | ${true}            | ${true}        | ${false}     | ${true}         | ${false}            | ${true}             | ${true}         | ${false}      | ${true}
-            ${false}           | ${false}           | ${true}        | ${false}     | ${true}         | ${false}            | ${false}            | ${true}         | ${false}      | ${true}
-            ${true}            | ${true}            | ${true}        | ${false}     | ${false}        | ${true}             | ${true}             | ${true}         | ${false}      | ${false}
-            ${true}            | ${false}           | ${true}        | ${false}     | ${false}        | ${true}             | ${false}            | ${true}         | ${false}      | ${false}
-            ${false}           | ${false}           | ${true}        | ${true}      | ${false}        | ${false}            | ${false}            | ${true}         | ${true}       | ${false}
-            ${false}           | ${true}            | ${true}        | ${true}      | ${false}        | ${false}            | ${true}             | ${true}         | ${true}       | ${false}
-            ${true}            | ${false}           | ${true}        | ${true}      | ${true}         | ${true}             | ${false}            | ${true}         | ${true}       | ${true}
             ${true}            | ${true}            | ${true}        | ${true}      | ${true}         | ${true}             | ${true}             | ${true}         | ${true}       | ${true}
-            ${false}           | ${true}            | ${true}        | ${true}      | ${true}         | ${false}            | ${true}             | ${true}         | ${true}       | ${true}
-            ${false}           | ${false}           | ${true}        | ${true}      | ${true}         | ${false}            | ${false}            | ${true}         | ${true}       | ${true}
-            ${true}            | ${true}            | ${true}        | ${true}      | ${false}        | ${true}             | ${true}             | ${true}         | ${true}       | ${false}
-            ${true}            | ${false}           | ${true}        | ${true}      | ${false}        | ${true}             | ${false}            | ${true}         | ${true}       | ${false}
         `(
             'should fetch the feed items based on features: annotationsEnabled=$annotationsEnabled, appActivityEnabled=$appActivityEnabled, repliesEnabled=$repliesEnabled, tasksEnabled=$tasksEnabled and versionsEnabled=$versionsEnabled',
             ({

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -358,32 +358,50 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         });
 
         test.each`
-            annotationsEnabled | appActivityEnabled | tasksEnabled | versionsEnabled | expectedAnnotations | expectedAppActivity | expectedTasks | expectedVersions
-            ${false}           | ${false}           | ${false}     | ${false}        | ${false}            | ${false}            | ${false}      | ${false}
-            ${false}           | ${true}            | ${false}     | ${false}        | ${false}            | ${true}             | ${false}      | ${false}
-            ${true}            | ${false}           | ${false}     | ${true}         | ${true}             | ${false}            | ${false}      | ${true}
-            ${true}            | ${true}            | ${false}     | ${true}         | ${true}             | ${true}             | ${false}      | ${true}
-            ${false}           | ${true}            | ${false}     | ${true}         | ${false}            | ${true}             | ${false}      | ${true}
-            ${false}           | ${false}           | ${false}     | ${true}         | ${false}            | ${false}            | ${false}      | ${true}
-            ${true}            | ${true}            | ${false}     | ${false}        | ${true}             | ${true}             | ${false}      | ${false}
-            ${true}            | ${false}           | ${false}     | ${false}        | ${true}             | ${false}            | ${false}      | ${false}
-            ${false}           | ${false}           | ${true}      | ${false}        | ${false}            | ${false}            | ${true}       | ${false}
-            ${false}           | ${true}            | ${true}      | ${false}        | ${false}            | ${true}             | ${true}       | ${false}
-            ${true}            | ${false}           | ${true}      | ${true}         | ${true}             | ${false}            | ${true}       | ${true}
-            ${true}            | ${true}            | ${true}      | ${true}         | ${true}             | ${true}             | ${true}       | ${true}
-            ${false}           | ${true}            | ${true}      | ${true}         | ${false}            | ${true}             | ${true}       | ${true}
-            ${false}           | ${false}           | ${true}      | ${true}         | ${false}            | ${false}            | ${true}       | ${true}
-            ${true}            | ${true}            | ${true}      | ${false}        | ${true}             | ${true}             | ${true}       | ${false}
-            ${true}            | ${false}           | ${true}      | ${false}        | ${true}             | ${false}            | ${true}       | ${false}
+            annotationsEnabled | appActivityEnabled | repliesEnabled | tasksEnabled | versionsEnabled | expectedAnnotations | expectedAppActivity | expectedReplies | expectedTasks | expectedVersions
+            ${false}           | ${false}           | ${false}       | ${false}     | ${false}        | ${false}            | ${false}            | ${false}        | ${false}      | ${false}
+            ${false}           | ${true}            | ${false}       | ${false}     | ${false}        | ${false}            | ${true}             | ${false}        | ${false}      | ${false}
+            ${true}            | ${false}           | ${false}       | ${false}     | ${true}         | ${true}             | ${false}            | ${false}        | ${false}      | ${true}
+            ${true}            | ${true}            | ${false}       | ${false}     | ${true}         | ${true}             | ${true}             | ${false}        | ${false}      | ${true}
+            ${false}           | ${true}            | ${false}       | ${false}     | ${true}         | ${false}            | ${true}             | ${false}        | ${false}      | ${true}
+            ${false}           | ${false}           | ${false}       | ${false}     | ${true}         | ${false}            | ${false}            | ${false}        | ${false}      | ${true}
+            ${true}            | ${true}            | ${false}       | ${false}     | ${false}        | ${true}             | ${true}             | ${false}        | ${false}      | ${false}
+            ${true}            | ${false}           | ${false}       | ${false}     | ${false}        | ${true}             | ${false}            | ${false}        | ${false}      | ${false}
+            ${false}           | ${false}           | ${false}       | ${true}      | ${false}        | ${false}            | ${false}            | ${false}        | ${true}       | ${false}
+            ${false}           | ${true}            | ${false}       | ${true}      | ${false}        | ${false}            | ${true}             | ${false}        | ${true}       | ${false}
+            ${true}            | ${false}           | ${false}       | ${true}      | ${true}         | ${true}             | ${false}            | ${false}        | ${true}       | ${true}
+            ${true}            | ${true}            | ${false}       | ${true}      | ${true}         | ${true}             | ${true}             | ${false}        | ${true}       | ${true}
+            ${false}           | ${true}            | ${false}       | ${true}      | ${true}         | ${false}            | ${true}             | ${false}        | ${true}       | ${true}
+            ${false}           | ${false}           | ${false}       | ${true}      | ${true}         | ${false}            | ${false}            | ${false}        | ${true}       | ${true}
+            ${true}            | ${true}            | ${false}       | ${true}      | ${false}        | ${true}             | ${true}             | ${false}        | ${true}       | ${false}
+            ${true}            | ${false}           | ${false}       | ${true}      | ${false}        | ${true}             | ${false}            | ${false}        | ${true}       | ${false}
+            ${false}           | ${false}           | ${true}        | ${false}     | ${false}        | ${false}            | ${false}            | ${true}         | ${false}      | ${false}
+            ${false}           | ${true}            | ${true}        | ${false}     | ${false}        | ${false}            | ${true}             | ${true}         | ${false}      | ${false}
+            ${true}            | ${false}           | ${true}        | ${false}     | ${true}         | ${true}             | ${false}            | ${true}         | ${false}      | ${true}
+            ${true}            | ${true}            | ${true}        | ${false}     | ${true}         | ${true}             | ${true}             | ${true}         | ${false}      | ${true}
+            ${false}           | ${true}            | ${true}        | ${false}     | ${true}         | ${false}            | ${true}             | ${true}         | ${false}      | ${true}
+            ${false}           | ${false}           | ${true}        | ${false}     | ${true}         | ${false}            | ${false}            | ${true}         | ${false}      | ${true}
+            ${true}            | ${true}            | ${true}        | ${false}     | ${false}        | ${true}             | ${true}             | ${true}         | ${false}      | ${false}
+            ${true}            | ${false}           | ${true}        | ${false}     | ${false}        | ${true}             | ${false}            | ${true}         | ${false}      | ${false}
+            ${false}           | ${false}           | ${true}        | ${true}      | ${false}        | ${false}            | ${false}            | ${true}         | ${true}       | ${false}
+            ${false}           | ${true}            | ${true}        | ${true}      | ${false}        | ${false}            | ${true}             | ${true}         | ${true}       | ${false}
+            ${true}            | ${false}           | ${true}        | ${true}      | ${true}         | ${true}             | ${false}            | ${true}         | ${true}       | ${true}
+            ${true}            | ${true}            | ${true}        | ${true}      | ${true}         | ${true}             | ${true}             | ${true}         | ${true}       | ${true}
+            ${false}           | ${true}            | ${true}        | ${true}      | ${true}         | ${false}            | ${true}             | ${true}         | ${true}       | ${true}
+            ${false}           | ${false}           | ${true}        | ${true}      | ${true}         | ${false}            | ${false}            | ${true}         | ${true}       | ${true}
+            ${true}            | ${true}            | ${true}        | ${true}      | ${false}        | ${true}             | ${true}             | ${true}         | ${true}       | ${false}
+            ${true}            | ${false}           | ${true}        | ${true}      | ${false}        | ${true}             | ${false}            | ${true}         | ${true}       | ${false}
         `(
-            'should fetch the feed items based on features: annotationsEnabled=$annotationsEnabled, appActivityEnabled=$appActivityEnabled, tasksEnabled=$tasksEnabled and versionsEnabled=$versionsEnabled',
+            'should fetch the feed items based on features: annotationsEnabled=$annotationsEnabled, appActivityEnabled=$appActivityEnabled, repliesEnabled=$repliesEnabled, tasksEnabled=$tasksEnabled and versionsEnabled=$versionsEnabled',
             ({
                 annotationsEnabled,
                 appActivityEnabled,
+                repliesEnabled,
                 tasksEnabled,
                 versionsEnabled,
                 expectedAnnotations,
                 expectedAppActivity,
+                expectedReplies,
                 expectedTasks,
                 expectedVersions,
             }) => {
@@ -394,6 +412,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                             appActivity: { enabled: appActivityEnabled },
                         },
                     },
+                    hasReplies: repliesEnabled,
                     hasTasks: tasksEnabled,
                     hasVersions: versionsEnabled,
                 });
@@ -413,6 +432,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                     {
                         shouldShowAnnotations: expectedAnnotations,
                         shouldShowAppActivity: expectedAppActivity,
+                        shouldShowReplies: expectedReplies,
                         shouldShowTasks: expectedTasks,
                         shouldShowVersions: expectedVersions,
                     },
@@ -843,17 +863,47 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             const instance = wrapper.instance();
             instance.fetchFeedItems = jest.fn();
 
-            wrapper.instance().handleAnnotationEdit({
-                id: '123',
-                text: 'hello',
-                permissions: {
-                    can_edit: true,
-                    can_delete: true,
-                },
+            wrapper.instance().handleAnnotationEdit('123', 'hello', {
+                can_edit: true,
+                can_delete: true,
+                can_resolve: true,
             });
 
-            expect(api.getFeedAPI().updateAnnotation).toHaveBeenCalled();
-            expect(instance.fetchFeedItems).toHaveBeenCalled();
+            expect(api.getFeedAPI().updateAnnotation).toBeCalledWith(
+                expect.anything(),
+                '123',
+                'hello',
+                undefined,
+                { can_edit: true, can_delete: true, can_resolve: true },
+                expect.any(Function),
+                expect.any(Function),
+            );
+            expect(instance.fetchFeedItems).toBeCalled();
+        });
+    });
+
+    describe('handleAnnotationStatusChange()', () => {
+        test('should call updateAnnotation API', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            instance.fetchFeedItems = jest.fn();
+
+            wrapper.instance().handleAnnotationStatusChange('123', 'open', {
+                can_edit: true,
+                can_delete: true,
+                can_resolve: true,
+            });
+
+            expect(api.getFeedAPI().updateAnnotation).toBeCalledWith(
+                expect.anything(),
+                '123',
+                undefined,
+                'open',
+                { can_edit: true, can_delete: true, can_resolve: true },
+                expect.any(Function),
+                expect.any(Function),
+            );
+            expect(instance.fetchFeedItems).toBeCalled();
         });
     });
 

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
@@ -48,6 +48,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
     onAnnotationDelete={[Function]}
     onAnnotationEdit={[Function]}
     onAnnotationSelect={[Function]}
+    onAnnotationStatusChange={[Function]}
     onAppActivityDelete={[Function]}
     onCommentCreate={[Function]}
     onCommentDelete={[Function]}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -17,6 +17,7 @@ import type {
     AnnotationPermission,
     FeedItem,
     FeedItems,
+    FeedItemStatus,
     FocusableFeedItemType,
 } from '../../../../common/types/feed';
 import type { SelectorItems, User } from '../../../../common/types/core';
@@ -40,6 +41,7 @@ type Props = {
     onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => void,
     onAnnotationEdit?: (id: string, text: string, permissions: AnnotationPermission) => void,
     onAnnotationSelect?: (annotation: Annotation) => void,
+    onAnnotationStatusChange?: (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => void,
     onAppActivityDelete?: Function,
     onCommentDelete?: Function,
     onCommentEdit?: Function,
@@ -66,6 +68,7 @@ const ActiveState = ({
     onAnnotationDelete,
     onAnnotationEdit,
     onAnnotationSelect,
+    onAnnotationStatusChange,
     onAppActivityDelete,
     onCommentDelete,
     onCommentEdit,
@@ -117,7 +120,6 @@ const ActiveState = ({
                                 </ActivityThread>
                             </ActivityItem>
                         );
-
                     case 'task':
                         return (
                             <ActivityItem
@@ -186,11 +188,11 @@ const ActiveState = ({
                                         onEdit={onAnnotationEdit}
                                         onDelete={onAnnotationDelete}
                                         onSelect={onAnnotationSelect}
+                                        onStatusChange={onAnnotationStatusChange}
                                     />
                                 </ActivityThread>
                             </ActivityItem>
                         );
-
                     default:
                         return null;
                 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -17,7 +17,13 @@ import messages from './messages';
 import { collapseFeedState, ItemTypes } from './activityFeedUtils';
 import { PERMISSION_CAN_CREATE_ANNOTATIONS } from '../../../../constants';
 import { scrollIntoView } from '../../../../utils/dom';
-import type { Annotation, AnnotationPermission, FocusableFeedItemType, FeedItems } from '../../../../common/types/feed';
+import type {
+    Annotation,
+    AnnotationPermission,
+    FocusableFeedItemType,
+    FeedItems,
+    FeedItemStatus,
+} from '../../../../common/types/feed';
 import type { SelectorItems, User, GroupMini, BoxItem } from '../../../../common/types/core';
 import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
 import type { Translations, Errors } from '../../flowTypes';
@@ -41,6 +47,7 @@ type Props = {
     onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => void,
     onAnnotationEdit?: (id: string, text: string, permissions: AnnotationPermission) => void,
     onAnnotationSelect?: (annotation: Annotation) => void,
+    onAnnotationStatusChange?: (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => void,
     onAppActivityDelete?: Function,
     onCommentCreate?: Function,
     onCommentDelete?: Function,
@@ -212,6 +219,7 @@ class ActivityFeed extends React.Component<Props, State> {
             onAnnotationDelete,
             onAnnotationEdit,
             onAnnotationSelect,
+            onAnnotationStatusChange,
             onAppActivityDelete,
             onCommentCreate,
             onCommentDelete,
@@ -281,6 +289,7 @@ class ActivityFeed extends React.Component<Props, State> {
                             onAnnotationDelete={onAnnotationDelete}
                             onAnnotationEdit={onAnnotationEdit}
                             onAnnotationSelect={onAnnotationSelect}
+                            onAnnotationStatusChange={onAnnotationStatusChange}
                             onAppActivityDelete={onAppActivityDelete}
                             onCommentDelete={hasCommentPermission ? onCommentDelete : noop}
                             onCommentEdit={hasCommentPermission ? onCommentUpdate : noop}


### PR DESCRIPTION
- Updated logic to fetch Annotations with replies when `hasReplies` flag is true
- Added logic to change Annotation's status
-- propagated status change handler down to `AnnotationActivity` (it's use will be implemented in future PR)