### PR TITLE
fix(content-explorer): hide instead of disable breadcrumbs

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorerFolderTreeBreadcrumbs.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorerFolderTreeBreadcrumbs.js
@@ -22,7 +22,6 @@ const ContentExplorerFolderTreeBreadcrumbs = ({
     foldersPath,
     intl: { formatMessage, formatNumber },
     isFolderTreeButtonHidden,
-    isFolderTreeButtonDisabled = false,
     numTotalItems,
     onBreadcrumbClick,
 }) => {
@@ -35,7 +34,6 @@ const ContentExplorerFolderTreeBreadcrumbs = ({
                     <Button
                         aria-label={formatMessage(messages.clickToViewPath)}
                         className="bdl-ContentExplorerFolderTreeBreadcrumbs-button"
-                        isDisabled={isFolderTreeButtonDisabled}
                         title={formatMessage(messages.filePath)}
                         type="button"
                     >
@@ -76,7 +74,6 @@ ContentExplorerFolderTreeBreadcrumbs.propTypes = {
     foldersPath: FoldersPathPropType.isRequired,
     intl: PropTypes.any,
     isFolderTreeButtonHidden: PropTypes.bool,
-    isFolderTreeButtonDisabled: PropTypes.bool,
     numTotalItems: PropTypes.number.isRequired,
     onBreadcrumbClick: PropTypes.func,
 };

--- a/src/features/content-explorer/content-explorer/ContentExplorerHeaderActions.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorerHeaderActions.js
@@ -194,8 +194,7 @@ class ContentExplorerHeaderActions extends Component {
                 {hasFolderTreeBreadcrumbs ? (
                     <ContentExplorerFolderTreeBreadcrumbs
                         foldersPath={foldersPath}
-                        isFolderTreeButtonHidden={this.isViewingSearchResults()}
-                        isFolderTreeButtonDisabled={isBreadcrumbButtonDisabled}
+                        isFolderTreeButtonHidden={isBreadcrumbButtonDisabled || this.isViewingSearchResults()}
                         numTotalItems={numTotalItems}
                         onBreadcrumbClick={this.handleBreadcrumbClick}
                     />

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorerFolderTreeBreadcrumbs.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorerFolderTreeBreadcrumbs.test.js
@@ -39,13 +39,6 @@ describe('features/content-explorer/content-explorer/ContentExplorerFolderTreeBr
             expect(breadcrumbTextId).toBe('boxui.contentExplorer.folderTreeBreadcrumbsText');
         });
 
-        test('should render disabled folder tree button when isFolderTreeButtonDisabled is true', () => {
-            const foldersPath = [{ id: '0', name: 'folder1' }];
-            const wrapper = renderComponent({ isFolderTreeButtonDisabled: true, foldersPath });
-
-            expect(wrapper.find('.bdl-ContentExplorerFolderTreeBreadcrumbs-button').prop('isDisabled')).toBe(true);
-        });
-
         test('should not render button nor icon when isFolderTreeButtonHidden is true', () => {
             const foldersPath = [
                 { id: '0', name: 'folder1' },
@@ -68,13 +61,6 @@ describe('features/content-explorer/content-explorer/ContentExplorerFolderTreeBr
             const breadcrumbTextId = lastBreadcrumb.find('FormattedMessage').prop('id');
 
             expect(breadcrumbTextId).toBe('boxui.contentExplorer.folderTreeBreadcrumbsText');
-        });
-
-        test('should render disabled folder tree button when isFolderTreeButtonDisabled is true', () => {
-            const foldersPath = [{ id: '0', name: 'folder1' }];
-            const wrapper = renderComponent({ isFolderTreeButtonDisabled: true, foldersPath });
-
-            expect(wrapper.find('.bdl-ContentExplorerFolderTreeBreadcrumbs-button').prop('isDisabled')).toBe(true);
         });
     });
 


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
