### PR TITLE
fix(react-virtualized): remove duplicate a11y label

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
         "@box/cldr-data": "^34.2.0",
         "@box/frontend": "8.0.0",
         "@box/languages": "^1.0.0",
-        "@box/react-virtualized": "^9.22.3-rc-box.3",
+        "@box/react-virtualized": "9.22.3-rc-box.5",
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.3.4",
         "@formatjs/intl-pluralrules": "^1.5.2",
@@ -328,7 +328,7 @@
     },
     "peerDependencies": {
         "@box/cldr-data": "^34.2.0",
-        "@box/react-virtualized": "9.22.3-rc-box.3",
+        "@box/react-virtualized": "9.22.3-rc-box.5",
         "@hapi/address": ">=2.0.0 <2.1.2",
         "axios": "^0.25.0",
         "classnames": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,10 +3136,10 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.0.0.tgz#e59b259b34b1b4c399778682732c3d0038864284"
   integrity sha512-VdrUJK8tICkE4KrgN9FcRmqI+I72vPiDeRnlzX0Ua06etEzNPUa5E3tBnuZleWfZiBshhSScXfEbZdNCWkDHtQ==
 
-"@box/react-virtualized@^9.22.3-rc-box.3":
-  version "9.22.3-rc-box.3"
-  resolved "https://registry.yarnpkg.com/@box/react-virtualized/-/react-virtualized-9.22.3-rc-box.3.tgz#ca2e3ff8121bda5e43c181fdbf2631993428580c"
-  integrity sha512-vsgDWf2LEKJP/1R2F8dD3cDVaIGwX/2ymLKeUtewTaE0dHrfUEayKSgoLRPGHWdCJEVOaJWDNcJoSTBZt2P2oA==
+"@box/react-virtualized@9.22.3-rc-box.5":
+  version "9.22.3-rc-box.5"
+  resolved "https://registry.yarnpkg.com/@box/react-virtualized/-/react-virtualized-9.22.3-rc-box.5.tgz#05b39952f718bcd4fae276cfa4badf9b8dc0e528"
+  integrity sha512-rW0RnxhGSLBPO3t7DAeqXfebBm2AHlaya3aiRdUV4xe5PkV4H4w0cwe8HagxNGZg+WTU3b//iNJVzbzHQkjXhg==
   dependencies:
     "@babel/runtime" "^7.7.2"
     clsx "^1.0.4"


### PR DESCRIPTION
bump @box/react-virtualized, removing duplicate a11y labels on react-virtualized table rows.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
