### PR TITLE
feat(selectable): change single-click from select to navigate behind FF

### DIFF
--- a/src/components/table/makeSelectable.js
+++ b/src/components/table/makeSelectable.js
@@ -22,8 +22,10 @@ function makeSelectable(BaseTable) {
             className: PropTypes.string,
             /** Array of unique IDs of the items in the table. Each item should be a string or number, in the order they appear in the table. */
             data: PropTypes.array.isRequired,
+            isListViewEnhancementsEnabled: PropTypes.bool,
             /** Called when focus changes. `(focusedIndex: number) => void` */
             onFocus: PropTypes.func,
+            onItemDoubleClick: PropTypes.func,
             /** Called when selection changes. `(selectedItems: Array<string> | Array<number> | Set<string> | Set<number>) => void` */
             onSelect: PropTypes.func.isRequired,
             /**
@@ -274,7 +276,7 @@ function makeSelectable(BaseTable) {
             });
         };
 
-        handleRowClick = (event, index) => {
+        handleSelect = (event, index) => {
             if (event.metaKey || event.ctrlKey) {
                 this.selectToggle(index);
             } else if (event.shiftKey) {
@@ -282,6 +284,12 @@ function makeSelectable(BaseTable) {
             } else {
                 this.selectOne(index);
             }
+        };
+
+        handleRowClick = (event, index) => {
+            this.props.isListViewEnhancementsEnabled
+                ? this.props.onItemDoubleClick(event, index)
+                : this.handleSelect(event, index);
         };
 
         handleRowFocus = (event, index) => {


### PR DESCRIPTION
LVE FF enabled:
![navigate-on-click](https://user-images.githubusercontent.com/5461045/193648801-140e4c58-7506-4ebf-9d5e-dc8840b88adf.gif)

LVE FF disabled:
![select-on-click](https://user-images.githubusercontent.com/5461045/193648861-11d7117c-5479-439c-8741-a40e0d70acc2.gif)

I tried two other approaches in EUA:
1. creating an alternate `withItemSelection` and changing `onDoubleClick` to `onClick`
    - This was not enough, as the crucial change happens here where something is assigned to `onRowClick`
    - We can still do the above in conjunction with these changes, but probably the best would be to wait until we redact the FF and then simply change `onDoubleClick` to `onClick` both here (`makeSelectable`) and there (`withItemSelection`).
2. wrapping `TableRow` in `ItemLink`, but that road was hard to hoe, and maybe not the best idea (not sure how that could affect the interactivity of `TableRow` descendants.

Please note that this change does not accomplish what is required for Grid View to navigate on click.

Also, I'm not sure how to test this, off the top of my head.