### PR TITLE
feat(annotation-thread): handle create reply

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -14,6 +14,8 @@ be.activitySidebar.activityFeed.feedInlineErrorTitle = Error
 be.activitySidebar.activityFeed.hideReplies = Hide replies
 # Text to show on button to start replying to comment
 be.activitySidebar.activityFeed.reply = Reply
+# Text to show on reply form input placeholder
+be.activitySidebar.activityFeed.replyInThread = Reply in thread
 # Text to show to get more replies of comment or annotation
 be.activitySidebar.activityFeed.showReplies = See {repliesToLoadCount, plural, one {# reply} other {# replies}}
 # Text to show when a task no longer exists

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -12,6 +12,8 @@ be.activitySidebar.activityFeed.commentMissingError = This comment no longer exi
 be.activitySidebar.activityFeed.feedInlineErrorTitle = Error
 # Text to show to hide more replies of comment or annotation
 be.activitySidebar.activityFeed.hideReplies = Hide replies
+# Text to show on button to start replying to comment
+be.activitySidebar.activityFeed.reply = Reply
 # Text to show to get more replies of comment or annotation
 be.activitySidebar.activityFeed.showReplies = See {repliesToLoadCount, plural, one {# reply} other {# replies}}
 # Text to show when a task no longer exists

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -13,6 +13,8 @@ import type { SelectorItems, User } from '../../../../common/types/core';
 import type { BoxCommentPermission, Comment as CommentType, FeedItemStatus } from '../../../../common/types/feed';
 
 import messages from './messages';
+import ActivityThreadReplyForm from './ActivityThreadReplyForm';
+
 import './ActivityThread.scss';
 
 type Props = {
@@ -50,6 +52,7 @@ const ActivityThread = ({
     hasReplies,
     isRepliesLoading,
     mentionSelectorContacts,
+    onReplyCreate = noop,
     onReplyDelete = noop,
     onReplyEdit = noop,
     onShowReplies = noop,
@@ -106,6 +109,16 @@ const ActivityThread = ({
                     translations={translations}
                 />
             )}
+
+            {onReplyCreate ? (
+                <ActivityThreadReplyForm
+                    currentUser={currentUser}
+                    getMentionWithQuery={getMentionWithQuery}
+                    getUserProfileUrl={getUserProfileUrl}
+                    mentionSelectorContacts={mentionSelectorContacts}
+                    onReplyCreate={onReplyCreate}
+                />
+            ) : null}
         </div>
     );
 };

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -112,9 +112,7 @@ const ActivityThread = ({
 
             {onReplyCreate ? (
                 <ActivityThreadReplyForm
-                    currentUser={currentUser}
                     getMentionWithQuery={getMentionWithQuery}
-                    getUserProfileUrl={getUserProfileUrl}
                     mentionSelectorContacts={mentionSelectorContacts}
                     onReplyCreate={onReplyCreate}
                 />

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -6,6 +6,7 @@ import noop from 'lodash/noop';
 import LoadingIndicator from '../../../../components/loading-indicator';
 import PlainButton from '../../../../components/plain-button';
 import ActivityThreadReplies from './ActivityThreadReplies';
+import ActivityThreadReplyForm from './ActivityThreadReplyForm';
 
 import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
 import type { Translations } from '../../flowTypes';
@@ -13,7 +14,6 @@ import type { SelectorItems, User } from '../../../../common/types/core';
 import type { BoxCommentPermission, Comment as CommentType, FeedItemStatus } from '../../../../common/types/feed';
 
 import messages from './messages';
-import ActivityThreadReplyForm from './ActivityThreadReplyForm';
 
 import './ActivityThread.scss';
 
@@ -52,7 +52,7 @@ const ActivityThread = ({
     hasReplies,
     isRepliesLoading,
     mentionSelectorContacts,
-    onReplyCreate = noop,
+    onReplyCreate,
     onReplyDelete = noop,
     onReplyEdit = noop,
     onShowReplies = noop,

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
@@ -37,9 +37,7 @@ const ActivityThreadReplies = ({
     const lastReply = replies[replies.length - 1];
 
     const getReplyPermissions = (reply: CommentType): BoxCommentPermission => {
-        const {
-            permissions: { can_delete = false, can_edit = false, can_resolve = false },
-        } = reply;
+        const { permissions: { can_delete = false, can_edit = false, can_resolve = false } = {} } = reply;
         return {
             can_delete,
             can_edit,

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
@@ -7,8 +7,7 @@ import type { InjectIntlProvidedProps } from 'react-intl';
 import PlainButton from '../../../../components/plain-button';
 import ArrowArcRight from '../../../../icon/fill/ArrowArcRight';
 
-import type { GetProfileUrlCallback } from '../../../common/flowTypes';
-import type { SelectorItems, User } from '../../../../common/types/core';
+import type { SelectorItems } from '../../../../common/types/core';
 
 import CommentForm from '../comment-form';
 
@@ -16,22 +15,14 @@ import messages from './messages';
 import './ActivityThreadReplyForm.scss';
 
 type ActivityThreadReplyFromProps = {
-    currentUser?: User,
-    getMentionWithQuery?: Function,
-    getUserProfileUrl?: GetProfileUrlCallback,
+    getMentionWithQuery?: (searchStr: string) => void,
     mentionSelectorContacts?: SelectorItems<>,
-    onReplyCreate: Function,
+    onReplyCreate: (text: string, hasMention: boolean) => void,
 };
 
 type Props = ActivityThreadReplyFromProps & InjectIntlProvidedProps;
 
-function ActivityThreadReplyForm({
-    currentUser,
-    mentionSelectorContacts,
-    getMentionWithQuery,
-    onReplyCreate,
-    intl,
-}: Props) {
+function ActivityThreadReplyForm({ mentionSelectorContacts, getMentionWithQuery, onReplyCreate, intl }: Props) {
     const [showReplyForm, setShowReplyForm] = React.useState(false);
     const placeholder = intl.formatMessage(messages.replyInThread);
 
@@ -40,9 +31,10 @@ function ActivityThreadReplyForm({
             className=""
             isOpen
             isEditing
+            showTip={false}
+            // $FlowFixMe user is needed for showing an avatar, we don't need that here
+            user={{}}
             getAvatarUrl={() => Promise.resolve()}
-            // $FlowFixMe
-            user={currentUser}
             onCancel={() => setShowReplyForm(false)}
             createComment={({ text, hasMentions }) => {
                 onReplyCreate(text, hasMentions);

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
@@ -28,7 +28,7 @@ function ActivityThreadReplyForm({ mentionSelectorContacts, getMentionWithQuery,
 
     return showReplyForm ? (
         <CommentForm
-            className=""
+            className="bcs-ActivityThreadReplyForm-comment"
             isOpen
             isEditing
             showTip={false}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
@@ -53,8 +53,12 @@ function ActivityThreadReplyForm({
             placeholder={placeholder}
         />
     ) : (
-        <PlainButton role="button" className="bcs-ActivityThread-replyForm" onClick={() => setShowReplyForm(true)}>
-            <ArrowArcRight className="bcs-ActivityThread-replyForm-arrow" />
+        <PlainButton
+            role="button"
+            className="bcs-ActivityThreadReplyForm-toggle"
+            onClick={() => setShowReplyForm(true)}
+        >
+            <ArrowArcRight className="bcs-ActivityThreadReplyForm-arrow" />
             <FormattedMessage {...messages.reply} />
         </PlainButton>
     );

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
@@ -1,0 +1,55 @@
+// @flow
+
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import PlainButton from '../../../../components/plain-button';
+import ArrowArcRight from '../../../../icon/fill/ArrowArcRight';
+
+import type { GetProfileUrlCallback } from '../../../common/flowTypes';
+import type { SelectorItems, User } from '../../../../common/types/core';
+
+import CommentForm from '../comment-form';
+
+import messages from './messages';
+import './ActivityThreadReplyForm.scss';
+
+type Props = {
+    currentUser?: User,
+    getMentionWithQuery?: Function,
+    getUserProfileUrl?: GetProfileUrlCallback,
+    mentionSelectorContacts?: SelectorItems<>,
+    onReplyCreate: Function,
+};
+
+export default function ActivityThreadReplyForm({
+    currentUser,
+    mentionSelectorContacts,
+    getMentionWithQuery,
+    onReplyCreate,
+}: Props) {
+    const [showReplyForm, setShowReplyForm] = React.useState(false);
+
+    return showReplyForm ? (
+        <CommentForm
+            className=""
+            isOpen
+            isEditing
+            getAvatarUrl={() => Promise.resolve()}
+            // $FlowFixMe
+            user={currentUser}
+            onCancel={() => setShowReplyForm(false)}
+            createComment={({ text, hasMentions }) => {
+                onReplyCreate(text, hasMentions);
+                setShowReplyForm(false);
+            }}
+            mentionSelectorContacts={mentionSelectorContacts}
+            getMentionWithQuery={getMentionWithQuery}
+        />
+    ) : (
+        <PlainButton role="button" className="bcs-ActivityThread-replyForm" onClick={() => setShowReplyForm(true)}>
+            <ArrowArcRight className="bcs-ActivityThread-replyForm-arrow" />
+            <FormattedMessage {...messages.reply} />
+        </PlainButton>
+    );
+}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
@@ -1,7 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import type { InjectIntlProvidedProps } from 'react-intl';
 
 import PlainButton from '../../../../components/plain-button';
 import ArrowArcRight from '../../../../icon/fill/ArrowArcRight';
@@ -14,7 +15,7 @@ import CommentForm from '../comment-form';
 import messages from './messages';
 import './ActivityThreadReplyForm.scss';
 
-type Props = {
+type ActivityThreadReplyFromProps = {
     currentUser?: User,
     getMentionWithQuery?: Function,
     getUserProfileUrl?: GetProfileUrlCallback,
@@ -22,14 +23,17 @@ type Props = {
     onReplyCreate: Function,
 };
 
-export default function ActivityThreadReplyForm({
+type Props = ActivityThreadReplyFromProps & InjectIntlProvidedProps;
+
+function ActivityThreadReplyForm({
     currentUser,
     mentionSelectorContacts,
     getMentionWithQuery,
     onReplyCreate,
+    intl,
 }: Props) {
     const [showReplyForm, setShowReplyForm] = React.useState(false);
-    const placeholder = useIntl().formatMessage(messages.replyInThread);
+    const placeholder = intl.formatMessage(messages.replyInThread);
 
     return showReplyForm ? (
         <CommentForm
@@ -55,3 +59,5 @@ export default function ActivityThreadReplyForm({
         </PlainButton>
     );
 }
+
+export default injectIntl(ActivityThreadReplyForm);

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import PlainButton from '../../../../components/plain-button';
 import ArrowArcRight from '../../../../icon/fill/ArrowArcRight';
@@ -29,6 +29,7 @@ export default function ActivityThreadReplyForm({
     onReplyCreate,
 }: Props) {
     const [showReplyForm, setShowReplyForm] = React.useState(false);
+    const placeholder = useIntl().formatMessage(messages.replyInThread);
 
     return showReplyForm ? (
         <CommentForm
@@ -45,6 +46,7 @@ export default function ActivityThreadReplyForm({
             }}
             mentionSelectorContacts={mentionSelectorContacts}
             getMentionWithQuery={getMentionWithQuery}
+            placeholder={placeholder}
         />
     ) : (
         <PlainButton role="button" className="bcs-ActivityThread-replyForm" onClick={() => setShowReplyForm(true)}>

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
@@ -1,18 +1,17 @@
 @import '../../../common/variables';
 
-.bcs-ActivityThread-replyForm {
-    $replyPadding: $bdl-grid-unit $sidebarActivityFeedSpacingHorizontal ($bdl-grid-unit * 5);
-
+.bcs-ActivityThreadReplyForm-toggle {
     display: flex;
     align-items: center;
-    padding: $replyPadding;
 
+    &,
     &:hover {
-        padding: $replyPadding;
+        padding: $bdl-grid-unit $sidebarActivityFeedSpacingHorizontal ($bdl-grid-unit * 5);
     }
 
-    .bcs-ActivityThread-replyForm-arrow {
+    .bcs-ActivityThreadReplyForm-arrow {
         margin-right: $bdl-grid-unit;
+        // in design arrow is turning left, but we only have ArrowArcRight, so will transfrom it to left one
         transform: matrix(-1, 0, 0, 1, 0, 0);
     }
 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
@@ -1,0 +1,18 @@
+@import '../../../common/variables';
+
+.bcs-ActivityThread-replyForm {
+    $replyPadding: $bdl-grid-unit $sidebarActivityFeedSpacingHorizontal ($bdl-grid-unit * 5);
+
+    display: flex;
+    align-items: center;
+    padding: $replyPadding;
+
+    &:hover {
+        padding: $replyPadding;
+    }
+
+    .bcs-ActivityThread-replyForm-arrow {
+        margin-right: $bdl-grid-unit;
+        transform: matrix(-1, 0, 0, 1, 0, 0);
+    }
+}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
@@ -15,3 +15,8 @@
         transform: matrix(-1, 0, 0, 1, 0, 0);
     }
 }
+
+.bcs-CommentForm.bcs-ActivityThreadReplyForm-comment {
+    padding-top: 0;
+    border-top: none;
+}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -66,8 +66,14 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         expect(queryByTestId('activity-thread-loading')).toBeInTheDocument();
     });
 
+    test('should NOT have reply button when onReplyCreate is not passed', () => {
+        getWrapper({ onReplyCreate: undefined });
+
+        expect(screen.queryByRole('button', { name: localize(messages.reply.id) })).not.toBeInTheDocument();
+    });
+
     test('should have reply button when onReplyCreate is passed', () => {
-        getWrapper({ onReplayCreate: () => {} });
+        getWrapper({ onReplyCreate: function someFunction() {} });
 
         expect(screen.getByRole('button', { name: localize(messages.reply.id) })).toBeInTheDocument();
     });

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -65,4 +65,10 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         expect(queryByTestId('activity-thread-button')).not.toBeInTheDocument();
         expect(queryByTestId('activity-thread-loading')).toBeInTheDocument();
     });
+
+    test('should have reply button when onReplyCreate is passed', () => {
+        getWrapper({ onReplayCreate: () => {} });
+
+        expect(screen.getByRole('button', { name: localize(messages.reply.id) })).toBeInTheDocument();
+    });
 });

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadRepliesForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadRepliesForm.test.js
@@ -29,6 +29,7 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         fireEvent.click(replyButton);
 
         expect(screen.getByTestId('bcs-CommentForm-body')).toBeInTheDocument();
+        expect(screen.getByText(localize(messages.replyInThread.id))).toBeInTheDocument();
     });
 
     test('should hide opened reply form when clicked on Cancel button', () => {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadRepliesForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadRepliesForm.test.js
@@ -1,12 +1,11 @@
 // @flow
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import noop from 'lodash/noop';
 import { IntlProvider } from 'react-intl';
 import localize from '../../../../../../test/support/i18n';
 import messages from '../messages';
 import ActivityThreadReplyForm from '../ActivityThreadReplyForm.js';
-
-const noop = () => {};
 
 jest.mock('react-intl', () => jest.requireActual('react-intl'));
 
@@ -16,7 +15,7 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
     };
 
     const renderComponent = props =>
-        render(<ActivityThreadReplyForm currentUser={{}} getAvatarUrl={noop} onReplyCreate={noop} {...props} />, {
+        render(<ActivityThreadReplyForm onReplyCreate={noop} {...props} />, {
             wrapper: Wrapper,
         });
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadRepliesForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadRepliesForm.test.js
@@ -1,0 +1,47 @@
+// @flow
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import localize from '../../../../../../test/support/i18n';
+import messages from '../messages';
+import ActivityThreadReplyForm from '../ActivityThreadReplyForm.js';
+
+const noop = () => {};
+
+jest.mock('react-intl', () => jest.requireActual('react-intl'));
+
+describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm', () => {
+    const Wrapper = ({ children }: { children?: React.ReactNode }) => {
+        return <IntlProvider locale="en">{children}</IntlProvider>;
+    };
+
+    const renderComponent = props =>
+        render(<ActivityThreadReplyForm currentUser={{}} getAvatarUrl={noop} onReplyCreate={noop} {...props} />, {
+            wrapper: Wrapper,
+        });
+
+    test('should show reply form when clicked on Reply button', () => {
+        renderComponent();
+
+        const replyButton = screen.getByRole('button', { name: localize(messages.reply.id) });
+        expect(screen.queryByTestId('bcs-CommentForm-body')).not.toBeInTheDocument();
+
+        fireEvent.click(replyButton);
+
+        expect(screen.getByTestId('bcs-CommentForm-body')).toBeInTheDocument();
+    });
+
+    test('should hide opened reply form when clicked on Cancel button', () => {
+        renderComponent();
+
+        const replyButton = screen.getByRole('button', { name: localize(messages.reply.id) });
+        fireEvent.click(replyButton);
+
+        expect(screen.getByTestId('bcs-CommentForm-body')).toBeInTheDocument();
+
+        const cancel = screen.getByRole('button', { name: 'Cancel' });
+        fireEvent.click(cancel);
+
+        expect(screen.queryByTestId('bcs-CommentForm-body')).not.toBeInTheDocument();
+    });
+});

--- a/src/elements/content-sidebar/activity-feed/activity-feed/messages.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/messages.js
@@ -42,6 +42,11 @@ const messages = defineMessages({
         defaultMessage: 'Reply',
         description: 'Text to show on button to start replying to comment',
     },
+    replyInThread: {
+        id: 'be.activitySidebar.activityFeed.replyInThread',
+        defaultMessage: 'Reply in thread',
+        description: 'Text to show on reply form input placeholder',
+    },
 });
 
 export default messages;

--- a/src/elements/content-sidebar/activity-feed/activity-feed/messages.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/messages.js
@@ -37,6 +37,11 @@ const messages = defineMessages({
         defaultMessage: 'Hide replies',
         description: 'Text to show to hide more replies of comment or annotation',
     },
+    reply: {
+        id: 'be.activitySidebar.activityFeed.reply',
+        defaultMessage: 'Reply',
+        description: 'Text to show on button to start replying to comment',
+    },
 });
 
 export default messages;

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -120,7 +120,7 @@ class CommentForm extends React.Component<Props, State> {
             tagged_message,
             getAvatarUrl,
             showTip = true,
-            placeholder,
+            placeholder = formatMessage(messages.commentWrite),
         } = this.props;
         const { commentEditorState } = this.state;
         const inputContainerClassNames = classNames('bcs-CommentForm', className, {
@@ -151,9 +151,7 @@ class CommentForm extends React.Component<Props, State> {
                             onChange={this.onMentionSelectorChangeHandler}
                             onFocus={onFocus}
                             onMention={getMentionWithQuery}
-                            placeholder={
-                                tagged_message ? undefined : placeholder ?? formatMessage(messages.commentWrite)
-                            }
+                            placeholder={tagged_message ? undefined : placeholder}
                             validateOnBlur={false}
                         />
                         {showTip && (

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -36,6 +36,7 @@ type Props = {
     onCancel: Function,
     onFocus?: Function,
     onSubmit?: Function,
+    placeholder?: string,
     showTip?: boolean,
     tagged_message?: string,
     updateComment?: Function,
@@ -119,6 +120,7 @@ class CommentForm extends React.Component<Props, State> {
             tagged_message,
             getAvatarUrl,
             showTip = true,
+            placeholder,
         } = this.props;
         const { commentEditorState } = this.state;
         const inputContainerClassNames = classNames('bcs-CommentForm', className, {
@@ -149,7 +151,9 @@ class CommentForm extends React.Component<Props, State> {
                             onChange={this.onMentionSelectorChangeHandler}
                             onFocus={onFocus}
                             onMention={getMentionWithQuery}
-                            placeholder={tagged_message ? undefined : formatMessage(messages.commentWrite)}
+                            placeholder={
+                                tagged_message ? undefined : placeholder ?? formatMessage(messages.commentWrite)
+                            }
                             validateOnBlur={false}
                         />
                         {showTip && (

--- a/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
@@ -152,4 +152,15 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
 
         expect(wrapper.find('.bcs-CommentForm-tip').length).toEqual(0);
     });
+
+    test('should show custom placeholder when provided', () => {
+        const wrapper = render({ placeholder: 'Your comment goes here' });
+
+        expect(
+            wrapper
+                .find('DraftJSMentionSelector')
+                .at(0)
+                .prop('placeholder'),
+        ).toEqual('Your comment goes here');
+    });
 });


### PR DESCRIPTION
New component `ActivityThreadReplyForm`
  * shows Reply button
  * handles showing/hiding `CommentForm`

Changes in `ActivityThread`
  * renders `ActivityThreadReplyForm`

Changes in `CommentForm.js`
  * adds new optional prop `placeholder`


#### Designs
From figma (don't mind the background it's part of different feature, and the black blocks on right are part of arrows showing the flow)
<img width="136" alt="Screenshot 2022-09-30 at 14 03 05" src="https://user-images.githubusercontent.com/8361509/193265449-950ca0b6-42c4-4846-b1cf-099262989ed7.png">
<img width="613" alt="Screenshot 2022-09-30 at 14 03 38" src="https://user-images.githubusercontent.com/8361509/193265522-ac6d502b-fe4c-4caa-bbc0-419d753d2516.png">

As it's implemented
<img width="74" alt="Screenshot 2022-09-30 at 14 04 59" src="https://user-images.githubusercontent.com/8361509/193265758-4690480a-0f71-4711-9af6-5648d220111b.png">
<img width="347" alt="Screenshot 2022-09-30 at 14 05 16" src="https://user-images.githubusercontent.com/8361509/193265806-ca66a0fe-175e-4e64-a464-841e95648bf6.png">

