### PR TITLE
fix(preview-sidebar): fix version not updating on small screens

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
+++ b/src/elements/content-sidebar/versions/VersionsSidebarContainer.js
@@ -95,11 +95,6 @@ class VersionsSidebarContainer extends React.Component<Props, State> {
         }
     }
 
-    componentWillUnmount() {
-        // Reset the current version id since the wrapping route is no longer active
-        this.props.onVersionChange(null);
-    }
-
     handleActionDelete = (versionId: string): Promise<void> => {
         this.setState({ isLoading: true });
 

--- a/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer.test.js
+++ b/src/elements/content-sidebar/versions/__tests__/VersionsSidebarContainer.test.js
@@ -58,17 +58,6 @@ describe('elements/content-sidebar/versions/VersionsSidebarContainer', () => {
         });
     });
 
-    describe('componentWillUnmount', () => {
-        test('should forward verison id reset to the parent component', () => {
-            const onVersionChange = jest.fn();
-            const wrapper = getWrapper({ onVersionChange });
-
-            wrapper.instance().componentWillUnmount();
-
-            expect(onVersionChange).toBeCalledWith(null);
-        });
-    });
-
     describe('componentDidMount', () => {
         test('should call onLoad after a successful fetchData() call', async () => {
             const onLoad = jest.fn();


### PR DESCRIPTION
## Overview
Currently, if a version is selected in the Preview sidebar and the Preview sidebar is closed, it reverts to the latest version of the document.

This creates problems for small screens where the Preview sidebar is moved to the bottom and becomes a vertical sliding drawer. When an old version is selected and the drawer is closed, a user cannot view the old version because, it reverts to the latest version of the document.

This PR fixes the issue by removing the version reset performed when the drawer is closed.

Note this would also affect the regular desktop experience. If a user closes the Preview Sidebar after selecting the version, it would remain on that version instead of changing back to the latest version.

## Demo
### Before
![Preview-Drawer-Before](https://user-images.githubusercontent.com/6400298/196263954-b8d9386f-7a05-412a-a06f-347675a3cfc8.gif)

### After
![Preview-Drawer-After](https://user-images.githubusercontent.com/6400298/196263999-505d40de-7bcc-40b0-9efc-989db7c5fbef.gif)
