### PR TITLE
fix(sub-header): add accessibility label to SortButton

### DIFF
--- a/src/elements/common/sub-header/SortButton.js
+++ b/src/elements/common/sub-header/SortButton.js
@@ -5,19 +5,22 @@
  */
 
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import Button from '../../../components/button';
 import IconSort from '../../../icons/general/IconSort';
 import messages from '../messages';
 import Tooltip from '../Tooltip';
 import './SortButton.scss';
 
-const SortButton = (props: ?Object) => (
-    <Tooltip text={<FormattedMessage {...messages.sort} />}>
-        <Button className="be-btn-sort" type="button" {...props}>
-            <IconSort />
-        </Button>
-    </Tooltip>
-);
+const SortButton = ({ intl, ...rest }: ?Object) => {
+    const sortMessage = intl.formatMessage(messages.sort);
+    return (
+        <Tooltip text={sortMessage}>
+            <Button aria-label={sortMessage} className="be-btn-sort" type="button" {...rest}>
+                <IconSort />
+            </Button>
+        </Tooltip>
+    );
+};
 
-export default SortButton;
+export default injectIntl(SortButton);

--- a/src/elements/common/sub-header/SortButton.js
+++ b/src/elements/common/sub-header/SortButton.js
@@ -6,13 +6,21 @@
 
 import React from 'react';
 import { injectIntl } from 'react-intl';
+import type { IntlShape } from 'react-intl';
+
 import Button from '../../../components/button';
 import IconSort from '../../../icons/general/IconSort';
-import messages from '../messages';
 import Tooltip from '../Tooltip';
+
+import messages from '../messages';
+
 import './SortButton.scss';
 
-const SortButton = ({ intl, ...rest }: ?Object) => {
+type Props = {
+    intl: IntlShape,
+};
+
+const SortButton = ({ intl, ...rest }: Props) => {
     const sortMessage = intl.formatMessage(messages.sort);
     return (
         <Tooltip text={sortMessage}>

--- a/src/elements/common/sub-header/SortButton.js
+++ b/src/elements/common/sub-header/SortButton.js
@@ -31,4 +31,5 @@ const SortButton = ({ intl, ...rest }: Props) => {
     );
 };
 
+export { SortButton as SortButtonBase };
 export default injectIntl(SortButton);

--- a/src/elements/common/sub-header/__tests__/Sort.test.js
+++ b/src/elements/common/sub-header/__tests__/Sort.test.js
@@ -7,7 +7,7 @@ import SortButton from '../SortButton';
 import messages from '../../messages';
 import { SORT_ASC, SORT_DESC } from '../../../../constants';
 
-describe('elements/SubHeader/Sort', () => {
+describe('elements/common/sub-header/Sort', () => {
     test('should render a button and menu with 4 menu items', () => {
         const wrapper = shallow(<Sort onSortChange={jest.fn()} sortBy="name" sortDirection={SORT_ASC} />);
 

--- a/src/elements/common/sub-header/__tests__/SortButton.test.js
+++ b/src/elements/common/sub-header/__tests__/SortButton.test.js
@@ -1,14 +1,13 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { SortButtonBase } from '../SortButton';
 import Button from '../../../../components/button';
 import IconSort from '../../../../icons/general/IconSort';
+import { SortButtonBase } from '../SortButton';
 
 const intlMock = {
     formatMessage: jest.fn().mockReturnValue('Sort'),
 };
 
-describe('Elements/SubHeader/SortButton', () => {
+describe('elements/common/sub-header/SortButton', () => {
     const getWrapper = () => shallow(<SortButtonBase intl={intlMock} />);
 
     test('should render IconSort', () => {
@@ -16,10 +15,10 @@ describe('Elements/SubHeader/SortButton', () => {
         expect(wrapper.exists(IconSort)).toBe(true);
     });
 
-    test('should have aria-label "sort"', () => {
+    test('should have aria-label "Sort"', () => {
         const wrapper = getWrapper();
         const button = wrapper.find(Button);
         expect(button.prop('aria-label')).toBe('Sort');
-        expect(button.prop('aria-describedBy')).toBeFalsy();
+        expect(button.prop('aria-describedby')).toBeFalsy();
     });
 });

--- a/src/elements/common/sub-header/__tests__/SortButton.test.js
+++ b/src/elements/common/sub-header/__tests__/SortButton.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SortButtonBase } from '../SortButton';
+import Button from '../../../../components/button';
+import IconSort from '../../../../icons/general/IconSort';
+
+const intlMock = {
+    formatMessage: jest.fn().mockReturnValue('Sort'),
+};
+
+describe('Elements/SubHeader/SortButton', () => {
+    const getWrapper = () => shallow(<SortButtonBase intl={intlMock} />);
+
+    test('should render IconSort', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.exists(IconSort)).toBe(true);
+    });
+
+    test('should have aria-label "sort"', () => {
+        const wrapper = getWrapper();
+        const button = wrapper.find(Button);
+        expect(button.prop('aria-label')).toBe('Sort');
+        expect(button.prop('aria-describedBy')).toBeFalsy();
+    });
+});

--- a/src/elements/common/sub-header/__tests__/SubHeaderRight.test.js
+++ b/src/elements/common/sub-header/__tests__/SubHeaderRight.test.js
@@ -8,7 +8,7 @@ import { VIEW_FOLDER, VIEW_MODE_GRID } from '../../../../constants';
 
 const getWrapper = props => shallow(<SubHeaderRight {...props} />);
 
-describe('Elements/SubHeader/SubHeaderRight', () => {
+describe('elements/common/sub-header/SubHeaderRight', () => {
     const currentCollection = {
         sortBy: '',
         sortDirection: '',


### PR DESCRIPTION
Normal source:
![image](https://user-images.githubusercontent.com/24941488/207426237-79be53b2-7ae9-48de-9469-889e6ed1c7cd.png)

Hover source:
![image](https://user-images.githubusercontent.com/24941488/207426384-9fcc1057-4ef1-4a6a-8521-690cfe0aabac.png)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
