### PR TITLE
fix(assets): Use correct icons after icons were renamed

### DIFF
--- a/src/components/date-picker/DatePicker.tsx
+++ b/src/components/date-picker/DatePicker.tsx
@@ -8,7 +8,7 @@ import uniqueId from 'lodash/uniqueId';
 
 // @ts-ignore flow import
 import { RESIN_TAG_TARGET } from '../../common/variables';
-import Alert16 from '../../icon/fill/Alert16';
+import AlertBadge16 from '../../icon/fill/AlertBadge16';
 import Calendar16 from '../../icon/fill/Calendar16';
 import ClearBadge16 from '../../icon/fill/ClearBadge16';
 
@@ -819,7 +819,7 @@ class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
                         </PlainButton>
                     ) : null}
                     {hasError ? (
-                        <Alert16
+                        <AlertBadge16
                             className="date-picker-icon-alert"
                             title={<FormattedMessage {...messages.iconAlertText} />}
                         />

--- a/src/components/date-picker/__tests__/DatePicker.test.tsx
+++ b/src/components/date-picker/__tests__/DatePicker.test.tsx
@@ -184,9 +184,9 @@ describe('components/date-picker/DatePicker', () => {
             maxDate: new Date('2021-12-31T00:00:00'),
         });
 
-        expect(wrapper.find('Alert16').length).toEqual(0);
+        expect(wrapper.find('AlertBadge16').length).toEqual(0);
         wrapper.find('.date-picker-input').simulate('change', { target: { value: '2022-01-01' } });
-        expect(wrapper.find('Alert16').length).toEqual(1);
+        expect(wrapper.find('AlertBadge16').length).toEqual(1);
     });
 
     test('should show alert icon when date value is before minimum date', () => {
@@ -195,9 +195,9 @@ describe('components/date-picker/DatePicker', () => {
             minDate: new Date('2022-01-01T00:00:00'),
         });
 
-        expect(wrapper.find('Alert16').length).toEqual(0);
+        expect(wrapper.find('AlertBadge16').length).toEqual(0);
         wrapper.find('.date-picker-input').simulate('change', { target: { value: '2021-12-31' } });
-        expect(wrapper.find('Alert16').length).toEqual(1);
+        expect(wrapper.find('AlertBadge16').length).toEqual(1);
     });
 
     test('should show tooltip when error exists', () => {

--- a/src/components/label/InfoIconWithTooltip.tsx
+++ b/src/components/label/InfoIconWithTooltip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import Info16 from '../../icon/fill/Info16';
+import InfoBadge16 from '../../icon/fill/InfoBadge16';
 import Tooltip, { TooltipPosition } from '../tooltip';
 
 export interface InfoIconWithTooltipProps {
@@ -16,7 +16,7 @@ const InfoIconWithTooltip = ({ className = '', iconProps, tooltipText }: InfoIco
     <span key="infoIcon" className={`${className} tooltip-icon-container`}>
         <Tooltip position={TooltipPosition.TOP_CENTER} text={tooltipText}>
             <span className="info-icon-container">
-                <Info16 {...iconProps} />
+                <InfoBadge16 {...iconProps} />
             </span>
         </Tooltip>
     </span>

--- a/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip.test.tsx.snap
+++ b/src/components/label/__tests__/__snapshots__/InfoIconWithTooltip.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`components/label/InfoIconWithTooltip should render correctly 1`] = `
     <span
       className="info-icon-container"
     >
-      <Info16
+      <InfoBadge16
         a="a"
         b="b"
         c="c"


### PR DESCRIPTION
**Background**
Alert16 and Info16 were renamed in the design-assets repo and pulled into BUIE in this PR: https://github.com/box/box-ui-elements/pull/3064 as AlertBadge16 and InfoBadge16

This fixes components that use the "old" version of the icons.

**Before**
![Screen Shot 2022-11-14 at 3 08 11 PM](https://user-images.githubusercontent.com/7311041/201792916-135bb8d4-f610-4cc7-be18-e5e57b6b0cc0.png)
![Screen Shot 2022-11-14 at 3 08 47 PM](https://user-images.githubusercontent.com/7311041/201792953-9bbb1d43-ffa4-4925-98cc-5e5d04e2c2f0.png)


**After**
![Screen Shot 2022-11-14 at 3 08 18 PM](https://user-images.githubusercontent.com/7311041/201792941-327fe73a-f3ec-4732-841a-876868c3aaa4.png)
![Screen Shot 2022-11-14 at 3 08 53 PM](https://user-images.githubusercontent.com/7311041/201792961-d51bbf74-4d5d-44fe-afac-3d56e6600b4b.png)

