### PR TITLE
feat(preview): add new sign dropdown under ff

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -320,8 +320,12 @@ be.contentSidebar.boxSignFtuxBody = Sign documents or send signature requests, r
 be.contentSidebar.boxSignFtuxTitle = Box Sign - Secure, seamless e-signatures in Box
 # label for button that opens a Box Sign signature request experience
 be.contentSidebar.boxSignRequest = Request Signature
+# One of the dropdown options that opens a Box Sign request signature experience
+be.contentSidebar.boxSignRequestSignature = Request Signature
 # Tooltip text for when Box Sign is blocked due to a security policy
 be.contentSidebar.boxSignSecurityBlockedTooltip = This action is unavailable due to a security policy.
+# One of the dropdown options that opens a Box Sign sign myself experience
+be.contentSidebar.boxSignSignMyself = Sign Myself
 # label for button that opens a Box Sign signature fulfillment experience
 be.contentSidebar.boxSignSignature = Sign
 # Tooltip text for when Box Sign is blocked due to an item being watermarked

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -13,7 +13,7 @@ import IconDocInfo from '../../icons/general/IconDocInfo';
 import IconMagicWand from '../../icons/general/IconMagicWand';
 import IconMetadataThick from '../../icons/general/IconMetadataThick';
 import SidebarNavButton from './SidebarNavButton';
-import SidebarNavSignButton from './SidebarNavSignButton';
+import SidebarNavSign from './SidebarNavSign';
 import SidebarNavTablist from './SidebarNavTablist';
 import SidebarToggle from './SidebarToggle';
 import messages from '../common/messages';
@@ -54,13 +54,7 @@ const SidebarNav = ({
     isOpen,
     onNavigate,
 }: Props) => {
-    const {
-        blockedReason: boxSignBlockedReason,
-        enabled: hasBoxSign,
-        onClick: onBoxSignClick,
-        status: boxSignStatus,
-        targetingApi: boxSignTargetingApi,
-    } = useFeatureConfig('boxSign');
+    const { enabled: hasBoxSign } = useFeatureConfig('boxSign');
 
     return (
         <div className="bcs-SidebarNav" aria-label={intl.formatMessage(messages.sidebarNavLabel)}>
@@ -108,15 +102,9 @@ const SidebarNav = ({
                     )}
                 </SidebarNavTablist>
 
-                {hasBoxSign && onBoxSignClick && (
+                {hasBoxSign && (
                     <div className="bcs-SidebarNav-secondary">
-                        <SidebarNavSignButton
-                            blockedReason={boxSignBlockedReason}
-                            data-resin-target={SIDEBAR_NAV_TARGETS.SIGN}
-                            onClick={() => onBoxSignClick({ fileId })}
-                            status={boxSignStatus}
-                            targetingApi={boxSignTargetingApi}
-                        />
+                        <SidebarNavSign />
                     </div>
                 )}
 

--- a/src/elements/content-sidebar/SidebarNavSign.scss
+++ b/src/elements/content-sidebar/SidebarNavSign.scss
@@ -1,0 +1,5 @@
+@import '../../styles/variables';
+
+.bcs-SidebarNavSign-icon path {
+    fill: $bdl-gray;
+}

--- a/src/elements/content-sidebar/SidebarNavSign.tsx
+++ b/src/elements/content-sidebar/SidebarNavSign.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+// @ts-ignore Module is written in Flow
+import { useFeatureConfig } from '../common/feature-checking';
+// @ts-ignore Module is written in Flow
+import { SIDEBAR_NAV_TARGETS } from '../common/interactionTargets';
+
+// @ts-ignore Module is written in Flow
+import DropdownMenu from '../../components/dropdown-menu';
+import SidebarNavSignButton from './SidebarNavSignButton';
+import SignMe32 from '../../icon/fill/SignMe32';
+import SignMeOthers32 from '../../icon/fill/SignMeOthers32';
+import { Menu, MenuItem } from '../../components/menu';
+
+// @ts-ignore Module is written in Flow
+import messages from './messages';
+
+import './SidebarNavSign.scss';
+
+export function SidebarNavSign() {
+    const {
+        blockedReason: boxSignBlockedReason,
+        onClick: onBoxClickRequestSignature,
+        onClickSignMyself: onBoxClickSignMyself,
+        status: boxSignStatus,
+        targetingApi: boxSignTargetingApi,
+        isSignRemoveInterstitialEnabled,
+    } = useFeatureConfig('boxSign');
+
+    return (
+        <>
+            {isSignRemoveInterstitialEnabled ? (
+                <DropdownMenu isResponsive constrainToWindow isRightAligned>
+                    <SidebarNavSignButton
+                        blockedReason={boxSignBlockedReason}
+                        status={boxSignStatus}
+                        targetingApi={boxSignTargetingApi}
+                        data-resin-target={SIDEBAR_NAV_TARGETS.SIGN}
+                    />
+                    <Menu>
+                        <MenuItem data-testid="sign-request-signature-button" onClick={onBoxClickRequestSignature}>
+                            <SignMeOthers32 width={16} height={16} className="bcs-SidebarNavSign-icon" />
+                            <FormattedMessage {...messages.boxSignRequestSignature} />
+                        </MenuItem>
+                        <MenuItem data-testid="sign-sign-myself-button" onClick={onBoxClickSignMyself}>
+                            <SignMe32 width={16} height={16} className="bcs-SidebarNavSign-icon" />
+                            <FormattedMessage {...messages.boxSignSignMyself} />
+                        </MenuItem>
+                    </Menu>
+                </DropdownMenu>
+            ) : (
+                <SidebarNavSignButton
+                    blockedReason={boxSignBlockedReason}
+                    data-resin-target={SIDEBAR_NAV_TARGETS.SIGN}
+                    onClick={onBoxClickRequestSignature}
+                    status={boxSignStatus}
+                    targetingApi={boxSignTargetingApi}
+                />
+            )}
+        </>
+    );
+}
+
+export default SidebarNavSign;

--- a/src/elements/content-sidebar/SidebarNavSignButton.tsx
+++ b/src/elements/content-sidebar/SidebarNavSignButton.tsx
@@ -55,7 +55,13 @@ export function SidebarNavSignButton({ blockedReason, intl, status, targetingApi
             useTargetingApi={() => targetingApi}
         >
             <Tooltip isDisabled={isTargeted} position={TooltipPosition.MIDDLE_LEFT} text={tooltipMessage}>
-                <PlainButton aria-label={label} className={buttonClassName} isDisabled={isSignDisabled} {...rest}>
+                <PlainButton
+                    aria-label={label}
+                    className={buttonClassName}
+                    data-testid="sign-button"
+                    isDisabled={isSignDisabled}
+                    {...rest}
+                >
                     <BoxSign28 className="bcs-SidebarNavSignButton-icon" />
                     <Sign16 width={20} height={20} className="bcs-SidebarNavSignButton-icon--grayscale" />
                 </PlainButton>

--- a/src/elements/content-sidebar/__tests__/SidebarNavSign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/SidebarNavSign.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import SidebarNavSign from '../SidebarNavSign';
+// @ts-ignore Module is written in Flow
+import FeatureProvider from '../../common/feature-checking/FeatureProvider';
+
+describe('elements/content-sidebar/SidebarNavSign', () => {
+    const onClickRequestSignature = jest.fn();
+    const onClickSignMyself = jest.fn();
+
+    const renderComponent = (props = {}, features = {}) =>
+        render(
+            <FeatureProvider features={features}>
+                <SidebarNavSign {...props} />
+            </FeatureProvider>,
+        );
+
+    test.each([true, false])('should render sign button', isRemoveInterstitialEnabled => {
+        const features = {
+            boxSign: {
+                isSignRemoveInterstitialEnabled: isRemoveInterstitialEnabled,
+            },
+        };
+
+        const wrapper = renderComponent({}, features);
+        expect(wrapper.getByTestId('sign-button')).toBeVisible();
+    });
+
+    test('should call correct handler when sign button is clicked', () => {
+        const features = {
+            boxSign: {
+                isSignRemoveInterstitialEnabled: false,
+                onClick: onClickRequestSignature,
+            },
+        };
+        const { getByTestId } = renderComponent({}, features);
+
+        fireEvent.click(getByTestId('sign-button'));
+
+        expect(onClickRequestSignature).toBeCalled();
+    });
+
+    test('should open dropdown with 2 menu items when sign button is clicked', () => {
+        const features = {
+            boxSign: {
+                isSignRemoveInterstitialEnabled: true,
+            },
+        };
+        const { getByTestId } = renderComponent({}, features);
+        fireEvent.click(getByTestId('sign-button'));
+        expect(getByTestId('sign-request-signature-button')).toBeVisible();
+        expect(getByTestId('sign-sign-myself-button')).toBeVisible();
+    });
+
+    test('should call correct handler when request signature option is clicked', () => {
+        const features = {
+            boxSign: {
+                isSignRemoveInterstitialEnabled: true,
+                onClick: onClickRequestSignature,
+            },
+        };
+        const { getByTestId } = renderComponent({}, features);
+        fireEvent.click(getByTestId('sign-button'));
+        fireEvent.click(getByTestId('sign-request-signature-button'));
+        expect(onClickRequestSignature).toBeCalled();
+    });
+
+    test('should call correct handler when sign myself option is clicked', () => {
+        const features = {
+            boxSign: {
+                isSignRemoveInterstitialEnabled: true,
+                onClickSignMyself,
+            },
+        };
+        const { getByTestId } = renderComponent({}, features);
+        fireEvent.click(getByTestId('sign-button'));
+        fireEvent.click(getByTestId('sign-sign-myself-button'));
+        expect(onClickSignMyself).toBeCalled();
+    });
+});

--- a/src/elements/content-sidebar/messages.js
+++ b/src/elements/content-sidebar/messages.js
@@ -32,6 +32,16 @@ const messages = defineMessages({
         defaultMessage: 'Request Signature',
         description: 'label for button that opens a Box Sign signature request experience',
     },
+    boxSignRequestSignature: {
+        id: 'be.contentSidebar.boxSignRequestSignature',
+        defaultMessage: 'Request Signature',
+        description: 'One of the dropdown options that opens a Box Sign request signature experience',
+    },
+    boxSignSignMyself: {
+        id: 'be.contentSidebar.boxSignSignMyself',
+        defaultMessage: 'Sign Myself',
+        description: 'One of the dropdown options that opens a Box Sign sign myself experience',
+    },
     boxSignSignature: {
         id: 'be.contentSidebar.boxSignSignature',
         defaultMessage: 'Sign',


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

- Moved `SidebarNavSign` logic to a new component `SidebarNavSignButton` that renders the sign button in the SideBar.

- Extended `SidebarNavSign`, it now renders a dropdown with 2 options ("**Request signature**" which navigates to `/sign/new/{fileId}` and **Sign Myself** which navigates to `/sign/new/me/{fileId}`) instead of just the Sign button, based on new feature flag "isSignRemoveInterstitialEnabled".
- Extended `SidebarNavSign` and `SidebarNavSignButton` tests

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/50145747/208967061-9c4ec1c8-a53f-4739-9fb8-10a1f56fb677.png">


 
