### PR TITLE
fix: Improve color contrast for input borders

### DIFF
--- a/src/elements/common/_variables.scss
+++ b/src/elements/common/_variables.scss
@@ -48,5 +48,5 @@ $sidebarTabResponsiveSize: 48px;
     color: $bdl-gray-62;
     font-weight: normal;
     font-family: $font;
-    opacity: 1; // https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#opaque_text
+    opacity: 1; // Firefox sets opacity for placeholder to less than 100%
 }

--- a/src/elements/common/_variables.scss
+++ b/src/elements/common/_variables.scss
@@ -48,5 +48,7 @@ $sidebarTabResponsiveSize: 48px;
     color: $bdl-gray-62;
     font-weight: normal;
     font-family: $font;
-    opacity: 1; // Firefox sets opacity for placeholder to less than 100%
+    // Firefox sets opacity for placeholder to less than 100%
+    // See https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#opaque_text
+    opacity: 1;
 }

--- a/src/elements/common/base.scss
+++ b/src/elements/common/base.scss
@@ -12,6 +12,20 @@
     line-height: 20px;
     letter-spacing: .3px;
 
+    // TODO: Remove when border-color in src/styles/_inputs.scss is accessible
+    input[type='text'],
+    input[type='date'],
+    input[type='password'],
+    input[type='search'],
+    input[type='email'],
+    input[type='url'],
+    input[type='tel'],
+    input[type='number'],
+    div[contentEditable='true'],
+    textarea {
+        border-color: $bdl-gray-50;
+    }
+
     /* stylelint-disable */
     ::-webkit-input-placeholder {
         @include placeholder;

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -226,7 +226,7 @@
 
     .bdl-PillSelectorDropdown .bdl-PillSelector {
         margin-top: 10px;
-        border: 1px solid $bdl-gray-20;
+        border: 1px solid $bdl-gray-50;
 
         .bdl-PillSelector-input::placeholder {
             color: $bdl-gray-62;

--- a/src/styles/common/_forms.scss
+++ b/src/styles/common/_forms.scss
@@ -47,6 +47,8 @@ textarea:focus {
     @include box-inputs-focus;
 }
 
+// NOTE: This does not work because vendor prefixes cannot be combined. Need
+// to work with the design team to update the color or remove this ruleset.
 input::-webkit-input-placeholder,
 input::-moz-placeholder,
 input:-ms-input-placeholder {


### PR DESCRIPTION
Updating the border-color of text fields to meet a 3:1 contrast ratio with the input background. Design's recommendation is to only update the ones in question (i.e. the inputs in the elements) and to update the other components to use UI Toolkit.

**Before**
<img width="498" alt="Screen Shot 2023-02-06 at 11 36 57 AM" src="https://user-images.githubusercontent.com/7311041/217068123-7a6f5db0-7f29-4bba-8299-891c995c44f4.png">
<img width="730" alt="Screen Shot 2023-02-06 at 11 39 57 AM" src="https://user-images.githubusercontent.com/7311041/217068738-b38a3004-debe-48be-89d4-32104900d180.png">

**After**
<img width="494" alt="Screen Shot 2023-02-06 at 11 37 09 AM" src="https://user-images.githubusercontent.com/7311041/217068138-c1e518f1-6417-44dd-b731-6169b6686824.png">
<img width="712" alt="Screen Shot 2023-02-06 at 11 40 22 AM" src="https://user-images.githubusercontent.com/7311041/217068758-0b39871b-9b56-4b39-8860-7e124559a908.png">
