### PR TITLE
fix(threaded-replies): fix styling for replies

### DIFF
--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
@@ -18,8 +18,8 @@
         padding: 0;
     }
 
-    button:focus-visible {
-        outline: -webkit-focus-ring-color auto 1px;
+    .btn-plain:focus-visible {
+        outline: auto;
     }
 }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
@@ -1,14 +1,16 @@
 @import '../../../common/variables';
 
-.bcs-ActivityThread-toggle {
-    margin-left: $sidebarActivityFeedSpacingHorizontal;
-    color: $bdl-box-blue;
-    font-weight: bold;
-
-    &:hover,
-    &:active {
+.bcs-ActivityThread {
+    .bcs-ActivityThread-toggle {
         margin-left: $sidebarActivityFeedSpacingHorizontal;
+        color: $bdl-box-blue;
         font-weight: bold;
+
+        &:hover,
+        &:active {
+            margin-left: $sidebarActivityFeedSpacingHorizontal;
+            font-weight: bold;
+        }
     }
 }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
@@ -2,12 +2,14 @@
 
 .bcs-ActivityThread {
     .bcs-ActivityThread-toggle {
+        margin-top: -9px;
         margin-left: $sidebarActivityFeedSpacingHorizontal;
         color: $bdl-box-blue;
         font-weight: bold;
 
         &:hover,
         &:active {
+            margin-top: -9px;
             margin-left: $sidebarActivityFeedSpacingHorizontal;
             font-weight: bold;
         }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
@@ -2,17 +2,24 @@
 
 .bcs-ActivityThread {
     .bcs-ActivityThread-toggle {
-        margin-top: -9px;
-        margin-left: $sidebarActivityFeedSpacingHorizontal;
         color: $bdl-box-blue;
-        font-weight: bold;
 
+        &,
         &:hover,
         &:active {
-            margin-top: -9px;
+            margin-top: -$bdl-grid-unit * 2; // to decreased spacing with parent comment
             margin-left: $sidebarActivityFeedSpacingHorizontal;
             font-weight: bold;
         }
+    }
+
+    .bcs-ActivityCard {
+        margin: $sidebarActivityFeedSpacingVertical $sidebarActivityFeedSpacingHorizontal;
+        padding: 0;
+    }
+
+    button:focus-visible {
+        outline: -webkit-focus-ring-color auto 1px;
     }
 }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.scss
@@ -6,12 +6,12 @@
 
     &::before {
         position: absolute;
-        top: $sidebarActivityFeedSpacingVertical;
-        bottom: $sidebarActivityFeedSpacingVertical;
+        top: 0;
+        bottom: 0;
         left: $sidebarActivityFeedSpacingHorizontal;
-        width: 4px;
+        width: $bdl-grid-unit;
         background: $bdl-gray-10;
-        border-radius: 2px;
+        border-radius: $bdl-border-radius-size;
         content: '';
     }
 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.scss
@@ -6,11 +6,17 @@
 
     &::before {
         position: absolute;
-        top: $sidebarActivityFeedSpacingVertical;
-        bottom: $sidebarActivityFeedSpacingVertical;
+        top: 0;
+        bottom: 0;
         left: $sidebarActivityFeedSpacingHorizontal;
         width: 4px;
         background: $bdl-gray-10;
+        border-radius: 2px;
         content: '';
+    }
+
+    .bcs-Comment {
+        margin: $sidebarActivityFeedSpacingVertical $sidebarActivityFeedSpacingHorizontal;
+        padding: 0;
     }
 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.scss
@@ -6,17 +6,12 @@
 
     &::before {
         position: absolute;
-        top: 0;
-        bottom: 0;
+        top: $sidebarActivityFeedSpacingVertical;
+        bottom: $sidebarActivityFeedSpacingVertical;
         left: $sidebarActivityFeedSpacingHorizontal;
         width: 4px;
         background: $bdl-gray-10;
         border-radius: 2px;
         content: '';
-    }
-
-    .bcs-Comment {
-        margin: $sidebarActivityFeedSpacingVertical $sidebarActivityFeedSpacingHorizontal;
-        padding: 0;
     }
 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
@@ -1,12 +1,15 @@
 @import '../../../common/variables';
 
-.bcs-ActivityThreadReplyForm-toggle {
+.btn-plain.bcs-ActivityThreadReplyForm-toggle {
     display: flex;
     align-items: center;
+    color: $bdl-gray-62;
+    font-weight: bold;
 
     &,
     &:hover {
         padding: $bdl-grid-unit $sidebarActivityFeedSpacingHorizontal ($bdl-grid-unit * 5);
+        font-weight: bold;
     }
 
     .bcs-ActivityThreadReplyForm-arrow {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
@@ -1,6 +1,6 @@
 @import '../../../common/variables';
 
-.btn-plain.bcs-ActivityThreadReplyForm-toggle {
+.bcs-ActivityThreadReplyForm-toggle {
     display: flex;
     align-items: center;
     color: $bdl-gray-62;
@@ -8,13 +8,19 @@
     &,
     &:hover {
         padding: $bdl-grid-unit $sidebarActivityFeedSpacingHorizontal ($bdl-grid-unit * 5);
-        font-weight: bold;
     }
 
     .bcs-ActivityThreadReplyForm-arrow {
         margin-right: $bdl-grid-unit;
         // in design arrow is turning left, but we only have ArrowArcRight, so will transfrom it to left one
         transform: matrix(-1, 0, 0, 1, 0, 0);
+    }
+}
+
+.btn-plain.bcs-ActivityThreadReplyForm-toggle {
+    &,
+    &:hover {
+        font-weight: bold;
     }
 }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
@@ -4,7 +4,6 @@
     display: flex;
     align-items: center;
     color: $bdl-gray-62;
-    font-weight: bold;
 
     &,
     &:hover {


### PR DESCRIPTION
- Round up the gray vertical line for replies in thread
- Make the “hide replies” and “show replies” button to be bold
- Make the “Reply” button to be bolded, and be $bdl-gray-62 (#767676)
- Decrease the space between replies
- Decrease space above "See more replies" button to 16px