### PR TITLE
fix(content-sidebar): reply operations interactions

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -523,6 +523,24 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     };
 
     /**
+     * Updates replies of a comment or annotation in the Feed
+     *
+     * @param {string} id - id of the feed item
+     * @param {Array<Comment>} replies - replies
+     * @return {void}
+     */
+    updateReplies = (id: string, replies: Array<Comment>) => {
+        const { api, file } = this.props;
+
+        const feedAPI = api.getFeedAPI(false);
+
+        feedAPI.file = file;
+        feedAPI.updateFeedItem({ replies }, id);
+
+        this.fetchFeedItems();
+    };
+
+    /**
      * Handles a successful update of a reply
      *
      * @private
@@ -999,6 +1017,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     onCommentCreate={this.createComment}
                     onCommentDelete={this.deleteComment}
                     onCommentUpdate={this.updateComment}
+                    onHideReplies={this.updateReplies}
                     onReplyCreate={this.createReply}
                     onReplyDelete={this.deleteReply}
                     onReplyUpdate={this.updateReply}

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import cloneDeep from 'lodash/cloneDeep';
 import { ActivitySidebarComponent, activityFeedInlineError } from '../ActivitySidebar';
-import { filterableActivityFeedItems } from '../fixtures';
+import { filterableActivityFeedItems, formattedReplies } from '../fixtures';
 import { FEED_ITEM_TYPE_COMMENT } from '../../../constants';
 
 jest.mock('lodash/debounce', () => jest.fn(i => i));
@@ -25,6 +25,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         fetchReplies: jest.fn(),
         updateAnnotation: jest.fn(),
         updateComment: jest.fn(),
+        updateFeedItem: jest.fn(),
         updateReply: jest.fn(),
         updateTaskCollaborator: jest.fn(),
         updateTaskNew: jest.fn(),
@@ -539,6 +540,23 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 parentId,
                 true,
             );
+        });
+    });
+
+    describe('updateReplies()', () => {
+        test('should call updateFeedItem API', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+
+            const id = '123';
+            const replies = cloneDeep(formattedReplies);
+
+            instance.fetchFeedItems = jest.fn();
+
+            instance.updateReplies(id, replies);
+
+            expect(api.getFeedAPI().updateFeedItem).toBeCalledWith({ replies }, id);
+            expect(instance.fetchFeedItems).toBeCalled();
         });
     });
 

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
@@ -60,6 +60,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
     onCommentCreate={[Function]}
     onCommentDelete={[Function]}
     onCommentUpdate={[Function]}
+    onHideReplies={[Function]}
     onReplyCreate={[Function]}
     onReplyDelete={[Function]}
     onReplyUpdate={[Function]}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -24,6 +24,7 @@ import type {
     Annotation,
     AnnotationPermission,
     BoxCommentPermission,
+    Comment as CommentType,
     CommentFeedItemType,
     FeedItem,
     FeedItems,
@@ -63,6 +64,7 @@ type Props = {
         onSuccess: ?Function,
         onError: ?Function,
     ) => void,
+    onHideReplies?: (id: string, replies: Array<CommentType>) => void,
     onReplyCreate?: (parentId: string, parentType: CommentFeedItemType, text: string) => void,
     onReplyDelete?: ({ id: string, parentId: string, permissions: BoxCommentPermission }) => void,
     onReplyUpdate?: (
@@ -90,10 +92,13 @@ const ActiveState = ({
     approverSelectorContacts,
     currentFileVersionId,
     currentUser,
+    getApproverWithQuery,
+    getAvatarUrl,
+    getMentionWithQuery,
+    getUserProfileUrl,
     hasReplies = false,
     items,
     mentionSelectorContacts,
-    getMentionWithQuery,
     onAnnotationDelete,
     onAnnotationEdit,
     onAnnotationSelect,
@@ -101,23 +106,24 @@ const ActiveState = ({
     onAppActivityDelete,
     onCommentDelete,
     onCommentEdit,
+    onHideReplies = noop,
     onReplyCreate = noop,
     onReplyDelete = noop,
     onReplyUpdate = noop,
     onShowReplies = noop,
+    onTaskAssignmentUpdate,
     onTaskDelete,
     onTaskEdit,
-    onTaskView,
-    onTaskAssignmentUpdate,
     onTaskModalClose,
+    onTaskView,
     onVersionInfo,
     translations,
-    getApproverWithQuery,
-    getAvatarUrl,
-    getUserProfileUrl,
 }: Props): React.Node => {
     const activeEntry = items.find(({ id, type }) => id === activeFeedEntryId && type === activeFeedEntryType);
 
+    const onHideRepliesHandler = (parentId: string) => (lastReply: CommentType) => {
+        onHideReplies(parentId, [lastReply]);
+    };
     const onReplyCreateHandler = (parentId: string, parentType: CommentFeedItemType) => (text: string) => {
         onReplyCreate(parentId, parentType, text);
     };
@@ -164,6 +170,7 @@ const ActiveState = ({
                                     hasReplies={hasReplies}
                                     isRepliesLoading={item.isRepliesLoading}
                                     mentionSelectorContacts={mentionSelectorContacts}
+                                    onHideReplies={onHideRepliesHandler(item.id)}
                                     onReplyCreate={onReplyCreateHandler(item.id, item.type)}
                                     onReplyDelete={onReplyDeleteHandler(item.id)}
                                     onReplyEdit={onReplyUpdateHandler(item.id)}
@@ -257,6 +264,7 @@ const ActiveState = ({
                                     hasReplies={hasReplies}
                                     isRepliesLoading={item.isRepliesLoading}
                                     mentionSelectorContacts={mentionSelectorContacts}
+                                    onHideReplies={onHideRepliesHandler(item.id)}
                                     onReplyCreate={onReplyCreateHandler(item.id, item.type)}
                                     onReplyDelete={onReplyDeleteHandler(item.id)}
                                     onReplyEdit={onReplyUpdateHandler(item.id)}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -21,6 +21,7 @@ import type {
     Annotation,
     AnnotationPermission,
     BoxCommentPermission,
+    Comment,
     CommentFeedItemType,
     FocusableFeedItemType,
     FeedItems,
@@ -63,6 +64,7 @@ type Props = {
         onSuccess: ?Function,
         onError: ?Function,
     ) => void,
+    onHideReplies?: (id: string, replies: Array<Comment>) => void,
     onReplyCreate?: (parentId: string, parentType: CommentFeedItemType, text: string) => void,
     onReplyDelete?: ({ id: string, parentId: string, permissions: BoxCommentPermission }) => void,
     onReplyUpdate?: (
@@ -247,6 +249,7 @@ class ActivityFeed extends React.Component<Props, State> {
             onCommentCreate,
             onCommentDelete,
             onCommentUpdate,
+            onHideReplies,
             onReplyCreate,
             onReplyDelete,
             onReplyUpdate,
@@ -329,6 +332,7 @@ class ActivityFeed extends React.Component<Props, State> {
                             onAppActivityDelete={onAppActivityDelete}
                             onCommentDelete={hasCommentPermission ? onCommentDelete : noop}
                             onCommentEdit={hasCommentPermission ? onCommentUpdate : noop}
+                            onHideReplies={onHideReplies}
                             onReplyCreate={hasCommentPermission ? onReplyCreate : noop}
                             onReplyDelete={hasCommentPermission ? onReplyDelete : noop}
                             onReplyUpdate={hasCommentPermission ? onReplyUpdate : noop}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.js
@@ -68,7 +68,9 @@ const ActivityThread = ({
     const repliesToLoadCount = Math.max(repliesTotalCount - repliesLength, 0);
 
     const onHideRepliesHandler = () => {
-        onHideReplies(replies[repliesLength - 1]);
+        if (repliesLength) {
+            onHideReplies(replies[repliesLength - 1]);
+        }
     };
 
     const renderButton = () => {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
@@ -45,7 +45,7 @@ const ActivityThreadReplies = ({
         <div className="bcs-ActivityThreadReplies" data-testid="activity-thread-replies">
             {replies.map((reply: CommentType) => (
                 <Comment
-                    key={reply.type + reply.id}
+                    key={`${reply.type}${reply.id}`}
                     {...reply}
                     currentUser={currentUser}
                     getAvatarUrl={getAvatarUrl}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
@@ -14,7 +14,6 @@ type Props = {
     getAvatarUrl: GetAvatarUrlCallback,
     getMentionWithQuery?: Function,
     getUserProfileUrl?: GetProfileUrlCallback,
-    isExpanded: boolean,
     mentionSelectorContacts?: SelectorItems<>,
     onDelete?: Function,
     onEdit?: Function,
@@ -27,15 +26,12 @@ const ActivityThreadReplies = ({
     getAvatarUrl,
     getMentionWithQuery,
     getUserProfileUrl,
-    isExpanded,
     mentionSelectorContacts,
     onDelete,
     onEdit,
     replies,
     translations,
 }: Props) => {
-    const lastReply = replies[replies.length - 1];
-
     const getReplyPermissions = (reply: CommentType): BoxCommentPermission => {
         const { permissions: { can_delete = false, can_edit = false, can_resolve = false } = {} } = reply;
         return {
@@ -47,10 +43,10 @@ const ActivityThreadReplies = ({
 
     return (
         <div className="bcs-ActivityThreadReplies" data-testid="activity-thread-replies">
-            {!isExpanded ? (
+            {replies.map((reply: CommentType) => (
                 <Comment
-                    key={lastReply.type + lastReply.id}
-                    {...lastReply}
+                    key={reply.type + reply.id}
+                    {...reply}
                     currentUser={currentUser}
                     getAvatarUrl={getAvatarUrl}
                     getMentionWithQuery={getMentionWithQuery}
@@ -58,26 +54,10 @@ const ActivityThreadReplies = ({
                     mentionSelectorContacts={mentionSelectorContacts}
                     onDelete={onDelete}
                     onEdit={onEdit}
-                    permissions={getReplyPermissions(lastReply)}
+                    permissions={getReplyPermissions(reply)}
                     translations={translations}
                 />
-            ) : (
-                replies.map((reply: CommentType) => (
-                    <Comment
-                        key={reply.type + reply.id}
-                        {...reply}
-                        currentUser={currentUser}
-                        getAvatarUrl={getAvatarUrl}
-                        getMentionWithQuery={getMentionWithQuery}
-                        getUserProfileUrl={getUserProfileUrl}
-                        mentionSelectorContacts={mentionSelectorContacts}
-                        onDelete={onDelete}
-                        onEdit={onEdit}
-                        permissions={getReplyPermissions(reply)}
-                        translations={translations}
-                    />
-                ))
-            )}
+            ))}
         </div>
     );
 };

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -39,7 +39,7 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         expect(getByText('Test')).toBeVisible();
     });
 
-    test('should call onShowReplies on button click if total replies is greater than the number of replies in Feed', () => {
+    test('should render button and call onShowReplies on click if total replies is greater than the number of replies in Feed', () => {
         const onShowReplies = jest.fn();
         const replies = [cloneDeep(repliesMock[0])];
         const { getByText } = getWrapper({ onShowReplies, replies });
@@ -51,7 +51,7 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         expect(onShowReplies).toBeCalled();
     });
 
-    test('should call onHideReplies on button click if total replies is equal to the number of replies in Feed', () => {
+    test('should render button and call onHideReplies on click if total replies is equal to the number of replies in Feed', () => {
         const onHideReplies = jest.fn();
         const lastReply = cloneDeep(repliesMock[repliesMock.length - 1]);
         const { getByText } = getWrapper({ onHideReplies });
@@ -63,10 +63,17 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         expect(onHideReplies).toBeCalledWith(lastReply);
     });
 
-    test('should not render button if total_reply_count is 1 or less', () => {
-        const { queryByTestId } = getWrapper({ repliesTotalCount: 1 });
-        expect(queryByTestId('activity-thread-button')).not.toBeInTheDocument();
-    });
+    test.each`
+        repliesTotalCount | replies
+        ${0}              | ${[]}
+        ${1}              | ${[{ id: 1 }]}
+    `(
+        'should not render button if repliesTotalCount = $repliesTotalCount and replies = $replies',
+        ({ replies, repliesTotalCount }) => {
+            const { queryByTestId } = getWrapper({ replies, repliesTotalCount });
+            expect(queryByTestId('activity-thread-button')).not.toBeInTheDocument();
+        },
+    );
 
     test('should not render replies if there is no replies', () => {
         const { queryByTestId } = getWrapper({ replies: [] });

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThread.test.js
@@ -1,10 +1,11 @@
 // @flow
 import React from 'react';
+import cloneDeep from 'lodash/cloneDeep';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import ActivityThread from '../ActivityThread.js';
 import localize from '../../../../../../test/support/i18n';
-import { replies } from '../fixtures';
+import { replies as repliesMock } from '../fixtures';
 import messages from '../messages';
 
 jest.mock('react-intl', () => jest.requireActual('react-intl'));
@@ -13,13 +14,16 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         return <IntlProvider locale="en">{children}</IntlProvider>;
     };
 
-    const getWrapper = props =>
-        render(
+    const getWrapper = props => {
+        const replies = cloneDeep(repliesMock);
+
+        return render(
             <ActivityThread replies={replies} repliesTotalCount={2} hasReplies {...props}>
                 Test
             </ActivityThread>,
             { wrapper: Wrapper },
         );
+    };
 
     test('should render children component wrapped in ActivityThread if hasReplies is true', () => {
         getWrapper();
@@ -35,16 +39,28 @@ describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThrea
         expect(getByText('Test')).toBeVisible();
     });
 
-    test('should call onShowReplies on button click', () => {
+    test('should call onShowReplies on button click if total replies is greater than the number of replies in Feed', () => {
         const onShowReplies = jest.fn();
-        const { getByText } = getWrapper({ onShowReplies });
+        const replies = [cloneDeep(repliesMock[0])];
+        const { getByText } = getWrapper({ onShowReplies, replies });
 
         const button = getByText(localize(messages.showReplies.id, { repliesToLoadCount: 1 }));
         expect(button).toBeVisible();
         fireEvent.click(button);
 
         expect(onShowReplies).toBeCalled();
-        expect(getByText(localize(messages.hideReplies.id))).toBeVisible();
+    });
+
+    test('should call onHideReplies on button click if total replies is equal to the number of replies in Feed', () => {
+        const onHideReplies = jest.fn();
+        const lastReply = cloneDeep(repliesMock[repliesMock.length - 1]);
+        const { getByText } = getWrapper({ onHideReplies });
+
+        const button = getByText(localize(messages.hideReplies.id));
+        expect(button).toBeVisible();
+        fireEvent.click(button);
+
+        expect(onHideReplies).toBeCalledWith(lastReply);
     });
 
     test('should not render button if total_reply_count is 1 or less', () => {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadReplies.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityThreadReplies.test.js
@@ -8,15 +8,8 @@ import { replies } from '../fixtures';
 describe('src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies', () => {
     const getWrapper = props => render(<ActivityThreadReplies replies={replies} isExpanded={false} {...props} />);
 
-    test('should render last reply by default', () => {
+    test('should render all replies', () => {
         const { queryByText } = getWrapper();
-
-        expect(queryByText(replies[1].message)).toBeVisible();
-        expect(queryByText(replies[0].message)).not.toBeInTheDocument();
-    });
-
-    test('should render all replies if isExpanded is true', () => {
-        const { queryByText } = getWrapper({ isExpanded: true });
 
         expect(queryByText(replies[1].message)).toBeVisible();
         expect(queryByText(replies[0].message)).toBeVisible();

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/__snapshots__/ActiveState.test.js.snap
@@ -58,6 +58,7 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
       }
       data-testid="activity-thread"
       hasReplies={false}
+      onHideReplies={[Function]}
       onReplyCreate={[Function]}
       onReplyDelete={[Function]}
       onReplyEdit={[Function]}
@@ -112,6 +113,7 @@ exports[`elements/content-sidebar/ActiveState/activity-feed/ActiveState should r
       }
       data-testid="activity-thread"
       hasReplies={false}
+      onHideReplies={[Function]}
       onReplyCreate={[Function]}
       onReplyDelete={[Function]}
       onReplyEdit={[Function]}

--- a/src/elements/content-sidebar/fixtures.js
+++ b/src/elements/content-sidebar/fixtures.js
@@ -180,6 +180,70 @@ export const filterableActivityFeedItems = {
     },
 };
 
+export const formattedReplies = [
+    {
+        created_at: '1970-01-01T00:00:00.002Z',
+        created_by: {
+            id: '11',
+            type: 'user',
+            name: 'u2_name',
+            login: 'u2@box.com',
+        },
+        id: '21',
+        item: {
+            type: 'file',
+            id: 'f1',
+        },
+        tagged_message: '@[u1:Mateusz Mamczarz] Yes, they really are!',
+        modified_at: '1970-01-01T00:00:00.002Z',
+        type: 'comment',
+        parent: {
+            id: 'c1',
+            type: 'comment',
+        },
+        permissions: {
+            can_delete: false,
+            can_edit: false,
+            can_reply: false,
+            can_resolve: true,
+        },
+        replies: [],
+        total_reply_count: 0,
+        status: 'open',
+    },
+    {
+        created_at: '1970-01-01T00:00:00.002Z',
+        created_by: {
+            id: '11',
+            type: 'user',
+            name: 'u2_name',
+            login: 'u2@box.com',
+        },
+        id: '22',
+        item: {
+            type: 'file',
+            id: 'f1',
+        },
+        tagged_message: '@[u1:Mateusz Mamczarz] Yes, they really are!',
+        modified_at: '1970-01-01T00:00:00.002Z',
+        type: 'comment',
+        parent: {
+            id: 'c1',
+            type: 'comment',
+        },
+        permissions: {
+            can_delete: false,
+            can_edit: false,
+            can_reply: false,
+            can_resolve: true,
+        },
+        replies: [],
+        total_reply_count: 0,
+        status: 'open',
+    },
+];
+
 export default {
     filterableActivityFeedItems,
+    formattedReplies,
 };


### PR DESCRIPTION
Changed the logic of hiding replies in a thread to removing them (leaving just the last one) from the Feed instead of displaying last one based on the internal `isExpanded` state in `ActivityThread`.

This allows to meet the requirement of displaying multiple replies when the thread is not expanded.