### PR TITLE
feat(classification): update security controls watermarking copy

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1276,6 +1276,8 @@ boxui.securityControls.downloadExternal = Download restricted on Box Drive for e
 boxui.securityControls.externalCollabBlock = External collaboration restricted.
 # Bullet point that summarizes external collaboration restriction applied to classification
 boxui.securityControls.externalCollabDomainList = External collaboration limited to approved domains.
+# The text of a link to a help article for more information.
+boxui.securityControls.linkForMoreDetails = Click here for more details.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users
 boxui.securityControls.mobileDownloadExternal = Download restricted on mobile for external users.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners
@@ -1330,6 +1332,8 @@ boxui.securityControls.shortSign = Sign restrictions apply
 boxui.securityControls.shortWatermarking = Watermarking applies
 # Button to display security controls modal
 boxui.securityControls.viewAll = View All
+# Bullet point that summarizes watermarking applied to classification
+boxui.securityControls.watermarkingApplied = Watermarking will be applied.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users
 boxui.securityControls.webDownloadExternal = Download restricted on web for external users.
 # Bullet point that summarizes web download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners

--- a/src/features/classification/security-controls/SecurityControlsItem.scss
+++ b/src/features/classification/security-controls/SecurityControlsItem.scss
@@ -15,6 +15,7 @@
     }
 
     .support-link {
+        padding-left: $bdl-grid-unit;
         color: $bdl-box-blue;
     }
 }

--- a/src/features/classification/security-controls/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/features/classification/security-controls/__tests__/__snapshots__/utils.test.js.snap
@@ -1,20 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`features/classification/security-controls/utils getFullSecurityControlsMessages() should include correct message when watermark is applied 1`] = `
-<FormattedCompMessage
-  description="Bullet point that summarizes watermarking applied to classification"
-  id="boxui.securityControls.watermarkingAppliedWithLink"
->
-  Watermarking will be applied, click
-   
-  <Link
-    className="support-link"
-    href="https://support.box.com/hc/en-us/articles/360044195253"
-    target="_blank"
-  >
-    here
-  </Link>
-   
-  more details on Watermarking
-</FormattedCompMessage>
+Object {
+  "children": Array [
+    <FormattedMessage
+      defaultMessage="Watermarking will be applied."
+      id="boxui.securityControls.watermarkingApplied"
+    />,
+    <Link
+      className="support-link"
+      href="https://support.box.com/hc/en-us/articles/360044195253"
+      target="_blank"
+    >
+      <FormattedMessage
+        defaultMessage="Click here for more details."
+        id="boxui.securityControls.linkForMoreDetails"
+      />
+    </Link>,
+  ],
+}
 `;

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -101,12 +101,20 @@ describe('features/classification/security-controls/utils', () => {
                     enabled: true,
                 },
             };
-            const { message: formattedCompMessage } = getFullSecurityControlsMessages(accessPolicy)[0];
-            const { props: formattedCompMessageProps = {} } = formattedCompMessage;
-            const expectedMessageId = 'boxui.securityControls.watermarkingAppliedWithLink';
+            const { message: watermarkFormattedMessages } = getFullSecurityControlsMessages(accessPolicy)[0];
+            const { props: formattedMessageProps = {} } = watermarkFormattedMessages;
+            const { children: objArr = [] } = formattedMessageProps;
+            const { props: firstMessageObj = {} } = objArr[0];
+            const { props: linkObj = {} } = objArr[1];
+            const { props: secondMessageObj = {} } = linkObj.children;
 
-            expect(formattedCompMessageProps.id).toEqual(expectedMessageId);
-            expect(formattedCompMessage).toMatchSnapshot();
+            const expectedFirstMessageId = 'boxui.securityControls.watermarkingApplied';
+            const expectedSecondMessageId = 'boxui.securityControls.linkForMoreDetails';
+
+            expect(objArr.length).toEqual(2);
+            expect(firstMessageObj.id).toEqual(expectedFirstMessageId);
+            expect(secondMessageObj.id).toEqual(expectedSecondMessageId);
+            expect(formattedMessageProps).toMatchSnapshot();
         });
 
         test('should include correct message when external collab is blocked', () => {

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -116,6 +116,16 @@ const messages = defineMessages({
         description: 'Bullet point that summarizes collaborators shared link restriction applied to classification',
         id: 'boxui.securityControls.sharingCollabAndCompanyOnly',
     },
+    watermarkingApplied: {
+        defaultMessage: 'Watermarking will be applied.',
+        description: 'Bullet point that summarizes watermarking applied to classification',
+        id: 'boxui.securityControls.watermarkingApplied',
+    },
+    linkForMoreDetails: {
+        defaultMessage: 'Click here for more details.',
+        description: 'The text of a link to a help article for more information.',
+        id: 'boxui.securityControls.linkForMoreDetails',
+    },
     externalCollabBlock: {
         defaultMessage: 'External collaboration restricted.',
         description:

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -2,10 +2,10 @@
 import * as React from 'react';
 import getProp from 'lodash/get';
 import isNil from 'lodash/isNil';
+import { FormattedMessage } from 'react-intl';
 
 import type { Controls, MessageItem } from '../flowTypes';
 
-import FormattedCompMessage from '../../../components/i18n/FormattedCompMessage';
 import Link from '../../../components/link/Link';
 import appRestrictionsMessageMap from './appRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from './downloadRestrictionsMessageMap';
@@ -100,23 +100,19 @@ const getWatermarkingMessages = (controls: Controls): Array<MessageItem> => {
     const items = [];
     const isWatermarkEnabled = getProp(controls, `${WATERMARK}.enabled`, false);
     if (isWatermarkEnabled) {
-        const formattedCompMessage = (
-            <FormattedCompMessage
-                id="boxui.securityControls.watermarkingAppliedWithLink"
-                description="Bullet point that summarizes watermarking applied to classification"
-            >
-                Watermarking will be applied, click{' '}
+        const formattedMessages = (
+            <>
+                <FormattedMessage {...messages.watermarkingApplied} />
                 <Link
                     className="support-link"
                     href="https://support.box.com/hc/en-us/articles/360044195253"
                     target="_blank"
                 >
-                    here
-                </Link>{' '}
-                more details on Watermarking
-            </FormattedCompMessage>
+                    <FormattedMessage {...messages.linkForMoreDetails} />
+                </Link>
+            </>
         );
-        items.push({ message: formattedCompMessage });
+        items.push({ message: formattedMessages });
     }
 
     return items;


### PR DESCRIPTION
Before
![BeforeWatermarkingCopy](https://user-images.githubusercontent.com/73257012/194653480-0f1395ae-61cf-471e-bddc-301ad19bd8f5.png)

After
![AfterWatermarkingCopy](https://user-images.githubusercontent.com/73257012/194653490-d5b9aa4b-28b7-4adc-bad7-d754ad483535.png)
