### PR TITLE
fix(content-explorer): status message for include subfolders

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -900,12 +900,8 @@ boxui.contentExplorer.copy = Copy
 boxui.contentExplorer.emptyFolder = There are no subfolders in this folder.
 # Text shown in the list when there are no search results
 boxui.contentExplorer.emptySearch = Sorry, we couldn't find what you're looking for.
-# Text shown to indicate the number of folders selected where there subfolders are selected as well
-boxui.contentExplorer.fileSelectedToIncludeSubfolders = {numSelected} folder and all subfolders within is selected
 # Tooltip message for the folder tree breadcrumb button
 boxui.contentExplorer.filepath = File path
-# Text shown to indicate the number of items selected with Include Subfolders feature
-boxui.contentExplorer.filesAndFoldersSelected = {numSelected} of folder and files selected
 # Text shown for the current folder and its number of items next to the folder tree breadcrumbs
 boxui.contentExplorer.folderTreeBreadcrumbsText = {folderName} ({totalItems})
 # Label text shown next to the Include Subfolders toggle
@@ -916,6 +912,10 @@ boxui.contentExplorer.move = Move
 boxui.contentExplorer.name = Name
 # Text shown on button used to create a new folder
 boxui.contentExplorer.newFolder = New Folder
+# Text shown to indicate the number of folders selected
+boxui.contentExplorer.numFoldersSelected =  {numSelected, plural, =0 {0 folders selected} one {1 folder selected} other {# folders selected} } 
+# Text shown to indicate the number of items selected with Include Subfolders feature
+boxui.contentExplorer.numItemsSelected =  {numSelected, plural, =0 {0 items selected} one {1 item selected} other {# items selected} } 
 # Text shown to indicate the number of items selected
 boxui.contentExplorer.numSelected = {numSelected} Selected
 # Results label for number of items on list when it's just 1

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -900,8 +900,12 @@ boxui.contentExplorer.copy = Copy
 boxui.contentExplorer.emptyFolder = There are no subfolders in this folder.
 # Text shown in the list when there are no search results
 boxui.contentExplorer.emptySearch = Sorry, we couldn't find what you're looking for.
+# Text shown to indicate the number of folders selected where there subfolders are selected as well
+boxui.contentExplorer.fileSelectedToIncludeSubfolders = {numSelected} folder and all subfolders within is selected
 # Tooltip message for the folder tree breadcrumb button
 boxui.contentExplorer.filepath = File path
+# Text shown to indicate the number of items selected with Include Subfolders feature
+boxui.contentExplorer.filesAndFoldersSelected = {numSelected} of folder and files selected
 # Text shown for the current folder and its number of items next to the folder tree breadcrumbs
 boxui.contentExplorer.folderTreeBreadcrumbsText = {folderName} ({totalItems})
 # Label text shown next to the Include Subfolders toggle

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -585,6 +585,7 @@ class ContentExplorer extends Component {
                     actionButtonsProps={actionButtonsProps}
                     areButtonsDisabled={areActionButtonsDisabled}
                     cancelButtonProps={cancelButtonProps}
+                    canIncludeSubfolders={canIncludeSubfolders}
                     chooseButtonProps={chooseButtonProps}
                     chooseButtonText={chooseButtonText}
                     contentExplorerMode={contentExplorerMode}
@@ -593,6 +594,7 @@ class ContentExplorer extends Component {
                     isCopyButtonLoading={isCopyButtonLoading}
                     isMoveButtonLoading={isMoveButtonLoading}
                     isResponsive={isResponsive}
+                    isSelectAllAllowed={isSelectAllAllowed}
                     onCancelClick={onCancelButtonClick}
                     onChooseClick={onChooseItems}
                     onCopyClick={onCopyItem}

--- a/src/features/content-explorer/content-explorer/ContentExplorerActionButtons.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorerActionButtons.js
@@ -24,6 +24,7 @@ const ContentExplorerActionButtons = ({
     actionButtonsProps = {},
     areButtonsDisabled = false,
     cancelButtonProps = {},
+    canIncludeSubfolders,
     chooseButtonProps = {},
     chooseButtonText,
     contentExplorerMode,
@@ -32,6 +33,7 @@ const ContentExplorerActionButtons = ({
     isCopyButtonLoading = false,
     isMoveButtonLoading = false,
     isResponsive = false,
+    isSelectAllAllowed,
     onCancelClick,
     onChooseClick,
     onCopyClick,
@@ -73,10 +75,20 @@ const ContentExplorerActionButtons = ({
     };
 
     const renderStatus = () => {
-        const chosenItems = getChosenItemsFromSelectedItems(selectedItems);
-        const statusMessage = (
-            <FormattedMessage {...messages.numSelected} values={{ numSelected: chosenItems.length }} />
-        );
+        const numChosenItems = getChosenItemsFromSelectedItems(selectedItems).length;
+
+        let statusMessage = <FormattedMessage {...messages.numSelected} values={{ numSelected: numChosenItems }} />;
+
+        if (canIncludeSubfolders && numChosenItems > 0) {
+            statusMessage = isSelectAllAllowed ? (
+                <FormattedMessage {...messages.filesAndFoldersSelected} values={{ numSelected: numChosenItems }} />
+            ) : (
+                <FormattedMessage
+                    {...messages.fileSelectedToIncludeSubfolders}
+                    values={{ numSelected: numChosenItems }}
+                />
+            );
+        }
 
         const statusElement = onSelectedClick ? (
             <Button className="status-message" onClick={onSelectedClick}>
@@ -151,6 +163,7 @@ ContentExplorerActionButtons.propTypes = {
     actionButtonsProps: PropTypes.object,
     areButtonsDisabled: PropTypes.bool,
     cancelButtonProps: PropTypes.object,
+    canIncludeSubfolders: PropTypes.bool,
     chooseButtonProps: PropTypes.object,
     chooseButtonText: PropTypes.node,
     contentExplorerMode: ContentExplorerModePropType.isRequired,
@@ -159,6 +172,7 @@ ContentExplorerActionButtons.propTypes = {
     isCopyButtonLoading: PropTypes.bool,
     isMoveButtonLoading: PropTypes.bool,
     isResponsive: PropTypes.bool,
+    isSelectAllAllowed: PropTypes.bool,
     onCancelClick: PropTypes.func,
     onChooseClick: PropTypes.func,
     onCopyClick: PropTypes.func,

--- a/src/features/content-explorer/content-explorer/ContentExplorerActionButtons.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorerActionButtons.js
@@ -75,18 +75,15 @@ const ContentExplorerActionButtons = ({
     };
 
     const renderStatus = () => {
-        const numChosenItems = getChosenItemsFromSelectedItems(selectedItems).length;
+        const numSelected = getChosenItemsFromSelectedItems(selectedItems).length;
 
-        let statusMessage = <FormattedMessage {...messages.numSelected} values={{ numSelected: numChosenItems }} />;
+        let statusMessage = <FormattedMessage {...messages.numSelected} values={{ numSelected }} />;
 
-        if (canIncludeSubfolders && numChosenItems > 0) {
+        if (canIncludeSubfolders) {
             statusMessage = isSelectAllAllowed ? (
-                <FormattedMessage {...messages.filesAndFoldersSelected} values={{ numSelected: numChosenItems }} />
+                <FormattedMessage {...messages.numItemsSelected} values={{ numSelected }} />
             ) : (
-                <FormattedMessage
-                    {...messages.fileSelectedToIncludeSubfolders}
-                    values={{ numSelected: numChosenItems }}
-                />
+                <FormattedMessage {...messages.numFoldersSelected} values={{ numSelected }} />
             );
         }
 

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorerActionButtons.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorerActionButtons.test.js
@@ -324,16 +324,59 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
     });
 
     describe('renderStatus', () => {
-        test('should show status message for multi select', () => {
+        test('should show default status message for multi select', () => {
             const item = { id: '0', name: 'item1' };
             const selectedItems = { '0': item };
             const wrapper = renderComponent({
                 contentExplorerMode: ContentExplorerModes.MULTI_SELECT,
                 selectedItems,
             });
+            const statusMessageId = wrapper
+                .find('.status-message')
+                .find('FormattedMessage')
+                .prop('id');
 
-            expect(wrapper.find('.status-message').length).toEqual(1);
+            expect(statusMessageId).toEqual('boxui.contentExplorer.numSelected');
         });
+
+        test('should show status message for multi select when items are selected and we can include subfolders and can select all', () => {
+            const item = { id: '0', name: 'item1' };
+            const selectedItems = { '0': item };
+            const canIncludeSubfolders = true;
+            const isSelectAllAllowed = true;
+            const wrapper = renderComponent({
+                contentExplorerMode: ContentExplorerModes.MULTI_SELECT,
+                selectedItems,
+                canIncludeSubfolders,
+                isSelectAllAllowed,
+            });
+            const statusMessageId = wrapper
+                .find('.status-message')
+                .find('FormattedMessage')
+                .prop('id');
+
+            expect(statusMessageId).toEqual('boxui.contentExplorer.filesAndFoldersSelected');
+        });
+
+        test('should show status message for multi select when items are selected and we can include subfolders and cannot select all', () => {
+            const item = { id: '0', name: 'item1' };
+            const selectedItems = { '0': item };
+            const canIncludeSubfolders = true;
+            const isSelectAllAllowed = false;
+            const wrapper = renderComponent({
+                contentExplorerMode: ContentExplorerModes.MULTI_SELECT,
+                selectedItems,
+                canIncludeSubfolders,
+                isSelectAllAllowed,
+            });
+            const statusMessageId = wrapper
+                .find('.status-message')
+                .find('FormattedMessage')
+                .prop('id');
+
+            expect(statusMessageId).toEqual('boxui.contentExplorer.fileSelectedToIncludeSubfolders');
+        });
+
         [
             {
                 contentExplorerMode: ContentExplorerModes.SELECT_FILE,

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorerActionButtons.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorerActionButtons.test.js
@@ -324,9 +324,15 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
     });
 
     describe('renderStatus', () => {
+        let item;
+        let selectedItems;
+
+        beforeEach(() => {
+            item = { id: '0', name: 'item1' };
+            selectedItems = { '0': item };
+        });
+
         test('should show default status message for multi select', () => {
-            const item = { id: '0', name: 'item1' };
-            const selectedItems = { '0': item };
             const wrapper = renderComponent({
                 contentExplorerMode: ContentExplorerModes.MULTI_SELECT,
                 selectedItems,
@@ -340,8 +346,6 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
         });
 
         test('should show status message for multi select when items are selected and we can include subfolders and can select all', () => {
-            const item = { id: '0', name: 'item1' };
-            const selectedItems = { '0': item };
             const canIncludeSubfolders = true;
             const isSelectAllAllowed = true;
             const wrapper = renderComponent({
@@ -359,8 +363,6 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
         });
 
         test('should show status message for multi select when items are selected and we can include subfolders and cannot select all', () => {
-            const item = { id: '0', name: 'item1' };
-            const selectedItems = { '0': item };
             const canIncludeSubfolders = true;
             const isSelectAllAllowed = false;
             const wrapper = renderComponent({
@@ -392,8 +394,6 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
             },
         ].forEach(({ contentExplorerMode }) => {
             test('should not show status message', () => {
-                const item = { id: '0', name: 'item1' };
-                const selectedItems = { '0': item };
                 const wrapper = renderComponent({
                     contentExplorerMode,
                     selectedItems,
@@ -404,8 +404,6 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
         });
 
         test('should render statusElement as button when onSelectedClick provided for multi select', () => {
-            const item = { id: '0', name: 'item1' };
-            const selectedItems = { '0': item };
             const onSelectedClick = () => {};
 
             const wrapper = renderComponent({

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorerActionButtons.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorerActionButtons.test.js
@@ -324,13 +324,8 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
     });
 
     describe('renderStatus', () => {
-        let item;
-        let selectedItems;
-
-        beforeEach(() => {
-            item = { id: '0', name: 'item1' };
-            selectedItems = { '0': item };
-        });
+        const item = { id: '0', name: 'item1' };
+        const selectedItems = { '0': item };
 
         test('should show default status message for multi select', () => {
             const wrapper = renderComponent({
@@ -342,41 +337,37 @@ describe('features/content-explorer/content-explorer/ContentExplorerActionButton
                 .find('FormattedMessage')
                 .prop('id');
 
-            expect(statusMessageId).toEqual('boxui.contentExplorer.numSelected');
+            expect(statusMessageId).toBe('boxui.contentExplorer.numSelected');
         });
 
         test('should show status message for multi select when items are selected and we can include subfolders and can select all', () => {
-            const canIncludeSubfolders = true;
-            const isSelectAllAllowed = true;
             const wrapper = renderComponent({
+                canIncludeSubfolders: true,
                 contentExplorerMode: ContentExplorerModes.MULTI_SELECT,
+                isSelectAllAllowed: true,
                 selectedItems,
-                canIncludeSubfolders,
-                isSelectAllAllowed,
             });
             const statusMessageId = wrapper
                 .find('.status-message')
                 .find('FormattedMessage')
                 .prop('id');
 
-            expect(statusMessageId).toEqual('boxui.contentExplorer.filesAndFoldersSelected');
+            expect(statusMessageId).toBe('boxui.contentExplorer.numItemsSelected');
         });
 
         test('should show status message for multi select when items are selected and we can include subfolders and cannot select all', () => {
-            const canIncludeSubfolders = true;
-            const isSelectAllAllowed = false;
             const wrapper = renderComponent({
+                canIncludeSubfolders: true,
                 contentExplorerMode: ContentExplorerModes.MULTI_SELECT,
+                isSelectAllAllowed: false,
                 selectedItems,
-                canIncludeSubfolders,
-                isSelectAllAllowed,
             });
             const statusMessageId = wrapper
                 .find('.status-message')
                 .find('FormattedMessage')
                 .prop('id');
 
-            expect(statusMessageId).toEqual('boxui.contentExplorer.fileSelectedToIncludeSubfolders');
+            expect(statusMessageId).toBe('boxui.contentExplorer.numFoldersSelected');
         });
 
         [

--- a/src/features/content-explorer/content-explorer/__tests__/__snapshots__/ContentExplorer.test.js.snap
+++ b/src/features/content-explorer/content-explorer/__tests__/__snapshots__/ContentExplorer.test.js.snap
@@ -42,6 +42,7 @@ exports[`features/content-explorer/content-explorer/ContentExplorer render() cus
   <ContentExplorerActionButtons
     actionButtonsProps={Object {}}
     areButtonsDisabled={true}
+    canIncludeSubfolders={false}
     cancelButtonProps={Object {}}
     chooseButtonProps={Object {}}
     contentExplorerMode="selectFile"

--- a/src/features/content-explorer/messages.js
+++ b/src/features/content-explorer/messages.js
@@ -82,6 +82,17 @@ const messages = defineMessages({
         description: 'Text shown to indicate the number of items selected',
         id: 'boxui.contentExplorer.numSelected',
     },
+    filesAndFoldersSelected: {
+        defaultMessage: '{numSelected} of folder and files selected',
+        description: 'Text shown to indicate the number of items selected with Include Subfolders feature',
+        id: 'boxui.contentExplorer.filesAndFoldersSelected',
+    },
+    fileSelectedToIncludeSubfolders: {
+        defaultMessage: '{numSelected} folder and all subfolders within is selected',
+        description:
+            'Text shown to indicate the number of folders selected where there subfolders are selected as well',
+        id: 'boxui.contentExplorer.fileSelectedToIncludeSubfolders',
+    },
     emptySearch: {
         defaultMessage: "Sorry, we couldn't find what you're looking for.",
         description: 'Text shown in the list when there are no search results',

--- a/src/features/content-explorer/messages.js
+++ b/src/features/content-explorer/messages.js
@@ -82,16 +82,27 @@ const messages = defineMessages({
         description: 'Text shown to indicate the number of items selected',
         id: 'boxui.contentExplorer.numSelected',
     },
-    filesAndFoldersSelected: {
-        defaultMessage: '{numSelected} of folder and files selected',
+    numItemsSelected: {
+        defaultMessage: `
+            {numSelected, plural,
+                =0 {0 items selected}
+                one {1 item selected}
+                other {# items selected}
+            }
+        `,
         description: 'Text shown to indicate the number of items selected with Include Subfolders feature',
-        id: 'boxui.contentExplorer.filesAndFoldersSelected',
+        id: 'boxui.contentExplorer.numItemsSelected',
     },
-    fileSelectedToIncludeSubfolders: {
-        defaultMessage: '{numSelected} folder and all subfolders within is selected',
-        description:
-            'Text shown to indicate the number of folders selected where there subfolders are selected as well',
-        id: 'boxui.contentExplorer.fileSelectedToIncludeSubfolders',
+    numFoldersSelected: {
+        defaultMessage: `
+            {numSelected, plural,
+                =0 {0 folders selected}
+                one {1 folder selected}
+                other {# folders selected}
+            }
+        `,
+        description: 'Text shown to indicate the number of folders selected',
+        id: 'boxui.contentExplorer.numFoldersSelected',
     },
     emptySearch: {
         defaultMessage: "Sorry, we couldn't find what you're looking for.",


### PR DESCRIPTION
For the Include Subfolders toggle feature, we want the modal to also have a new footer for the text in the bottom left of the modal.