### PR TITLE
fix(grid-view): unhide focus outline for grid view slider

### DIFF
--- a/src/components/grid-view/GridViewSlider.scss
+++ b/src/components/grid-view/GridViewSlider.scss
@@ -69,16 +69,6 @@
         @include bdl-GridViewSlider-thumb;
     }
 
-    /* hide the outline behind the border */
-    &:-moz-focusring {
-        outline: 1px solid $white;
-        outline-offset: -1px;
-    }
-
-    &:focus {
-        outline: none;
-    }
-
     &:focus::-ms-fill-lower {
         background: $bdl-gray-50;
     }


### PR DESCRIPTION
Remove styles that hide focus outline. Not sure why it was hidden in the first place, it doesn't show up with mouse interaction.

Initially introduced here: https://github.com/box/box-ui-elements/commit/ef4a7ee68ca1b2e2d0eb3410a05c1e66fc5dceb6

Before:
https://user-images.githubusercontent.com/24941488/212198025-651b4076-73f3-4000-be5d-c4f9a0baa50f.mov




After:
https://user-images.githubusercontent.com/24941488/212197943-ccb3473d-8f81-426e-9cfb-a094eab9619e.mov


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
