### PR TITLE
fix(react-virtualized): Remove role for Table_Grid_innerScrollContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
         "@box/cldr-data": "^34.2.0",
         "@box/frontend": "8.0.0",
         "@box/languages": "^1.0.0",
-        "@box/react-virtualized": "9.22.3-rc-box.5",
+        "@box/react-virtualized": "9.22.3-rc-box.6",
         "@commitlint/cli": "^8.3.5",
         "@commitlint/config-conventional": "^8.3.4",
         "@formatjs/intl-pluralrules": "^1.5.2",
@@ -328,7 +328,7 @@
     },
     "peerDependencies": {
         "@box/cldr-data": "^34.2.0",
-        "@box/react-virtualized": "9.22.3-rc-box.5",
+        "@box/react-virtualized": "9.22.3-rc-box.6",
         "@hapi/address": ">=2.0.0 <2.1.2",
         "axios": "^0.25.0",
         "classnames": "^2.2.5",

--- a/src/components/grid-view/__tests__/__snapshots__/GridView.test.js.snap
+++ b/src/components/grid-view/__tests__/__snapshots__/GridView.test.js.snap
@@ -6,6 +6,7 @@ exports[`components/grid-view/GridView should render() 1`] = `
   disableHeader={true}
   estimatedRowSize={30}
   gridClassName="bdl-GridView-body"
+  gridContainerRole=""
   headerHeight={0}
   headerRowRenderer={[Function]}
   headerStyle={Object {}}

--- a/src/features/virtualized-table/__tests__/__snapshots__/BaseVirtualizedTable.test.js.snap
+++ b/src/features/virtualized-table/__tests__/__snapshots__/BaseVirtualizedTable.test.js.snap
@@ -5,6 +5,7 @@ exports[`features/virtualized-table/BaseVirtualizedTable should successfully ren
   className="bdl-VirtualizedTable className"
   disableHeader={false}
   estimatedRowSize={30}
+  gridContainerRole=""
   headerHeight={39}
   headerRowRenderer={[Function]}
   headerStyle={Object {}}

--- a/src/features/virtualized-table/__tests__/__snapshots__/VirtualizedTable.test.js.snap
+++ b/src/features/virtualized-table/__tests__/__snapshots__/VirtualizedTable.test.js.snap
@@ -86,6 +86,7 @@ exports[`features/virtualized-table/VirtualizedTable should successfully render 
   className="bdl-VirtualizedTable"
   disableHeader={false}
   estimatedRowSize={30}
+  gridContainerRole=""
   headerHeight={39}
   headerRowRenderer={[Function]}
   headerStyle={Object {}}
@@ -156,6 +157,7 @@ exports[`features/virtualized-table/VirtualizedTable should successfully render 
   className="bdl-VirtualizedTable"
   disableHeader={false}
   estimatedRowSize={30}
+  gridContainerRole=""
   headerHeight={39}
   headerRowRenderer={[Function]}
   headerStyle={Object {}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,10 +3136,10 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.0.0.tgz#e59b259b34b1b4c399778682732c3d0038864284"
   integrity sha512-VdrUJK8tICkE4KrgN9FcRmqI+I72vPiDeRnlzX0Ua06etEzNPUa5E3tBnuZleWfZiBshhSScXfEbZdNCWkDHtQ==
 
-"@box/react-virtualized@9.22.3-rc-box.5":
-  version "9.22.3-rc-box.5"
-  resolved "https://registry.yarnpkg.com/@box/react-virtualized/-/react-virtualized-9.22.3-rc-box.5.tgz#05b39952f718bcd4fae276cfa4badf9b8dc0e528"
-  integrity sha512-rW0RnxhGSLBPO3t7DAeqXfebBm2AHlaya3aiRdUV4xe5PkV4H4w0cwe8HagxNGZg+WTU3b//iNJVzbzHQkjXhg==
+"@box/react-virtualized@9.22.3-rc-box.6":
+  version "9.22.3-rc-box.6"
+  resolved "https://registry.yarnpkg.com/@box/react-virtualized/-/react-virtualized-9.22.3-rc-box.6.tgz#3cf98522b44ffcc1bbe98c3a6506a9b8cbd2498e"
+  integrity sha512-SsFIvXG8Y7Ve1aQE7kKCiBhHntfTA64CdPL7Pr4gLrDGCGQvM0M6jV8DAXwongTKpsssXYGzTwvhcHKz/KViDw==
   dependencies:
     "@babel/runtime" "^7.7.2"
     clsx "^1.0.4"
@@ -10667,7 +10667,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-debug@2.6.9, debug@^2.1.1, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -10694,13 +10694,6 @@ debug@4, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
 
 debuglog@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Removes the default role "row" for Grid_innerScrollContainer when used inside of Table. The innerScrollContainer contains a group of rows and is not a row itself.

The solution follows the approach we're using for the main webapp.