### PR TITLE
fix(content-insights): Allow undefined error ContentAnalyticsErrorState

### DIFF
--- a/src/features/content-insights/ContentAnalyticsErrorState.tsx
+++ b/src/features/content-insights/ContentAnalyticsErrorState.tsx
@@ -8,12 +8,12 @@ import { ResponseError } from './types';
 import './ContentAnalyticsErrorState.scss';
 
 interface Props {
-    error: ResponseError;
+    error?: ResponseError;
 }
 
 const ContentAnalyticsErrorState = ({ error }: Props) => {
-    const renderErrorMessage = (responseError: ResponseError) => {
-        const isPermissionError = responseError.status === 403;
+    const renderErrorMessage = (responseError?: ResponseError) => {
+        const isPermissionError = !!responseError && responseError.status === 403;
 
         if (isPermissionError) {
             return (

--- a/src/features/content-insights/__tests__/ContentAnalyticsErrorState.test.tsx
+++ b/src/features/content-insights/__tests__/ContentAnalyticsErrorState.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ContentAnalyticsErrorState from '../ContentAnalyticsErrorState';
+
+const baseError = new Error('An error has occured');
+
+describe('features/content-insights/ContentAnalyticsErrorState', () => {
+    const getWrapper = (props = {}) => render(<ContentAnalyticsErrorState error={undefined} {...props} />);
+
+    describe('render', () => {
+        test('should show the default error state', () => {
+            getWrapper();
+
+            expect(screen.getByTestId('ContentAnalyticsErrorState-text')).toBeVisible();
+            expect(screen.queryByTestId('ContentAnalyticsErrorState-text--permission')).not.toBeInTheDocument();
+        });
+
+        test('should show default error state when theres an error passed in', () => {
+            getWrapper({ error: baseError });
+
+            expect(screen.getByTestId('ContentAnalyticsErrorState-text')).toBeVisible();
+            expect(screen.queryByTestId('ContentAnalyticsErrorState-text--permission')).not.toBeInTheDocument();
+        });
+
+        test('should show the permission error state when error exists and is a permission error', () => {
+            getWrapper({ error: { ...baseError, status: 403 } });
+
+            expect(screen.getByTestId('ContentAnalyticsErrorState-text--permission')).toBeVisible();
+            expect(screen.queryByTestId('ContentAnalyticsErrorState-text')).not.toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
- [ x ] Unit tests

Makes the error prop optional since we are only using the error prop to check if it's a permission error

![image](https://user-images.githubusercontent.com/11734293/192067678-087bf69e-8c73-4d7a-a980-188dabe69622.png)
