### PR TITLE
feat(annotation-thread): annotation thread events handling

### DIFF
--- a/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThread.scss
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThread.scss
@@ -6,6 +6,10 @@
 
     .bcs-ActivityThread {
         box-shadow: none;
+
+        &:hover {
+            background: none;
+        }
     }
 
     .bcs-ActivityThread-content {

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/__mocks__/useAnnotationThread.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/__mocks__/useAnnotationThread.js
@@ -3,13 +3,10 @@ import { annotation as mockAnnotation } from '../../../../../__mocks__/annotatio
 export default () => ({
     annotation: mockAnnotation,
     annotationActions: {
+        handleCreate: jest.fn(),
         handleDelete: jest.fn(),
         handleEdit: jest.fn(),
         handleResolve: jest.fn(),
-    },
-    annotationEvents: {
-        handleAnnotationCreateStart: jest.fn(),
-        handleAnnotationCreateEnd: jest.fn(),
     },
     error: {},
     isLoading: false,

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/__tests__/AnnotationThreadCreate.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/__tests__/AnnotationThreadCreate.test.js
@@ -50,7 +50,7 @@ describe('elements/content-sidebar/activity-feed/annotation-thread/AnnotationThr
         expect(getByTestId('annotation-create')).toHaveClass('is-pending');
     });
 
-    test('Should handle create', () => {
+    test('Should call onFormSubmit on create', () => {
         const onFormSubmit = jest.fn();
 
         const { getByText } = getWrapper({ onFormSubmit });
@@ -60,7 +60,7 @@ describe('elements/content-sidebar/activity-feed/annotation-thread/AnnotationThr
         expect(onFormSubmit).toBeCalledWith('example message');
     });
 
-    test('Should call handleCancel on cancel', () => {
+    test('Should call onFormCancel on cancel', () => {
         const onFormCancel = jest.fn();
 
         const { getByText } = getWrapper({ onFormCancel });

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/useAnnotationThread.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/useAnnotationThread.js
@@ -137,14 +137,6 @@ const useAnnotationThread = ({
         setAnnotation(prevAnnotation => ({ ...prevAnnotation, ...updatedValues }));
     };
 
-    const handleFetchAnnotationSuccess = ({ replies: fetchedReplies, ...normalizedAnnotation }: Annotation) => {
-        setAnnotation({ ...normalizedAnnotation });
-        setReplies(normalizeReplies(fetchedReplies));
-        setError(undefined);
-        setIsLoading(false);
-        emitAnnotationActiveChangeEvent(normalizedAnnotation.id, fileVersionId);
-    };
-
     const annotationErrorCallback = React.useCallback(
         (e: ElementsXhrError, code: string): void => {
             setIsLoading(false);
@@ -167,12 +159,21 @@ const useAnnotationThread = ({
     });
 
     React.useEffect(() => {
-        if (!annotationId || (annotation && annotation.id === annotationId)) {
+        if (!annotationId || isLoading || (annotation && annotation.id === annotationId)) {
             return;
         }
         setIsLoading(true);
-        handleFetch({ id: annotationId, successCallback: handleFetchAnnotationSuccess });
-    }, [annotation, annotationId, handleFetch]);
+        handleFetch({
+            id: annotationId,
+            successCallback: ({ replies: fetchedReplies, ...normalizedAnnotation }: Annotation) => {
+                setAnnotation({ ...normalizedAnnotation });
+                setReplies(normalizeReplies(fetchedReplies));
+                setError(undefined);
+                setIsLoading(false);
+                emitAnnotationActiveChangeEvent(normalizedAnnotation.id, fileVersionId);
+            },
+        });
+    }, [annotation, annotationId, emitAnnotationActiveChangeEvent, fileVersionId, handleFetch, isLoading]);
 
     const { handleReplyCreate, handleReplyEdit, handleReplyDelete } = useRepliesAPI({
         annotationId,


### PR DESCRIPTION
- Addressed code review findings from https://github.com/box/box-ui-elements/pull/3192
- Added handling of Annotation related events 
- Removed `ActivityThread` css hover effect inside `AnnotationThread`