### PR TITLE
fix(usm): add aria-label to tooltip close button

### DIFF
--- a/src/components/tooltip/CloseButton.tsx
+++ b/src/components/tooltip/CloseButton.tsx
@@ -18,4 +18,5 @@ const CloseButton = ({ intl, onClick }: Props) => (
     </PlainButton>
 );
 
+export { CloseButton as CloseButtonBase };
 export default injectIntl(CloseButton);

--- a/src/components/tooltip/CloseButton.tsx
+++ b/src/components/tooltip/CloseButton.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { injectIntl, IntlShape } from 'react-intl';
+
+import IconClose from '../../icon/fill/X16';
+import PlainButton from '../plain-button';
+
+// @ts-ignore flow import
+import messages from '../../common/messages';
+
+type Props = {
+    intl: IntlShape;
+    onClick: (event: React.SyntheticEvent<HTMLButtonElement, Event>) => void;
+};
+
+const CloseButton = ({ intl, onClick }: Props) => (
+    <PlainButton aria-label={intl.formatMessage(messages.close)} className="tooltip-close-button" onClick={onClick}>
+        <IconClose className="bdl-Tooltip-iconClose" width={14} height={14} />
+    </PlainButton>
+);
+
+export default injectIntl(CloseButton);

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -5,8 +5,7 @@ import getProp from 'lodash/get';
 import TetherComponent from 'react-tether';
 
 import TetherPosition from '../../common/tether-positions';
-import IconClose from '../../icon/fill/X16';
-import PlainButton from '../plain-button';
+import CloseButton from './CloseButton';
 
 import './Tooltip.scss';
 
@@ -342,11 +341,7 @@ class Tooltip extends React.Component<TooltipProps, State> {
         const tooltipInner = (
             <>
                 {text}
-                {withCloseButton && (
-                    <PlainButton className="tooltip-close-button" onClick={this.closeTooltip}>
-                        <IconClose className="bdl-Tooltip-iconClose" width={14} height={14} />
-                    </PlainButton>
-                )}
+                {withCloseButton && <CloseButton onClick={this.closeTooltip} />}
             </>
         );
 

--- a/src/components/tooltip/__tests__/CloseButton.test.tsx
+++ b/src/components/tooltip/__tests__/CloseButton.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import noop from 'lodash/noop';
+import { IntlShape } from 'react-intl';
+import { CloseButtonBase as CloseButton } from '../CloseButton';
+import PlainButton from '../../plain-button';
+
+const intlMock = ({ formatMessage: jest.fn().mockReturnValue('Close') } as unknown) as IntlShape;
+
+describe('components/tooltip/CloseButton', () => {
+    const defaultProps = {
+        onClick: noop,
+    };
+    const getWrapper = (props = {}) => shallow(<CloseButton intl={intlMock} {...defaultProps} {...props} />);
+
+    test('should call onClick when PlainButton is clicked', () => {
+        const onClickMock = jest.fn();
+        const wrapper = getWrapper({ onClick: onClickMock });
+        const plainButton = wrapper.find(PlainButton);
+
+        expect(onClickMock).not.toBeCalled();
+        plainButton.simulate('click');
+        expect(onClickMock).toBeCalledTimes(1);
+    });
+
+    test('should have aria label `Close` on PlainButton', () => {
+        const wrapper = getWrapper();
+        const plainButton = wrapper.find(PlainButton);
+
+        expect(plainButton.prop('aria-label')).toBe('Close');
+    });
+});

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -247,16 +247,9 @@ exports[`components/tooltip/Tooltip render() should render with close button if 
     role="tooltip"
   >
     hi
-    <PlainButton
-      className="tooltip-close-button"
+    <CloseButton
       onClick={[Function]}
-    >
-      <X16
-        className="bdl-Tooltip-iconClose"
-        height={14}
-        width={14}
-      />
-    </PlainButton>
+    />
   </div>
 </TetherComponent>
 `;


### PR DESCRIPTION
Adding the aria-label directly to the tooltip requires updating at least 20 tests, and 150+ snapshots. Trevor recommended the idea of a separate component for the close button for the tooltip, which seems to work! The existing BUIE close button won't work, due to a mismatched icon size, as well as no support for localization without a wrapper.


<img width="1607" alt="image" src="https://user-images.githubusercontent.com/24941488/212161321-c4e70326-0565-4247-9a53-3c3ae8a877ab.png">


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
