### PR TITLE
chore(template): Use ready to merge label instead of merge button

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,10 +4,7 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
----
-
-**_If you are a Box employee, you do not need to create an issue to open a pull request_**
+---**_If you are a Box employee, you do not need to create an issue to open a pull request_**
 
 Please fill out the following template so we can reproduce and fix your issue as quickly as possible!
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,10 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
----**_If you are a Box employee, you do not need to create an issue to open a pull request_**
+
+---
+
+**_If you are a Box employee, you do not need to create an issue to open a pull request_**
 
 Please fill out the following template so we can reproduce and fix your issue as quickly as possible!
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+<!-- Please add the `ready-to-merge` label when you have received both approvals instead of clicking the merge button
+Using the `ready-to-merge` label adds your approved PR to the merge train and when master is in a green state from the previous merge.
+Mergify will merge your PR based on the queue -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,4 +105,4 @@ Keep in mind that we like to see one issue addressed per pull request, as this h
 
 ### Step 8: Add `ready-to-merge` label
 
-After you have received your approvals and the check statuses are green, please add the `ready-to-merge` label instead of using the merge button. This will add your approved PR to the merge train to safely merge your PR after the previous merge is green.
+After your pull request has been approved and the check statuses are green, please add the `ready-to-merge` label instead of using the merge button. This will add your pull request to the merge queue and merge your pull request when it is safe. If you are unable to add the `ready-to-merge` label, please ask an approver or maintainer for assistance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,3 +102,7 @@ Make sure that all tests are passing before submitting a pull request. See the [
 Send the pull request from your feature branch to us. Be sure to include a description (as mentioned above in step 4) that lets us know what work you did.
 
 Keep in mind that we like to see one issue addressed per pull request, as this helps keep our git history clean and we can more easily track down issues.
+
+### Step 8: Add `ready-to-merge` label
+
+After you have received your approvals and the check statuses are green, please add the `ready-to-merge` label instead of using the merge button. This will add your approved PR to the merge train to safely merge your PR after the previous merge is green.


### PR DESCRIPTION
Added PR template to highlight that people should use the ready-to-merge label instead of clicking the merge button.  Adding the label, adds their PR to the merge train for safe merging.