### PR TITLE
feat: add additionalColumns prop to ContentExplorerModalContainer

### DIFF
--- a/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
+++ b/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
@@ -118,6 +118,11 @@ class ContentExplorerModalContainer extends Component {
         chooseButtonText: PropTypes.node,
         /** Table row height */
         rowHeight: PropTypes.number,
+        /**
+         * Extra columns displayed in the folders table after folder name column
+         * Each column has to be a Column element
+         */
+        additionalColumns: PropTypes.arrayOf(PropTypes.element),
     };
 
     static defaultProps = {

--- a/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
+++ b/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import Column from '@box/react-virtualized/dist/commonjs/Table/Column';
 import ContentExplorer from '../content-explorer';
 import { Modal } from '../../../components/modal';
 
@@ -10,6 +11,7 @@ import type { BreadcrumbProps } from '../../../components/breadcrumb/Breadcrumb'
 import './ContentExplorerModal.scss';
 
 type Props = {
+    additionalColumns?: Array<React.ComponentType<Column>>,
     breadcrumbProps?: BreadcrumbProps,
     className?: string,
     customInput?: React.ComponentType<any>,

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -127,6 +127,11 @@ class ContentExplorer extends Component {
         searchInputProps: PropTypes.object,
         /** Height of the row */
         rowHeight: PropTypes.number,
+        /**
+         * Extra columns displayed in the folders table after folder name column
+         * Each column has to be a Column element
+         */
+        additionalColumns: PropTypes.arrayOf(PropTypes.element),
     };
 
     static defaultProps = {
@@ -424,6 +429,7 @@ class ContentExplorer extends Component {
             listHeight,
             searchInputProps,
             rowHeight,
+            additionalColumns,
             ...rest
         } = this.props;
         const { isInSearchMode, foldersPath, selectedItems, isSelectAllChecked } = this.state;
@@ -499,6 +505,7 @@ class ContentExplorer extends Component {
                     />
                 )}
                 <ItemList
+                    additionalColumns={additionalColumns}
                     contentExplorerMode={contentExplorerMode}
                     height={listHeight}
                     isResponsive={isResponsive}

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -125,6 +125,7 @@ const itemLoadingPlaceholderRenderer = rendererParams => {
 };
 
 const ItemList = ({
+    additionalColumns,
     contentExplorerMode,
     className = '',
     isResponsive = false,
@@ -249,6 +250,7 @@ const ItemList = ({
                     flexGrow={1}
                     flexShrink={0}
                 />
+                {additionalColumns}
                 <Column
                     className="item-list-button-col"
                     cellRenderer={itemButtonCellRenderer}
@@ -268,6 +270,7 @@ const ItemList = ({
 ItemList.displayName = 'ItemList';
 
 ItemList.propTypes = {
+    additionalColumns: PropTypes.arrayOf(PropTypes.element),
     className: PropTypes.string,
     contentExplorerMode: ContentExplorerModePropType.isRequired,
     isResponsive: PropTypes.bool,

--- a/src/features/content-explorer/item-list/__tests__/ItemList.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemList.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 
+import { Column } from '@box/react-virtualized';
 import { ItemListBase as ItemList } from '../ItemList';
 import ContentExplorerMode from '../../modes';
 
@@ -265,6 +266,29 @@ describe('features/content-explorer/item-list/ItemList', () => {
             });
 
             expect(wrapper.find('h1').text()).toEqual(emptyText);
+        });
+    });
+
+    describe('additionalColumns', () => {
+        test('should render extra column', () => {
+            const items = [
+                { id: '1', name: 'item1' },
+                { id: '2', name: 'item2' },
+                { id: '3', name: 'item3' },
+            ];
+
+            const additionalColumns = [
+                <Column
+                    key="accessLevel"
+                    className="item-list-accessLevel-col"
+                    dataKey="accessLevel"
+                    flexGrow={1}
+                    flexShrink={0}
+                    width={0}
+                />,
+            ];
+            const wrapper = renderComponent({ items, additionalColumns });
+            expect(wrapper.find('.item-list-accessLevel-col').length).toBe(3);
         });
     });
 });


### PR DESCRIPTION
What I'm trying to achieve here? We would like to use the current ContentExplorerModalContainer in admin console but we need to add extra column, namely access level column. The most generic way to do it without breaking changes is to allow developer to pass any extra column they wish - those would appear after the folder name column - I chose this arbitrary but I think it makes sense - you would most probably like to keep the folder name and icon first and the select checkbox last so any additional columns should probably go in between. We could and try to make the column order configurable but I think it wouldn't be very useful and it would complicate the code. 
Of course this is not the greatest solution but it's non breaking and it allows us to use ContentExplorerModalContainer as is which is a huge time saver.

Another idea we had was to use custom row renderer but I don't like it - it's hard to align the items in the extra column, the accessibility is breaking etc.

I am open to some other ideas as long as they achieve our goal.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/3791384/202690543-955a9ed8-01e4-4905-8b9b-95c0418a31a7.png">
