### PR TITLE
feat(checkbox): prop to add class to input

### DIFF
--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -17,6 +17,7 @@ export interface CheckboxProps {
     hideLabel?: boolean;
     /** id - Unique `id` for the input */
     id?: string;
+    inputClassName?: string;
     /** isChecked - whether the checkbox is checked or not */
     isChecked?: boolean; // @TODO: eventually call this `checked`
     /** isDisabled - whether the checkbox is disabled or not */
@@ -47,6 +48,7 @@ const Checkbox = ({
     fieldLabel,
     hideLabel,
     id,
+    inputClassName,
     isChecked,
     isDisabled,
     label,
@@ -65,6 +67,7 @@ const Checkbox = ({
             <input
                 aria-describedby={description ? `description_${inputID}` : ''}
                 checked={isChecked}
+                className={inputClassName}
                 disabled={isDisabled}
                 id={inputID}
                 name={name}

--- a/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -9,12 +9,15 @@ describe('components/checkbox/Checkbox', () => {
 
     beforeEach(() => {
         onChange = jest.fn();
-        wrapper = shallow(<Checkbox id="1" label="Check things" name="name" onChange={onChange} />);
+        wrapper = shallow(
+            <Checkbox id="1" inputClassName="inputClassName" label="Check things" name="name" onChange={onChange} />,
+        );
     });
 
     test('should correctly render default component', () => {
         expect(wrapper.find('.checkbox-container').length).toBeTruthy();
         expect(wrapper.find('input').prop('id')).toEqual('1');
+        expect(wrapper.find('input').prop('className')).toEqual('inputClassName');
         expect(wrapper.find('input').prop('name')).toEqual('name');
         expect(wrapper.find('input').prop('type')).toEqual('checkbox');
         expect(wrapper.find('.checkbox-pointer-target').length).toBe(1);


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
