### PR TITLE
fix(menu): fix long title in menu header

### DIFF
--- a/src/components/menu/MenuHeader.scss
+++ b/src/components/menu/MenuHeader.scss
@@ -23,11 +23,9 @@
     @include bdl-lineClamp;
 
     margin: 0;
-    overflow: hidden;
     color: $bdl-gray;
     font-weight: bold;
     font-size: 16px;
-    text-overflow: ellipsis;
 }
 
 .bdl-MenuHeader-subtitle {

--- a/src/components/menu/MenuHeader.scss
+++ b/src/components/menu/MenuHeader.scss
@@ -20,6 +20,8 @@
 }
 
 .bdl-MenuHeader-title {
+    @include bdl-lineClamp;
+
     margin: 0;
     overflow: hidden;
     color: $bdl-gray;


### PR DESCRIPTION
## Summary of change
Apply new `bdl-lineClamp` mixin to menu header title.

## Demo
More options menu in full screen
### Before:
<img width="319" alt="before" src="https://user-images.githubusercontent.com/17888863/199827728-75913755-1fe2-4936-b747-2d78b7f0fbc5.png">

### After:
<img width="318" alt="after" src="https://user-images.githubusercontent.com/17888863/199827742-8ef551d5-4b43-4448-bae0-4f50af10ef77.png">
