### PR TITLE
fix(content-sidebar): reply operations interactions

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -220,7 +220,8 @@ class Feed extends Base {
             annotationId,
             permissions,
             feedItemChanges,
-            (annotation: Annotation) => {
+            // Do not update replies and total_reply_count props as their current values are not included in the response
+            ({ replies, total_reply_count, ...annotation }: Annotation) => {
                 this.updateFeedItem(
                     {
                         ...annotation,
@@ -505,9 +506,12 @@ class Feed extends Base {
 
         this.updateFeedItem({ isRepliesLoading: true }, commentFeedItemId);
 
-        const successCallbackFn = (comments: ThreadedCommentsType) => {
-            this.updateFeedItem({ isRepliesLoading: false, replies: comments.entries }, commentFeedItemId);
-            successCallback(comments.entries);
+        const successCallbackFn = ({ entries }: ThreadedCommentsType) => {
+            this.updateFeedItem(
+                { isRepliesLoading: false, replies: entries, total_reply_count: entries.length },
+                commentFeedItemId,
+            );
+            successCallback(entries);
         };
         const errorCallbackFn = (error: ErrorResponseData, code: string) => {
             this.fetchRepliesErrorCallback(error, code, commentFeedItemId);
@@ -898,11 +902,24 @@ class Feed extends Base {
             fileId: file.id,
             commentId: id,
             permissions,
-            successCallback: this.deleteReplyItem.bind(this, id, parentId, successCallback),
+            successCallback: this.deleteReplySuccessCallback.bind(this, id, parentId, successCallback),
             errorCallback: (e: ElementsXhrError, code: string) => {
                 this.deleteReplyErrorCallback(e, code, id, parentId);
             },
         });
+    };
+
+    /**
+     * Callback for successful deletion of a reply.
+     *
+     * @param {string} id - ID of the reply
+     * @param {string} parentId - ID of the parent feed item
+     * @param {Function} successCallback - success callback
+     * @return {void}
+     */
+    deleteReplySuccessCallback = (id: string, parentId: string, successCallback: Function): void => {
+        this.deleteReplyItem(id, parentId, successCallback);
+        this.modifyFeedItemRepliesCountBy(parentId, -1);
     };
 
     /**
@@ -1727,6 +1744,7 @@ class Feed extends Base {
         this.file = file;
         this.errorCallback = errorCallback;
         this.addPendingReply(parentId, currentUser, commentData);
+        this.modifyFeedItemRepliesCountBy(parentId, 1);
 
         const successCallbackFn = (comment: Comment) => {
             this.createReplySuccessCallback(comment, parentId, uuid, successCallback);
@@ -1876,7 +1894,8 @@ class Feed extends Base {
             permissions,
             message: text,
             status,
-            successCallback: (comment: Comment) => {
+            // Do not update replies and total_reply_count props as their current values are not included in the response
+            successCallback: ({ replies, total_reply_count, ...comment }: Comment) => {
                 this.updateFeedItem(
                     {
                         ...comment,
@@ -1948,6 +1967,31 @@ class Feed extends Base {
                 this.updateReplyErrorCallback(error, code, id, parentId);
             },
         });
+    };
+
+    /**
+     * Modify feed item replies count
+     *
+     * @param {string} id - id of the item
+     * @param {number} n - number to modify the count by
+     * @return {void}
+     */
+    modifyFeedItemRepliesCountBy = (id: string, n: number) => {
+        if (!this.file.id) {
+            throw getBadItemError();
+        }
+
+        const { items: feedItems = [] } = this.getCachedItems(this.file.id) || {};
+        const feedItem = feedItems.find(({ id: itemId }) => itemId === id);
+
+        if (!feedItem) {
+            return;
+        }
+
+        const newReplyCount = (feedItem.total_reply_count || 0) + n;
+        if (newReplyCount >= 0) {
+            this.updateFeedItem({ total_reply_count: newReplyCount }, id);
+        }
     };
 
     destroyTaskCollaborators() {

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -220,11 +220,11 @@ class Feed extends Base {
             annotationId,
             permissions,
             feedItemChanges,
-            // Do not update replies and total_reply_count props as their current values are not included in the response
             (annotation: Annotation) => {
                 const { replies, total_reply_count, ...annotationBase } = annotation;
                 this.updateFeedItem(
                     {
+                        // Do not update replies and total_reply_count props as their current values are not included in the response
                         ...annotationBase,
                         isPending: false,
                     },
@@ -1895,11 +1895,11 @@ class Feed extends Base {
             permissions,
             message: text,
             status,
-            // Do not update replies and total_reply_count props as their current values are not included in the response
             successCallback: (comment: Comment) => {
                 const { replies, total_reply_count, ...commentBase } = comment;
                 this.updateFeedItem(
                     {
+                        // Do not update replies and total_reply_count props as their current values are not included in the response
                         ...commentBase,
                         isPending: false,
                     },

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -221,10 +221,11 @@ class Feed extends Base {
             permissions,
             feedItemChanges,
             // Do not update replies and total_reply_count props as their current values are not included in the response
-            ({ replies, total_reply_count, ...annotation }: Annotation) => {
+            (annotation: Annotation) => {
+                const { replies, total_reply_count, ...annotationBase } = annotation;
                 this.updateFeedItem(
                     {
-                        ...annotation,
+                        ...annotationBase,
                         isPending: false,
                     },
                     annotationId,
@@ -1895,10 +1896,11 @@ class Feed extends Base {
             message: text,
             status,
             // Do not update replies and total_reply_count props as their current values are not included in the response
-            successCallback: ({ replies, total_reply_count, ...comment }: Comment) => {
+            successCallback: (comment: Comment) => {
+                const { replies, total_reply_count, ...commentBase } = comment;
                 this.updateFeedItem(
                     {
-                        ...comment,
+                        ...commentBase,
                         isPending: false,
                     },
                     commentId,
@@ -1984,7 +1986,7 @@ class Feed extends Base {
         const { items: feedItems = [] } = this.getCachedItems(this.file.id) || {};
         const feedItem = feedItems.find(({ id: itemId }) => itemId === id);
 
-        if (!feedItem) {
+        if (!feedItem || (feedItem.type !== 'annotation' && feedItem.type !== 'comment')) {
             return;
         }
 

--- a/src/elements/content-sidebar/__tests__/withSidebarAnnotations.test.js
+++ b/src/elements/content-sidebar/__tests__/withSidebarAnnotations.test.js
@@ -32,6 +32,7 @@ describe('elements/content-sidebar/withSidebarAnnotations', () => {
         deleteAnnotation: jest.fn(),
         deleteFeedItem: jest.fn(),
         deleteReplyItem: jest.fn(),
+        modifyFeedItemRepliesCountBy: jest.fn(),
         updateFeedItem: jest.fn(),
         updateReplyItem: jest.fn(),
     };
@@ -337,7 +338,7 @@ describe('elements/content-sidebar/withSidebarAnnotations', () => {
             instance.addAnnotationReply();
 
             const expectedReplyData = { ...annotationReply, isPending: false };
-            expect(feedAPI.updateFeedItem).toBeCalledWith({ total_reply_count: 3 }, annotation.id);
+            expect(feedAPI.modifyFeedItemRepliesCountBy).toBeCalledWith(annotation.id, 1);
             expect(feedAPI.updateReplyItem).toBeCalledWith(expectedReplyData, annotation.id, requestId);
         });
     });
@@ -415,7 +416,7 @@ describe('elements/content-sidebar/withSidebarAnnotations', () => {
 
             instance.deleteAnnotationReply();
 
-            expect(feedAPI.updateFeedItem).toBeCalledWith({ total_reply_count: 1 }, annotation.id);
+            expect(feedAPI.modifyFeedItemRepliesCountBy).toBeCalledWith(annotation.id, -1);
         });
 
         test('should delete appropriate reply from the feed if it is currently in the feed given action = reply_delete_end', () => {
@@ -442,6 +443,7 @@ describe('elements/content-sidebar/withSidebarAnnotations', () => {
             instance.deleteAnnotationReply();
 
             expect(feedAPI.deleteReplyItem).toBeCalledWith(annotationReply.id, annotation.id);
+            expect(feedAPI.modifyFeedItemRepliesCountBy).toBeCalledWith(annotation.id, -1);
         });
     });
 

--- a/src/elements/content-sidebar/withSidebarAnnotations.js
+++ b/src/elements/content-sidebar/withSidebarAnnotations.js
@@ -173,7 +173,7 @@ export default function withSidebarAnnotations(
                     return;
                 }
 
-                feedAPI.updateFeedItem({ total_reply_count: annotationItem.total_reply_count + 1 }, annotationId);
+                feedAPI.modifyFeedItemRepliesCountBy(annotationId, 1);
                 feedAPI.updateReplyItem({ ...annotationReply, isPending: false }, annotationId, requestId);
             }
 
@@ -223,14 +223,14 @@ export default function withSidebarAnnotations(
                     return;
                 }
 
-                // Check if the parent annotation has the reply currently visible
+                // Check if the parent annotation has the reply currently visible and if so, remove it
                 const replyItem = annotationItem.replies.find(({ id }) => id === replyId);
                 if (replyItem) {
                     feedAPI.deleteReplyItem(replyId, annotationId);
-                } else if (annotationItem.total_reply_count > 0) {
-                    // Decrease the amount of replies by 1
-                    feedAPI.updateFeedItem({ total_reply_count: annotationItem.total_reply_count - 1 }, annotationId);
                 }
+
+                // Decrease the amount of replies by 1
+                feedAPI.modifyFeedItemRepliesCountBy(annotationId, -1);
             }
 
             this.refreshActivitySidebar();


### PR DESCRIPTION
- Added `modifyFeedItemRepliesCountBy` method for changing replies count
- Used `modifyFeedItemRepliesCountBy` in the create and delete reply actions
- Refactored `withSidebarAnnotations` to also use modifyFeedItemRepliesCountBy
- Updated `updateAnnotation` and `updateThreadedComment` methods to not update the feed item with `replies` and `total_reply_count` as their values are not included in the server response