### PR TITLE
feat(left-nav): Update medium width in _sizes.media.scss

### DIFF
--- a/src/features/collapsible-sidebar/CollapsibleSidebar.scss
+++ b/src/features/collapsible-sidebar/CollapsibleSidebar.scss
@@ -111,13 +111,7 @@ $left-sidebar-z-index: 40 !default;
     }
 }
 
-@include large-size {
-    .bdl-CollapsibleSidebar-logo {
-        margin-left: $collapsible-side-bar-h-padding + $bdl-grid-unit * 2 - 1px /* border */;
-    }
-}
-
-@include medium-minus-size {
+@include breakpoint($xlarge-screen) {
     .bdl-CollapsibleSidebar-logo {
         .bdl-CollapsibleSidebar-toggleButton {
             display: block;

--- a/src/features/collapsible-sidebar/CollapsibleSidebar.scss
+++ b/src/features/collapsible-sidebar/CollapsibleSidebar.scss
@@ -7,6 +7,7 @@ $collapsible-side-bar-collapsed-width: 68px;
 $collapsible-side-bar-h-padding: $bdl-grid-unit * 3;
 $collapsible-side-bar-v-padding: $bdl-grid-unit * 3;
 $collaspsible-side-bar-logo-v-margin: $collapsible-side-bar-v-padding + $bdl-grid-unit;
+$collaspsible-side-bar-logo-h-margin-left: $collapsible-side-bar-h-padding + $bdl-grid-unit * 2 - 1px;
 $left-sidebar-z-index: 40 !default;
 
 .bdl-CollapsibleSidebar-wrapper {
@@ -50,7 +51,7 @@ $left-sidebar-z-index: 40 !default;
     // TODO: is there a grid-based value for this sizing?
     // fixed height is to keep the menu in the same spot vertically when Box logo is hidden
     height: 32px + $collapsible-side-bar-v-padding + 4 * 1px; // logo height + padding + border
-    margin: $collaspsible-side-bar-logo-v-margin -1px $collaspsible-side-bar-logo-v-margin $collapsible-side-bar-h-padding - 1px;
+    margin: $collaspsible-side-bar-logo-v-margin -1px $collaspsible-side-bar-logo-v-margin $collaspsible-side-bar-logo-h-margin-left;
     overflow-x: hidden;
 
     .bdl-CollapsibleSidebar-toggleButton {
@@ -113,6 +114,8 @@ $left-sidebar-z-index: 40 !default;
 
 @include breakpoint($xlarge-screen) {
     .bdl-CollapsibleSidebar-logo {
+        margin-left: $collapsible-side-bar-h-padding - 1px;
+
         .bdl-CollapsibleSidebar-toggleButton {
             display: block;
         }

--- a/src/styles/_sizes.media.scss
+++ b/src/styles/_sizes.media.scss
@@ -1,7 +1,7 @@
 $small-width: 480px;
 $single-column-width: 693px;
 $sidebar-toggle-width: 1038px;
-$medium-width: 1219px;
+$medium-width: 1220px;
 $preview-small-width: 849px;
 $preview-medium-width: 1000px;
 

--- a/src/styles/_sizes.media.scss
+++ b/src/styles/_sizes.media.scss
@@ -1,7 +1,7 @@
 $small-width: 480px;
 $single-column-width: 693px;
 $sidebar-toggle-width: 1038px;
-$medium-width: 1220px;
+$medium-width: 1219px;
 $preview-small-width: 849px;
 $preview-medium-width: 1000px;
 


### PR DESCRIPTION
### Current behavior

- 1220 
    - Hamburger menu (correctly doesn't work)
    - Left nav overlaps content (should push right content over)
- 1221+
     - page layout shifts into largest size layout (sidebar auto expands and right content shifts to the right)

![File2022-11-08 at 09 25 22](https://user-images.githubusercontent.com/16271040/200591497-57da06ff-906e-43de-a7ba-afd8adf63579.gif)


### Desired behavior

- 1219 
    - Hamburger menu
    - Left nav should overlap content
- 1220+
     - page layout should shift into largest size. (sidebar auto expands and right content shifts to the right)
     - No hamburger menu
     
    
![File2022-11-08 at 09 31 01](https://user-images.githubusercontent.com/16271040/200591744-57f8697f-c62f-4ba5-9f69-b73145e134f9.gif)
