### PR TITLE
fix(shared-link-section): accessibility tooltip

### DIFF
--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -21,6 +21,12 @@ type Props = {
     onBlur?: (e: SyntheticInputEvent<HTMLInputElement>) => any,
     /** change callback function called with event as the argument */
     onChange?: (e: SyntheticInputEvent<HTMLInputElement>) => any,
+    /** focus callback function called with event as the argument */
+    onFocus?: (e: SyntheticInputEvent<HTMLInputElement>) => any,
+    /** mouse enter callback function called with event as the argument */
+    onMouseEnter?: (e: SyntheticInputEvent<HTMLDivElement>) => any,
+    /** mouse leave callback function called with event as the argument */
+    onMouseLeave?: (e: SyntheticInputEvent<HTMLDivElement>) => any,
     /** optional value for the toggles checkbox */
     value?: any,
 };
@@ -37,6 +43,9 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
             name,
             onBlur,
             onChange,
+            onFocus,
+            onMouseEnter,
+            onMouseLeave,
             ...rest
         }: Props,
         ref,
@@ -56,7 +65,7 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
         }
 
         return (
-            <div className={classes}>
+            <div className={classes} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                 {/* eslint-disable-next-line jsx-a11y/label-has-for */}
                 <label className="toggle-simple">
                     <input
@@ -67,6 +76,7 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
                         name={name}
                         onBlur={onBlur}
                         onChange={onChange}
+                        onFocus={onFocus}
                         type="checkbox"
                         {...rest}
                     />

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -487,18 +487,16 @@ class SharedLinkSection extends React.Component<Props, State> {
         }
 
         const toggleComponent = (
-            <div className="share-toggle-container">
-                <Toggle
-                    isDisabled={!isToggleEnabled}
-                    isOn={isSharedLinkEnabled}
-                    label={linkText}
-                    name="toggle"
-                    onChange={onToggleSharedLink}
-                    ref={ref => {
-                        this.toggleRef = ref;
-                    }}
-                />
-            </div>
+            <Toggle
+                isDisabled={!isToggleEnabled}
+                isOn={isSharedLinkEnabled}
+                label={linkText}
+                name="toggle"
+                onChange={onToggleSharedLink}
+                ref={ref => {
+                    this.toggleRef = ref;
+                }}
+            />
         );
 
         if (!submitting) {

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -255,14 +255,10 @@
         justify-content: space-between;
         margin-top: 10px;
 
-        .share-toggle-container {
+        .toggle-container {
             flex: 0 1 80%;
             margin-bottom: 0;
             overflow-y: hidden;
-
-            .toggle-container {
-                margin-bottom: 0;
-            }
 
             .toggle-simple-label {
                 color: $bdl-gray;

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -20,41 +20,37 @@ exports[`features/unified-share-modal/SharedLinkSection should match snapshot wh
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={false}
-        isOn={true}
-        label={
-          <span>
-            <FormattedMessage
-              defaultMessage="Shared link is created"
-              id="boxui.unifiedShare.linkShareOn"
-            />
-            <Tooltip
-              constrainToScrollParent={false}
-              constrainToWindow={true}
-              isDisabled={false}
-              position="top-center"
-              text="This link will expire and be inaccessible on {expiration, date, long}."
-              theme="default"
+    <Toggle
+      isDisabled={false}
+      isOn={true}
+      label={
+        <span>
+          <FormattedMessage
+            defaultMessage="Shared link is created"
+            id="boxui.unifiedShare.linkShareOn"
+          />
+          <Tooltip
+            constrainToScrollParent={false}
+            constrainToWindow={true}
+            isDisabled={false}
+            position="top-center"
+            text="This link will expire and be inaccessible on {expiration, date, long}."
+            theme="default"
+          >
+            <span
+              aria-label="Expires"
+              className="shared-link-expiration-badge"
+              role="img"
             >
-              <span
-                aria-label="Expires"
-                className="shared-link-expiration-badge"
-                role="img"
-              >
-                <IconClock
-                  color="#ed3757"
-                />
-              </span>
-            </Tooltip>
-          </span>
-        }
-        name="toggle"
-      />
-    </div>
+              <IconClock
+                color="#ed3757"
+              />
+            </span>
+          </Tooltip>
+        </span>
+      }
+      name="toggle"
+    />
   </div>
   <div
     className="shared-link-field-row"
@@ -193,21 +189,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
       text="You do not have permission to remove the link."
       theme="default"
     >
-      <div
-        className="share-toggle-container"
-      >
-        <Toggle
-          isDisabled={true}
-          isOn={true}
-          label={
-            <FormattedMessage
-              defaultMessage="Shared link is created"
-              id="boxui.unifiedShare.linkShareOn"
-            />
-          }
-          name="toggle"
-        />
-      </div>
+      <Toggle
+        isDisabled={true}
+        isOn={true}
+        label={
+          <FormattedMessage
+            defaultMessage="Shared link is created"
+            id="boxui.unifiedShare.linkShareOn"
+          />
+        }
+        name="toggle"
+      />
     </Tooltip>
   </div>
   <div
@@ -342,21 +334,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       text="Create and copy link for sharing"
       theme="default"
     >
-      <div
-        className="share-toggle-container"
-      >
-        <Toggle
-          isDisabled={false}
-          isOn={false}
-          label={
-            <FormattedMessage
-              defaultMessage="Create shared link"
-              id="boxui.unifiedShare.linkShareOff"
-            />
-          }
-          name="toggle"
-        />
-      </div>
+      <Toggle
+        isDisabled={false}
+        isOn={false}
+        label={
+          <FormattedMessage
+            defaultMessage="Create shared link"
+            id="boxui.unifiedShare.linkShareOff"
+          />
+        }
+        name="toggle"
+      />
     </Tooltip>
   </div>
 </div>
@@ -382,21 +370,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={false}
-        isOn={true}
-        label={
-          <FormattedMessage
-            defaultMessage="Shared link is created"
-            id="boxui.unifiedShare.linkShareOn"
-          />
-        }
-        name="toggle"
-      />
-    </div>
+    <Toggle
+      isDisabled={false}
+      isOn={true}
+      label={
+        <FormattedMessage
+          defaultMessage="Shared link is created"
+          id="boxui.unifiedShare.linkShareOn"
+        />
+      }
+      name="toggle"
+    />
   </div>
   <div
     className="shared-link-field-row"
@@ -526,21 +510,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={true}
-        isOn={false}
-        label={
-          <FormattedMessage
-            defaultMessage="Create shared link"
-            id="boxui.unifiedShare.linkShareOff"
-          />
-        }
-        name="toggle"
-      />
-    </div>
+    <Toggle
+      isDisabled={true}
+      isOn={false}
+      label={
+        <FormattedMessage
+          defaultMessage="Create shared link"
+          id="boxui.unifiedShare.linkShareOff"
+        />
+      }
+      name="toggle"
+    />
   </div>
 </div>
 `;
@@ -555,21 +535,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled c
   text="You do not have permission to create the link."
   theme="default"
 >
-  <div
-    className="share-toggle-container"
-  >
-    <Toggle
-      isDisabled={true}
-      isOn={false}
-      label={
-        <FormattedMessage
-          defaultMessage="Create shared link"
-          id="boxui.unifiedShare.linkShareOff"
-        />
-      }
-      name="toggle"
-    />
-  </div>
+  <Toggle
+    isDisabled={true}
+    isOn={false}
+    label={
+      <FormattedMessage
+        defaultMessage="Create shared link"
+        id="boxui.unifiedShare.linkShareOff"
+      />
+    }
+    name="toggle"
+  />
 </Tooltip>
 `;
 
@@ -583,21 +559,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled r
   text="You do not have permission to remove the link."
   theme="default"
 >
-  <div
-    className="share-toggle-container"
-  >
-    <Toggle
-      isDisabled={true}
-      isOn={true}
-      label={
-        <FormattedMessage
-          defaultMessage="Shared link is created"
-          id="boxui.unifiedShare.linkShareOn"
-        />
-      }
-      name="toggle"
-    />
-  </div>
+  <Toggle
+    isDisabled={true}
+    isOn={true}
+    label={
+      <FormattedMessage
+        defaultMessage="Shared link is created"
+        id="boxui.unifiedShare.linkShareOn"
+      />
+    }
+    name="toggle"
+  />
 </Tooltip>
 `;
 
@@ -630,21 +602,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
       text="You do not have permission to remove the link."
       theme="default"
     >
-      <div
-        className="share-toggle-container"
-      >
-        <Toggle
-          isDisabled={true}
-          isOn={true}
-          label={
-            <FormattedMessage
-              defaultMessage="Shared link is created"
-              id="boxui.unifiedShare.linkShareOn"
-            />
-          }
-          name="toggle"
-        />
-      </div>
+      <Toggle
+        isDisabled={true}
+        isOn={true}
+        label={
+          <FormattedMessage
+            defaultMessage="Shared link is created"
+            id="boxui.unifiedShare.linkShareOn"
+          />
+        }
+        name="toggle"
+      />
     </Tooltip>
   </div>
   <div
@@ -767,21 +735,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={false}
-        isOn={true}
-        label={
-          <FormattedMessage
-            defaultMessage="Shared link is created"
-            id="boxui.unifiedShare.linkShareOn"
-          />
-        }
-        name="toggle"
-      />
-    </div>
+    <Toggle
+      isDisabled={false}
+      isOn={true}
+      label={
+        <FormattedMessage
+          defaultMessage="Shared link is created"
+          id="boxui.unifiedShare.linkShareOn"
+        />
+      }
+      name="toggle"
+    />
   </div>
   <div
     className="shared-link-field-row"
@@ -912,21 +876,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={false}
-        isOn={true}
-        label={
-          <FormattedMessage
-            defaultMessage="Shared link is created"
-            id="boxui.unifiedShare.linkShareOn"
-          />
-        }
-        name="toggle"
-      />
-    </div>
+    <Toggle
+      isDisabled={false}
+      isOn={true}
+      label={
+        <FormattedMessage
+          defaultMessage="Shared link is created"
+          id="boxui.unifiedShare.linkShareOn"
+        />
+      }
+      name="toggle"
+    />
   </div>
   <div
     className="shared-link-field-row"
@@ -1056,21 +1016,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={false}
-        isOn={true}
-        label={
-          <FormattedMessage
-            defaultMessage="Shared link is created"
-            id="boxui.unifiedShare.linkShareOn"
-          />
-        }
-        name="toggle"
-      />
-    </div>
+    <Toggle
+      isDisabled={false}
+      isOn={true}
+      label={
+        <FormattedMessage
+          defaultMessage="Shared link is created"
+          id="boxui.unifiedShare.linkShareOn"
+        />
+      }
+      name="toggle"
+    />
   </div>
   <div
     className="shared-link-field-row"
@@ -1200,21 +1156,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={false}
-        isOn={true}
-        label={
-          <FormattedMessage
-            defaultMessage="Shared link is created"
-            id="boxui.unifiedShare.linkShareOn"
-          />
-        }
-        name="toggle"
-      />
-    </div>
+    <Toggle
+      isDisabled={false}
+      isOn={true}
+      label={
+        <FormattedMessage
+          defaultMessage="Shared link is created"
+          id="boxui.unifiedShare.linkShareOn"
+        />
+      }
+      name="toggle"
+    />
   </div>
   <div
     className="shared-link-field-row"
@@ -1371,21 +1323,17 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
   <div
     className="shared-link-toggle-row"
   >
-    <div
-      className="share-toggle-container"
-    >
-      <Toggle
-        isDisabled={false}
-        isOn={true}
-        label={
-          <FormattedMessage
-            defaultMessage="Shared link is created"
-            id="boxui.unifiedShare.linkShareOn"
-          />
-        }
-        name="toggle"
-      />
-    </div>
+    <Toggle
+      isDisabled={false}
+      isOn={true}
+      label={
+        <FormattedMessage
+          defaultMessage="Shared link is created"
+          id="boxui.unifiedShare.linkShareOn"
+        />
+      }
+      name="toggle"
+    />
   </div>
   <div
     className="shared-link-field-row"


### PR DESCRIPTION
<img width="1334" alt="Screen Shot 2023-01-25 at 5 20 42 PM" src="https://user-images.githubusercontent.com/75504287/214734160-ca526655-248b-486e-b289-7ecf7ef2ac22.png">


<img width="434" alt="Screen Shot 2023-01-26 at 4 52 53 PM" src="https://user-images.githubusercontent.com/75504287/214983137-48694f7a-a3f6-4d5b-a64c-99189909c560.png">


Description:
The tooltip for the "Create shared link" is not presented to a screen reader. That is because it is associated to the `<div with tabindex="0>`, but since `<div>` does not support aria-describedby, the tooltip will not be read reliably by screen reader users.

Element Source
```
<div class="share-toggle-container tooltip-target tooltip-abutted tooltip-abutted-top tooltip-element-attached-bottom tooltip-element-attached-left tooltip-target-attached-top tooltip-target-attached-left" tabindex="0">
...
<input class="toggle-simple-input" name="toggle" type="checkbox">
```
Recommendation:

Move aria-describedby to the switch <input> and ensure that it is read reliably by screen readers.


