### PR TITLE
fix(content-picker): add disabled

### DIFF
--- a/src/elements/content-picker/Footer.js
+++ b/src/elements/content-picker/Footer.js
@@ -59,6 +59,7 @@ const Footer = ({
 }: Props) => {
     const cancelMessage = intl.formatMessage(messages.cancel);
     const chooseMessage = intl.formatMessage(messages.choose);
+    const isChooseButtonDisabled = !selectedCount;
     return (
         <footer className="bcp-footer">
             <div className="bcp-footer-left">
@@ -96,10 +97,11 @@ const Footer = ({
                                 <IconClose height={16} width={16} />
                             </Button>
                         </Tooltip>
-                        <Tooltip isDisabled={!selectedCount} text={chooseButtonLabel || chooseMessage}>
+                        <Tooltip isDisabled={isChooseButtonDisabled} text={chooseButtonLabel || chooseMessage}>
                             <PrimaryButton
                                 aria-label={chooseMessage}
-                                isDisabled={!selectedCount}
+                                disabled={isChooseButtonDisabled} // sets disabled attribute
+                                isDisabled={isChooseButtonDisabled} // used in Button component
                                 onClick={onChoose}
                                 type="button"
                             >

--- a/src/elements/content-picker/__tests__/Footer.test.js
+++ b/src/elements/content-picker/__tests__/Footer.test.js
@@ -25,6 +25,16 @@ describe('elements/content-picker/Footer', () => {
             expect(wrapper.find('.footer-child').length).toBe(1);
         });
 
+        test('should render footer with disabled button', () => {
+            const buttons = getWrapper().find('Button');
+            const chooseButton = buttons.at(1);
+
+            // https://www.w3.org/WAI/ARIA/apg/patterns/button/
+            // When the action associated with a button is unavailable, the button has aria-disabled set to true.
+            expect(chooseButton.html().includes('aria-disabled')).toBe(true);
+            expect(chooseButton.prop('disabled')).toBe(true);
+        });
+
         test('should render Footer buttons with aria-label', () => {
             const buttons = getWrapper().find('Button');
 


### PR DESCRIPTION
Add `disabled` attribute to picker choose button when no items are selected.

<img width="1678" alt="Screenshot 2023-02-13 at 6 13 19 PM" src="https://user-images.githubusercontent.com/37150601/218595460-4bbfe7b2-4c08-4991-bd03-5de2ab338fc8.png">
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
