### PR TITLE
fix(usm): simplified sharing tooltip at high zoom

### DIFF
--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -482,7 +482,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             className: 'usm-ftux-tooltip',
             // don't want ftux tooltip to show if the recommended sharing tooltip callout is showing
             isShown: !recommendedSharingTooltipCalloutName && shouldRenderFTUXTooltip && showCalloutForUser,
-            position: 'middle-left',
+            position: 'bottom-center',
             showCloseButton: true,
             text: ftuxTooltipText,
             theme: 'callout',

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -106,6 +106,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
                 shouldRenderFTUXTooltip: true,
                 showCalloutForUser: true,
             });
+            expect(wrapper.find('.usm-ftux-tooltip').prop('position')).toBe('bottom-center');
             expect(wrapper).toMatchSnapshot();
         });
 

--- a/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/UnifiedShareForm.test.js.snap
@@ -12,7 +12,7 @@ exports[`features/unified-share-modal/UnifiedShareForm closeEmailSharedLinkForm(
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -212,7 +212,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
       constrainToWindow={true}
       isDisabled={false}
       isShown={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -376,7 +376,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should not rende
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -540,7 +540,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -709,7 +709,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToWindow={true}
       isDisabled={false}
       isShown={true}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -874,7 +874,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -1040,7 +1040,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -1175,7 +1175,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -1341,7 +1341,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -1507,7 +1507,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -1674,7 +1674,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -1851,7 +1851,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -2016,7 +2016,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -2185,7 +2185,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -2351,7 +2351,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>
@@ -2516,7 +2516,7 @@ exports[`features/unified-share-modal/UnifiedShareForm render() should render a 
       constrainToScrollParent={false}
       constrainToWindow={true}
       isDisabled={false}
-      position="middle-left"
+      position="bottom-center"
       showCloseButton={true}
       text={
         <div>


### PR DESCRIPTION
Make simplified sharing visible at high zoom
by moving from middle-left to bottom-center

Should not merge until we are confident tab order may flow between the tooltip and the primary modal.

QUESTION: The updated snapshots reflect the intended change, HOWEVER, I am wondering why the Tooltip component still shows up in some of these snapshots where I expect the tooltip to NOT render at all, i.e. when isShown prop is NOT true?

![Screenshot 2023-01-19 at 4 11 59 PM](https://user-images.githubusercontent.com/37150601/214123026-b9003e36-d0e9-41cd-914b-d730cc387fde.png)

![Screenshot 2023-01-19 at 4 12 10 PM](https://user-images.githubusercontent.com/37150601/214123044-c6eb533e-a5be-4bc1-9d98-bb0323c628fb.png)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
