### PR TITLE
feat(content-insights): Add permission error state for 403 errors

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -74,6 +74,8 @@ be.close = Close
 be.collapse = Collapse
 # Text shown to users when opening the content insights flyout and there is an error
 be.contentInsights.contentAnalyticsErrorText = There was a problem loading content insights. Please try again.
+# Message shown when the user does not have access to view content insights anymore
+be.contentInsights.contentAnalyticsPermissionError = Oops! You no longer have access to view content insights.
 # Title for Content Insights section in file sidebar
 be.contentInsights.contentInsightsTitle = Content Insights
 # Label for the chart displaying the number of downloads over the selected time period
@@ -1760,5 +1762,3 @@ boxui.validation.requiredError = Required Field
 boxui.validation.tooLongError = Input cannot exceed {max} characters
 # Error message for when an input value is too short. {min} is the minimum length
 boxui.validation.tooShortError = Input must be at least {min} characters
-# Message shown when the user does not have access to view content insights anymore
-enduser.contentInsights.contentAnalyticsPermissionError = Oops! You no longer have access to view content insights.

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1760,3 +1760,5 @@ boxui.validation.requiredError = Required Field
 boxui.validation.tooLongError = Input cannot exceed {max} characters
 # Error message for when an input value is too short. {min} is the minimum length
 boxui.validation.tooShortError = Input must be at least {min} characters
+# Message shown when the user does not have access to view content insights anymore
+enduser.contentInsights.contentAnalyticsPermissionError = Oops! You no longer have access to view content insights.

--- a/src/features/content-insights/ContentAnalyticsErrorState.scss
+++ b/src/features/content-insights/ContentAnalyticsErrorState.scss
@@ -6,6 +6,27 @@
     align-items: center;
     justify-content: center;
     height: 100%;
+
+    &.small {
+        svg {
+            width: 56px;
+            height: 56px;
+        }
+    }
+
+    &.medium {
+        svg {
+            width: 80px;
+            height: 80px;
+        }
+    }
+
+    &.large {
+        svg {
+            width: 95px;
+            height: 95px;
+        }
+    }
 }
 
 .ContentAnalyticsErrorState-text,

--- a/src/features/content-insights/ContentAnalyticsErrorState.scss
+++ b/src/features/content-insights/ContentAnalyticsErrorState.scss
@@ -4,9 +4,12 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
+    height: 100%;
 }
 
-.ContentAnalyticsErrorState-text {
+.ContentAnalyticsErrorState-text,
+.ContentAnalyticsPermissionError-text {
     width: 100%;
     margin-top: $bdl-grid-unit * 5;
     font-size: $bdl-fontSize--dejaBlue;

--- a/src/features/content-insights/ContentAnalyticsErrorState.scss
+++ b/src/features/content-insights/ContentAnalyticsErrorState.scss
@@ -6,31 +6,10 @@
     align-items: center;
     justify-content: center;
     height: 100%;
-
-    &.small {
-        svg {
-            width: 56px;
-            height: 56px;
-        }
-    }
-
-    &.medium {
-        svg {
-            width: 80px;
-            height: 80px;
-        }
-    }
-
-    &.large {
-        svg {
-            width: 95px;
-            height: 95px;
-        }
-    }
 }
 
 .ContentAnalyticsErrorState-text,
-.ContentAnalyticsPermissionError-text {
+.ContentAnalyticsErrorState-text--permission {
     width: 100%;
     margin-top: $bdl-grid-unit * 5;
     font-size: $bdl-fontSize--dejaBlue;

--- a/src/features/content-insights/ContentAnalyticsErrorState.tsx
+++ b/src/features/content-insights/ContentAnalyticsErrorState.tsx
@@ -2,45 +2,52 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import PropTypes from 'prop-types';
-import HatWand140 from '../../illustration/HatWand140';
 import MetricsReview56 from '../../illustration/MetricsReview56';
 import messages from './messages';
 import { ResponseError } from './types';
 
 import './ContentAnalyticsErrorState.scss';
 
+const SIZE_MAP = {
+    small: 56,
+    medium: 80,
+    large: 95,
+};
 interface Props {
     error: ResponseError;
+    size?: 'small' | 'medium' | 'large';
 }
 
-const ContentAnalyticsErrorState = ({ error }: Props) => {
-    const renderErrorContent = () => {
+const ContentAnalyticsErrorState = ({ error, size = 'small' }: Props) => {
+    const renderErrorMessage = () => {
         const isPermissionError = error.status === 403;
 
         if (isPermissionError) {
             return (
-                <>
-                    <MetricsReview56 data-testid="ContentAnalyticsPermissionError-image" />
-                    <div className="ContentAnalyticsErrorState-text">
-                        <FormattedMessage {...messages.contentAnalyticsPermissionError} />
-                    </div>
-                </>
+                <div
+                    className="ContentAnalyticsPermissionError-text"
+                    data-testid="ContentAnalyticsPermissionError-text"
+                >
+                    <FormattedMessage {...messages.contentAnalyticsPermissionError} />
+                </div>
             );
         }
 
         return (
-            <>
-                <HatWand140 data-testid="ContentAnalyticsErrorState-image" />
-                <div className="ContentAnalyticsErrorState-text">
-                    <FormattedMessage {...messages.contentAnalyticsErrorText} />
-                </div>
-            </>
+            <div className="ContentAnalyticsErrorState-text" data-testid="ContentAnalyticsErrorState-text">
+                <FormattedMessage {...messages.contentAnalyticsErrorText} />
+            </div>
         );
     };
 
     return (
         <div className="ContentAnalyticsErrorState" data-testid="ContentAnalyticsErrorState">
-            {renderErrorContent()}
+            <MetricsReview56
+                height={SIZE_MAP[size]}
+                width={SIZE_MAP[size]}
+                data-testid="ContentAnalyticsErrorState-image"
+            />
+            {renderErrorMessage()}
         </div>
     );
 };

--- a/src/features/content-insights/ContentAnalyticsErrorState.tsx
+++ b/src/features/content-insights/ContentAnalyticsErrorState.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import MetricsReview56 from '../../illustration/MetricsReview56';
 import messages from './messages';
@@ -8,11 +9,6 @@ import { ResponseError } from './types';
 
 import './ContentAnalyticsErrorState.scss';
 
-const SIZE_MAP = {
-    small: 56,
-    medium: 80,
-    large: 95,
-};
 interface Props {
     error: ResponseError;
     size?: 'small' | 'medium' | 'large';
@@ -41,12 +37,8 @@ const ContentAnalyticsErrorState = ({ error, size = 'small' }: Props) => {
     };
 
     return (
-        <div className="ContentAnalyticsErrorState" data-testid="ContentAnalyticsErrorState">
-            <MetricsReview56
-                height={SIZE_MAP[size]}
-                width={SIZE_MAP[size]}
-                data-testid="ContentAnalyticsErrorState-image"
-            />
+        <div className={classNames('ContentAnalyticsErrorState', size)} data-testid="ContentAnalyticsErrorState">
+            <MetricsReview56 data-testid="ContentAnalyticsErrorState-image" />
             {renderErrorMessage()}
         </div>
     );

--- a/src/features/content-insights/ContentAnalyticsErrorState.tsx
+++ b/src/features/content-insights/ContentAnalyticsErrorState.tsx
@@ -2,17 +2,43 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import HatWand140 from '../../illustration/HatWand140';
+import MetricsReview56 from '../../illustration/MetricsReview56';
 import messages from './messages';
 
 import './ContentAnalyticsErrorState.scss';
 
-const ContentAnalyticsErrorState = () => (
-    <div className="ContentAnalyticsErrorState" data-testid="ContentAnalyticsErrorState">
-        <HatWand140 data-testid="ContentAnalyticsErrorState-image" />
-        <div className="ContentAnalyticsErrorState-text">
-            <FormattedMessage {...messages.contentAnalyticsErrorText} />
+interface Props {
+    isPermissionError?: boolean;
+}
+
+const ContentAnalyticsErrorState = ({ isPermissionError = false }: Props) => {
+    const renderErrorContent = () => {
+        if (isPermissionError) {
+            return (
+                <>
+                    <MetricsReview56 data-testid="ContentAnalyticsPermissionError-image" />
+                    <div className="ContentAnalyticsErrorState-text">
+                        <FormattedMessage {...messages.contentAnalyticsPermissionError} />
+                    </div>
+                </>
+            );
+        }
+
+        return (
+            <>
+                <HatWand140 data-testid="ContentAnalyticsErrorState-image" />
+                <div className="ContentAnalyticsErrorState-text">
+                    <FormattedMessage {...messages.contentAnalyticsErrorText} />
+                </div>
+            </>
+        );
+    };
+
+    return (
+        <div className="ContentAnalyticsErrorState" data-testid="ContentAnalyticsErrorState">
+            {renderErrorContent()}
         </div>
-    </div>
-);
+    );
+};
 
 export default ContentAnalyticsErrorState;

--- a/src/features/content-insights/ContentAnalyticsErrorState.tsx
+++ b/src/features/content-insights/ContentAnalyticsErrorState.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import MetricsReview56 from '../../illustration/MetricsReview56';
 import messages from './messages';
@@ -11,18 +10,17 @@ import './ContentAnalyticsErrorState.scss';
 
 interface Props {
     error: ResponseError;
-    size?: 'small' | 'medium' | 'large';
 }
 
-const ContentAnalyticsErrorState = ({ error, size = 'small' }: Props) => {
+const ContentAnalyticsErrorState = ({ error }: Props) => {
     const renderErrorMessage = () => {
         const isPermissionError = error.status === 403;
 
         if (isPermissionError) {
             return (
                 <div
-                    className="ContentAnalyticsPermissionError-text"
-                    data-testid="ContentAnalyticsPermissionError-text"
+                    className="ContentAnalyticsErrorState-text--permission"
+                    data-testid="ContentAnalyticsErrorState-text--permission"
                 >
                     <FormattedMessage {...messages.contentAnalyticsPermissionError} />
                 </div>
@@ -37,7 +35,7 @@ const ContentAnalyticsErrorState = ({ error, size = 'small' }: Props) => {
     };
 
     return (
-        <div className={classNames('ContentAnalyticsErrorState', size)} data-testid="ContentAnalyticsErrorState">
+        <div className="ContentAnalyticsErrorState" data-testid="ContentAnalyticsErrorState">
             <MetricsReview56 data-testid="ContentAnalyticsErrorState-image" />
             {renderErrorMessage()}
         </div>

--- a/src/features/content-insights/ContentAnalyticsErrorState.tsx
+++ b/src/features/content-insights/ContentAnalyticsErrorState.tsx
@@ -1,18 +1,22 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import PropTypes from 'prop-types';
 import HatWand140 from '../../illustration/HatWand140';
 import MetricsReview56 from '../../illustration/MetricsReview56';
 import messages from './messages';
+import { ResponseError } from './types';
 
 import './ContentAnalyticsErrorState.scss';
 
 interface Props {
-    isPermissionError?: boolean;
+    error: ResponseError;
 }
 
-const ContentAnalyticsErrorState = ({ isPermissionError = false }: Props) => {
+const ContentAnalyticsErrorState = ({ error }: Props) => {
     const renderErrorContent = () => {
+        const isPermissionError = error.status === 403;
+
         if (isPermissionError) {
             return (
                 <>
@@ -39,6 +43,10 @@ const ContentAnalyticsErrorState = ({ isPermissionError = false }: Props) => {
             {renderErrorContent()}
         </div>
     );
+};
+
+ContentAnalyticsErrorState.propTypes = {
+    error: PropTypes.object,
 };
 
 export default ContentAnalyticsErrorState;

--- a/src/features/content-insights/ContentAnalyticsErrorState.tsx
+++ b/src/features/content-insights/ContentAnalyticsErrorState.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import PropTypes from 'prop-types';
 import MetricsReview56 from '../../illustration/MetricsReview56';
 import messages from './messages';
 import { ResponseError } from './types';
@@ -13,8 +12,8 @@ interface Props {
 }
 
 const ContentAnalyticsErrorState = ({ error }: Props) => {
-    const renderErrorMessage = () => {
-        const isPermissionError = error.status === 403;
+    const renderErrorMessage = (responseError: ResponseError) => {
+        const isPermissionError = responseError.status === 403;
 
         if (isPermissionError) {
             return (
@@ -37,13 +36,9 @@ const ContentAnalyticsErrorState = ({ error }: Props) => {
     return (
         <div className="ContentAnalyticsErrorState" data-testid="ContentAnalyticsErrorState">
             <MetricsReview56 data-testid="ContentAnalyticsErrorState-image" />
-            {renderErrorMessage()}
+            {renderErrorMessage(error)}
         </div>
     );
-};
-
-ContentAnalyticsErrorState.propTypes = {
-    error: PropTypes.object,
 };
 
 export default ContentAnalyticsErrorState;

--- a/src/features/content-insights/ContentInsightsSummary.tsx
+++ b/src/features/content-insights/ContentInsightsSummary.tsx
@@ -21,8 +21,7 @@ interface Props {
 const ContentInsightsSummary = ({ error, graphData, isLoading, previousPeriodCount, onClick, totalCount }: Props) => {
     const renderContentAnalyticsSummary = () => {
         if (error) {
-            const isPermissionError = error.status === 403;
-            return <ContentAnalyticsErrorState isPermissionError={isPermissionError} />;
+            return <ContentAnalyticsErrorState error={error} />;
         }
 
         if (isLoading) {

--- a/src/features/content-insights/ContentInsightsSummary.tsx
+++ b/src/features/content-insights/ContentInsightsSummary.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 
+import PropTypes from 'prop-types';
 import ContentAnalyticsErrorState from './ContentAnalyticsErrorState';
 import ContentInsightsSummaryGhostState from './ContentInsightsSummaryGhostState';
 import GraphCardPreviewsSummary from './GraphCardPreviewsSummary';
 import OpenContentInsightsButton from './OpenContentInsightsButton';
-import { GraphData } from './types';
+import { GraphData, ResponseError } from './types';
 
 import './ContentInsightsSummary.scss';
 
 interface Props {
     graphData: GraphData;
-    error?: Object;
+    error?: ResponseError;
     isLoading: boolean;
     onClick: () => void;
     previousPeriodCount: number;
@@ -20,7 +21,8 @@ interface Props {
 const ContentInsightsSummary = ({ error, graphData, isLoading, previousPeriodCount, onClick, totalCount }: Props) => {
     const renderContentAnalyticsSummary = () => {
         if (error) {
-            return <ContentAnalyticsErrorState />;
+            const isPermissionError = error.status === 403;
+            return <ContentAnalyticsErrorState isPermissionError={isPermissionError} />;
         }
 
         if (isLoading) {
@@ -40,6 +42,10 @@ const ContentInsightsSummary = ({ error, graphData, isLoading, previousPeriodCou
     };
 
     return <div className="ContentInsightsSummary">{renderContentAnalyticsSummary()}</div>;
+};
+
+ContentInsightsSummary.propTypes = {
+    error: PropTypes.object,
 };
 
 export default ContentInsightsSummary;

--- a/src/features/content-insights/ContentInsightsSummary.tsx
+++ b/src/features/content-insights/ContentInsightsSummary.tsx
@@ -20,7 +20,7 @@ interface Props {
 const ContentInsightsSummary = ({ error, graphData, isLoading, previousPeriodCount, onClick, totalCount }: Props) => {
     const renderContentAnalyticsSummary = () => {
         if (error) {
-            return <ContentAnalyticsErrorState error={error} size="small" />;
+            return <ContentAnalyticsErrorState error={error} />;
         }
 
         if (isLoading) {

--- a/src/features/content-insights/ContentInsightsSummary.tsx
+++ b/src/features/content-insights/ContentInsightsSummary.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import PropTypes from 'prop-types';
 import ContentAnalyticsErrorState from './ContentAnalyticsErrorState';
 import ContentInsightsSummaryGhostState from './ContentInsightsSummaryGhostState';
 import GraphCardPreviewsSummary from './GraphCardPreviewsSummary';
@@ -21,7 +20,7 @@ interface Props {
 const ContentInsightsSummary = ({ error, graphData, isLoading, previousPeriodCount, onClick, totalCount }: Props) => {
     const renderContentAnalyticsSummary = () => {
         if (error) {
-            return <ContentAnalyticsErrorState error={error} />;
+            return <ContentAnalyticsErrorState error={error} size="small" />;
         }
 
         if (isLoading) {
@@ -41,10 +40,6 @@ const ContentInsightsSummary = ({ error, graphData, isLoading, previousPeriodCou
     };
 
     return <div className="ContentInsightsSummary">{renderContentAnalyticsSummary()}</div>;
-};
-
-ContentInsightsSummary.propTypes = {
-    error: PropTypes.object,
 };
 
 export default ContentInsightsSummary;

--- a/src/features/content-insights/__tests__/ContentInsightsSummary.test.tsx
+++ b/src/features/content-insights/__tests__/ContentInsightsSummary.test.tsx
@@ -52,8 +52,8 @@ describe('features/content-insights/ContentInsightsSummary', () => {
         test('should show the error state when error exists', () => {
             getWrapper({ error: baseError });
 
-            expect(screen.getByTestId('ContentAnalyticsErrorState-image')).toBeVisible();
-            expect(screen.queryByTestId('ContentAnalyticsPermissionError-image')).not.toBeInTheDocument();
+            expect(screen.getByTestId('ContentAnalyticsErrorState-text')).toBeVisible();
+            expect(screen.queryByTestId('ContentAnalyticsPermissionError-text')).not.toBeInTheDocument();
             expect(screen.queryByTestId('GraphCardGhostState')).toBeNull();
             expect(screen.queryByLabelText(localize(messages.previewGraphLabel.id))).toBeNull();
         });
@@ -61,8 +61,8 @@ describe('features/content-insights/ContentInsightsSummary', () => {
         test('should show the permission error state when error exists and is a permission error', () => {
             getWrapper({ error: { ...baseError, status: 403 } });
 
-            expect(screen.getByTestId('ContentAnalyticsPermissionError-image')).toBeVisible();
-            expect(screen.queryByTestId('ContentAnalyticsErrorState-image')).not.toBeInTheDocument();
+            expect(screen.getByTestId('ContentAnalyticsPermissionError-text')).toBeVisible();
+            expect(screen.queryByTestId('ContentAnalyticsErrorState-text')).not.toBeInTheDocument();
             expect(screen.queryByTestId('GraphCardGhostState')).toBeNull();
             expect(screen.queryByLabelText(localize(messages.previewGraphLabel.id))).toBeNull();
         });

--- a/src/features/content-insights/__tests__/ContentInsightsSummary.test.tsx
+++ b/src/features/content-insights/__tests__/ContentInsightsSummary.test.tsx
@@ -53,7 +53,7 @@ describe('features/content-insights/ContentInsightsSummary', () => {
             getWrapper({ error: baseError });
 
             expect(screen.getByTestId('ContentAnalyticsErrorState-text')).toBeVisible();
-            expect(screen.queryByTestId('ContentAnalyticsPermissionError-text')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('ContentAnalyticsErrorState-text--permission')).not.toBeInTheDocument();
             expect(screen.queryByTestId('GraphCardGhostState')).toBeNull();
             expect(screen.queryByLabelText(localize(messages.previewGraphLabel.id))).toBeNull();
         });
@@ -61,7 +61,7 @@ describe('features/content-insights/ContentInsightsSummary', () => {
         test('should show the permission error state when error exists and is a permission error', () => {
             getWrapper({ error: { ...baseError, status: 403 } });
 
-            expect(screen.getByTestId('ContentAnalyticsPermissionError-text')).toBeVisible();
+            expect(screen.getByTestId('ContentAnalyticsErrorState-text--permission')).toBeVisible();
             expect(screen.queryByTestId('ContentAnalyticsErrorState-text')).not.toBeInTheDocument();
             expect(screen.queryByTestId('GraphCardGhostState')).toBeNull();
             expect(screen.queryByLabelText(localize(messages.previewGraphLabel.id))).toBeNull();

--- a/src/features/content-insights/__tests__/ContentInsightsSummary.test.tsx
+++ b/src/features/content-insights/__tests__/ContentInsightsSummary.test.tsx
@@ -17,6 +17,8 @@ const mockData = [
     { start: 7, previewsCount: 1, type: 'day' },
 ] as GraphData;
 
+const baseError = new Error('An error has occured');
+
 describe('features/content-insights/ContentInsightsSummary', () => {
     const getWrapper = (props = {}) =>
         render(
@@ -46,10 +48,21 @@ describe('features/content-insights/ContentInsightsSummary', () => {
             expect(screen.queryByTestId('GraphCardGhostState')).toBeNull();
             expect(screen.getByLabelText(localize(messages.previewGraphLabel.id))).toBeVisible();
         });
-        test('should show the error state when isError is true', () => {
-            getWrapper({ error: new Error('An error has occured.') });
 
-            expect(screen.getByTestId('ContentAnalyticsErrorState')).toBeVisible();
+        test('should show the error state when error exists', () => {
+            getWrapper({ error: baseError });
+
+            expect(screen.getByTestId('ContentAnalyticsErrorState-image')).toBeVisible();
+            expect(screen.queryByTestId('ContentAnalyticsPermissionError-image')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('GraphCardGhostState')).toBeNull();
+            expect(screen.queryByLabelText(localize(messages.previewGraphLabel.id))).toBeNull();
+        });
+
+        test('should show the permission error state when error exists and is a permission error', () => {
+            getWrapper({ error: { ...baseError, status: 403 } });
+
+            expect(screen.getByTestId('ContentAnalyticsPermissionError-image')).toBeVisible();
+            expect(screen.queryByTestId('ContentAnalyticsErrorState-image')).not.toBeInTheDocument();
             expect(screen.queryByTestId('GraphCardGhostState')).toBeNull();
             expect(screen.queryByLabelText(localize(messages.previewGraphLabel.id))).toBeNull();
         });

--- a/src/features/content-insights/messages.ts
+++ b/src/features/content-insights/messages.ts
@@ -6,6 +6,11 @@ const messages = defineMessages({
         description: 'Text shown to users when opening the content insights flyout and there is an error',
         id: 'be.contentInsights.contentAnalyticsErrorText',
     },
+    contentAnalyticsPermissionError: {
+        defaultMessage: 'Oops! You no longer have access to view content insights.',
+        description: 'Message shown when the user does not have access to view content insights anymore',
+        id: 'enduser.contentInsights.contentAnalyticsPermissionError',
+    },
     contentInsightsTitle: {
         defaultMessage: 'Content Insights',
         description: 'Title for Content Insights section in file sidebar',

--- a/src/features/content-insights/messages.ts
+++ b/src/features/content-insights/messages.ts
@@ -9,7 +9,7 @@ const messages = defineMessages({
     contentAnalyticsPermissionError: {
         defaultMessage: 'Oops! You no longer have access to view content insights.',
         description: 'Message shown when the user does not have access to view content insights anymore',
-        id: 'enduser.contentInsights.contentAnalyticsPermissionError',
+        id: 'be.contentInsights.contentAnalyticsPermissionError',
     },
     contentInsightsTitle: {
         defaultMessage: 'Content Insights',

--- a/src/features/content-insights/types.ts
+++ b/src/features/content-insights/types.ts
@@ -28,6 +28,6 @@ export type ResponseError = Error & {
     data?: string;
     detail?: string;
     errorCode?: string;
-    status?: number;
+    status: number;
     title?: string;
 };


### PR DESCRIPTION
Adds error state for permission errors

Updated error states: 

![image](https://user-images.githubusercontent.com/11734293/191849023-a13eaaf2-0b6d-445b-b3c1-587cdfea43ba.png)
![image](https://user-images.githubusercontent.com/11734293/191849371-5b6e3cbf-d712-43af-8c7a-2dcc8fc9466b.png)

![image](https://user-images.githubusercontent.com/11734293/191850569-870f4955-bbed-4684-8e30-1c4c4940bea1.png)
![image](https://user-images.githubusercontent.com/11734293/191850886-42604239-cce0-44b9-ba2f-fba7bd4c4e1a.png)

![image](https://user-images.githubusercontent.com/11734293/191850413-3ccf8e07-1c4f-4baa-b75e-55bf9d6bee4d.png)
![image](https://user-images.githubusercontent.com/11734293/191850933-7d60050c-eccc-4699-82ec-ece12e2d1dbb.png)




