### PR TITLE
fix: Update box-shadow for inputs

### DIFF
--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -5,17 +5,16 @@
     color: $bdl-gray;
     border: 1px solid $bdl-gray-20;
     border-radius: $bdl-border-radius-size-med;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .1);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, .1);
     transition: border-color linear .15s, box-shadow linear .1s;
     -webkit-font-smoothing: antialiased;
 }
 
 @mixin box-inputs-hover {
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .15);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, .1);
 }
 
 @mixin box-inputs-focus {
     border: 1px solid $primary-color;
     outline: 0;
-    box-shadow: none;
 }


### PR DESCRIPTION
Confirmed with the designer of design-system that box-shadows for input should be the following:
![image (2)](https://user-images.githubusercontent.com/7311041/217109459-0468b082-9592-4128-8003-923f7b3abaf6.png)
and there is no value change for the different interaction states.

**Before**
<img width="840" alt="Screen Shot 2023-02-06 at 3 39 50 PM" src="https://user-images.githubusercontent.com/7311041/217111728-0420ac8c-f68b-4e6e-869a-c7c52d99a8be.png">

**After**
<img width="840" alt="Screen Shot 2023-02-06 at 3 40 05 PM" src="https://user-images.githubusercontent.com/7311041/217111743-c8a7a860-b9ee-41eb-8301-63d839e1be34.png">