### PR TITLE
feat(menu): Allow stop propagation on menu click

### DIFF
--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -51,6 +51,7 @@ interface MenuProps {
     setRef?: Function;
     /** shouldOutlineFocus - whether the focused menu item should have an outline */
     shouldOutlineFocus?: boolean;
+    shouldStopPropagationOnClick?: boolean;
     /** tabIndex - indicator of whether the menu is focusable */
     tabIndex?: number;
 }
@@ -202,6 +203,12 @@ class Menu extends React.Component<MenuProps> {
     };
 
     handleClick = (event: React.MouseEvent<HTMLUListElement, MouseEvent>) => {
+        const { shouldStopPropagationOnClick } = this.props;
+
+        if (shouldStopPropagationOnClick) {
+            event.stopPropagation();
+        }
+
         const { menuItemEl }: { menuItemEl?: HTMLElement | null } =
             event.target instanceof Node ? this.getMenuItemElFromEventTarget(event.target) : {};
 

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -51,6 +51,7 @@ interface MenuProps {
     setRef?: Function;
     /** shouldOutlineFocus - whether the focused menu item should have an outline */
     shouldOutlineFocus?: boolean;
+    /** shouldStopPropagationOnClick - whether we should stop propagation on menu click */
     shouldStopPropagationOnClick?: boolean;
     /** tabIndex - indicator of whether the menu is focusable */
     tabIndex?: number;
@@ -290,7 +291,13 @@ class Menu extends React.Component<MenuProps> {
     render() {
         const { children, className, isHidden, setRef, shouldOutlineFocus, ...rest } = this.props;
 
-        const menuProps = omit(rest, ['onClose', 'initialFocusIndex', 'isSubmenu', 'menuItemSelector']) as MenuProps;
+        const menuProps = omit(rest, [
+            'onClose',
+            'initialFocusIndex',
+            'isSubmenu',
+            'menuItemSelector',
+            'shouldStopPropagationOnClick',
+        ]) as MenuProps;
         menuProps.className = classNames('aria-menu', className, {
             'is-hidden': isHidden,
             'should-outline-focus': shouldOutlineFocus,

--- a/src/components/menu/__tests__/Menu.test.tsx
+++ b/src/components/menu/__tests__/Menu.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import { fireEvent, render, screen } from '@testing-library/react';
 import sinon from 'sinon';
 
 import Menu from '../Menu';
@@ -264,9 +265,43 @@ describe('components/menu/Menu', () => {
             });
         });
 
+        test('should call outer function onClick when shouldStopPropagationOnClick is false', () => {
+            const outerClickFunc = jest.fn();
+
+            render(
+                /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+                <div onClick={outerClickFunc}>
+                    <Menu>
+                        <li role="menuitem" />
+                    </Menu>
+                    ,
+                </div>,
+            );
+
+            fireEvent.click(screen.getByRole('menu'));
+            expect(outerClickFunc).toHaveBeenCalled();
+        });
+
+        test('should not call outer function onClick when shouldStopPropagationOnClick is true', () => {
+            const outerClickFunc = jest.fn();
+
+            render(
+                /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+                <div onClick={outerClickFunc}>
+                    <Menu shouldStopPropagationOnClick>
+                        <li role="menuitem" />
+                    </Menu>
+                    ,
+                </div>,
+            );
+
+            fireEvent.click(screen.getByRole('menu'));
+            expect(outerClickFunc).not.toHaveBeenCalled();
+        });
+
         test('should call fireOnCloseHandler() when click occurred on a valid menu item', () => {
             const wrapper = mount(
-                <Menu>
+                <Menu data>
                     <li role="menuitem" />
                     <li role="separator" />
                 </Menu>,

--- a/src/components/menu/__tests__/Menu.test.tsx
+++ b/src/components/menu/__tests__/Menu.test.tsx
@@ -301,7 +301,7 @@ describe('components/menu/Menu', () => {
 
         test('should call fireOnCloseHandler() when click occurred on a valid menu item', () => {
             const wrapper = mount(
-                <Menu data>
+                <Menu>
                     <li role="menuitem" />
                     <li role="separator" />
                 </Menu>,


### PR DESCRIPTION
Add prop `shouldStopPropagationOnClick` to allow `stopPropagation` to be called on menu click