### PR TITLE
fix(usm): add aria label

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1656,6 +1656,8 @@ boxui.unifiedShare.emailModalTitle = Send Link to ‘{itemName}’
 boxui.unifiedShare.enterAtLeastOneEmail = Enter at least one valid email
 # Tooltip text shown in the share modal, encouraging users to enter email addresses to share the item with
 boxui.unifiedShare.enterEmailAddressesCalloutText = Share this item with coworkers by entering their email addresses
+# Label for tooltips or other components that display expiration icons
+boxui.unifiedShare.expiresMessage = Expires
 # This is label for the button so a user understands the new interface
 boxui.unifiedShare.ftuxConfirmLabel = Got it
 # Text for the body of the tooltip for the ftux experience when the edit option is available for the user

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -459,7 +459,6 @@ class SharedLinkSection extends React.Component<Props, State> {
         const isToggleEnabled = (canAddSharedLink || canRemoveSharedLink) && !submitting;
 
         let linkText;
-
         if (isSharedLinkEnabled) {
             linkText = <FormattedMessage {...messages.linkShareOn} />;
             if (expirationTimestamp && expirationTimestamp !== 0) {
@@ -472,7 +471,11 @@ class SharedLinkSection extends React.Component<Props, State> {
                                 expiration: convertToMs(expirationTimestamp),
                             })}
                         >
-                            <span className="shared-link-expiration-badge" role="img">
+                            <span
+                                aria-label={intl.formatMessage(messages.expiresMessage)}
+                                className="shared-link-expiration-badge"
+                                role="img"
+                            >
                                 <IconClock color={bdlWatermelonRed} />
                             </span>
                         </Tooltip>

--- a/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkSection.test.js
@@ -148,7 +148,7 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('should account for shared link expirations being set', () => {
+    test('should match snapshot when shared link expiration is set', () => {
         const wrapper = getWrapper({
             sharedLink: {
                 accessLevel: 'peopleInYourCompany',
@@ -308,6 +308,22 @@ describe('features/unified-share-modal/SharedLinkSection', () => {
         const sharedLink = { url: 'https://example.com/shared-link' };
         const wrapper = getWrapper({ config, sharedLink });
         expect(wrapper.exists('.email-shared-link-btn')).toBe(emailButtonExists);
+    });
+
+    test('should have aria-label and role on shared link expiration badge when expiration timestamp exists', () => {
+        // Set an expiration timestamp so that Toggle is rendered with expiration icon
+        const sharedLink = {
+            expirationTimestamp: 1,
+            url: 'https://example.com/shared-link',
+        };
+        const wrapper = getWrapper({ sharedLink });
+        const toggle = wrapper.find('Toggle');
+
+        // The aria-label attr is on a span, which is contained within the label of the Toggle component
+        const spanLabel = toggle.dive().find('.shared-link-expiration-badge');
+
+        expect(spanLabel.prop('aria-label')).toBe('Expires');
+        expect(spanLabel.prop('role')).toBe('img');
     });
 
     describe('componentDidMount()', () => {

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/unified-share-modal/SharedLinkSection should account for shared link expirations being set 1`] = `
+exports[`features/unified-share-modal/SharedLinkSection should match snapshot when shared link expiration is set 1`] = `
 <div
   className="be"
 >
@@ -41,6 +41,7 @@ exports[`features/unified-share-modal/SharedLinkSection should account for share
               theme="default"
             >
               <span
+                aria-label="Expires"
                 className="shared-link-expiration-badge"
                 role="img"
               >

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -540,6 +540,11 @@ const messages = defineMessages({
             'Text to show when the number of contact email addresses displayed on a tooltip exceeds the maximum amount that can be displayed',
         id: 'boxui.unifiedShare.contactEmailsTooltipText',
     },
+    expiresMessage: {
+        defaultMessage: 'Expires',
+        description: 'Label for tooltips or other components that display expiration icons',
+        id: 'boxui.unifiedShare.expiresMessage',
+    },
 });
 
 export default messages;


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

Requested changes:
* add aria-label="expires" to the span containing the clock icon.