### PR TITLE
fix(metadata): fix template dropdown truncation issue

### DIFF
--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -120,6 +120,10 @@ export type FlyoutProps = {
      */
     constrainToWindow?: boolean,
     /**
+     * Sets tether constrain to window with pin
+     */
+    constrainToWindowWithPin?: boolean,
+    /**
      * Toggles responsive behavior
      */
     isResponsive?: boolean,
@@ -373,6 +377,7 @@ class Flyout extends React.Component<Props, State> {
             className = '',
             constrainToScrollParent,
             constrainToWindow,
+            constrainToWindowWithPin,
             isResponsive,
             offset,
             openOnHover,
@@ -432,6 +437,14 @@ class Flyout extends React.Component<Props, State> {
             constraints.push({
                 to: 'window',
                 attachment: 'together',
+            });
+        }
+
+        if (constrainToWindowWithPin) {
+            constraints.push({
+                to: 'window',
+                attachment: 'together',
+                pin: true,
             });
         }
 

--- a/src/components/flyout/__tests__/Flyout.test.js
+++ b/src/components/flyout/__tests__/Flyout.test.js
@@ -206,7 +206,7 @@ describe('components/flyout/Flyout', () => {
             expect(wrapper.prop('constraints')).toEqual([]);
         });
 
-        test('should render TetherComponent with window constraint when constrainToScrollParent=true', () => {
+        test('should render TetherComponent with window constraint when constrainToWindow=true', () => {
             const wrapper = shallow(
                 <Flyout constrainToWindow>
                     <FakeButton />
@@ -222,6 +222,27 @@ describe('components/flyout/Flyout', () => {
                 {
                     to: 'window',
                     attachment: 'together',
+                },
+            ]);
+        });
+
+        test('should render TetherComponent with window constraint when constrainToWindowWithPin=true', () => {
+            const wrapper = shallow(
+                <Flyout constrainToWindowWithPin>
+                    <FakeButton />
+                    <FakeOverlay />
+                </Flyout>,
+            );
+
+            expect(wrapper.prop('constraints')).toEqual([
+                {
+                    to: 'scrollParent',
+                    attachment: 'together',
+                },
+                {
+                    to: 'window',
+                    attachment: 'together',
+                    pin: true,
                 },
             ]);
         });

--- a/src/features/metadata-instance-editor/TemplateDropdown.js
+++ b/src/features/metadata-instance-editor/TemplateDropdown.js
@@ -265,6 +265,7 @@ class TemplateDropdown extends React.PureComponent<Props, State> {
                 className={flyoutClassName}
                 closeOnClick
                 closeOnClickOutside
+                constrainToWindowWithPin
                 onClose={this.onClose}
                 onOpen={this.onOpen}
                 position="bottom-left"

--- a/src/features/metadata-instance-editor/__tests__/__snapshots__/TemplateDropdown.test.js.snap
+++ b/src/features/metadata-instance-editor/__tests__/__snapshots__/TemplateDropdown.test.js.snap
@@ -8,6 +8,7 @@ exports[`features/metadata-instance-editor/fields/ should correctly render butto
   closeOnWindowBlur={false}
   constrainToScrollParent={true}
   constrainToWindow={false}
+  constrainToWindowWithPin={true}
   isResponsive={false}
   isVisibleByDefault={false}
   onClose={[Function]}
@@ -68,6 +69,7 @@ exports[`features/metadata-instance-editor/fields/ should correctly render dropd
   closeOnWindowBlur={false}
   constrainToScrollParent={true}
   constrainToWindow={false}
+  constrainToWindowWithPin={true}
   isResponsive={false}
   isVisibleByDefault={false}
   onClose={[Function]}
@@ -134,6 +136,7 @@ exports[`features/metadata-instance-editor/fields/ should correctly render dropd
   closeOnWindowBlur={false}
   constrainToScrollParent={true}
   constrainToWindow={false}
+  constrainToWindowWithPin={true}
   isResponsive={false}
   isVisibleByDefault={false}
   onClose={[Function]}
@@ -200,6 +203,7 @@ exports[`features/metadata-instance-editor/fields/ should correctly render empty
   closeOnWindowBlur={false}
   constrainToScrollParent={true}
   constrainToWindow={false}
+  constrainToWindowWithPin={true}
   isResponsive={false}
   isVisibleByDefault={false}
   onClose={[Function]}
@@ -258,6 +262,7 @@ exports[`features/metadata-instance-editor/fields/ should correctly render error
   closeOnWindowBlur={false}
   constrainToScrollParent={true}
   constrainToWindow={false}
+  constrainToWindowWithPin={true}
   isResponsive={false}
   isVisibleByDefault={false}
   onClose={[Function]}
@@ -316,6 +321,7 @@ exports[`features/metadata-instance-editor/fields/ should correctly render loadi
   closeOnWindowBlur={false}
   constrainToScrollParent={true}
   constrainToWindow={false}
+  constrainToWindowWithPin={true}
   isResponsive={false}
   isVisibleByDefault={false}
   onClose={[Function]}
@@ -369,6 +375,7 @@ exports[`features/metadata-instance-editor/fields/ should correctly render plain
   closeOnWindowBlur={false}
   constrainToScrollParent={true}
   constrainToWindow={false}
+  constrainToWindowWithPin={true}
   isResponsive={false}
   isVisibleByDefault={false}
   onClose={[Function]}


### PR DESCRIPTION
The metadata template dropdown uses the Flyout component which flips the overlay upward if it exceeds the bottom of the viewport, making the dropdown look truncated.

To fix this issue, I added a new prop `contrainToWindowWithPin` to Flyout. When set to true, it pins the overlay to edges on small screens and makes good use of available space.

The main use case is in the Embed Widget 2.0 with the smallest recommended dimensions of 330px x 400px. Anything < 400px in height is out of our consideration.

## Demo

### Before
![metadata_template_before](https://user-images.githubusercontent.com/17888863/221673854-83a3250b-ee9d-422c-8bb9-233e18d3a44f.gif)

### After
![metadata_template_after](https://user-images.githubusercontent.com/17888863/221673889-680d61f1-f493-427a-941f-774a07a668f3.gif)
