### PR TITLE
feat(annotation-thread): annotation thread replies events handling

### DIFF
--- a/src/elements/common/_variables.scss
+++ b/src/elements/common/_variables.scss
@@ -8,6 +8,7 @@ $sidebarHeaderHeight: 60px;
 $sidebarContentWidth: 340px;
 $sidebarActivityFeedSpacingHorizontal: 20px;
 $sidebarActivityFeedSpacingVertical: 20px;
+$sidebarActivityFeedSelectedItemSpacing: 10px;
 $sidebarTabResponsiveSize: 48px;
 
 @mixin rendering {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThread.scss
@@ -1,6 +1,5 @@
 @import '../../../common/variables';
 
-$sidebarActivityFeedSelectedItemSpacing: 10px;
 $sidebarThreadedActivityCardSpacingTop: 10px;
 $sidebarThreadedActivityCardSpacingHorizontal: $sidebarActivityFeedSpacingHorizontal - $sidebarActivityFeedSelectedItemSpacing;
 $sidebarActivityFeedSelectedItemBorderWidth: 2px;

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThread.scss
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThread.scss
@@ -19,7 +19,7 @@
         overflow: auto;
 
         .bcs-AnnotationActivity-menu {
-            top: $sidebarActivityFeedSpacingVertical;
+            right: $sidebarActivityFeedSpacingHorizontal - $sidebarActivityFeedSelectedItemSpacing;
         }
     }
 

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/__tests__/useRepliesAPI.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/__tests__/useRepliesAPI.test.js
@@ -3,8 +3,6 @@ import { annotation } from '../../../../../__mocks__/annotations';
 import { threadedCommentsFormatted as replies } from '../../../../../api/fixtures';
 import useRepliesAPI from '../useRepliesAPI';
 
-jest.mock('lodash/uniqueId', () => () => 'uniqueId');
-
 describe('src/elements/content-sidebar/activity-feed/annotation-thread/useRepliesAPI', () => {
     const getApi = ({ createAnnotationReply = jest.fn, deleteComment = jest.fn(), updateComment = jest.fn() }) => {
         const getAnnotationsAPI = () => ({

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/errors.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/errors.js
@@ -6,8 +6,9 @@ import {
     ERROR_CODE_FETCH_ANNOTATION,
     ERROR_CODE_UPDATE_COMMENT,
 } from '../../../../constants';
-import messages from './messages';
+import apiMessages from '../../../../api/messages';
 import commonMessages from '../../../common/messages';
+import messages from './messages';
 
 const annotationErrors = {
     [ERROR_CODE_FETCH_ANNOTATION]: messages.errorFetchAnnotation,
@@ -17,9 +18,9 @@ const annotationErrors = {
 };
 
 const commentsErrors = {
-    [ERROR_CODE_UPDATE_COMMENT]: messages.commentUpdateErrorMessage,
-    [ERROR_CODE_CREATE_REPLY]: messages.commentCreateErrorMessage,
-    [ERROR_CODE_DELETE_COMMENT]: messages.commentDeleteErrorMessage,
+    [ERROR_CODE_UPDATE_COMMENT]: apiMessages.commentUpdateErrorMessage,
+    [ERROR_CODE_CREATE_REPLY]: apiMessages.commentCreateErrorMessage,
+    [ERROR_CODE_DELETE_COMMENT]: apiMessages.commentDeleteErrorMessage,
     default: commonMessages.error,
 };
 

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/useAnnotationThread.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/useAnnotationThread.js
@@ -4,7 +4,7 @@ import React from 'react';
 import uniqueId from 'lodash/uniqueId';
 import type EventEmitter from 'events';
 import commonMessages from '../../../common/messages';
-import { annotationErrors } from './errors';
+import { annotationErrors, commentsErrors } from './errors';
 import API from '../../../../api/APIFactory';
 import useRepliesAPI from './useRepliesAPI';
 import { useAnnotatorEvents } from '../../../common/annotator-context';
@@ -88,34 +88,7 @@ const useAnnotationThread = ({
 
     const { file_version: { id: fileVersionId } = {}, id: fileId, permissions: filePermissions = {} } = file;
 
-    const setAnnotationPending = () => {
-        if (annotation) {
-            setAnnotation(prevAnnotation => ({ ...prevAnnotation, isPending: true }));
-        }
-    };
-
-    const handleAnnotationUpdateEnd = (updatedAnnotation: Annotation) => {
-        if (annotation && updatedAnnotation.id === annotationId) {
-            setAnnotation(prevAnnotation => ({ ...prevAnnotation, ...updatedAnnotation, isPending: false }));
-        }
-    };
-
-    const {
-        emitAddAnnotationEndEvent,
-        emitAddAnnotationStartEvent,
-        emitAnnotationActiveChangeEvent,
-        emitDeleteAnnotationEndEvent,
-        emitDeleteAnnotationStartEvent,
-        emitUpdateAnnotationEndEvent,
-        emitUpdateAnnotationStartEvent,
-    } = useAnnotatorEvents({
-        eventEmitter,
-        onAnnotationDeleteStart: setAnnotationPending,
-        onAnnotationUpdateEnd: handleAnnotationUpdateEnd,
-        onAnnotationUpdateStart: setAnnotationPending,
-    });
-
-    const handleUpdateOrCreateReplyItem = (replyId: string, updatedReplyValues: Object) => {
+    const updateOrCreateReplyItem = (replyId: string, updatedReplyValues: Object) => {
         setReplies(prevReplies => ({
             ...prevReplies,
             [replyId]: {
@@ -125,13 +98,118 @@ const useAnnotationThread = ({
         }));
     };
 
-    const handleRemoveReplyItem = (replyId: string) => {
+    const removeReplyItem = (replyId: string) => {
         setReplies(prevReplies => {
             const newReplies = { ...prevReplies };
             delete newReplies[replyId];
             return newReplies;
         });
     };
+
+    const addPendingReply = (baseReply: Object, requestId: string) => {
+        const date = new Date().toISOString();
+        const pendingReply: Comment = {
+            created_at: date,
+            created_by: currentUser,
+            id: requestId,
+            isPending: true,
+            modified_at: date,
+            ...baseReply,
+        };
+        updateOrCreateReplyItem(requestId, pendingReply);
+    };
+
+    const isCurrentAnnotation = (id: string) => annotationId === id;
+
+    const handleAnnotationUpdateStartEvent = (updatedAnnotation: Annotation) => {
+        if (!isCurrentAnnotation(updatedAnnotation.id) || !annotation) {
+            return;
+        }
+        setAnnotation(prevAnnotation => ({ ...prevAnnotation, ...updatedAnnotation, isPending: true }));
+    };
+
+    const handleAnnotationUpdateEndEvent = (updatedAnnotation: Annotation) => {
+        if (!isCurrentAnnotation(updatedAnnotation.id) || !annotation) {
+            return;
+        }
+        setAnnotation(prevAnnotation => ({ ...prevAnnotation, ...updatedAnnotation, isPending: false }));
+    };
+
+    const handleAnnotationDeleteStartEvent = (originAnnotationId: string) => {
+        if (!isCurrentAnnotation(originAnnotationId) || !annotation) {
+            return;
+        }
+        setAnnotation(prevAnnotation => ({ ...prevAnnotation, isPending: true }));
+    };
+
+    const handleAnnotationReplyAddStartEvent = ({ annotationId: originAnnotationId, reply, requestId }) => {
+        if (!isCurrentAnnotation(originAnnotationId)) {
+            return;
+        }
+        addPendingReply(reply, requestId);
+    };
+
+    const handleAnnotationReplyAddEndEvent = ({ annotationId: originAnnotationId, reply, requestId }) => {
+        if (!isCurrentAnnotation(originAnnotationId)) {
+            return;
+        }
+        updateOrCreateReplyItem(requestId, { ...reply, isPending: false });
+    };
+
+    const handleAnnotationReplyUpdateStart = ({ annotationId: originAnnotationId, reply }) => {
+        if (!isCurrentAnnotation(originAnnotationId)) {
+            return;
+        }
+        updateOrCreateReplyItem(reply.id, { ...reply, isPending: true });
+    };
+
+    const handleAnnotationReplyUpdateEnd = ({ annotationId: originAnnotationId, reply }) => {
+        if (!isCurrentAnnotation(originAnnotationId)) {
+            return;
+        }
+        updateOrCreateReplyItem(reply.id, { ...reply, isPending: false });
+    };
+
+    const handleAnnotationReplyDeleteStart = ({ annotationId: originAnnotationId, id: replyId }) => {
+        if (!isCurrentAnnotation(originAnnotationId)) {
+            return;
+        }
+        updateOrCreateReplyItem(replyId, { isPending: true });
+    };
+
+    const handleAnnotationReplyDeleteEnd = ({ annotationId: originAnnotationId, id: replyId }) => {
+        if (!isCurrentAnnotation(originAnnotationId)) {
+            return;
+        }
+        removeReplyItem(replyId);
+    };
+
+    const {
+        emitAddAnnotationEndEvent,
+        emitAddAnnotationReplyEndEvent,
+        emitAddAnnotationReplyStartEvent,
+        emitAddAnnotationStartEvent,
+        emitAnnotationActiveChangeEvent,
+        emitDeleteAnnotationEndEvent,
+        emitDeleteAnnotationReplyEndEvent,
+        emitDeleteAnnotationReplyStartEvent,
+        emitDeleteAnnotationStartEvent,
+        emitUpdateAnnotationEndEvent,
+        emitUpdateAnnotationReplyEndEvent,
+        emitUpdateAnnotationReplyStartEvent,
+        emitUpdateAnnotationStartEvent,
+    } = useAnnotatorEvents({
+        eventEmitter,
+        onAnnotationDeleteStart: handleAnnotationDeleteStartEvent,
+        onAnnotationReplyAddEnd: handleAnnotationReplyAddEndEvent,
+        onAnnotationReplyAddStart: handleAnnotationReplyAddStartEvent,
+        onAnnotationReplyUpdateEnd: handleAnnotationReplyUpdateEnd,
+        onAnnotationReplyUpdateStart: handleAnnotationReplyUpdateStart,
+        onAnnotationUpdateEnd: handleAnnotationUpdateEndEvent,
+        onAnnotationUpdateStart: handleAnnotationUpdateStartEvent,
+        onAnnotationReplyDeleteEnd: handleAnnotationReplyDeleteEnd,
+        onAnnotationReplyDeleteStart: handleAnnotationReplyDeleteStart,
+    });
 
     const handleUpdateAnnotation = (updatedValues: Object) => {
         setAnnotation(prevAnnotation => ({ ...prevAnnotation, ...updatedValues }));
@@ -158,31 +236,28 @@ const useAnnotationThread = ({
         errorCallback: annotationErrorCallback,
     });
 
-    React.useEffect(() => {
-        if (!annotationId || isLoading || (annotation && annotation.id === annotationId)) {
-            return;
-        }
-        setIsLoading(true);
-        handleFetch({
-            id: annotationId,
-            successCallback: ({ replies: fetchedReplies, ...normalizedAnnotation }: Annotation) => {
-                setAnnotation({ ...normalizedAnnotation });
-                setReplies(normalizeReplies(fetchedReplies));
-                setError(undefined);
-                setIsLoading(false);
-                emitAnnotationActiveChangeEvent(normalizedAnnotation.id, fileVersionId);
-            },
-        });
-    }, [annotation, annotationId, emitAnnotationActiveChangeEvent, fileVersionId, handleFetch, isLoading]);
+    const replyErrorCallback = React.useCallback(
+        (replyId: string, e: ElementsXhrError, code: string): void => {
+            updateOrCreateReplyItem(replyId, {
+                error: {
+                    title: commonMessages.errorOccured,
+                    message: commentsErrors[code] || commentsErrors.default,
+                },
+            });
 
-    const { handleReplyCreate, handleReplyEdit, handleReplyDelete } = useRepliesAPI({
+            errorCallback(e, code, {
+                error: e,
+            });
+        },
+        [errorCallback],
+    );
+
+    const { createReply, deleteReply, editReply } = useRepliesAPI({
         annotationId,
         api,
-        currentUser,
+        errorCallback: replyErrorCallback,
         fileId,
         filePermissions,
-        handleRemoveReplyItem,
-        handleUpdateOrCreateReplyItem,
     });
 
     const handleAnnotationCreate = (text: string) => {
@@ -261,6 +336,76 @@ const useAnnotationThread = ({
             successCallback: onAnnotationEditSuccessCallback,
         });
     };
+
+    const handleReplyCreate = (message: string) => {
+        const requestId = uniqueId('reply_');
+        const replyData = {
+            tagged_message: message,
+            type: 'comment',
+        };
+
+        const successCallback = (comment: Comment) => {
+            updateOrCreateReplyItem(requestId, { ...comment, isPending: false });
+            emitAddAnnotationReplyEndEvent(comment, annotationId, requestId);
+        };
+
+        addPendingReply(replyData, requestId);
+        emitAddAnnotationReplyStartEvent(replyData, annotationId, requestId);
+
+        createReply({ message, requestId, successCallback });
+    };
+
+    const handleReplyEdit = (
+        replyId: string,
+        message: string,
+        status?: FeedItemStatus,
+        hasMention?: boolean,
+        permissions: BoxCommentPermission,
+    ) => {
+        const updates = {
+            id: replyId,
+            tagged_message: message,
+        };
+
+        const successCallback = (comment: Comment) => {
+            updateOrCreateReplyItem(comment.id, { ...comment, isPending: false });
+            emitUpdateAnnotationReplyEndEvent(comment, annotationId);
+        };
+
+        updateOrCreateReplyItem(replyId, { message, isPending: true });
+        emitUpdateAnnotationReplyStartEvent(updates, annotationId);
+
+        editReply({ id: replyId, message, permissions, successCallback });
+    };
+
+    const handleReplyDelete = ({ id, permissions }: { id: string, permissions: BoxCommentPermission }) => {
+        updateOrCreateReplyItem(id, { isPending: true });
+        emitDeleteAnnotationReplyStartEvent(id, annotationId);
+
+        const successCallback = () => {
+            removeReplyItem(id);
+            emitDeleteAnnotationReplyEndEvent(id, annotationId);
+        };
+
+        deleteReply({ id, permissions, successCallback });
+    };
+
+    React.useEffect(() => {
+        if (!annotationId || isLoading || (annotation && annotation.id === annotationId)) {
+            return;
+        }
+        setIsLoading(true);
+        handleFetch({
+            id: annotationId,
+            successCallback: ({ replies: fetchedReplies, ...normalizedAnnotation }: Annotation) => {
+                setAnnotation({ ...normalizedAnnotation });
+                setReplies(normalizeReplies(fetchedReplies));
+                setError(undefined);
+                setIsLoading(false);
+                emitAnnotationActiveChangeEvent(normalizedAnnotation.id, fileVersionId);
+            },
+        });
+    }, [annotation, annotationId, emitAnnotationActiveChangeEvent, fileVersionId, handleFetch, isLoading]);
 
     return {
         annotation,

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/useRepliesAPI.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/useRepliesAPI.js
@@ -1,126 +1,81 @@
 // @flow
-import uniqueId from 'lodash/uniqueId';
 import APIFactory from '../../../../api';
-import commonMessages from '../../../common/messages';
-import { commentsErrors } from './errors';
 
-import type { BoxItemPermission, User } from '../../../../common/types/core';
-import type { BoxCommentPermission, Comment, FeedItemStatus } from '../../../../common/types/feed';
+import type { BoxItemPermission } from '../../../../common/types/core';
+import type { BoxCommentPermission, Comment } from '../../../../common/types/feed';
 import type { ElementsXhrError } from '../../../../common/types/api';
 
 type Props = {
     annotationId?: string,
     api: APIFactory,
-    currentUser: User,
+    errorCallback: (replyId: string, error: ElementsXhrError | Error, code: string) => void,
     fileId: string,
     filePermissions: BoxItemPermission,
-    handleRemoveReplyItem: (id: string) => void,
-    handleUpdateOrCreateReplyItem: (id: string, updatedValues: Object) => void,
 };
 
-const useRepliesAPI = ({
-    annotationId,
-    api,
-    currentUser,
-    fileId,
-    filePermissions,
-    handleRemoveReplyItem,
-    handleUpdateOrCreateReplyItem,
-}: Props) => {
-    const setReplyPendingStatus = (replyId: string, pendingStatus: boolean) => {
-        handleUpdateOrCreateReplyItem(replyId, { isPending: pendingStatus });
-    };
-
-    const addNewPendingReply = (baseReply: Object) => {
-        const date = new Date().toISOString();
-        const pendingReply: Comment = {
-            created_at: date,
-            created_by: currentUser,
-            modified_at: date,
-            isPending: true,
-            ...baseReply,
-        };
-
-        handleUpdateOrCreateReplyItem(pendingReply.id, pendingReply);
-    };
-
-    const createReplySuccessCallback = (replyId: string, reply: Comment) => {
-        handleUpdateOrCreateReplyItem(replyId, {
-            ...reply,
-            isPending: false,
-        });
-    };
-
-    const createReplyErrorCallback = (error: ElementsXhrError, code: string, replyId: string) => {
-        handleUpdateOrCreateReplyItem(replyId, {
-            error: {
-                title: commonMessages.errorOccured,
-                message: commentsErrors[code] || commentsErrors.default,
-            },
-        });
-    };
-
-    const handleReplyCreate = (message: string) => {
+const useRepliesAPI = ({ annotationId, api, errorCallback, fileId, filePermissions }: Props) => {
+    const createReply = ({
+        message,
+        requestId,
+        successCallback,
+    }: {
+        message: string,
+        requestId: string,
+        successCallback: (comment: Comment) => void,
+    }) => {
         if (!annotationId) {
             return;
         }
-
-        const uuid = uniqueId('reply_');
-        const replyData = {
-            id: uuid,
-            tagged_message: message,
-            type: 'comment',
-        };
-        addNewPendingReply(replyData);
-
-        const successCallback = (reply: Comment) => createReplySuccessCallback(uuid, reply);
-        const errorCallbackFn = (error, code) => createReplyErrorCallback(error, code, uuid);
-
         api.getAnnotationsAPI(false).createAnnotationReply(
             fileId,
             annotationId,
             filePermissions,
             message,
             successCallback,
-            errorCallbackFn,
+            errorCallback.bind(null, requestId),
         );
     };
 
-    const handleReplyDelete = ({ id, permissions }: { id: string, permissions: BoxCommentPermission }) => {
-        setReplyPendingStatus(id, true);
-        const errorCallbackFn = (error, code) => createReplyErrorCallback(error, code, id);
-
+    const deleteReply = ({
+        id,
+        permissions,
+        successCallback,
+    }: {
+        id: string,
+        permissions: BoxCommentPermission,
+        successCallback: () => void,
+    }) => {
         api.getThreadedCommentsAPI(false).deleteComment({
             fileId,
             commentId: id,
             permissions,
-            successCallback: () => handleRemoveReplyItem(id),
-            errorCallback: errorCallbackFn,
+            successCallback,
+            errorCallback: errorCallback.bind(null, id),
         });
     };
 
-    const handleReplyEdit = (
-        replyId: string,
+    const editReply = ({
+        id,
+        message,
+        permissions,
+        successCallback,
+    }: {
+        id: string,
         message: string,
-        status?: FeedItemStatus,
-        hasMention?: boolean,
         permissions: BoxCommentPermission,
-    ) => {
-        setReplyPendingStatus(replyId, true);
-
-        const errorCallbackFn = (error, code) => createReplyErrorCallback(error, code, replyId);
+        successCallback: (comment: Comment) => void,
+    }) => {
         api.getThreadedCommentsAPI(false).updateComment({
             fileId,
-            commentId: replyId,
+            commentId: id,
             message,
             permissions,
-            successCallback: updatedReply =>
-                handleUpdateOrCreateReplyItem(replyId, { ...updatedReply, isPending: false }),
-            errorCallback: errorCallbackFn,
+            successCallback,
+            errorCallback: errorCallback.bind(null, id),
         });
     };
 
-    return { handleReplyDelete, handleReplyEdit, handleReplyCreate };
+    return { createReply, deleteReply, editReply };
 };
 
 export default useRepliesAPI;


### PR DESCRIPTION
- Refactored `useRepliesAPI` to correspond to the approach taken in `useAnnotationAPI`
- Added handling for replies related events
- Fixed css styling issue of annotation menu button in `AnnotationThread`
- Fixed other bugs