### PR TITLE
feat(checkbox): make focus behavior configurable

### DIFF
--- a/src/components/checkbox/Checkbox.js.flow
+++ b/src/components/checkbox/Checkbox.js.flow
@@ -13,8 +13,6 @@ type Props = {
     description?: React.Node,
     /** Label for the field shown on top of the checkbox */
     fieldLabel?: React.Node,
-    /** hideFocusStyles - whether the focus styles are hidden or not */
-    hideFocusStyles?: boolean,
     /** Hides the checkbox label when true */
     hideLabel?: boolean,
     /** Unique `id` for the input */
@@ -46,7 +44,6 @@ const Checkbox = ({
     className = '',
     description,
     fieldLabel,
-    hideFocusStyles,
     hideLabel,
     id,
     inputClassName,
@@ -68,7 +65,7 @@ const Checkbox = ({
         <span className="checkbox-label">
             <input
                 checked={isChecked}
-                className={classNames(inputClassName, { 'Checkbox--isFocused': !hideFocusStyles })}
+                className={classNames(inputClassName)}
                 disabled={isDisabled}
                 id={inputID}
                 name={name}

--- a/src/components/checkbox/Checkbox.js.flow
+++ b/src/components/checkbox/Checkbox.js.flow
@@ -33,7 +33,7 @@ type Props = {
     /** change callback function called with event as the argument */
     onChange?: (e: SyntheticInputEvent<HTMLInputElement>) => any,
     /** onFocus - focus callback function that takes the event as the argument  */
-    onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void,
+    onFocus?: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
     /** Subsection below the checkbox */
     subsection?: React.Node,
     /** Info tooltip text next to the checkbox label */

--- a/src/components/checkbox/Checkbox.js.flow
+++ b/src/components/checkbox/Checkbox.js.flow
@@ -13,10 +13,13 @@ type Props = {
     description?: React.Node,
     /** Label for the field shown on top of the checkbox */
     fieldLabel?: React.Node,
+    /** hideFocusStyles - whether the focus styles are hidden or not */
+    hideFocusStyles?: boolean,
     /** Hides the checkbox label when true */
     hideLabel?: boolean,
     /** Unique `id` for the input */
     id?: string,
+    inputClassName?: string,
     /** Checkbox checked state */
     isChecked?: boolean, // @TODO: eventually call this `checked`
     /** Checkbox disabled state */
@@ -29,6 +32,8 @@ type Props = {
     onBlur?: (e: SyntheticInputEvent<HTMLInputElement>) => any,
     /** change callback function called with event as the argument */
     onChange?: (e: SyntheticInputEvent<HTMLInputElement>) => any,
+    /** onFocus - focus callback function that takes the event as the argument  */
+    onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void,
     /** Subsection below the checkbox */
     subsection?: React.Node,
     /** Info tooltip text next to the checkbox label */
@@ -41,12 +46,15 @@ const Checkbox = ({
     className = '',
     description,
     fieldLabel,
+    hideFocusStyles,
     hideLabel,
     id,
+    inputClassName,
     isChecked,
     isDisabled,
     label,
     name,
+    onFocus,
     onChange,
     subsection,
     tooltip,
@@ -60,9 +68,11 @@ const Checkbox = ({
         <span className="checkbox-label">
             <input
                 checked={isChecked}
+                className={classNames(inputClassName, { 'Checkbox--isFocused': !hideFocusStyles })}
                 disabled={isDisabled}
                 id={inputID}
                 name={name}
+                onFocus={onFocus}
                 onChange={onChange}
                 type="checkbox"
                 {...rest}

--- a/src/components/checkbox/Checkbox.scss
+++ b/src/components/checkbox/Checkbox.scss
@@ -4,6 +4,12 @@
  * Checkbox
  **************************************/
 
+.Checkbox--isFocused {
+    &:focus + span::before {
+        border: 2px solid $primary-color;
+    }
+}
+
 .checkbox-label {
     position: relative;
     display: inline-flex;
@@ -52,7 +58,7 @@
         }
 
         &:focus + span::before {
-            border: 2px solid $primary-color;
+            border: none;
         }
 
         &:disabled {

--- a/src/components/checkbox/Checkbox.scss
+++ b/src/components/checkbox/Checkbox.scss
@@ -4,12 +4,6 @@
  * Checkbox
  **************************************/
 
-.Checkbox--isFocused {
-    &:focus + span::before {
-        border: 2px solid $primary-color;
-    }
-}
-
 .checkbox-label {
     position: relative;
     display: inline-flex;
@@ -58,7 +52,7 @@
         }
 
         &:focus + span::before {
-            border: none;
+            border: 2px solid $primary-color;
         }
 
         &:disabled {

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -13,6 +13,8 @@ export interface CheckboxProps {
     description?: React.ReactNode;
     /** fieldLabel - label for the field shown on top of the checkbox */
     fieldLabel?: React.ReactNode;
+    /** hideFocusStyles - whether the focus styles are hidden or not */
+    hideFocusStyles?: boolean;
     /** hideLabel - whether the checkbox label is hidden or not */
     hideLabel?: boolean;
     /** id - Unique `id` for the input */
@@ -32,6 +34,8 @@ export interface CheckboxProps {
         | {
               (e: React.FocusEvent<HTMLInputElement>): void;
           };
+    /** onFocus - focus callback function that takes the event as the argument  */
+    onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
     /** onChange - change callback function that takes the event as the argument */
     onChange?: (e: React.SyntheticEvent<HTMLInputElement, Event>) => string | number | boolean | void;
     /** Subsection below the checkbox */
@@ -46,6 +50,7 @@ const Checkbox = ({
     className = '',
     description,
     fieldLabel,
+    hideFocusStyles,
     hideLabel,
     id,
     inputClassName,
@@ -53,6 +58,7 @@ const Checkbox = ({
     isDisabled,
     label,
     name,
+    onFocus,
     onChange,
     subsection,
     tooltip,
@@ -67,10 +73,11 @@ const Checkbox = ({
             <input
                 aria-describedby={description ? `description_${inputID}` : ''}
                 checked={isChecked}
-                className={inputClassName}
+                className={classNames(inputClassName, { 'Checkbox--isFocused': !hideFocusStyles })}
                 disabled={isDisabled}
                 id={inputID}
                 name={name}
+                onFocus={onFocus}
                 onChange={onChange}
                 type="checkbox"
                 {...rest}

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -13,8 +13,6 @@ export interface CheckboxProps {
     description?: React.ReactNode;
     /** fieldLabel - label for the field shown on top of the checkbox */
     fieldLabel?: React.ReactNode;
-    /** hideFocusStyles - whether the focus styles are hidden or not */
-    hideFocusStyles?: boolean;
     /** hideLabel - whether the checkbox label is hidden or not */
     hideLabel?: boolean;
     /** id - Unique `id` for the input */
@@ -50,7 +48,6 @@ const Checkbox = ({
     className = '',
     description,
     fieldLabel,
-    hideFocusStyles,
     hideLabel,
     id,
     inputClassName,
@@ -73,7 +70,7 @@ const Checkbox = ({
             <input
                 aria-describedby={description ? `description_${inputID}` : ''}
                 checked={isChecked}
-                className={classNames(inputClassName, { 'Checkbox--isFocused': !hideFocusStyles })}
+                className={classNames(inputClassName)}
                 disabled={isDisabled}
                 id={inputID}
                 name={name}

--- a/src/components/checkbox/Checkbox.tsx
+++ b/src/components/checkbox/Checkbox.tsx
@@ -70,7 +70,7 @@ const Checkbox = ({
             <input
                 aria-describedby={description ? `description_${inputID}` : ''}
                 checked={isChecked}
-                className={classNames(inputClassName)}
+                className={inputClassName}
                 disabled={isDisabled}
                 id={inputID}
                 name={name}

--- a/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -17,7 +17,7 @@ describe('components/checkbox/Checkbox', () => {
     test('should correctly render default component', () => {
         expect(wrapper.find('.checkbox-container').length).toBeTruthy();
         expect(wrapper.find('input').prop('id')).toEqual('1');
-        expect(wrapper.find('input').prop('className')).toEqual('inputClassName');
+        expect(wrapper.find('input').prop('className')).toEqual('inputClassName Checkbox--isFocused');
         expect(wrapper.find('input').prop('name')).toEqual('name');
         expect(wrapper.find('input').prop('type')).toEqual('checkbox');
         expect(wrapper.find('.checkbox-pointer-target').length).toBe(1);

--- a/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -1,16 +1,25 @@
 import React, { SyntheticEvent } from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 
-import Checkbox from '..';
+import Checkbox from '../Checkbox';
 
 describe('components/checkbox/Checkbox', () => {
     let wrapper: ShallowWrapper;
     let onChange: (e: SyntheticEvent<HTMLInputElement, Event>) => string | number | boolean | void;
+    let onFocus: (e: SyntheticEvent<HTMLInputElement, Event>) => string | number | boolean | void;
 
     beforeEach(() => {
         onChange = jest.fn();
+        onFocus = jest.fn();
         wrapper = shallow(
-            <Checkbox id="1" inputClassName="inputClassName" label="Check things" name="name" onChange={onChange} />,
+            <Checkbox
+                id="1"
+                inputClassName="inputClassName"
+                label="Check things"
+                name="name"
+                onChange={onChange}
+                onFocus={onFocus}
+            />,
         );
     });
 
@@ -71,6 +80,11 @@ describe('components/checkbox/Checkbox', () => {
         };
         wrapper.find('input').simulate('change', event);
         expect(onChange).toBeCalledWith(event);
+    });
+
+    test('should call onFocus callback when onFocus triggers', () => {
+        wrapper.find('input').simulate('focus');
+        expect(onFocus).toBeCalledTimes(1);
     });
 
     test('should render a hidden label when hideLabel is specified', () => {

--- a/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -72,6 +72,33 @@ describe('components/checkbox/Checkbox', () => {
         expect(wrapper.find('input').prop('checked')).toBeTruthy();
     });
 
+    test('should not apply Checkbox--isFocused class when hideFocusStyle is true', () => {
+        // wrapper.setProps({ hideFocusStyle: true }) did not work here
+        wrapper = shallow(
+            <Checkbox
+                hideFocusStyles
+                id="1"
+                inputClassName="inputClassName"
+                label="Check things"
+                name="name"
+                onChange={onChange}
+                onFocus={onFocus}
+            />,
+        );
+        expect(wrapper.find('input').hasClass('Checkbox--isFocused')).toBe(false);
+    });
+
+    test('should apply Checkbox--isFocused class when hideFocusStyle is false', () => {
+        wrapper.debug();
+        wrapper.setProps({ hideFocusStyle: false });
+        expect(wrapper.find('input').hasClass('Checkbox--isFocused')).toBe(true);
+    });
+
+    test('should apply Checkbox--isFocused class when hideFocusStyle is undefined', () => {
+        wrapper.setProps({ hideFocusStyle: undefined });
+        expect(wrapper.find('input').hasClass('Checkbox--isFocused')).toBe(true);
+    });
+
     test('should call onChange callback when onchange triggers', () => {
         const event = {
             target: {

--- a/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -26,7 +26,7 @@ describe('components/checkbox/Checkbox', () => {
     test('should correctly render default component', () => {
         expect(wrapper.find('.checkbox-container').length).toBeTruthy();
         expect(wrapper.find('input').prop('id')).toEqual('1');
-        expect(wrapper.find('input').prop('className')).toEqual('inputClassName Checkbox--isFocused');
+        expect(wrapper.find('input').prop('className')).toEqual('inputClassName');
         expect(wrapper.find('input').prop('name')).toEqual('name');
         expect(wrapper.find('input').prop('type')).toEqual('checkbox');
         expect(wrapper.find('.checkbox-pointer-target').length).toBe(1);

--- a/src/components/checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/checkbox/__tests__/Checkbox.test.tsx
@@ -72,33 +72,6 @@ describe('components/checkbox/Checkbox', () => {
         expect(wrapper.find('input').prop('checked')).toBeTruthy();
     });
 
-    test('should not apply Checkbox--isFocused class when hideFocusStyle is true', () => {
-        // wrapper.setProps({ hideFocusStyle: true }) did not work here
-        wrapper = shallow(
-            <Checkbox
-                hideFocusStyles
-                id="1"
-                inputClassName="inputClassName"
-                label="Check things"
-                name="name"
-                onChange={onChange}
-                onFocus={onFocus}
-            />,
-        );
-        expect(wrapper.find('input').hasClass('Checkbox--isFocused')).toBe(false);
-    });
-
-    test('should apply Checkbox--isFocused class when hideFocusStyle is false', () => {
-        wrapper.debug();
-        wrapper.setProps({ hideFocusStyle: false });
-        expect(wrapper.find('input').hasClass('Checkbox--isFocused')).toBe(true);
-    });
-
-    test('should apply Checkbox--isFocused class when hideFocusStyle is undefined', () => {
-        wrapper.setProps({ hideFocusStyle: undefined });
-        expect(wrapper.find('input').hasClass('Checkbox--isFocused')).toBe(true);
-    });
-
     test('should call onChange callback when onchange triggers', () => {
         const event = {
             target: {


### PR DESCRIPTION
These changes allow more control over focus styles by moving focus styles to a separate class and by declaring `onFocus` prop. These changes are needed in order to move focus styles to a click-target wrapper around the checkbox while maintaining the checkbox input as the actual focus. Here is an example usage:

![Screenshot 2023-01-17 at 12 01 25 PM](https://user-images.githubusercontent.com/5461045/212963746-8818e5b5-35da-400b-92a1-d3bb29cd42d9.png)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
