### PR TITLE
fix: remove warning when passing initialSelectedItems to ContentExplorer

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -447,6 +447,7 @@ class ContentExplorer extends Component {
             'onSelectItem',
             'onSearchSubmit',
             'onExitSearch',
+            'initialSelectedItems',
         ]);
 
         const selectedItemsIds = Object.keys(selectedItems);


### PR DESCRIPTION
I'm sorry but it's driving me crazy
![Screen Shot 2022-11-23 at 17 06 42](https://user-images.githubusercontent.com/3791384/203596523-aa2a5e1c-a77c-4fe9-8603-a085d281d365.png)
