### PR TITLE
fix(item-action): add aria-label to plainbutton

### DIFF
--- a/src/elements/content-uploader/ItemAction.js
+++ b/src/elements/content-uploader/ItemAction.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @file Item action component
+ * @file Item action component displayed on the upload toast, e.g. cancel/resume
  */
 
 import React from 'react';
@@ -50,6 +50,7 @@ const ItemAction = ({
     let icon = <IconClose />;
     let tooltip;
     const { code } = error;
+    const { formatMessage } = intl;
 
     if (isFolder && status !== STATUS_PENDING) {
         return null;
@@ -96,12 +97,14 @@ const ItemAction = ({
             </PrimaryButton>
         );
     }
+    const isDisabled = status === STATUS_STAGED;
+    const tooltipText = tooltip && formatMessage(tooltip);
 
     return (
         <div className="bcu-item-action">
             {tooltip ? (
-                <Tooltip position="top-left" text={intl.formatMessage(tooltip)}>
-                    <PlainButton onClick={onClick} type="button" isDisabled={status === STATUS_STAGED}>
+                <Tooltip position="top-left" text={tooltipText}>
+                    <PlainButton aria-label={tooltipText} isDisabled={isDisabled} onClick={onClick} type="button">
                         {icon}
                     </PlainButton>
                 </Tooltip>

--- a/src/elements/content-uploader/__tests__/ItemAction.test.js
+++ b/src/elements/content-uploader/__tests__/ItemAction.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import noop from 'lodash/noop';
 import { shallow } from 'enzyme';
+import PlainButton from '../../../components/plain-button';
 import { ItemActionForTesting as ItemAction } from '../ItemAction';
 import {
     ERROR_CODE_UPLOAD_FILE_SIZE_LIMIT_EXCEEDED,
@@ -15,7 +16,7 @@ describe('elements/content-uploader/ItemAction', () => {
     const getWrapper = props =>
         shallow(
             <ItemAction
-                intl={{ formatMessage: data => <span {...data} /> }}
+                intl={{ formatMessage: data => data.defaultMessage }}
                 onClick={noop}
                 status={STATUS_PENDING}
                 {...props}
@@ -75,5 +76,14 @@ describe('elements/content-uploader/ItemAction', () => {
 
         expect(wrapper.exists('PrimaryButton')).toBe(true);
         expect(wrapper.exists('PlainButton')).toBe(false);
+    });
+
+    test('should have aria-label "Cancel this upload" when status is pending', () => {
+        const wrapper = getWrapper({
+            status: STATUS_PENDING,
+        });
+        const plainButton = wrapper.find(PlainButton);
+        expect(plainButton.prop('aria-label')).toBe('Cancel this upload');
+        expect(plainButton.prop('aria-describedby')).toBeFalsy();
     });
 });

--- a/src/elements/content-uploader/__tests__/__snapshots__/ItemAction.test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/ItemAction.test.js.snap
@@ -20,6 +20,12 @@ exports[`elements/content-uploader/ItemAction should render correctly with compl
     theme="default"
   >
     <PlainButton
+      aria-label={
+        <span
+          defaultMessage="Remove"
+          id="be.remove"
+        />
+      }
       isDisabled={false}
       onClick={[Function]}
       type="button"
@@ -60,6 +66,12 @@ exports[`elements/content-uploader/ItemAction should render correctly with error
     theme="default"
   >
     <PlainButton
+      aria-label={
+        <span
+          defaultMessage="Retry"
+          id="be.retry"
+        />
+      }
       isDisabled={false}
       onClick={[Function]}
       type="button"
@@ -91,6 +103,12 @@ exports[`elements/content-uploader/ItemAction should render correctly with error
     theme="default"
   >
     <PlainButton
+      aria-label={
+        <span
+          defaultMessage="Resume"
+          id="be.resume"
+        />
+      }
       isDisabled={false}
       onClick={[Function]}
       type="button"
@@ -122,6 +140,12 @@ exports[`elements/content-uploader/ItemAction should render correctly with inpro
     theme="default"
   >
     <PlainButton
+      aria-label={
+        <span
+          defaultMessage="Cancel this upload"
+          id="be.uploadsCancelButtonTooltip"
+        />
+      }
       isDisabled={false}
       onClick={[Function]}
       type="button"
@@ -158,6 +182,12 @@ exports[`elements/content-uploader/ItemAction should render correctly with pendi
     theme="default"
   >
     <PlainButton
+      aria-label={
+        <span
+          defaultMessage="Cancel this upload"
+          id="be.uploadsCancelButtonTooltip"
+        />
+      }
       isDisabled={false}
       onClick={[Function]}
       type="button"
@@ -194,6 +224,12 @@ exports[`elements/content-uploader/ItemAction should render correctly with stage
     theme="default"
   >
     <PlainButton
+      aria-label={
+        <span
+          defaultMessage="Cancel this upload"
+          id="be.uploadsCancelButtonTooltip"
+        />
+      }
       isDisabled={true}
       onClick={[Function]}
       type="button"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

**After**
* aria-label added, matching hover text
* aria-describedby removed
<img width="1792" alt="Screenshot 2022-12-13 at 4 56 16 PM" src="https://user-images.githubusercontent.com/37150601/207658807-3e179e7a-1314-4e7c-a1df-9207c786bbc2.png">
<img width="1674" alt="Screenshot 2022-12-14 at 10 56 01 AM" src="https://user-images.githubusercontent.com/37150601/207658812-f327e047-1e82-45a2-b2e5-c2420c5db212.png">

