### PR TITLE
fix(content-explorer): Remove props from styleguidist examples

### DIFF
--- a/examples/src/ContentExplorerModalContainerExamples.js
+++ b/examples/src/ContentExplorerModalContainerExamples.js
@@ -163,8 +163,6 @@ class ContentExplorerModalContainerExamples extends Component {
                         numItemsPerPage={100}
                         numTotalItems={items.length}
                         onLoadMoreItems={() => {}}
-                        listWidth={600}
-                        listHeight={350}
                     />
                 )}
             </div>

--- a/examples/src/ContentExplorerMultiSelectModalContainerExamples.js
+++ b/examples/src/ContentExplorerMultiSelectModalContainerExamples.js
@@ -187,8 +187,6 @@ class ContentExplorerMultiSelectModalContainerExamples extends Component {
                         numItemsPerPage={100}
                         numTotalItems={items.length}
                         onLoadMoreItems={() => {}}
-                        listWidth={600}
-                        listHeight={350}
                     />
                 )}
             </div>

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -440,7 +440,7 @@ class ContentExplorer extends Component {
         // ContentExplorerActionButtons instead. There's a lot of implicit knowledge
         // of what the action buttons are and what they should be doing.
         if (contentExplorerMode === ContentExplorerModes.MULTI_SELECT) {
-            // NOTE:o nly expecting to have 1 (choose) button so as long as something
+            // NOTE: only expecting to have 1 (choose) button so as long as something
             // is selected and that item's isActionDisabled is false, we enable the action button
             areActionButtonsDisabled =
                 selectedItemsIds.length === 0 ||

--- a/src/features/metadata-instance-editor/TemplateDropdown.scss
+++ b/src/features/metadata-instance-editor/TemplateDropdown.scss
@@ -34,7 +34,7 @@
             border-top: none;
             border-radius: 0 0 $bdl-border-radius-size-med $bdl-border-radius-size-med;
 
-            // NOTE (cwei): targets ie11
+            // NOTE: targets ie11
             @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
                 max-height: 300px;
             }
@@ -67,7 +67,7 @@
 
             // NOTE: targets ie11
             @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-                // Note (lbarrick) Avoids cutting off the last item in the list.
+                // NOTE: Avoids cutting off the last item in the list
                 height: 300px;
             }
 


### PR DESCRIPTION
the styleguidist examples included extra props not specified in the [prop types list](https://github.com/box/box-ui-elements/blob/master/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js#L10) for `ContentExplorerModalContainer` that were passed to `ItemList` causing overflow issues

**Before**
<img width="650" alt="Screen Shot 2022-11-21 at 4 18 02 PM" src="https://user-images.githubusercontent.com/7311041/203185402-ef07d6f7-0e30-4692-b836-794c127f5c1e.png">

**After**
<img width="634" alt="Screen Shot 2022-11-21 at 4 17 40 PM" src="https://user-images.githubusercontent.com/7311041/203185414-dfa79dab-12b4-4324-b9b7-d54ead6d7e40.png">
