### PR TITLE
feat: Add option to display header in ContentExplorerModalContainer

### DIFF
--- a/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
+++ b/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
@@ -123,6 +123,10 @@ class ContentExplorerModalContainer extends Component {
          * Each column has to be a Column element
          */
         additionalColumns: PropTypes.arrayOf(PropTypes.element),
+        /** Height of the table header, defaults to 0, which makes header not visible */
+        headerHeight: PropTypes.number,
+        /** Custom header row function */
+        headerRowRenderer: PropTypes.func,
     };
 
     static defaultProps = {

--- a/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
+++ b/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
@@ -8,6 +8,11 @@ import NewFolderModal from '../new-folder-modal';
 
 class ContentExplorerModalContainer extends Component {
     static propTypes = {
+        /**
+         * Extra columns displayed in the folders table after folder name column
+         * Each column has to be a Column element
+         */
+        additionalColumns: PropTypes.arrayOf(PropTypes.element),
         /** Breadcrumb component options */
         breadcrumbProps: BreadcrumbPropType,
         /** Adds class name. */
@@ -110,23 +115,20 @@ class ContentExplorerModalContainer extends Component {
         itemNameLinkRenderer: PropTypes.func,
         /** Used to render item buttons in the list. Overrides the default buttons. */
         itemButtonRenderer: PropTypes.func,
+        /** Height of an item row */
+        itemRowHeight: PropTypes.number,
+        /** Used to render the row element for items on the list */
+        itemRowRenderer: PropTypes.func,
+        /** Height of the item list header, defaults to 0, which makes header not visible */
+        listHeaderHeight: PropTypes.number,
+        /** Used to render the header row on the item list */
+        listHeaderRenderer: PropTypes.func,
         /** Whether the new folder button should be shown */
         showCreateNewFolderButton: PropTypes.bool,
         /** Props for the search input */
         searchInputProps: PropTypes.object,
         /** Custom text for the choose button */
         chooseButtonText: PropTypes.node,
-        /** Table row height */
-        rowHeight: PropTypes.number,
-        /**
-         * Extra columns displayed in the folders table after folder name column
-         * Each column has to be a Column element
-         */
-        additionalColumns: PropTypes.arrayOf(PropTypes.element),
-        /** Height of the table header, defaults to 0, which makes header not visible */
-        headerHeight: PropTypes.number,
-        /** Custom header row function */
-        headerRowRenderer: PropTypes.func,
     };
 
     static defaultProps = {

--- a/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
+++ b/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
@@ -16,14 +16,15 @@ type Props = {
     className?: string,
     customInput?: React.ComponentType<any>,
     description?: string,
-    headerHeight?: number,
-    headerRowRenderer?: Function,
     isOpen?: boolean,
     isResponsive?: boolean,
+    itemRowHeight?: number,
+    itemRowRenderer?: Function,
+    listHeaderHeight?: number,
+    listHeaderRenderer?: Function,
     onRequestClose?: Function,
     onSelectItem?: (item: Object, index: number) => void,
     onSelectedClick?: () => void,
-    rowHeight?: number,
     title?: string,
 };
 

--- a/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
+++ b/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
@@ -16,6 +16,8 @@ type Props = {
     className?: string,
     customInput?: React.ComponentType<any>,
     description?: string,
+    headerHeight?: number,
+    headerRowRenderer?: Function,
     isOpen?: boolean,
     isResponsive?: boolean,
     onRequestClose?: Function,

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -132,6 +132,10 @@ class ContentExplorer extends Component {
          * Each column has to be a Column element
          */
         additionalColumns: PropTypes.arrayOf(PropTypes.element),
+        /** Height of the table header, defaults to 0, which makes header not visible */
+        headerHeight: PropTypes.number,
+        /** Custom header row function */
+        headerRowRenderer: PropTypes.func,
     };
 
     static defaultProps = {
@@ -430,6 +434,8 @@ class ContentExplorer extends Component {
             searchInputProps,
             rowHeight,
             additionalColumns,
+            headerHeight,
+            headerRowRenderer,
             ...rest
         } = this.props;
         const { isInSearchMode, foldersPath, selectedItems, isSelectAllChecked } = this.state;
@@ -524,6 +530,8 @@ class ContentExplorer extends Component {
                     selectedItems={selectedItems}
                     width={listWidth}
                     rowHeight={rowHeight}
+                    headerHeight={headerHeight}
+                    headerRowRenderer={headerRowRenderer}
                 />
                 <ContentExplorerActionButtons
                     actionButtonsProps={actionButtonsProps}

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -19,6 +19,11 @@ class ContentExplorer extends Component {
     static propTypes = {
         /** Props for the action buttons container */
         actionButtonsProps: PropTypes.object,
+        /**
+         * Extra columns displayed in the folders table after folder name column
+         * Each column has to be a Column element
+         */
+        additionalColumns: PropTypes.arrayOf(PropTypes.element),
         /** Props for breadcrumbs */
         breadcrumbProps: PropTypes.object,
         /** Props for the cancel button */
@@ -117,25 +122,20 @@ class ContentExplorer extends Component {
         itemNameLinkRenderer: PropTypes.func,
         /** Used to render item buttons in the list. Overrides the default buttons. */
         itemButtonRenderer: PropTypes.func,
+        /** Height of an item row */
+        itemRowHeight: PropTypes.number,
         /** Used to render the row element for items on the list. Allows row customizations such as adding tooltips, etc. */
         itemRowRenderer: PropTypes.func,
+        /** Height of the item list header, defaults to 0, which makes header not visible */
+        listHeaderHeight: PropTypes.number,
+        /** Used to render the header row on the item list */
+        listHeaderRenderer: PropTypes.func,
         /** Width of the item list */
         listWidth: PropTypes.number.isRequired,
         /** Height of the item list */
         listHeight: PropTypes.number.isRequired,
         /** Props for the search input */
         searchInputProps: PropTypes.object,
-        /** Height of the row */
-        rowHeight: PropTypes.number,
-        /**
-         * Extra columns displayed in the folders table after folder name column
-         * Each column has to be a Column element
-         */
-        additionalColumns: PropTypes.arrayOf(PropTypes.element),
-        /** Height of the table header, defaults to 0, which makes header not visible */
-        headerHeight: PropTypes.number,
-        /** Custom header row function */
-        headerRowRenderer: PropTypes.func,
     };
 
     static defaultProps = {
@@ -400,6 +400,7 @@ class ContentExplorer extends Component {
     render() {
         const {
             actionButtonsProps,
+            additionalColumns,
             breadcrumbProps,
             cancelButtonProps,
             chooseButtonProps,
@@ -428,14 +429,13 @@ class ContentExplorer extends Component {
             itemIconRenderer,
             itemNameLinkRenderer,
             itemButtonRenderer,
+            itemRowHeight,
             itemRowRenderer,
+            listHeaderHeight,
+            listHeaderRenderer,
             listWidth,
             listHeight,
             searchInputProps,
-            rowHeight,
-            additionalColumns,
-            headerHeight,
-            headerRowRenderer,
             ...rest
         } = this.props;
         const { isInSearchMode, foldersPath, selectedItems, isSelectAllChecked } = this.state;
@@ -513,6 +513,8 @@ class ContentExplorer extends Component {
                 <ItemList
                     additionalColumns={additionalColumns}
                     contentExplorerMode={contentExplorerMode}
+                    headerHeight={listHeaderHeight}
+                    headerRenderer={listHeaderRenderer}
                     height={listHeight}
                     isResponsive={isResponsive}
                     itemButtonRenderer={itemButtonRenderer}
@@ -527,11 +529,9 @@ class ContentExplorer extends Component {
                     onItemDoubleClick={this.handleItemDoubleClick}
                     onItemNameClick={this.handleItemNameClick}
                     onLoadMoreItems={onLoadMoreItems}
+                    rowHeight={itemRowHeight}
                     selectedItems={selectedItems}
                     width={listWidth}
-                    rowHeight={rowHeight}
-                    headerHeight={headerHeight}
-                    headerRowRenderer={headerRowRenderer}
                 />
                 <ContentExplorerActionButtons
                     actionButtonsProps={actionButtonsProps}

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -137,6 +137,8 @@ const ItemList = ({
     onItemDoubleClick,
     onItemNameClick,
     onLoadMoreItems,
+    headerHeight,
+    headerRenderer,
     itemIconRenderer,
     itemNameLinkRenderer,
     itemButtonRenderer,
@@ -145,8 +147,6 @@ const ItemList = ({
     width,
     height,
     rowHeight = DEFAULT_ROW_HEIGHT,
-    headerHeight,
-    headerRowRenderer,
 }) => {
     const getRow = ({ index }) => items[index];
 
@@ -221,6 +221,8 @@ const ItemList = ({
                 headerClassName="table-header-item"
                 width={width}
                 height={height}
+                headerHeight={headerHeight}
+                headerRowRenderer={headerRenderer}
                 rowHeight={rowHeight}
                 rowCount={items.length}
                 onRowClick={onItemClick}
@@ -228,8 +230,6 @@ const ItemList = ({
                 rowGetter={getRow}
                 rowRenderer={renderRow}
                 noRowsRenderer={noItemsRenderer}
-                headerHeight={headerHeight}
-                headerRowRenderer={headerRowRenderer}
                 {...tableProps}
             >
                 <Column
@@ -286,6 +286,8 @@ ItemList.propTypes = {
     onItemDoubleClick: PropTypes.func,
     onItemNameClick: PropTypes.func,
     onLoadMoreItems: PropTypes.func,
+    headerHeight: PropTypes.number,
+    headerRenderer: PropTypes.func,
     itemIconRenderer: PropTypes.func,
     itemNameLinkRenderer: PropTypes.func,
     itemButtonRenderer: PropTypes.func,
@@ -294,8 +296,6 @@ ItemList.propTypes = {
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
     rowHeight: PropTypes.number,
-    headerHeight: PropTypes.number,
-    headerRowRenderer: PropTypes.func,
 };
 
 export { ItemList as ItemListBase };

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -145,6 +145,8 @@ const ItemList = ({
     width,
     height,
     rowHeight = DEFAULT_ROW_HEIGHT,
+    headerHeight,
+    headerRowRenderer,
 }) => {
     const getRow = ({ index }) => items[index];
 
@@ -226,6 +228,8 @@ const ItemList = ({
                 rowGetter={getRow}
                 rowRenderer={renderRow}
                 noRowsRenderer={noItemsRenderer}
+                headerHeight={headerHeight}
+                headerRowRenderer={headerRowRenderer}
                 {...tableProps}
             >
                 <Column
@@ -290,6 +294,8 @@ ItemList.propTypes = {
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
     rowHeight: PropTypes.number,
+    headerHeight: PropTypes.number,
+    headerRowRenderer: PropTypes.func,
 };
 
 export { ItemList as ItemListBase };

--- a/src/features/content-explorer/item-list/__tests__/ItemList.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemList.test.js
@@ -291,4 +291,26 @@ describe('features/content-explorer/item-list/ItemList', () => {
             expect(wrapper.find('.item-list-accessLevel-col').length).toBe(3);
         });
     });
+
+    describe('headerHeight', () => {
+        test('should display folder name header label', () => {
+            const headerHeight = 30;
+            const wrapper = renderComponent({
+                headerHeight,
+            });
+
+            const header = wrapper.find('.ReactVirtualized__Table__headerRow');
+            expect(header.props().style.height).toBe(headerHeight);
+        });
+    });
+
+    describe('headerRowRenderer', () => {
+        test('should display custom header', () => {
+            const wrapper = renderComponent({
+                headerRowRenderer: () => <div data-testid="customHeader">Custom Header</div>,
+            });
+            const headerRow = wrapper.find("[data-testid='customHeader']");
+            expect(headerRow.length).toBe(1);
+        });
+    });
 });

--- a/src/features/content-explorer/item-list/__tests__/ItemList.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemList.test.js
@@ -293,7 +293,7 @@ describe('features/content-explorer/item-list/ItemList', () => {
     });
 
     describe('headerHeight', () => {
-        test('should display folder name header label', () => {
+        test('should display header row with specified height', () => {
             const headerHeight = 30;
             const wrapper = renderComponent({
                 headerHeight,
@@ -304,10 +304,10 @@ describe('features/content-explorer/item-list/ItemList', () => {
         });
     });
 
-    describe('headerRowRenderer', () => {
-        test('should display custom header', () => {
+    describe('headerRenderer', () => {
+        test('should use headerRenderer when specified', () => {
             const wrapper = renderComponent({
-                headerRowRenderer: () => <div data-testid="customHeader">Custom Header</div>,
+                headerRenderer: () => <div data-testid="customHeader">Custom Header</div>,
             });
             const headerRow = wrapper.find("[data-testid='customHeader']");
             expect(headerRow.length).toBe(1);


### PR DESCRIPTION
What are we trying to do here?
We're trying to show the custom header for the table. 
Because by default it won't be visible because table header height is 0 I am also introducing tableHeaderHeight prop in order to make the header visible. 
I am also adding `headerRowRenderer` that we can pass through to the Table component that will allow to create a custom table headers.
If this is not clear enough we could introduce another prop `disableHeader` that would control the header visibility (you'd still need the height though). 
This is a non breaking change. 


<img width="781" alt="image" src="https://user-images.githubusercontent.com/3791384/202710590-58ba3fe1-e450-4492-8262-ca3cdfdacc44.png">
