### PR TITLE
fix(content-sidebar): ThreadedComments api; handling reply edit logic

### DIFF
--- a/src/api/ThreadedComments.js
+++ b/src/api/ThreadedComments.js
@@ -276,7 +276,6 @@ class ThreadedComments extends MarkerBasedApi {
             marker,
             limit,
             requestData: {
-                file_id: fileId,
                 ...(repliesCount ? { replies_count: repliesCount } : null),
             },
             shouldFetchAll,

--- a/src/api/__tests__/ThreadedComments.test.js
+++ b/src/api/__tests__/ThreadedComments.test.js
@@ -212,7 +212,6 @@ describe('api/ThreadedComments', () => {
                 id: '12345',
                 errorCallback,
                 requestData: {
-                    file_id: '12345',
                     replies_count: 1,
                 },
                 successCallback,

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -128,6 +128,7 @@ const ActiveState = ({
         id: string,
         text: string,
         status?: FeedItemStatus,
+        hasMention?: boolean,
         permissions: BoxCommentPermission,
         onSuccess: ?Function,
         onError: ?Function,

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -33,6 +33,7 @@ type Props = {
         id: string,
         text: string,
         status?: FeedItemStatus,
+        hasMention?: boolean,
         permissions: BoxCommentPermission,
         onSuccess: ?Function,
         onError: ?Function,

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThreadContent.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThreadContent.js
@@ -9,6 +9,7 @@ import useAnnotationAPI from './useAnnotationAPI';
 
 import type { BoxItem, SelectorItems, User } from '../../../../common/types/core';
 import type { ErrorContextProps } from '../../../../common/types/api';
+import type { BoxCommentPermission, FeedItemStatus } from '../../../../common/types/feed';
 
 import './AnnotationThreadContent.scss';
 
@@ -54,6 +55,16 @@ const AnnotationThreadContent = ({
         errorCallback: onError,
     });
 
+    const onReplyEditHandler = (
+        id: string,
+        text: string,
+        status?: FeedItemStatus,
+        hasMention?: boolean,
+        replyPermissions: BoxCommentPermission,
+    ) => {
+        handleEditReply(id, text, status, replyPermissions);
+    };
+
     return (
         <ActivityThread
             hasReplies
@@ -64,7 +75,7 @@ const AnnotationThreadContent = ({
             mentionSelectorContacts={mentionSelectorContacts}
             onReplyCreate={handleCreateReply}
             onReplyDelete={handleDeleteReply}
-            onReplyEdit={handleEditReply}
+            onReplyEdit={onReplyEditHandler}
             replies={replies}
             repliesTotalCount={replies.length}
         >


### PR DESCRIPTION
- Fixed handling reply edit logic to include `hasMention` attribute in the handler ultimately passed to `Comment` component
- Fixed double `file_id` url param being created in GET requests in `ThreadedComments` API