### PR TITLE
fix: Improve color contrast for placeholder text

### DIFF
--- a/src/elements/common/_variables.scss
+++ b/src/elements/common/_variables.scss
@@ -45,7 +45,8 @@ $sidebarTabResponsiveSize: 48px;
 }
 
 @mixin placeholder {
+    color: $bdl-gray-62;
     font-weight: normal;
     font-family: $font;
-    opacity: .6;
+    opacity: 1; // https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#opaque_text
 }

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -216,7 +216,7 @@
         }
 
         .text-area-container textarea::placeholder {
-            color: $bdl-gray-50;
+            color: $bdl-gray-62;
         }
 
         .bdl-PillSelector {
@@ -229,7 +229,7 @@
         border: 1px solid $bdl-gray-20;
 
         .bdl-PillSelector-input::placeholder {
-            color: $bdl-gray-50;
+            color: $bdl-gray-62;
         }
 
         &.bdl-is-disabled,
@@ -239,7 +239,7 @@
             box-shadow: none;
 
             .bdl-PillSelector-input::placeholder {
-                color: $bdl-gray-50;
+                color: $bdl-gray-62;
             }
 
             &:hover {


### PR DESCRIPTION
The placeholder text color of inputs/textareas does not meet a 4.5:1 color contrast ratio. The issue affects all inputs but the design team recommended only updating the specific usages in question since it would be a global change. The other usages would be fixed with the migration to the UI toolkit.

Design and accessibility team recommended using #767676 - $bdl-gray-62

**Before - Content Explorer**
<img width="604" alt="Screen Shot 2023-02-01 at 5 44 03 PM" src="https://user-images.githubusercontent.com/7311041/216210651-829170a3-f30f-486e-9742-adfcfc273cfa.png">

**After - Content Explorer**
<img width="610" alt="Screen Shot 2023-02-01 at 5 43 51 PM" src="https://user-images.githubusercontent.com/7311041/216210666-8272083b-a62e-40af-abc6-97cbdf701a9a.png">

**Before - USM**
<img width="782" alt="Screen Shot 2023-02-01 at 5 46 32 PM" src="https://user-images.githubusercontent.com/7311041/216211118-6b761f8d-b8c6-4031-8af3-d4f4fe5ff7f4.png">

**After - USM**
<img width="754" alt="Screen Shot 2023-02-01 at 5 46 24 PM" src="https://user-images.githubusercontent.com/7311041/216211140-6534ef97-e546-49f7-8e23-05fd716dc913.png">