### PR TITLE
ci: remove package.json engines from production build

### DIFF
--- a/scripts/cut_release.sh
+++ b/scripts/cut_release.sh
@@ -198,6 +198,10 @@ check_npm_login() {
     fi
 }
 
+remove_package_json_engines() {
+    ./scripts/utils/removeEnginesFromPackageJson || return 1
+}
+
 push_new_release() {
     # Check branch being dirty
     check_branch_dirty || return 1
@@ -258,6 +262,9 @@ push_new_release() {
 
     # Check untracked files
     check_untracked_files || return 1
+
+    # Remove engines object from package.json as it is needed only for development
+    remove_package_json_engines || return 1
 
     # Publish to npm
     if ! push_to_npm; then

--- a/scripts/utils/removeEnginesFromPackageJson
+++ b/scripts/utils/removeEnginesFromPackageJson
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const { promisify } = require("util");
+
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+async function main() {
+  const content = await readFile("./package.json", { encoding: "utf8" });
+  const json = JSON.parse(content);
+  json.engines = undefined;
+  await writeFile("./package.json", JSON.stringify(json, null, 4), { encoding: "utf8" });
+}
+
+main();


### PR DESCRIPTION
This dependencies are only required for development.

Closes Update node.js to v18 and npm to v8 #3100

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
