### PR TITLE
fix(infinite-scroll): fix documentation and prop name mismatch

### DIFF
--- a/src/components/infinite-scroll/InfiniteScroll.md
+++ b/src/components/infinite-scroll/InfiniteScroll.md
@@ -58,7 +58,7 @@ const hasMore = true;
       isLoading={isLoading}
       onLoadMore={onLoadMore}
       useWindow={false}
-      scrollContainerRef={scrollRef}
+      scrollContainerNode={scrollRef}
     >
       <React.Fragment>
         {items.map((item, i) => (

--- a/src/components/infinite-scroll/InfiniteScroll.tsx
+++ b/src/components/infinite-scroll/InfiniteScroll.tsx
@@ -23,7 +23,7 @@ export interface InfiniteScrollProps {
     threshold?: number;
     /** Throttle rate */
     throttle?: number;
-    /** Set useWindow to true to use the window as scroll container. If set to true, will ignore scrollContainerRef. */
+    /** Set useWindow to true to use the window as scroll container. If set to true, will ignore scrollContainerNode. */
     useWindow?: boolean;
 }
 


### PR DESCRIPTION
One of the props for `infinite-scroll` is called `scrollContainerNode`, but is sometimes referred to as `scrollContainerRef`. Fixed for consistency. 