### PR TITLE
fix(flyout): increase flyout overlay css specificity

### DIFF
--- a/src/components/flyout/Flyout.scss
+++ b/src/components/flyout/Flyout.scss
@@ -32,7 +32,7 @@
             transform: none !important;
         }
 
-        .overlay {
+        .bdl-Overlay > .overlay {
             position: fixed;
             top: 0;
             right: 0;

--- a/src/components/flyout/Overlay.js
+++ b/src/components/flyout/Overlay.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import classNames from 'classnames';
 import omit from 'lodash/omit';
 
 import FocusTrap from '../focus-trap';
@@ -35,7 +36,7 @@ class Overlay extends React.Component<Props> {
     render() {
         const { children, className, ...rest } = this.props;
         const overlayProps = omit(rest, ['onClose']);
-        overlayProps.className = className;
+        overlayProps.className = classNames('bdl-Overlay', className);
         overlayProps.handleOverlayKeyDown = this.handleOverlayKeyDown;
         overlayProps.tabIndex = 0;
 

--- a/src/components/flyout/__tests__/Overlay.test.js
+++ b/src/components/flyout/__tests__/Overlay.test.js
@@ -29,7 +29,7 @@ describe('components/flyout/Overlay', () => {
             expect(wrapper.childAt(0).is('FocusTrap')).toBe(true);
             expect(wrapper.find('div.overlay').length).toBe(1);
 
-            expect(wrapper.childAt(0).prop('className')).toEqual('hey');
+            expect(wrapper.childAt(0).prop('className')).toEqual('bdl-Overlay hey');
             expect(wrapper.childAt(0).prop('id')).toEqual('overlay');
             expect(wrapper.childAt(0).prop('tabIndex')).toEqual(0);
         });


### PR DESCRIPTION
This fixes an issue with the responsive overlay CSS being applied other .overlay elements that are within the **Flyout** **Overlay**. One example is when we have a **SelectorDropdown** within a **Flyout**. **SelectorDropdown** defines its own `.overlay` element and the responsive behaviors defined for **FlyoutOverlay** is spilling over to other unintended elements.

The chosen solution to increase the specificity was to add `.flyout-overlay` class name and restrict the CSS to the direct child descendent
`.flyout-overlay > .overlay`

Another accepted approach might have been to rename the **Flyout** and **Overlay** components to match SUIT naming but that comes with inherent risks as there are other CSS classes that override `.overlay`.

Observed Bug
![flyout-responsive-css-issue](https://user-images.githubusercontent.com/96507973/220499816-0a6c9ea2-2779-442a-89cc-07ab407b24de.gif)

Fixed
![flyout-responsive-fix](https://user-images.githubusercontent.com/96507973/220499897-2110a7f1-1362-49ef-9fe2-fc3adb94958b.gif)

