### PR TITLE
feat(progress-bar): extended with ability to accept custom message

### DIFF
--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -53,7 +53,7 @@ const getPercent = (view: string, percent: number): number => {
 };
 
 type Props = {
-    customPrompt: { defaultMessage: string, description: string, id: string },
+    customPrompt?: { defaultMessage: string, description: string, id: string },
     hasMultipleFailedUploads: boolean,
     isDragging: boolean,
     isExpanded: boolean,

--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -53,6 +53,7 @@ const getPercent = (view: string, percent: number): number => {
 };
 
 type Props = {
+    customPrompt: { defaultMessage: string, description: string, id: string },
     hasMultipleFailedUploads: boolean,
     isDragging: boolean,
     isExpanded: boolean,
@@ -76,15 +77,13 @@ const OverallUploadsProgressBar = ({
     isVisible,
     isExpanded,
     hasMultipleFailedUploads,
+    customPrompt,
 }: Props) => {
     // Show the upload prompt and set progress to 0 when the uploads manager
     // is invisible or is having files dragged to it
     const shouldShowPrompt = isDragging || !isVisible;
-    const status = shouldShowPrompt ? (
-        <FormattedMessage {...messages.uploadsManagerUploadPrompt} />
-    ) : (
-        getUploadStatus(view)
-    );
+    const message = customPrompt || messages.uploadsManagerUploadPrompt;
+    const status = shouldShowPrompt ? <FormattedMessage {...message} /> : getUploadStatus(view);
     const updatedPercent = shouldShowPrompt ? 0 : getPercent(view, percent);
 
     return (

--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -67,17 +67,17 @@ type Props = {
 };
 
 const OverallUploadsProgressBar = ({
-    percent,
-    view,
+    customPrompt,
+    hasMultipleFailedUploads,
+    isDragging,
+    isExpanded,
+    isResumeVisible,
+    isVisible,
     onClick,
     onKeyDown,
     onUploadsManagerActionClick,
-    isDragging,
-    isResumeVisible,
-    isVisible,
-    isExpanded,
-    hasMultipleFailedUploads,
-    customPrompt,
+    percent,
+    view,
 }: Props) => {
     // Show the upload prompt and set progress to 0 when the uploads manager
     // is invisible or is having files dragged to it


### PR DESCRIPTION
We would like to reuse OverallUploadsProgressBar element for BoxSign, but we need to show a different message while dragging files. 
In the PR I made it possible to pass a custom message as a prop.
Please, take a look and let me know if any improvements in my code needed.