### PR TITLE
feat(content-sidebar): added support for active comment reply

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -463,6 +463,51 @@ class Feed extends Base {
     }
 
     /**
+     * Fetches a comment for a file
+     *
+     * @param {BoxItem} file - The file to which the comment belongs to
+     * @param {string} commentId - comment id
+     * @param {Function} successCallback
+     * @param {ErrorCallback} errorCallback
+     * @return {Promise} - the file comments
+     */
+    fetchThreadedComment(
+        file: BoxItem,
+        commentId: string,
+        successCallback: (comment: Comment) => void,
+        errorCallback: ErrorCallback,
+    ): Promise<?Comment> {
+        const { id, permissions } = file;
+        if (!id || !permissions) {
+            throw getBadItemError();
+        }
+
+        this.threadedCommentsAPI = new ThreadedCommentsAPI(this.options);
+        return new Promise(resolve => {
+            this.threadedCommentsAPI.getComment({
+                commentId,
+                errorCallback,
+                fileId: id,
+                permissions,
+                successCallback: this.fetchThreadedCommentSuccessCallback.bind(this, resolve, successCallback),
+            });
+        });
+    }
+
+    /**
+     * Callback for successful fetch of a comment
+     *
+     * @param {Function} resolve - resolve function
+     * @param {Function} successCallback - success callback
+     * @param {Comment} comment - comment data
+     * @return {void}
+     */
+    fetchThreadedCommentSuccessCallback = (resolve: Function, successCallback: Function, comment: Comment): void => {
+        successCallback(comment);
+        resolve();
+    };
+
+    /**
      * Fetches the comments with replies for a file
      *
      * @param {Object} permissions - the file permissions

--- a/src/api/ThreadedComments.js
+++ b/src/api/ThreadedComments.js
@@ -229,6 +229,45 @@ class ThreadedComments extends MarkerBasedApi {
     }
 
     /**
+     * API for fetching comment
+     *
+     * @param {string} commentId - comment id
+     * @param {string} fileId - the file id
+     * @param {BoxItemPermission} permissions - the permissions for the file
+     * @param {Function} successCallback - the success callback
+     * @param {Function} errorCallback - the error callback
+     * @returns {void}
+     */
+    getComment({
+        commentId,
+        errorCallback,
+        fileId,
+        permissions,
+        successCallback,
+    }: {
+        commentId: string,
+        errorCallback: (e: ElementsXhrError, code: string) => void,
+        fileId: string,
+        permissions: BoxItemPermission,
+        successCallback: (comment: Comment) => void,
+    }): void {
+        this.errorCode = ERROR_CODE_FETCH_COMMENTS;
+        try {
+            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileId);
+        } catch (e) {
+            errorCallback(e, this.errorCode);
+            return;
+        }
+
+        this.get({
+            id: fileId,
+            errorCallback,
+            successCallback,
+            url: this.getUrlForId(commentId),
+        });
+    }
+
+    /**
      * API for fetching comments
      *
      * @param {string} fileId - the file id

--- a/src/api/ThreadedComments.js
+++ b/src/api/ThreadedComments.js
@@ -12,6 +12,7 @@ import {
     ERROR_CODE_CREATE_COMMENT,
     ERROR_CODE_UPDATE_COMMENT,
     ERROR_CODE_DELETE_COMMENT,
+    ERROR_CODE_FETCH_COMMENT,
     ERROR_CODE_FETCH_COMMENTS,
     PERMISSION_CAN_RESOLVE,
     ERROR_CODE_FETCH_REPLIES,
@@ -251,7 +252,7 @@ class ThreadedComments extends MarkerBasedApi {
         permissions: BoxItemPermission,
         successCallback: (comment: Comment) => void,
     }): void {
-        this.errorCode = ERROR_CODE_FETCH_COMMENTS;
+        this.errorCode = ERROR_CODE_FETCH_COMMENT;
         try {
             this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileId);
         } catch (e) {

--- a/src/api/__tests__/ThreadedComments.test.js
+++ b/src/api/__tests__/ThreadedComments.test.js
@@ -4,6 +4,7 @@ import {
     ERROR_CODE_CREATE_COMMENT,
     ERROR_CODE_UPDATE_COMMENT,
     ERROR_CODE_DELETE_COMMENT,
+    ERROR_CODE_FETCH_COMMENT,
     ERROR_CODE_FETCH_COMMENTS,
     ERROR_CODE_FETCH_REPLIES,
     ERROR_CODE_CREATE_REPLY,
@@ -231,7 +232,7 @@ describe('api/ThreadedComments', () => {
                 errorCallback,
             });
 
-            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_FETCH_COMMENTS);
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_FETCH_COMMENT);
             expect(threadedComments.get).not.toBeCalled();
         });
     });

--- a/src/api/__tests__/ThreadedComments.test.js
+++ b/src/api/__tests__/ThreadedComments.test.js
@@ -191,6 +191,51 @@ describe('api/ThreadedComments', () => {
         });
     });
 
+    describe('getComment()', () => {
+        const errorCallback = jest.fn();
+        const successCallback = jest.fn();
+
+        test('should format its parameters and call the get method', () => {
+            const permissions = {
+                can_comment: true,
+            };
+            const url = 'http://test-url.com';
+
+            threadedComments.getUrlForId = jest.fn().mockImplementationOnce(() => url);
+
+            threadedComments.getComment({
+                commentId: '123',
+                fileId: '12345',
+                permissions,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(threadedComments.get).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                successCallback,
+                url,
+            });
+        });
+
+        test('should reject with an error code for calls with invalid permissions', () => {
+            const permissions = {
+                can_comment: false,
+            };
+            threadedComments.getComment({
+                commentId: '123',
+                fileId: '12345',
+                permissions,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(errorCallback).toBeCalledWith(expect.any(Error), ERROR_CODE_FETCH_COMMENTS);
+            expect(threadedComments.get).not.toBeCalled();
+        });
+    });
+
     describe('getComments()', () => {
         const errorCallback = jest.fn();
         const successCallback = jest.fn();

--- a/src/common/types/feed.js
+++ b/src/common/types/feed.js
@@ -6,10 +6,18 @@ import {
     FEED_ITEM_TYPE_ANNOTATION,
     FEED_ITEM_TYPE_APP_ACTIVITY,
     FEED_ITEM_TYPE_COMMENT,
+    FEED_ITEM_TYPE_VERSION,
     FEED_ITEM_TYPE_TASK,
 } from '../../constants';
 import type { BoxItemPermission, BoxItemVersion, Reply, User } from './core';
 import type { Annotation, AnnotationPermission, Annotations } from './annotations';
+
+type FeedItemType =
+    | typeof FEED_ITEM_TYPE_ANNOTATION
+    | typeof FEED_ITEM_TYPE_APP_ACTIVITY
+    | typeof FEED_ITEM_TYPE_COMMENT
+    | typeof FEED_ITEM_TYPE_VERSION
+    | typeof FEED_ITEM_TYPE_TASK;
 
 // Feed item types that can receive deeplinks inline in the feed
 type FocusableFeedItemType =
@@ -128,6 +136,10 @@ type FeedItem = Annotation | Comment | Task | BoxItemVersion | AppActivityItem;
 
 type FeedItems = Array<FeedItem>;
 
+type FocusableFeedItem = Annotation | Comment | Task;
+
+type CommentFeedItem = Annotation | Comment;
+
 type ActionItemError = {
     action?: {
         onAction: () => void,
@@ -150,11 +162,14 @@ export type {
     AppItem,
     BoxCommentPermission,
     Comment,
+    CommentFeedItem,
     CommentFeedItemType,
     Comments,
     FeedItem,
     FeedItems,
     FeedItemStatus,
+    FeedItemType,
+    FocusableFeedItem,
     FocusableFeedItemType,
     Reply,
     Task,

--- a/src/constants.js
+++ b/src/constants.js
@@ -250,6 +250,7 @@ export const ERROR_CODE_FETCH_FILE_DUE_TO_POLICY = 'forbidden_by_policy';
 export const ERROR_CODE_FETCH_FOLDER = 'fetch_folder_error';
 export const ERROR_CODE_FETCH_WEBLINK = 'fetch_weblink_error';
 export const ERROR_CODE_FETCH_CLASSIFICATION = 'fetch_classification_error';
+export const ERROR_CODE_FETCH_COMMENT = 'fetch_comment_error';
 export const ERROR_CODE_FETCH_COMMENTS = 'fetch_comments_error';
 export const ERROR_CODE_FETCH_REPLIES = 'fetch_replies_error';
 export const ERROR_CODE_FETCH_VERSION = 'fetch_version_error';

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -828,6 +828,24 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     }, DEFAULT_COLLAB_DEBOUNCE);
 
     /**
+     * Fetches comment data
+     *
+     * @param {string} id - id of the comment
+     * @param {Function} onSuccess - the success callback
+     * @param {ErrorCallback} onError -the error callback
+     * @return {void}
+     */
+    getComment = (
+        id: string,
+        onSuccess: (comment: Comment) => void,
+        onError: (error: ElementsXhrError, code: string, contextInfo?: Object) => void,
+    ): void => {
+        const { api, file } = this.props;
+
+        api.getFeedAPI(false).fetchThreadedComment(file, id, onSuccess, onError);
+    };
+
+    /**
      * Fetches replies (comments) of a comment or annotation
      *
      * @param {string} id - id of the feed item
@@ -1004,6 +1022,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                     file={file}
                     getApproverWithQuery={this.getApprover}
                     getAvatarUrl={this.getAvatarUrl}
+                    getComment={this.getComment}
                     getMentionWithQuery={this.getMention}
                     getUserProfileUrl={getUserProfileUrl}
                     hasReplies={hasReplies}

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -23,6 +23,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         deleteThreadedComment: jest.fn(),
         feedItems: jest.fn(),
         fetchReplies: jest.fn(),
+        fetchThreadedComment: jest.fn(),
         updateAnnotation: jest.fn(),
         updateComment: jest.fn(),
         updateFeedItem: jest.fn(),
@@ -834,6 +835,20 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             instance.getMentionContactsSuccessCallback(collaborators);
             expect(wrapper.state('contactsLoaded')).toBeTruthy();
             expect(wrapper.state('mentionSelectorContacts')).toEqual(collaborators.entries);
+        });
+    });
+
+    describe('getComment()', () => {
+        test('should call fetchThreadedComment API', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            const id = '123';
+            const successCallback = jest.fn();
+            const errorCallback = jest.fn();
+
+            instance.getComment(id, successCallback, errorCallback);
+
+            expect(api.getFeedAPI().fetchThreadedComment).toBeCalledWith(file, id, successCallback, errorCallback);
         });
     });
 

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
@@ -9,7 +9,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
         onTaskModalClose={[Function]}
         taskFormProps={
           Object {
-            "approverSelectorContacts": Array [],
+            "approverSelectorContacts": undefined,
             "approvers": Array [],
             "completionRule": "ALL_ASSIGNEES",
             "createTask": [Function],
@@ -33,7 +33,6 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
   }
 >
   <ActivityFeed
-    approverSelectorContacts={Array []}
     currentUser={
       Object {
         "id": "123",
@@ -54,7 +53,6 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
     hasReplies={false}
     hasVersions={true}
     isDisabled={false}
-    isItemInFeed={[Function]}
     onAnnotationDelete={[Function]}
     onAnnotationEdit={[Function]}
     onAnnotationSelect={[Function]}

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
@@ -9,7 +9,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
         onTaskModalClose={[Function]}
         taskFormProps={
           Object {
-            "approverSelectorContacts": undefined,
+            "approverSelectorContacts": Array [],
             "approvers": Array [],
             "completionRule": "ALL_ASSIGNEES",
             "createTask": [Function],
@@ -33,6 +33,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
   }
 >
   <ActivityFeed
+    approverSelectorContacts={Array []}
     currentUser={
       Object {
         "id": "123",
@@ -49,11 +50,11 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
     }
     getApproverWithQuery={[Function]}
     getAvatarUrl={[Function]}
-    getComment={[Function]}
     getMentionWithQuery={[Function]}
     hasReplies={false}
     hasVersions={true}
     isDisabled={false}
+    isItemInFeed={[Function]}
     onAnnotationDelete={[Function]}
     onAnnotationEdit={[Function]}
     onAnnotationSelect={[Function]}

--- a/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/ActivitySidebar.test.js.snap
@@ -49,6 +49,7 @@ exports[`elements/content-sidebar/ActivitySidebar render() should render the act
     }
     getApproverWithQuery={[Function]}
     getAvatarUrl={[Function]}
+    getComment={[Function]}
     getMentionWithQuery={[Function]}
     hasReplies={false}
     hasVersions={true}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -29,15 +29,13 @@ import type {
     FeedItem,
     FeedItems,
     FeedItemStatus,
-    FocusableFeedItemType,
 } from '../../../../common/types/feed';
 import type { SelectorItems, User } from '../../../../common/types/core';
 import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
 import type { Translations } from '../../flowTypes';
 
 type Props = {
-    activeFeedEntryId?: string,
-    activeFeedEntryType?: FocusableFeedItemType,
+    activeFeedItem: FeedItem,
     activeFeedItemRef: { current: null | HTMLElement },
     approverSelectorContacts?: SelectorItems<>,
     currentFileVersionId: string,
@@ -87,8 +85,7 @@ type Props = {
 };
 
 const ActiveState = ({
-    activeFeedEntryId,
-    activeFeedEntryType,
+    activeFeedItem,
     activeFeedItemRef,
     approverSelectorContacts,
     currentFileVersionId,
@@ -121,8 +118,6 @@ const ActiveState = ({
     onVersionInfo,
     translations,
 }: Props): React.Node => {
-    const activeEntry = items.find(({ id, type }) => id === activeFeedEntryId && type === activeFeedEntryType);
-
     const onHideRepliesHandler = (parentId: string) => (lastReply: CommentType) => {
         onHideReplies(parentId, [lastReply]);
     };
@@ -150,7 +145,7 @@ const ActiveState = ({
     return (
         <ul className="bcs-activity-feed-active-state">
             {items.map((item: FeedItem) => {
-                const isFocused = item === activeEntry;
+                const isFocused = item === activeFeedItem;
                 const refValue = isFocused ? activeFeedItemRef : undefined;
                 const itemFileVersionId = getProp(item, 'file_version.id');
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -15,11 +15,7 @@ import InlineError from '../../../../components/inline-error/InlineError';
 import LoadingIndicator from '../../../../components/loading-indicator/LoadingIndicator';
 import messages from './messages';
 import { collapseFeedState, ItemTypes } from './activityFeedUtils';
-import {
-    FEED_ITEM_TYPE_ANNOTATION,
-    FEED_ITEM_TYPE_COMMENT,
-    PERMISSION_CAN_CREATE_ANNOTATIONS,
-} from '../../../../constants';
+import { PERMISSION_CAN_CREATE_ANNOTATIONS } from '../../../../constants';
 import { scrollIntoView } from '../../../../utils/dom';
 import type {
     Annotation,
@@ -38,7 +34,6 @@ import './ActivityFeed.scss';
 
 type Props = {
     activeFeedEntryId?: string,
-    activeFeedEntryReplyId?: string,
     activeFeedEntryType?: FocusableFeedItemType,
     activityFeedError: ?Errors,
     approverSelectorContacts?: SelectorItems<User | GroupMini>,
@@ -53,7 +48,6 @@ type Props = {
     hasReplies?: boolean,
     hasVersions?: boolean,
     isDisabled?: boolean,
-    isItemInFeed: (feedItems: FeedItems, itemId: string) => boolean,
     mentionSelectorContacts?: SelectorItems<User>,
     onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => void,
     onAnnotationEdit?: (id: string, text: string, permissions: AnnotationPermission) => void,
@@ -116,14 +110,7 @@ class ActivityFeed extends React.Component<Props, State> {
             currentUser: prevCurrentUser,
             feedItems: prevFeedItems,
         } = prevProps;
-        const {
-            activeFeedEntryId,
-            activeFeedEntryReplyId,
-            activeFeedEntryType,
-            feedItems: currFeedItems,
-            isItemInFeed,
-            onShowReplies,
-        } = this.props;
+        const { feedItems: currFeedItems, activeFeedEntryId } = this.props;
         const { isInputOpen: prevIsInputOpen } = prevState;
         const { isInputOpen: currIsInputOpen } = this.state;
 
@@ -139,20 +126,6 @@ class ActivityFeed extends React.Component<Props, State> {
 
         if (didLoadFeedItems || hasActiveFeedEntryIdChanged) {
             this.scrollToActiveFeedItemOrErrorMessage();
-        }
-
-        // Load replies if active entry reply is set and it's not currently within feed items or its replies
-        if (
-            onShowReplies &&
-            activeFeedEntryId &&
-            activeFeedEntryType &&
-            (activeFeedEntryType === FEED_ITEM_TYPE_COMMENT || activeFeedEntryType === FEED_ITEM_TYPE_ANNOTATION) &&
-            hasLoaded &&
-            activeFeedEntryReplyId &&
-            currFeedItems &&
-            !isItemInFeed(currFeedItems, activeFeedEntryReplyId)
-        ) {
-            onShowReplies(activeFeedEntryId, activeFeedEntryType);
         }
     }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -152,9 +152,7 @@ class ActivityFeed extends React.Component<Props, State> {
             currFeedItems &&
             !isItemInFeed(currFeedItems, activeFeedEntryReplyId)
         ) {
-            if (activeFeedEntryType === FEED_ITEM_TYPE_COMMENT || activeFeedEntryType === FEED_ITEM_TYPE_ANNOTATION) {
-                onShowReplies(activeFeedEntryId, activeFeedEntryType);
-            }
+            onShowReplies(activeFeedEntryId, activeFeedEntryType);
         }
     }
 

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -357,21 +357,6 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
 
             expect(instance.scrollToActiveFeedItemOrErrorMessage).not.toBeCalled();
         });
-
-        // test('should not call scrollToActiveFeedItemOrErrorMessage if activeFeedEntryId changed', () => {
-        //     const wrapper = getWrapper({ activeFeedEntryId: '456' });
-        //     const instance = wrapper.instance();
-        //     instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
-        //
-        //     instance.componentDidUpdate(
-        //         {
-        //             activeFeedEntryId: '456',
-        //         },
-        //         { isInputOpen: false },
-        //     );
-        //
-        //     expect(instance.scrollToActiveFeedItemOrErrorMessage).not.toHaveBeenCalled();
-        // });
     });
 
     test('should pass activeFeedItemRef to the ActiveState', () => {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -477,4 +477,43 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
             expect(instance.hasLoaded(prevCurrentUser, prevFeedItems)).toBe(expected);
         });
     });
+
+    describe('isFeedItemActive()', () => {
+        test.each`
+            id       | type            | expected
+            ${'123'} | ${'comment'}    | ${true}
+            ${'456'} | ${'annotation'} | ${false}
+            ${'456'} | ${'comment'}    | ${false}
+        `('should return $expected given id=$id and type=$type', ({ id, type, expected }) => {
+            const wrapper = getWrapper({
+                activeFeedEntryId: '123',
+                activeFeedEntryType: 'comment',
+            });
+            const instance = wrapper.instance();
+            expect(instance.isFeedItemActive({ id, type })).toBe(expected);
+        });
+    });
+
+    describe('isCommentFeedItemActive()', () => {
+        test.each`
+            replies            | isFeedItemActiveResult | expected
+            ${[{ id: '123' }]} | ${false}               | ${true}
+            ${[{ id: '456' }]} | ${false}               | ${false}
+            ${[{ id: '456' }]} | ${true}                | ${true}
+            ${[]}              | ${false}               | ${false}
+            ${[]}              | ${true}                | ${true}
+            ${undefined}       | ${false}               | ${false}
+            ${undefined}       | ${true}                | ${true}
+        `(
+            'should return $expected when replies=replies and isFeedItemActive results with $isFeedItemActiveResult',
+            ({ replies, isFeedItemActiveResult, expected }) => {
+                const wrapper = getWrapper({
+                    activeFeedEntryId: '123',
+                });
+                const instance = wrapper.instance();
+                instance.isFeedItemActive = jest.fn().mockImplementation(() => isFeedItemActiveResult);
+                expect(instance.isCommentFeedItemActive({ id: 'foo', replies, type: 'bar' })).toBe(expected);
+            },
+        );
+    });
 });

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -287,10 +287,10 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
             expect(instance.feedContainer.scrollTop).toEqual(100);
         });
 
-        test('should call scrollToActiveFeedItemOrErrorMessage if feed items loaded', () => {
+        test('should call getActiveEntry if feed items loaded', () => {
             const wrapper = getWrapper({ feedItems: [{ type: FEED_ITEM_TYPE_COMMENT }] });
             const instance = wrapper.instance();
-            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+            instance.getActiveEntry = jest.fn();
 
             instance.componentDidUpdate(
                 {
@@ -299,13 +299,13 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
                 { isInputOpen: false },
             );
 
-            expect(instance.scrollToActiveFeedItemOrErrorMessage).toHaveBeenCalled();
+            expect(instance.getActiveEntry).toBeCalledWith(expect.any(Function));
         });
 
-        test('should call scrollToActiveFeedItemOrErrorMessage if activeFeedEntryId changed', () => {
+        test('should call getActiveEntry if activeFeedEntryId changed', () => {
             const wrapper = getWrapper({ activeFeedEntryId: '123' });
             const instance = wrapper.instance();
-            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+            instance.getActiveEntry = jest.fn();
 
             instance.componentDidUpdate(
                 {
@@ -314,13 +314,13 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
                 { isInputOpen: false },
             );
 
-            expect(instance.scrollToActiveFeedItemOrErrorMessage).toHaveBeenCalled();
+            expect(instance.getActiveEntry).toBeCalledWith(expect.any(Function));
         });
 
-        test('should not call scrollToActiveFeedItemOrErrorMessage if activeFeedEntryId changed', () => {
+        test('should not call getActiveEntry if activeFeedEntryId did not change', () => {
             const wrapper = getWrapper({ activeFeedEntryId: '456' });
             const instance = wrapper.instance();
-            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+            instance.getActiveEntry = jest.fn();
 
             instance.componentDidUpdate(
                 {
@@ -329,8 +329,49 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
                 { isInputOpen: false },
             );
 
-            expect(instance.scrollToActiveFeedItemOrErrorMessage).not.toHaveBeenCalled();
+            expect(instance.getActiveEntry).not.toHaveBeenCalled();
         });
+
+        test('should call scrollToActiveFeedItemOrErrorMessage if activeEntry changed', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            wrapper.setState({
+                activeEntry: { id: '123' },
+            });
+            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+
+            instance.componentDidUpdate({}, { activeEntry: undefined, isInputOpen: false });
+
+            expect(instance.scrollToActiveFeedItemOrErrorMessage).toBeCalled();
+        });
+
+        test('should not call scrollToActiveFeedItemOrErrorMessage if activeEntry did not change', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+            wrapper.setState({
+                activeEntry: { id: '123' },
+            });
+            instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+
+            instance.componentDidUpdate({}, { activeEntry: { id: '123' }, isInputOpen: false });
+
+            expect(instance.scrollToActiveFeedItemOrErrorMessage).not.toBeCalled();
+        });
+
+        // test('should not call scrollToActiveFeedItemOrErrorMessage if activeFeedEntryId changed', () => {
+        //     const wrapper = getWrapper({ activeFeedEntryId: '456' });
+        //     const instance = wrapper.instance();
+        //     instance.scrollToActiveFeedItemOrErrorMessage = jest.fn();
+        //
+        //     instance.componentDidUpdate(
+        //         {
+        //             activeFeedEntryId: '456',
+        //         },
+        //         { isInputOpen: false },
+        //     );
+        //
+        //     expect(instance.scrollToActiveFeedItemOrErrorMessage).not.toHaveBeenCalled();
+        // });
     });
 
     test('should pass activeFeedItemRef to the ActiveState', () => {
@@ -352,10 +393,8 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
         const instance = wrapper.instance();
         const li = document.createElement('li');
         instance.activeFeedItemRef.current = li;
-        wrapper.setProps({
-            feedItems: [{ type: FEED_ITEM_TYPE_COMMENT }],
-        });
-        expect(scrollIntoView).toHaveBeenCalledWith(li);
+        instance.scrollToActiveFeedItemOrErrorMessage();
+        expect(scrollIntoView).toBeCalledWith(li);
     });
 
     test('should not scroll to active feed item when activeFeedItemRef is null', () => {
@@ -426,28 +465,28 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
 
     test('should correctly handle an inline error for a comment id being invalid', () => {
         const wrapper = getWrapper({
-            feedItems,
             activeFeedEntryId: 'invalid id',
             activeFeedEntryType: comments.entries[0].type,
         });
+        wrapper.setProps({ feedItems });
         expect(wrapper.exists('InlineError')).toBe(true);
     });
 
     test('should correctly handle an inline error for a task id being invalid', () => {
         const wrapper = getWrapper({
-            feedItems,
             activeFeedEntryId: 'invalid id',
             activeFeedEntryType: taskWithAssignment.type,
         });
+        wrapper.setProps({ feedItems });
         expect(wrapper.exists('InlineError')).toBe(true);
     });
 
     test('should correctly handle an inline error for an annotation id being invalid', () => {
         const wrapper = getWrapper({
-            feedItems,
             activeFeedEntryId: 'invalid id',
             activeFeedEntryType: annotations.entries[0].type,
         });
+        wrapper.setProps({ feedItems });
         expect(wrapper.exists('InlineError')).toBe(true);
     });
 
@@ -459,6 +498,142 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
         });
 
         expect(wrapper.exists('InlineError')).toBe(false);
+    });
+
+    describe('getActiveEntry()', () => {
+        test.each`
+            activeFeedEntryId | feedItems
+            ${undefined}      | ${undefined}
+            ${undefined}      | ${[{ id: 1 }]}
+            ${'1234'}         | ${undefined}
+        `(
+            'should call callback with null if activeFeedEntryId or feedItems is not available (activeFeedEntryId = $activeFeedEntryId and mockFeedItems = $feedItems)',
+            ({ activeFeedEntryId, feedItems: mockFeedItems }) => {
+                const wrapper = getWrapper({
+                    activeFeedEntryId,
+                    feedItems: mockFeedItems,
+                });
+                const instance = wrapper.instance();
+                const callback = jest.fn();
+
+                instance.getActiveEntry(callback);
+                expect(callback).toBeCalledWith(null);
+            },
+        );
+
+        describe('given activeFeedEntryId and feedItems exist', () => {
+            test.each`
+                hasReplies   | activeFeedEntryType | activeFeedEntryId | feedItems                                                        | expectedActiveItem
+                ${undefined} | ${'comment'}        | ${'456'}          | ${[{ id: '456', type: 'comment' }]}                              | ${{ id: '456', type: 'comment' }}
+                ${true}      | ${'comment'}        | ${'456'}          | ${[{ id: '456', type: 'comment' }]}                              | ${{ id: '456', type: 'comment' }}
+                ${undefined} | ${'comment'}        | ${'123'}          | ${[{ id: '456', replies: [], type: 'comment' }]}                 | ${null}
+                ${undefined} | ${'task'}           | ${'123'}          | ${[{ id: '456', replies: [], type: 'comment' }]}                 | ${null}
+                ${undefined} | ${'comment'}        | ${'123'}          | ${[{ id: '456', replies: [{ id: '123' }], type: 'comment' }]}    | ${null}
+                ${undefined} | ${'task'}           | ${'123'}          | ${[{ id: '456', replies: [{ id: '123' }], type: 'comment' }]}    | ${null}
+                ${true}      | ${'comment'}        | ${'123'}          | ${[{ id: '456', replies: [{ id: '123' }], type: 'comment' }]}    | ${{ id: '456', replies: [{ id: '123' }], type: 'comment' }}
+                ${true}      | ${'comment'}        | ${'123'}          | ${[{ id: '456', replies: [{ id: '123' }], type: 'annotation' }]} | ${{ id: '456', replies: [{ id: '123' }], type: 'annotation' }}
+                ${true}      | ${'comment'}        | ${'123'}          | ${[{ id: '456', replies: [{ id: '123' }], type: 'task' }]}       | ${null}
+                ${true}      | ${'task'}           | ${'123'}          | ${[{ id: '456', replies: [{ id: '123' }], type: 'comment' }]}    | ${null}
+            `(
+                'given hasReplies = $hasReplies, activeFeedEntryType = $activeFeedEntryType, activeFeedEntryId = $activeFeedEntryId and feedItem = $feedItems, should call callback with $expectedActiveItem ',
+                ({
+                    hasReplies,
+                    activeFeedEntryType,
+                    activeFeedEntryId,
+                    feedItems: mockFeedItems,
+                    expectedActiveItem,
+                }) => {
+                    const wrapper = getWrapper({
+                        activeFeedEntryId,
+                        activeFeedEntryType,
+                        hasReplies,
+                        feedItems: mockFeedItems,
+                    });
+                    const instance = wrapper.instance();
+                    const callback = jest.fn();
+
+                    instance.getActiveEntry(callback);
+                    expect(callback).toBeCalledWith(expectedActiveItem);
+                },
+            );
+
+            describe("given hasReplies = true and active item not found within first level feed items and its' replies", () => {
+                test('should call callback with null if getComment is not defined', () => {
+                    const mockFeedItem = { id: '123', replies: [{ id: '456' }] };
+                    const mockFeedItems = [mockFeedItem];
+                    const wrapper = getWrapper({
+                        activeFeedEntryId: '999',
+                        feedItems: mockFeedItems,
+                        hasReplies: true,
+                    });
+                    const instance = wrapper.instance();
+                    const callback = jest.fn();
+
+                    instance.getActiveEntry(callback);
+                    expect(callback).toBeCalledWith(null);
+                });
+
+                test('should call getComment and if onError is called, should call callback with null', () => {
+                    const mockFeedItem = { id: '123', replies: [{ id: '456' }] };
+                    const mockFeedItems = [mockFeedItem];
+                    const activeFeedEntryId = '999';
+                    const activeFeedEntryType = 'comment';
+                    const getComment = jest.fn().mockImplementation((id, onSuccess, onError) => {
+                        onError();
+                    });
+                    const wrapper = getWrapper({
+                        activeFeedEntryId,
+                        activeFeedEntryType,
+                        feedItems: mockFeedItems,
+                        getComment,
+                        hasReplies: true,
+                    });
+                    const instance = wrapper.instance();
+                    instance.setState = jest.fn();
+                    const callback = jest.fn();
+
+                    instance.getActiveEntry(callback);
+                    expect(instance.setState).toBeCalledWith({ isReplyDataLoading: true });
+                    expect(getComment).toBeCalledWith(activeFeedEntryId, expect.any(Function), expect.any(Function));
+                    expect(callback).toBeCalledWith(null);
+                });
+
+                test.each`
+                    returnedReply                           | feedItems                                    | expectedActiveItem
+                    ${{ id: '999' }}                        | ${[{ id: '456', replies: [{ id: '123' }] }]} | ${null}
+                    ${{ id: '999', parent: { id: '888' } }} | ${[{ id: '456', replies: [{ id: '123' }] }]} | ${null}
+                    ${{ id: '999', parent: { id: '456' } }} | ${[{ id: '456', replies: [{ id: '123' }] }]} | ${{ id: '456', replies: [{ id: '123' }] }}
+                `(
+                    'should call getComment and if onSuccess is called with $returnedReply, should call callback with $expectedActiveItem',
+                    ({ returnedReply, feedItems: mockFeedItems, expectedActiveItem }) => {
+                        const activeFeedEntryId = '999';
+                        const activeFeedEntryType = 'comment';
+                        const getComment = jest.fn().mockImplementation((id, onSuccess) => {
+                            onSuccess(returnedReply);
+                        });
+                        const wrapper = getWrapper({
+                            activeFeedEntryId,
+                            activeFeedEntryType,
+                            feedItems: mockFeedItems,
+                            getComment,
+                            hasReplies: true,
+                        });
+                        const instance = wrapper.instance();
+                        instance.setState = jest.fn();
+                        const callback = jest.fn();
+
+                        instance.getActiveEntry(callback);
+                        expect(instance.setState).toBeCalledWith({ isReplyDataLoading: true });
+                        expect(getComment).toBeCalledWith(
+                            activeFeedEntryId,
+                            expect.any(Function),
+                            expect.any(Function),
+                        );
+                        expect(callback).toBeCalledWith(expectedActiveItem, true);
+                    },
+                );
+            });
+        });
     });
 
     describe('hasLoaded()', () => {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActivityFeed.test.js
@@ -331,54 +331,6 @@ describe('elements/content-sidebar/ActivityFeed/activity-feed/ActivityFeed', () 
 
             expect(instance.scrollToActiveFeedItemOrErrorMessage).not.toHaveBeenCalled();
         });
-
-        test('should call onShowReplies if feed items have loaded, active feed entry reply is set and it is not within current feed items and its replies', () => {
-            const isItemInFeed = jest.fn().mockImplementation(() => false);
-            const onShowReplies = jest.fn();
-
-            const wrapper = getWrapper({
-                activeFeedEntryId: '456',
-                activeFeedEntryReplyId: '123',
-                activeFeedEntryType: 'comment',
-                isItemInFeed,
-                onShowReplies,
-            });
-            wrapper.setProps({ feedItems: [{ id: '789' }] });
-
-            const instance = wrapper.instance();
-            instance.hasLoaded = jest.fn().mockImplementation(() => true);
-
-            expect(onShowReplies).toBeCalledWith('456', 'comment');
-        });
-
-        test.each`
-            hasLoadedResult | activeFeedEntryReplyId | isItemInFeedResult
-            ${false}        | ${undefined}           | ${false}
-            ${true}         | ${undefined}           | ${false}
-            ${false}        | ${'123'}               | ${false}
-            ${false}        | ${undefined}           | ${true}
-            ${true}         | ${'123'}               | ${false}
-            ${true}         | ${undefined}           | ${true}
-            ${false}        | ${'123'}               | ${true}
-        `(
-            'should NOT call onShowReplies given hasLoaded=$hasLoaded, activeFeedEntryReplyId=$activeFeedEntryReplyId and isItemInFeed=$isItemInFeedResult',
-            ({ hasLoadedResult, activeFeedEntryReplyId, isItemInFeedResult }) => {
-                const isItemInFeed = jest.fn().mockImplementation(() => isItemInFeedResult);
-                const onShowReplies = jest.fn();
-
-                const wrapper = getWrapper({
-                    activeFeedEntryId: '456',
-                    activeFeedEntryReplyId,
-                    activeEntryType: 'comment',
-                    isItemInFeed,
-                    onShowReplies,
-                });
-                const instance = wrapper.instance();
-                instance.hasLoaded = jest.fn().mockImplementation(() => hasLoadedResult);
-
-                expect(onShowReplies).not.toBeCalled();
-            },
-        );
     });
 
     test('should pass activeFeedItemRef to the ActiveState', () => {


### PR DESCRIPTION
Added support for handling links with active item that is a reply. This is to support mentioning users directly in a reply. The link that user will receive in notification email will have only type and id of the feed item. This change covers that scenario by doing additional request for that replie's details (in order to get id of its parent). Logic can be seen in the diagram:

![handling-active-comment-reply](https://user-images.githubusercontent.com/105496865/200943320-c07e66fb-6153-4e65-9266-2a088efd308b.png)

**Please note that this is a temporary solution done based on time constraints presented by Product. Final solution would be to change the link in notification email to also include `parentId`, thus making this additional request mentioned above not needed.**