### PR TITLE
feat(checkbox): allow stopPropagation on onClick events

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -33,6 +33,8 @@ export interface CheckboxProps {
           };
     /** onChange - change callback function that takes the event as the argument */
     onChange?: (e: React.SyntheticEvent<HTMLInputElement, Event>) => string | number | boolean | void;
+    /** Stops propagation when the checkbox container is clicked */
+    shouldStopPropagationOnClick?: boolean;
     /** Subsection below the checkbox */
     subsection?: React.ReactNode;
     /** Tooltip text next to the checkbox label */
@@ -52,6 +54,7 @@ const Checkbox = ({
     label,
     name,
     onChange,
+    shouldStopPropagationOnClick,
     subsection,
     tooltip,
     ...rest // @TODO: eventually remove `rest` in favor of explicit props
@@ -59,6 +62,12 @@ const Checkbox = ({
     const generatedID = React.useRef(uniqueId('checkbox')).current;
     // use passed-in ID from props; otherwise generate one
     const inputID = id || generatedID;
+
+    const handleOnClick = (e: React.SyntheticEvent<HTMLDivElement>) => {
+        if (shouldStopPropagationOnClick) {
+            e.stopPropagation();
+        }
+    };
 
     const checkboxAndLabel = (
         <span className="checkbox-label">
@@ -83,7 +92,12 @@ const Checkbox = ({
     );
 
     return (
-        <div className={classNames('checkbox-container', className, { 'is-disabled bdl-is-disabled': isDisabled })}>
+        /* The <div> element has a child <input type="checkbox"> element that allows keyboard interaction */
+        /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+        <div
+            className={classNames('checkbox-container', className, { 'is-disabled bdl-is-disabled': isDisabled })}
+            onClick={handleOnClick}
+        >
             {fieldLabel && <div className="label">{fieldLabel}</div>}
             {checkboxAndLabel}
             {description ? (

--- a/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -1,5 +1,6 @@
 import React, { SyntheticEvent } from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import Checkbox from '..';
 
@@ -84,5 +85,31 @@ describe('components/checkbox/Checkbox', () => {
         const label = wrapper.find('.label');
         expect(label.length).toBe(1);
         expect(label.contains(fieldLabel)).toBe(true);
+    });
+
+    test('should call outer function when shouldStopPropagationOnClick is false', () => {
+        const outerClickFunc = jest.fn();
+        render(
+            /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+            <div onClick={outerClickFunc}>
+                <Checkbox id="1" label="Check things" name="name" onChange={onChange} />
+            </div>,
+        );
+
+        fireEvent.click(screen.getByRole('checkbox'));
+        expect(outerClickFunc).toHaveBeenCalled();
+    });
+
+    test('should not call outer function when shouldStopPropagationOnClick is true', () => {
+        const outerClickFunc = jest.fn();
+        render(
+            /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+            <div onClick={outerClickFunc}>
+                <Checkbox id="1" label="Check things" name="name" onChange={onChange} shouldStopPropagationOnClick />
+            </div>,
+        );
+
+        fireEvent.click(screen.getByRole('checkbox'));
+        expect(outerClickFunc).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
- Add `shouldStopPropagationOnClick` to `Checkbox` component to allow for `stopPropagation` to be called in an `onClick` event. This allows outside `onClick` events to not be called when the checkbox is clicked