### PR TITLE
fix(makeselectable): shift and arrow selects first row

### DIFF
--- a/src/components/table/__tests__/makeSelectable.test.js
+++ b/src/components/table/__tests__/makeSelectable.test.js
@@ -296,14 +296,14 @@ describe('components/table/makeSelectable', () => {
             wrapper.instance().handleShiftKeyDown(0, 0);
         });
 
-        test('should select target when it is not already selected', () => {
+        test('should select target when it is not already selected and source is selected', () => {
             const wrapper = getWrapper({
-                selectedItems: [],
+                selectedItems: ['b'],
             });
             wrapper.setState({ focusedIndex: 1 });
             const instance = wrapper.instance();
             instance.onSelect = (selectedItems, focusedIndex) => {
-                expect(selectedItems.equals(new Set(['a']))).toBe(true);
+                expect(selectedItems.equals(new Set(['a', 'b']))).toBe(true);
                 expect(focusedIndex).toEqual(0);
             };
 
@@ -336,6 +336,20 @@ describe('components/table/makeSelectable', () => {
             };
 
             instance.handleShiftKeyDown(1, 0);
+        });
+
+        test('should select both source and target when neither are selected', () => {
+            const wrapper = getWrapper({
+                selectedItems: [],
+            });
+            wrapper.setState({ focusedIndex: 0 });
+            const instance = wrapper.instance();
+            instance.onSelect = (selectedItems, focusedIndex) => {
+                expect(selectedItems.equals(new Set(['a', 'b']))).toBe(true);
+                expect(focusedIndex).toEqual(1);
+            };
+
+            instance.handleShiftKeyDown(1, 4);
         });
     });
 

--- a/src/components/table/makeSelectable.js
+++ b/src/components/table/makeSelectable.js
@@ -451,25 +451,34 @@ function makeSelectable(BaseTable) {
             const { data, selectedItems } = this.getProcessedProps();
             const { focusedIndex } = this.state;
 
+            const focusedIndexData = data[focusedIndex];
+            const newFocusedIndexData = data[newFocusedIndex];
+
             // if we're at a boundary of the table and the row is selected, no-op
-            if (focusedIndex === boundary && selectedItems.has(data[focusedIndex])) {
+            if (focusedIndex === boundary && selectedItems.has(focusedIndexData)) {
+                return;
+            }
+
+            // if both the target and source are not selected, select them both
+            if (!selectedItems.has(focusedIndexData) && !selectedItems.has(newFocusedIndexData)) {
+                this.onSelect(selectedItems.union([focusedIndexData, newFocusedIndexData]), newFocusedIndex);
                 return;
             }
 
             // if target is not selected, select it
-            if (!selectedItems.has(data[newFocusedIndex])) {
-                this.onSelect(selectedItems.add(data[newFocusedIndex]), newFocusedIndex);
+            if (!selectedItems.has(newFocusedIndexData)) {
+                this.onSelect(selectedItems.add(newFocusedIndexData), newFocusedIndex);
                 return;
             }
 
             // if both source and target are selected, deselect source
-            if (selectedItems.has(data[newFocusedIndex]) && selectedItems.has(data[focusedIndex])) {
-                this.onSelect(selectedItems.delete(data[focusedIndex]), newFocusedIndex);
+            if (selectedItems.has(newFocusedIndexData) && selectedItems.has(focusedIndexData)) {
+                this.onSelect(selectedItems.delete(focusedIndexData), newFocusedIndex);
                 return;
             }
 
             // if target is selected and source is not, select source
-            this.onSelect(selectedItems.add(data[focusedIndex]), newFocusedIndex);
+            this.onSelect(selectedItems.add(focusedIndexData), newFocusedIndex);
         };
 
         isContiguousSelection = (selectedItemIndecies, sourceIndex, targetIndex) => {


### PR DESCRIPTION
- select the first row when using shift arrow navigation and neither the source or the target is selected
- small refactor to the function

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
