### PR TITLE
feat(tooltip): support error tooltip position

### DIFF
--- a/src/components/select-button/SelectButton.js
+++ b/src/components/select-button/SelectButton.js
@@ -3,18 +3,23 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import Tooltip from '../tooltip';
+import type { Position } from '../tooltip';
 import './SelectButton.scss';
 
 type Props = {
     children?: React.Node,
     className: string,
     error?: React.Node,
+    errorTooltipPosition?: Position,
     isDisabled: boolean,
 };
 
 const SelectButton = React.forwardRef<Props, HTMLButtonElement>(
-    ({ children, className = '', error, isDisabled = false, ...rest }: Props, ref) => (
-        <Tooltip isShown={!!error} position="middle-right" text={error} theme="error">
+    (
+        { children, className = '', error, errorTooltipPosition = 'middle-right', isDisabled = false, ...rest }: Props,
+        ref,
+    ) => (
+        <Tooltip isShown={!!error} position={errorTooltipPosition} text={error} theme="error">
             <button
                 className={classNames(className, 'select-button', 'bdl-SelectButton', {
                     'is-invalid': !!error,

--- a/src/components/select-button/__tests__/SelectButton.test.js
+++ b/src/components/select-button/__tests__/SelectButton.test.js
@@ -20,4 +20,12 @@ describe('components/select-button/SelectButton', () => {
         const wrapper = shallow(<SelectButton error="error">Button Text</SelectButton>);
         expect(wrapper).toMatchSnapshot();
     });
+    test('should align error tooltip on button when errorTooltipPosition has some value', () => {
+        const wrapper = shallow(
+            <SelectButton error="error" errorTooltipPosition="middle-left">
+                Button Text
+            </SelectButton>,
+        );
+        expect(wrapper.find('Tooltip').prop('position')).toBe('middle-left');
+    });
 });

--- a/src/components/select-field/BaseSelectField.js
+++ b/src/components/select-field/BaseSelectField.js
@@ -11,6 +11,7 @@ import SelectButton from '../select-button';
 import DatalistItem from '../datalist-item';
 import PopperComponent from '../popper';
 import SelectFieldDropdown from './SelectFieldDropdown';
+import type { Position } from '../tooltip';
 import type { SelectOptionValueProp, SelectOptionProp } from './props';
 import { PLACEMENT_BOTTOM_END, PLACEMENT_BOTTOM_START } from '../popper/constants';
 import SearchForm from '../search-form/SearchForm';
@@ -47,6 +48,8 @@ type Props = {
     defaultValue?: SelectOptionValueProp,
     /** An optional error to show within a tooltip. */
     error?: React.Node,
+    /** Position of error message tooltip */
+    errorTooltipPosition?: Position,
     /* Intl object */
     intl: Object,
     /** The select button is disabled if true */
@@ -453,7 +456,7 @@ class BaseSelectField extends React.Component<Props, State> {
 
     renderSelectButton = () => {
         const { activeItemID, isOpen } = this.state;
-        const { buttonProps: buttonElProps, isDisabled, className, error } = this.props;
+        const { buttonProps: buttonElProps, isDisabled, className, error, errorTooltipPosition } = this.props;
         const buttonText = this.renderButtonText();
         const buttonProps = {
             ...buttonElProps,
@@ -473,7 +476,7 @@ class BaseSelectField extends React.Component<Props, State> {
         return (
             // Need to store the select button reference so we can calculate the button width
             // in order to set it as the min width of the dropdown list
-            <SelectButton {...buttonProps} error={error}>
+            <SelectButton {...buttonProps} error={error} errorTooltipPosition={errorTooltipPosition}>
                 {buttonText}
             </SelectButton>
         );

--- a/src/components/select-field/__tests__/BaseSelectField.test.js
+++ b/src/components/select-field/__tests__/BaseSelectField.test.js
@@ -135,6 +135,15 @@ describe('components/select-field/BaseSelectField', () => {
             const buttonWrapper = wrapper.find('PopperComponent').childAt(0);
             expect(buttonWrapper).toMatchSnapshot();
         });
+
+        test('should send error tooltip positon to select button when errorTooltipPosition prop has some value', () => {
+            const wrapper = shallowRenderSelectField({
+                error: 'error',
+                errorTooltipPosition: 'middle-left',
+            });
+            const buttonWrapper = wrapper.find('PopperComponent').childAt(0);
+            expect(buttonWrapper.prop('errorTooltipPosition')).toBe('middle-left');
+        });
     });
 
     describe('renderSearchInput', () => {


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
