### PR TITLE
fix(collaborator-list-item): remove redundant titles

### DIFF
--- a/src/features/collaborator-avatars/CollaboratorListItem.js
+++ b/src/features/collaborator-avatars/CollaboratorListItem.js
@@ -35,13 +35,7 @@ const CollaboratorListItem = (props: Props) => {
     const userOrGroupNameContent =
         type !== COLLAB_GROUP_TYPE ? (
             <div className={classnames('name', type)}>
-                <Link
-                    href={profileURL || `/profile/${userID}`}
-                    rel="noopener"
-                    target="_blank"
-                    title={name}
-                    {...usernameProps}
-                >
+                <Link href={profileURL || `/profile/${userID}`} rel="noopener" target="_blank" {...usernameProps}>
                     {name}
                 </Link>
             </div>
@@ -52,7 +46,7 @@ const CollaboratorListItem = (props: Props) => {
     const emailContent =
         type !== COLLAB_GROUP_TYPE && email ? (
             <div className="email">
-                <Link href={`mailto:${email}`} title={email} {...emailProps}>
+                <Link href={`mailto:${email}`} {...emailProps}>
                     {email}
                 </Link>
             </div>

--- a/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorListItem.test.js.snap
+++ b/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorListItem.test.js.snap
@@ -31,7 +31,6 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
             href="/profile/undefined"
             rel="noopener"
             target="_blank"
-            title="test c"
           >
             test c
           </Link>
@@ -42,7 +41,6 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
           <Link
             className=""
             href="mailto:testc@example.com"
-            title="testc@example.com"
           >
             testc@example.com
           </Link>
@@ -124,7 +122,6 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
             href="/profile/undefined"
             rel="noopener"
             target="_blank"
-            title="test c"
           >
             test c
           </Link>
@@ -135,7 +132,6 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
           <Link
             className=""
             href="mailto:testc@example.com"
-            title="testc@example.com"
           >
             testc@example.com
           </Link>


### PR DESCRIPTION
When the `title` attribute is the same as the link text, it does not serve a purpose and can be distracting to users.