### PR TITLE
chore(scripts): Adjust design assets import script

### DIFF
--- a/scripts/asset-import/cli.js
+++ b/scripts/asset-import/cli.js
@@ -16,6 +16,10 @@ const { argv } = yargs
         alias: 'b',
         description: 'The branch or tag to use',
     })
+    .option('assetDirectory', {
+        alias: 'a',
+        description: 'Directory from which to take assets',
+    })
     .option('working-dir', {
         alias: 'w',
         description: 'Temporary working directory for assets',
@@ -33,7 +37,9 @@ const { argv } = yargs
 
 (async function cli() {
     try {
-        await importer(pick(argv, ['repository', 'branch', 'workingDir', 'destinationDir', 'verbose']));
+        await importer(
+            pick(argv, ['repository', 'branch', 'workingDir', 'destinationDir', 'verbose', 'assetDirectory']),
+        );
     } catch (e) {
         // eslint-disable-next-line
         console.log(colors.red('There was an unexpected error when processing assets\n'), e);

--- a/scripts/asset-import/cli.js
+++ b/scripts/asset-import/cli.js
@@ -16,9 +16,9 @@ const { argv } = yargs
         alias: 'b',
         description: 'The branch or tag to use',
     })
-    .option('assetDirectory', {
+    .option('asset-path', {
         alias: 'a',
-        description: 'Directory from which to take assets',
+        description: 'Path under root repo directory, from which to take assets',
     })
     .option('working-dir', {
         alias: 'w',
@@ -37,9 +37,7 @@ const { argv } = yargs
 
 (async function cli() {
     try {
-        await importer(
-            pick(argv, ['repository', 'branch', 'workingDir', 'destinationDir', 'verbose', 'assetDirectory']),
-        );
+        await importer(pick(argv, ['repository', 'branch', 'workingDir', 'destinationDir', 'verbose', 'assetPath']));
     } catch (e) {
         // eslint-disable-next-line
         console.log(colors.red('There was an unexpected error when processing assets\n'), e);

--- a/scripts/asset-import/src/defaultConfig.js
+++ b/scripts/asset-import/src/defaultConfig.js
@@ -1,5 +1,5 @@
 module.exports = {
-    assetDirectory: '_Deprecated',
+    assetPath: './_Deprecated',
     branch: 'master',
     workingDir: '/tmp',
     destinationDir: 'src',

--- a/scripts/asset-import/src/defaultConfig.js
+++ b/scripts/asset-import/src/defaultConfig.js
@@ -1,4 +1,5 @@
 module.exports = {
+    assetDirectory: '_Deprecated',
     branch: 'master',
     workingDir: '/tmp',
     destinationDir: 'src',

--- a/scripts/asset-import/src/import.js
+++ b/scripts/asset-import/src/import.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-unresolved,  no-shadow, import/no-extraneous-dependencies, no-console */
 const SimpleGit = require('simple-git/promise');
+const path = require('path');
 const colors = require('colors/safe');
 const ora = require('ora');
 const rimraf = require('rimraf');
@@ -91,7 +92,7 @@ module.exports = async cliOptions => {
 
     const git = new SimpleGit(config.workingDir);
     const sourcePath = `${config.workingDir}/${uniqid('design-assets-')}`;
-    const assetDirectory = `${sourcePath}/${config.assetDirectory}`;
+    const assetPath = path.join(sourcePath, config.assetPath);
 
     rimraf(sourcePath, async () => {
         try {
@@ -105,8 +106,8 @@ module.exports = async cliOptions => {
                 await git.checkout(config.branch);
                 progress.succeed();
 
-                progress.start(colors.cyan(`Parse contents of ${assetDirectory}. . .`));
-                util.parseContentsOf(assetDirectory, assetDirectory, config.destinationDir, parser);
+                progress.start(colors.cyan(`Parse contents of ${assetPath}. . .`));
+                util.parseContentsOf(assetPath, assetPath, config.destinationDir, parser);
                 progress.succeed(colors.cyan('Parsing completed successfully.'));
 
                 progress.start('Cleaning up. . .');

--- a/scripts/asset-import/src/import.js
+++ b/scripts/asset-import/src/import.js
@@ -91,6 +91,7 @@ module.exports = async cliOptions => {
 
     const git = new SimpleGit(config.workingDir);
     const sourcePath = `${config.workingDir}/${uniqid('design-assets-')}`;
+    const assetDirectory = `${sourcePath}/${config.assetDirectory}`;
 
     rimraf(sourcePath, async () => {
         try {
@@ -104,8 +105,8 @@ module.exports = async cliOptions => {
                 await git.checkout(config.branch);
                 progress.succeed();
 
-                progress.start(colors.cyan(`Parse contents of ${sourcePath}. . .`));
-                util.parseContentsOf(sourcePath, sourcePath, config.destinationDir, parser);
+                progress.start(colors.cyan(`Parse contents of ${assetDirectory}. . .`));
+                util.parseContentsOf(assetDirectory, assetDirectory, config.destinationDir, parser);
                 progress.succeed(colors.cyan('Parsing completed successfully.'));
 
                 progress.start('Cleaning up. . .');


### PR DESCRIPTION
This PR updates assets-import script.
It will take assets from `_Deprecated` directory instead of the root directory