### PR TITLE
feat(usm): Add support for group restrictions

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1553,15 +1553,17 @@ boxui.unifiedShare.collaborators.expirationTooltipClickableText = Access expires
 # Text to show when the number of contact email addresses displayed on a tooltip exceeds the maximum amount that can be displayed
 boxui.unifiedShare.contactEmailsTooltipText = {emails}, and {remainingEmailsCount} more
 # Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts
-boxui.unifiedShare.contactRestrictionNotice = Invitations cannot be sent to {count, plural, one {{count} person} other {{count} people}} because external collaboration is restricted due to the applied security policy.
+boxui.unifiedShare.contactRestrictionNotice = {count, plural, one {{count} invitation} other {{count} invitations}} cannot be sent because external collaboration is restricted due to the applied security policy.
 # Text for the notice that is displayed when there are Information Barrier collaboration restrictions that apply to one or more of the selected contacts
-boxui.unifiedShare.contactRestrictionNoticeInformationBarrier = Invitations cannot be sent to {count, plural, one {{count} person} other {{count} people}} due to a security policy.
+boxui.unifiedShare.contactRestrictionNoticeInformationBarrier = {count, plural, one {{count} invitation} other {{count} invitations}} cannot be sent due to a security policy.
 # Text for the notice that is displayed when there are Information Barrier collaboration restrictions that apply to only one of the selected contacts
 boxui.unifiedShare.contactRestrictionNoticeInformationBarrierSingular = Invitations cannot be sent to {email} due to a security policy.
+# Text for the notice that is displayed when there are Information Barrier collaboration restrictions that apply to only one of the selected contacts, which is a group
+boxui.unifiedShare.contactRestrictionNoticeInformationBarrierSingularGroup = Invitations cannot be sent to "{groupName}" due to a security policy.
 # Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts
 boxui.unifiedShare.contactRestrictionNoticeSingular = Invitations cannot be sent to {email} because external collaboration is restricted due to the applied security policy.
 # Label for the button that removes restricted contacts on the contact restriction notice
-boxui.unifiedShare.contactRestrictionRemoveButtonLabel = Remove {count, plural, one {the person} other {{count} people}} and continue
+boxui.unifiedShare.contactRestrictionRemoveButtonLabel = Remove to continue
 # Error message when more than the maximum number of contacts is entered
 boxui.unifiedShare.contactsExceedLimitError = Oops! The maximum number of collaborators that can be added at once is {maxContacts} collaborators. Please try again by splitting your invitations into batches.
 # Text shown in share modal when there is at least one external collaborators
@@ -1615,13 +1617,13 @@ boxui.unifiedShare.inviteDisabledWeblinkTooltip = Collaborators cannot be added 
 # Label of the field where a user designates who to invite to collaborate on an item
 boxui.unifiedShare.inviteFieldLabel = Invite People
 # Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts and business justifications are allowed for bypassing restrictions
-boxui.unifiedShare.justifiableContactRestrictionNotice = This content requires a business justification to invite {count, plural, one {{count} person} other {{count} people}}. Please select a business justification below.
+boxui.unifiedShare.justifiableContactRestrictionNotice = This content requires a business justification for {count, plural, one {{count} invitation} other {{count} invitations}}. Please select a business justification below.
 # Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts and business justifications are allowed for bypassing restrictions
 boxui.unifiedShare.justifiableContactRestrictionNoticeSingular = This content requires a business justification to invite {email}. Please select a business justification below.
 # Label for the button that removes restricted contacts on the contact restriction notice when business justifications are allowed for bypassing restrictions
-boxui.unifiedShare.justifiableContactRestrictionRemoveButtonLabel = Alternatively, remove {count, plural, one {the person} other {{count} people}} and continue
+boxui.unifiedShare.justifiableContactRestrictionRemoveButtonLabel = Alternatively, remove to continue
 # The error message that is displayed when a user tries to send invitations to external collaborators, but a business justification is required before proceeding
-boxui.unifiedShare.justificationRequiredError = Select a justification or remove people to continue
+boxui.unifiedShare.justificationRequiredError = Select a justification or remove to continue
 # The placeholder text of the select field that allows selecting a business justification reason
 boxui.unifiedShare.justificationSelectPlaceholder = Select Justification
 # Call to action text for allowing the user to create a new shared link
@@ -1677,7 +1679,7 @@ boxui.unifiedShare.removeLinkConfirmationTitle = Remove Shared Link
 # Tooltip description for not having access to remove link
 boxui.unifiedShare.removeLinkTooltip = You do not have permission to remove the link.
 # The error message that is displayed when a user tries to send invitations to external collaborators, but restricted contacts need to be removed before proceeding
-boxui.unifiedShare.restrictedContactsError = Remove people to continue
+boxui.unifiedShare.restrictedContactsError = Remove to continue
 # Tooltip text for email shared link button (title-case)
 boxui.unifiedShare.sendSharedLink = Send Shared Link
 # Field label for shared link recipient list (title-case)

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -57,6 +57,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
         createSharedLinkOnLoad: false,
         focusSharedLinkOnLoad: false,
         restrictedCollabEmails: [],
+        retrictedGroups: [],
         trackingProps: {
             collaboratorListTracking: {},
             inviteCollabsEmailTracking: {},
@@ -85,13 +86,15 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
     }
 
     componentDidUpdate(prevProps: USFProps) {
-        const { isCollabRestrictionJustificationAllowed, item, restrictedCollabEmails } = this.props;
+        const { isCollabRestrictionJustificationAllowed, item, restrictedCollabEmails, restrictedGroups } = this.props;
         const {
+            restrictedGroups: prevRestrictedGroups,
             restrictedCollabEmails: prevRestrictedCollabEmails,
             isCollabRestrictionJustificationAllowed: prevIsCollabRestrictionJustificationAllowed,
         } = prevProps;
 
         const didCollabRestrictionsChange =
+            !isEqual(restrictedGroups, prevRestrictedGroups) ||
             !isEqual(restrictedCollabEmails, prevRestrictedCollabEmails) ||
             isCollabRestrictionJustificationAllowed !== prevIsCollabRestrictionJustificationAllowed;
 
@@ -127,9 +130,13 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
 
     shouldRequireCollabJustification = () => {
         const { inviteCollabsContacts } = this.state;
-        const { isCollabRestrictionJustificationAllowed, restrictedCollabEmails } = this.props;
+        const { isCollabRestrictionJustificationAllowed, restrictedCollabEmails, restrictedGroups } = this.props;
 
-        const hasRestrictedCollabs = hasRestrictedContacts(inviteCollabsContacts, restrictedCollabEmails);
+        const hasRestrictedCollabs = hasRestrictedContacts(
+            inviteCollabsContacts,
+            restrictedCollabEmails,
+            restrictedGroups,
+        );
         return hasRestrictedCollabs && isCollabRestrictionJustificationAllowed;
     };
 
@@ -185,7 +192,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
         const { classificationLabelId, inviteePermissionLevel } = this.state;
         const defaultPermissionLevel = getDefaultPermissionLevel(inviteePermissions);
         const selectedPermissionLevel = inviteePermissionLevel || defaultPermissionLevel;
-        const { emails, groupIDs, justificationReason, message, restrictedEmails } = data;
+        const { emails, groupIDs, justificationReason, message, restrictedEmails, restrictedGroups } = data;
 
         let params = {
             emails: emails.join(','),
@@ -197,7 +204,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
         };
 
         const hasJustificationReason = !!justificationReason;
-        const hasRestrictedInvitees = !isEmpty(restrictedEmails);
+        const hasRestrictedInvitees = !isEmpty(restrictedEmails) || !isEmpty(restrictedGroups);
         const shouldSubmitJustificationReason =
             hasJustificationReason && hasRestrictedInvitees && isCollabRestrictionJustificationAllowed;
 
@@ -348,10 +355,18 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
         currentInviteCollabsContacts: Array<Contact>,
         newInviteCollabsContacts: Array<Contact>,
     ) => {
-        const { restrictedCollabEmails } = this.props;
+        const { restrictedCollabEmails, restrictedGroups } = this.props;
 
-        const hasRestrictedCollabs = hasRestrictedContacts(currentInviteCollabsContacts, restrictedCollabEmails);
-        const hasRestrictedCollabsAfterUpdate = hasRestrictedContacts(newInviteCollabsContacts, restrictedCollabEmails);
+        const hasRestrictedCollabs = hasRestrictedContacts(
+            currentInviteCollabsContacts,
+            restrictedCollabEmails,
+            restrictedGroups,
+        );
+        const hasRestrictedCollabsAfterUpdate = hasRestrictedContacts(
+            newInviteCollabsContacts,
+            restrictedCollabEmails,
+            restrictedGroups,
+        );
 
         return hasRestrictedCollabs && !hasRestrictedCollabsAfterUpdate;
     };
@@ -413,6 +428,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             item,
             recommendedSharingTooltipCalloutName = null,
             restrictedCollabEmails,
+            restrictedGroups,
             sendInvitesError,
             shouldRenderFTUXTooltip,
             showEnterEmailsCallout = false,
@@ -498,6 +514,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             openInviteCollaboratorsSection={this.openInviteCollaboratorsSection}
                             recommendedSharingTooltipCalloutName={recommendedSharingTooltipCalloutName}
                             restrictedEmails={restrictedCollabEmails}
+                            restrictedGroups={restrictedGroups}
                             showEnterEmailsCallout={showEnterEmailsCallout}
                             submitting={submitting}
                             selectedContacts={this.state.inviteCollabsContacts}

--- a/src/features/unified-share-modal/UnifiedShareModal.js
+++ b/src/features/unified-share-modal/UnifiedShareModal.js
@@ -30,6 +30,7 @@ class UnifiedShareModal extends React.Component<USMProps, State> {
         createSharedLinkOnLoad: false,
         focusSharedLinkOnLoad: false,
         restrictedCollabEmails: [],
+        restrictedGroups: [],
         trackingProps: {
             inviteCollabsEmailTracking: {},
             sharedLinkEmailTracking: {},

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
@@ -107,6 +107,7 @@ exports[`features/unified-share-modal/UnifiedShareForm closeEmailSharedLinkForm(
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -306,6 +307,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -469,6 +471,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -632,6 +635,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -800,6 +804,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -964,6 +969,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -1129,6 +1135,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -1264,6 +1271,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -1429,6 +1437,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -1594,6 +1603,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -1760,6 +1770,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -1935,6 +1946,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -2099,6 +2111,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -2267,6 +2280,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}
@@ -2433,6 +2447,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           submitting={false}
@@ -2599,6 +2614,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
           openInviteCollaboratorsSection={[Function]}
           recommendedSharingTooltipCalloutName={null}
           restrictedEmails={Array []}
+          restrictedGroups={Array []}
           selectedContacts={Array []}
           showEnterEmailsCallout={false}
           updateSelectedContacts={[Function]}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareModal.test.js.snap
@@ -76,6 +76,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={true}
@@ -171,6 +172,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should not rend
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -266,6 +268,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={
         Object {
           "url": "https://foo.com",
@@ -364,6 +367,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={true}
@@ -459,6 +463,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -553,6 +558,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -648,6 +654,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -743,6 +750,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -838,6 +846,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -933,6 +942,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -1036,6 +1046,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -1131,6 +1142,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -1230,6 +1242,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={
         Object {
           "url": "https://foo.com",
@@ -1328,6 +1341,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -1420,6 +1434,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}
@@ -1516,6 +1531,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sendInvitesError={
         <span>
           Some Error
@@ -1616,6 +1632,7 @@ exports[`features/unified-share-modal/UnifiedShareModal render() should render a
       }
       openConfirmModal={[Function]}
       restrictedCollabEmails={Array []}
+      restrictedGroups={Array []}
       sharedLink={Object {}}
       sharedLinkLoaded={false}
       shouldRenderFTUXTooltip={false}

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -246,7 +246,7 @@ export type CollabRestrictionType =
     | typeof constants.COLLAB_RESTRICTION_TYPE_ACCESS_POLICY
     | typeof constants.COLLAB_RESTRICTION_TYPE_INFORMATION_BARRIER;
 
-type ExternalCollabRestrictionsTypes = {
+type CollabRestrictionsTypes = {
     /** The type of restriction that applies to restrictedCollabEmails */
     collabRestrictionType?: CollabRestrictionType,
     /** Function that fetches the array of justification reason options to display on the justification select field */
@@ -260,6 +260,8 @@ type ExternalCollabRestrictionsTypes = {
     onRemoveAllRestrictedCollabs?: () => void,
     /** An array of all the collab email addresses that have been determined to be restricted by a security policy. */
     restrictedCollabEmails: Array<string>,
+    /** An array of all the group ids that have been determined to be restricted by a security policy. */
+    restrictedGroups: Array<number>,
 };
 
 // Prop types used in the shared link section of the Unified Share Form
@@ -326,7 +328,7 @@ export type USMConfig = {
 // Prop types shared by both the Unified Share Modal and the Unified Share Form
 type BaseUnifiedShareProps = CollaboratorAvatarsTypes &
     EmailFormTypes &
-    ExternalCollabRestrictionsTypes &
+    CollabRestrictionsTypes &
     InviteSectionTypes &
     SharedLinkSectionTypes & {
         /** Inline message */

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -458,27 +458,27 @@ const messages = defineMessages({
         id: 'boxui.unifiedShare.recommendedSharingTooltipCalloutText',
     },
 
-    // External collab restrictions and business justifications
+    // Information Barrier restrictions, external collab restrictions and business justifications
     justificationSelectPlaceholder: {
         defaultMessage: 'Select Justification',
         description: 'The placeholder text of the select field that allows selecting a business justification reason',
         id: 'boxui.unifiedShare.justificationSelectPlaceholder',
     },
     justificationRequiredError: {
-        defaultMessage: 'Select a justification or remove people to continue',
+        defaultMessage: 'Select a justification or remove to continue',
         description:
             'The error message that is displayed when a user tries to send invitations to external collaborators, but a business justification is required before proceeding',
         id: 'boxui.unifiedShare.justificationRequiredError',
     },
     restrictedContactsError: {
-        defaultMessage: 'Remove people to continue',
+        defaultMessage: 'Remove to continue',
         description:
             'The error message that is displayed when a user tries to send invitations to external collaborators, but restricted contacts need to be removed before proceeding',
         id: 'boxui.unifiedShare.restrictedContactsError',
     },
     justifiableContactRestrictionNotice: {
         defaultMessage:
-            'This content requires a business justification to invite {count, plural, one {{count} person} other {{count} people}}. Please select a business justification below.',
+            'This content requires a business justification for {count, plural, one {{count} invitation} other {{count} invitations}}. Please select a business justification below.',
         description:
             'Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts and business justifications are allowed for bypassing restrictions',
         id: 'boxui.unifiedShare.justifiableContactRestrictionNotice',
@@ -491,14 +491,14 @@ const messages = defineMessages({
         id: 'boxui.unifiedShare.justifiableContactRestrictionNoticeSingular',
     },
     justifiableContactRestrictionRemoveButtonLabel: {
-        defaultMessage: 'Alternatively, remove {count, plural, one {the person} other {{count} people}} and continue',
+        defaultMessage: 'Alternatively, remove to continue',
         description:
             'Label for the button that removes restricted contacts on the contact restriction notice when business justifications are allowed for bypassing restrictions',
         id: 'boxui.unifiedShare.justifiableContactRestrictionRemoveButtonLabel',
     },
     contactRestrictionNotice: {
         defaultMessage:
-            'Invitations cannot be sent to {count, plural, one {{count} person} other {{count} people}} because external collaboration is restricted due to the applied security policy.',
+            '{count, plural, one {{count} invitation} other {{count} invitations}} cannot be sent because external collaboration is restricted due to the applied security policy.',
         description:
             'Text for the notice that is displayed when there are collaboration restrictions that apply to one or more of the selected contacts',
         id: 'boxui.unifiedShare.contactRestrictionNotice',
@@ -512,7 +512,7 @@ const messages = defineMessages({
     },
     contactRestrictionNoticeInformationBarrier: {
         defaultMessage:
-            'Invitations cannot be sent to {count, plural, one {{count} person} other {{count} people}} due to a security policy.',
+            '{count, plural, one {{count} invitation} other {{count} invitations}} cannot be sent due to a security policy.',
         description:
             'Text for the notice that is displayed when there are Information Barrier collaboration restrictions that apply to one or more of the selected contacts',
         id: 'boxui.unifiedShare.contactRestrictionNoticeInformationBarrier',
@@ -523,8 +523,14 @@ const messages = defineMessages({
             'Text for the notice that is displayed when there are Information Barrier collaboration restrictions that apply to only one of the selected contacts',
         id: 'boxui.unifiedShare.contactRestrictionNoticeInformationBarrierSingular',
     },
+    contactRestrictionNoticeInformationBarrierSingularGroup: {
+        defaultMessage: 'Invitations cannot be sent to "{groupName}" due to a security policy.',
+        description:
+            'Text for the notice that is displayed when there are Information Barrier collaboration restrictions that apply to only one of the selected contacts, which is a group',
+        id: 'boxui.unifiedShare.contactRestrictionNoticeInformationBarrierSingularGroup',
+    },
     contactRestrictionRemoveButtonLabel: {
-        defaultMessage: 'Remove {count, plural, one {the person} other {{count} people}} and continue',
+        defaultMessage: 'Remove to continue',
         description: 'Label for the button that removes restricted contacts on the contact restriction notice',
         id: 'boxui.unifiedShare.contactRestrictionRemoveButtonLabel',
     },

--- a/src/features/unified-share-modal/utils/__tests__/hasRestrictedContacts.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/hasRestrictedContacts.test.js
@@ -3,22 +3,20 @@ import hasRestrictedContacts from '../hasRestrictedContacts';
 describe('features/unified-share-modal/utils/hasRestrictedContacts', () => {
     const contacts = [
         {
-            email: 'x@example.com',
-            id: '12345',
+            id: 12345,
             text: 'X User',
             type: 'group',
-            value: 'x@example.com',
         },
         {
             email: 'y@example.com',
-            id: '23456',
+            id: 23456,
             text: 'Y User',
             type: 'user',
             value: 'y@example.com',
         },
         {
             email: 'z@example.com',
-            id: '34567',
+            id: 34567,
             text: 'Z User',
             type: 'user',
             value: 'z@example.com',
@@ -29,19 +27,35 @@ describe('features/unified-share-modal/utils/hasRestrictedContacts', () => {
         let restrictedEmails;
 
         restrictedEmails = [];
-        expect(hasRestrictedContacts(contacts, restrictedEmails)).toBe(false);
+        expect(hasRestrictedContacts(contacts, restrictedEmails, [])).toBe(false);
 
         restrictedEmails = ['a@example.com', 'b@example.com'];
-        expect(hasRestrictedContacts(contacts, restrictedEmails)).toBe(false);
+        expect(hasRestrictedContacts(contacts, restrictedEmails, [])).toBe(false);
+    });
+
+    test('should return false when no restricted groups are found within contacts', () => {
+        let restrictedGroups = [];
+
+        restrictedGroups = [];
+        expect(hasRestrictedContacts(contacts, [], restrictedGroups)).toBe(false);
+
+        restrictedGroups = [1111];
+        expect(hasRestrictedContacts(contacts, [], restrictedGroups)).toBe(false);
     });
 
     test('should return true when at least one restricted email is found within contacts', () => {
         let restrictedEmails;
 
         restrictedEmails = ['z@example.com'];
-        expect(hasRestrictedContacts(contacts, restrictedEmails)).toBe(true);
+        expect(hasRestrictedContacts(contacts, restrictedEmails, [])).toBe(true);
 
-        restrictedEmails = ['x@example.com', 'y@example.com', 'z@example.com'];
-        expect(hasRestrictedContacts(contacts, restrictedEmails)).toBe(true);
+        restrictedEmails = ['y@example.com', 'z@example.com'];
+        expect(hasRestrictedContacts(contacts, restrictedEmails, [])).toBe(true);
+    });
+
+    test('should return true when at least one restricted group is found within contacts', () => {
+        const restrictedGroups = [12345];
+
+        expect(hasRestrictedContacts(contacts, [], restrictedGroups)).toBe(true);
     });
 });

--- a/src/features/unified-share-modal/utils/__tests__/isRestrictedContact.test.js
+++ b/src/features/unified-share-modal/utils/__tests__/isRestrictedContact.test.js
@@ -1,0 +1,33 @@
+import isRestrictedContact from '../isRestrictedContact';
+
+describe('features/unified-share-modal/utils/isRestrictedContact', () => {
+    const groupContact = {
+        id: 12345,
+        text: 'X User',
+        type: 'group',
+    };
+    const userContact = {
+        email: 'y@example.com',
+        id: 23456,
+        text: 'Y User',
+        type: 'user',
+        value: 'y@example.com',
+    };
+
+    test.each`
+        contact         | restrictedEmails     | restrictedGroups | description                                                                      | expectedResult
+        ${groupContact} | ${[]}                | ${[]}            | ${'is group contact and restrictedEmails and restrictedGroups are empty'}        | ${false}
+        ${userContact}  | ${[]}                | ${[]}            | ${'is user contact and restrictedEmails and restrictedGroups are empty'}         | ${false}
+        ${groupContact} | ${[]}                | ${[1111]}        | ${'group contact id is not in restrictedGroups'}                                 | ${false}
+        ${userContact}  | ${['a@example.com']} | ${[]}            | ${'user contact email is not in restrictedEmails'}                               | ${false}
+        ${groupContact} | ${[]}                | ${[12345]}       | ${'group contact id is in restrictedGroups'}                                     | ${true}
+        ${userContact}  | ${['y@example.com']} | ${[]}            | ${'user contact email is in restrictedEmails'}                                   | ${true}
+        ${groupContact} | ${['y@example.com']} | ${[12345]}       | ${'group contact id is in restrictedGroups and restrictedEmails is not empty'}   | ${true}
+        ${userContact}  | ${['y@example.com']} | ${[12345]}       | ${'user contact email is in restrictedEmails and restrictedGroups is not empty'} | ${true}
+    `(
+        'should return $expectedResult when $description',
+        ({ contact, restrictedEmails, restrictedGroups, expectedResult }) => {
+            expect(isRestrictedContact(contact, restrictedEmails, restrictedGroups)).toBe(expectedResult);
+        },
+    );
+});

--- a/src/features/unified-share-modal/utils/hasRestrictedContacts.js
+++ b/src/features/unified-share-modal/utils/hasRestrictedContacts.js
@@ -1,11 +1,18 @@
 // @flow
 import type { contactType as Contact } from '../flowTypes';
 
-const hasRestrictedContacts = (contacts: Array<Contact>, restrictedEmails: Array<string>): boolean => {
-    if (!restrictedEmails.length) {
+const hasRestrictedContacts = (
+    contacts: Array<Contact>,
+    restrictedEmails: Array<string>,
+    restrictedGroups: Array<number>,
+): boolean => {
+    if (!restrictedEmails.length && !restrictedGroups.length) {
         return false;
     }
-    return contacts.some(({ value }) => restrictedEmails.includes(value));
+    const hasRestrictedGroups = contacts.some(({ id }) => restrictedGroups.includes(id));
+    const hasRestrictedEmails = contacts.some(({ value }) => restrictedEmails.includes(value));
+
+    return hasRestrictedGroups || hasRestrictedEmails;
 };
 
 export default hasRestrictedContacts;

--- a/src/features/unified-share-modal/utils/isRestrictedContact.js
+++ b/src/features/unified-share-modal/utils/isRestrictedContact.js
@@ -1,0 +1,21 @@
+// @flow
+import type { SelectOptionProp } from '../../../components/select-field/props';
+import type { contactType as Contact } from '../flowTypes';
+
+const isRestrictedContact = (
+    contact: Contact | SelectOptionProp,
+    restrictedEmails: Array<string>,
+    restrictedGroups: Array<number>,
+) => {
+    let isRestrictedEmail = false;
+    let isRestrictedGroup = false;
+
+    if (contact.id && contact.type === 'group') {
+        isRestrictedGroup = restrictedGroups.includes(Number(contact.id));
+    } else {
+        isRestrictedEmail = restrictedEmails.includes(String(contact.value));
+    }
+    return isRestrictedEmail || isRestrictedGroup;
+};
+
+export default isRestrictedContact;


### PR DESCRIPTION
Unified Share Modal will now also support displaying restrictions for groups in the same way that we do for individual contacts. Group restrictions are currently only possible for Information Barrier.

<img width="512" alt="Screen Shot 2022-09-12 at 5 30 31 PM" src="https://user-images.githubusercontent.com/1322503/189781889-df22e867-17cd-4c61-9cd7-ef289a381e36.png">
