### PR TITLE
fix(content-uploader): make disabled buttons unfocusable

### DIFF
--- a/src/elements/content-uploader/Footer.js
+++ b/src/elements/content-uploader/Footer.js
@@ -39,7 +39,7 @@ const Footer = ({ isLoading, hasFiles, errorCode, onCancel, onClose, onUpload, f
         <div className="bcu-footer">
             <div className="bcu-footer-left">
                 {onClose ? (
-                    <Button isDisabled={hasFiles} onClick={onClose} type="button">
+                    <Button isDisabled={hasFiles} disabled={hasFiles} onClick={onClose} type="button">
                         <FormattedMessage {...messages.close} />
                     </Button>
                 ) : null}

--- a/src/elements/content-uploader/Footer.js
+++ b/src/elements/content-uploader/Footer.js
@@ -23,6 +23,9 @@ type Props = {
 };
 
 const Footer = ({ isLoading, hasFiles, errorCode, onCancel, onClose, onUpload, fileLimit, isDone }: Props) => {
+    const isCancelButtonDisabled = !hasFiles || isDone;
+    const isUploadButtonDisabled = !hasFiles;
+
     let message;
     switch (errorCode) {
         case ERROR_CODE_UPLOAD_FILE_LIMIT:
@@ -43,10 +46,21 @@ const Footer = ({ isLoading, hasFiles, errorCode, onCancel, onClose, onUpload, f
             </div>
             {message && <div className="bcu-footer-message">{message}</div>}
             <div className="bcu-footer-right">
-                <Button isDisabled={!hasFiles || isDone} onClick={onCancel} type="button">
+                <Button
+                    disabled={isCancelButtonDisabled}
+                    isDisabled={isCancelButtonDisabled}
+                    onClick={onCancel}
+                    type="button"
+                >
                     <FormattedMessage {...messages.cancel} />
                 </Button>
-                <PrimaryButton isDisabled={!hasFiles} isLoading={isLoading} onClick={onUpload} type="button">
+                <PrimaryButton
+                    disabled={isUploadButtonDisabled}
+                    isDisabled={isUploadButtonDisabled}
+                    isLoading={isLoading}
+                    onClick={onUpload}
+                    type="button"
+                >
                     <FormattedMessage {...messages.upload} />
                 </PrimaryButton>
             </div>

--- a/src/elements/content-uploader/Footer.js
+++ b/src/elements/content-uploader/Footer.js
@@ -23,6 +23,7 @@ type Props = {
 };
 
 const Footer = ({ isLoading, hasFiles, errorCode, onCancel, onClose, onUpload, fileLimit, isDone }: Props) => {
+    const isCloseButtonDisabled = hasFiles;
     const isCancelButtonDisabled = !hasFiles || isDone;
     const isUploadButtonDisabled = !hasFiles;
 
@@ -39,7 +40,12 @@ const Footer = ({ isLoading, hasFiles, errorCode, onCancel, onClose, onUpload, f
         <div className="bcu-footer">
             <div className="bcu-footer-left">
                 {onClose ? (
-                    <Button isDisabled={hasFiles} disabled={hasFiles} onClick={onClose} type="button">
+                    <Button
+                        disabled={isCloseButtonDisabled}
+                        isDisabled={isCloseButtonDisabled}
+                        onClick={onClose}
+                        type="button"
+                    >
                         <FormattedMessage {...messages.close} />
                     </Button>
                 ) : null}

--- a/src/elements/content-uploader/__tests__/Footer.test.js
+++ b/src/elements/content-uploader/__tests__/Footer.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import noop from 'lodash/noop';
+import Button from '../../../components/button/Button';
+import PrimaryButton from '../../../components/primary-button/PrimaryButton';
+import Footer from '../Footer';
+
+describe('elements/content-uploader/Footer', () => {
+    const defaultProps = {
+        fileLimit: 10,
+        hasFiles: false,
+        isDone: false,
+        isLoading: false,
+        onCancel: noop,
+        onUpload: noop,
+    };
+    const getWrapper = (props = {}) => shallow(<Footer {...defaultProps} {...props} />);
+
+    test.each`
+        hasFiles | isDone   | isDisabled
+        ${true}  | ${false} | ${false}
+        ${false} | ${true}  | ${true}
+        ${false} | ${false} | ${true}
+        ${true}  | ${true}  | ${true}
+    `(
+        'cancel button disabled props should be $isDisabled when hasFiles is $hasFiles and isDone is $isDone',
+        ({ hasFiles, isDone, isDisabled }) => {
+            const wrapper = getWrapper({ hasFiles, isDone });
+            const closeButton = wrapper.find(Button);
+
+            expect(closeButton.prop('disabled')).toBe(isDisabled);
+            expect(closeButton.prop('isDisabled')).toBe(isDisabled);
+        },
+    );
+
+    test.each`
+        hasFiles | isDisabled
+        ${true}  | ${false}
+        ${false} | ${true}
+    `('upload button disabled props should be $isDisabled when hasFiles is $hasFiles', ({ hasFiles, isDisabled }) => {
+        const wrapper = getWrapper({ hasFiles });
+        const uploadButton = wrapper.find(PrimaryButton);
+
+        expect(uploadButton.prop('disabled')).toBe(isDisabled);
+        expect(uploadButton.prop('isDisabled')).toBe(isDisabled);
+    });
+});

--- a/src/elements/content-uploader/__tests__/Footer.test.js
+++ b/src/elements/content-uploader/__tests__/Footer.test.js
@@ -47,13 +47,13 @@ describe('elements/content-uploader/Footer', () => {
 
     test.each`
         hasFiles | isDisabled
-        ${true}  | ${false}
-        ${false} | ${true}
+        ${true}  | ${true}
+        ${false} | ${false}
     `('close button disabled props should be $isDisabled when hasFiles is $hasFiles', ({ hasFiles, isDisabled }) => {
         const wrapper = getWrapper({ hasFiles, onClose: noop });
-        const uploadButton = wrapper.find(PrimaryButton).at(0);
+        const closeButton = wrapper.find(Button).at(0);
 
-        expect(uploadButton.prop('disabled')).toBe(isDisabled);
-        expect(uploadButton.prop('isDisabled')).toBe(isDisabled);
+        expect(closeButton.prop('disabled')).toBe(isDisabled);
+        expect(closeButton.prop('isDisabled')).toBe(isDisabled);
     });
 });

--- a/src/elements/content-uploader/__tests__/Footer.test.js
+++ b/src/elements/content-uploader/__tests__/Footer.test.js
@@ -44,4 +44,16 @@ describe('elements/content-uploader/Footer', () => {
         expect(uploadButton.prop('disabled')).toBe(isDisabled);
         expect(uploadButton.prop('isDisabled')).toBe(isDisabled);
     });
+
+    test.each`
+        hasFiles | isDisabled
+        ${true}  | ${false}
+        ${false} | ${true}
+    `('onClose button disabled props should be $isDisabled when hasFiles is $hasFiles', ({ hasFiles, isDisabled }) => {
+        const wrapper = getWrapper({ hasFiles, onClose: noop });
+        const uploadButton = wrapper.find(PrimaryButton).at(0);
+
+        expect(uploadButton.prop('disabled')).toBe(isDisabled);
+        expect(uploadButton.prop('isDisabled')).toBe(isDisabled);
+    });
 });

--- a/src/elements/content-uploader/__tests__/Footer.test.js
+++ b/src/elements/content-uploader/__tests__/Footer.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import noop from 'lodash/noop';
-import Footer from '../Footer';
 import Button from '../../../components/button/Button';
+import Footer from '../Footer';
 import PrimaryButton from '../../../components/primary-button/PrimaryButton';
 
 describe('elements/content-uploader/Footer', () => {

--- a/src/elements/content-uploader/__tests__/Footer.test.js
+++ b/src/elements/content-uploader/__tests__/Footer.test.js
@@ -49,7 +49,7 @@ describe('elements/content-uploader/Footer', () => {
         hasFiles | isDisabled
         ${true}  | ${false}
         ${false} | ${true}
-    `('onClose button disabled props should be $isDisabled when hasFiles is $hasFiles', ({ hasFiles, isDisabled }) => {
+    `('close button disabled props should be $isDisabled when hasFiles is $hasFiles', ({ hasFiles, isDisabled }) => {
         const wrapper = getWrapper({ hasFiles, onClose: noop });
         const uploadButton = wrapper.find(PrimaryButton).at(0);
 

--- a/src/elements/content-uploader/__tests__/Footer.test.js
+++ b/src/elements/content-uploader/__tests__/Footer.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import noop from 'lodash/noop';
+import Footer from '../Footer';
 import Button from '../../../components/button/Button';
 import PrimaryButton from '../../../components/primary-button/PrimaryButton';
-import Footer from '../Footer';
 
 describe('elements/content-uploader/Footer', () => {
     const defaultProps = {


### PR DESCRIPTION
Similar fix to this: https://github.com/box/box-ui-elements/pull/3243/files

Essentially: The `isDisabled` prop does not set the `disabled` property, which means that it is still focusable by the keyboard.

Potential idea to have `isDisabled` set the `disabled` property as well, but because it might cause unintended consequences in parent apps we won't do so here.

https://www.w3.org/WAI/ARIA/apg/patterns/button/

<img width="1587" alt="image" src="https://user-images.githubusercontent.com/24941488/218890045-f9a8347a-931a-4cfc-95dc-2d01fa6ce89d.png">


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
