### PR TITLE
feat(input-with-copy): add node for settings button

### DIFF
--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -16,7 +16,7 @@ const defaultCopyText = <FormattedMessage {...messages.copy} />;
 const defaultCopiedText = <FormattedMessage {...messages.copied} />;
 
 type Props = {
-    /** Node for settings button */
+    /** Array of nodes for additional buttons */
     additionalButtons?: Array<React.Node>,
     /** Set the focus to input when component loads */
     autofocus?: boolean,

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -28,6 +28,8 @@ type Props = {
     /** Label displayed for the text input */
     // TODO: Make label required
     label?: React.Node,
+    /** Node for settings button */
+    nodeForButton?: React.Node,
     /** onFocus handler for the input el */
     onCopySuccess?: Function,
     /** Function called when link is copied by keyboard or button */
@@ -216,6 +218,7 @@ class TextInputWithCopyButton extends React.PureComponent<Props, State> {
         return (
             <div className={wrapperClasses} {...copyEvent}>
                 <TextInput {...inputProps} onFocus={this.handleFocus} />
+                {rest.nodeForButton}
                 {this.renderCopyButton()}
             </div>
         );

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -188,7 +188,7 @@ class TextInputWithCopyButton extends React.PureComponent<Props, State> {
         ) : null;
 
     render() {
-        const { className, additionalButtons, ...rest } = this.props;
+        const { additionalButtons, className, ...rest } = this.props;
         const { copySuccess } = this.state;
         const { isCopyCommandSupported } = this;
 

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -16,6 +16,8 @@ const defaultCopyText = <FormattedMessage {...messages.copy} />;
 const defaultCopiedText = <FormattedMessage {...messages.copied} />;
 
 type Props = {
+    /** Node for settings button */
+    additionalButtons?: Array<React.Node>,
     /** Set the focus to input when component loads */
     autofocus?: boolean,
     /** Default copy button text */
@@ -28,8 +30,6 @@ type Props = {
     /** Label displayed for the text input */
     // TODO: Make label required
     label?: React.Node,
-    /** Node for settings button */
-    nodeForButton?: React.Node,
     /** onFocus handler for the input el */
     onCopySuccess?: Function,
     /** Function called when link is copied by keyboard or button */
@@ -188,7 +188,7 @@ class TextInputWithCopyButton extends React.PureComponent<Props, State> {
         ) : null;
 
     render() {
-        const { className, ...rest } = this.props;
+        const { className, additionalButtons, ...rest } = this.props;
         const { copySuccess } = this.state;
         const { isCopyCommandSupported } = this;
 
@@ -218,7 +218,7 @@ class TextInputWithCopyButton extends React.PureComponent<Props, State> {
         return (
             <div className={wrapperClasses} {...copyEvent}>
                 <TextInput {...inputProps} onFocus={this.handleFocus} />
-                {rest.nodeForButton}
+                {additionalButtons}
                 {this.renderCopyButton()}
             </div>
         );

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.scss
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.scss
@@ -17,8 +17,8 @@
         }
     }
 
-    .bdl-Button,
-    .btn {
+    .bdl-Button:last-child,
+    .btn:last-child {
         min-width: 80px;
         margin: 0;
         border-left: 0;
@@ -27,11 +27,19 @@
         transition: background-color .5s ease, border-color .5s ease;
     }
 
+    .bdl-Button:not(:last-child),
+    .btn:not(:last-child) {
+        margin: 0;
+        border-left: 0;
+        border-radius: 0;
+        transition: background-color .5s ease, border-color .5s ease;
+    }
+
     &.copy-success {
-        .btn,
-        .btn:hover,
-        .btn:active,
-        .btn:active:hover {
+        .btn:last-child,
+        .btn:last-child:hover,
+        .btn:last-child:active,
+        .btn:active:last-child:hover {
             color: $white;
             background-color: $bdl-green-light;
             border-color: $bdl-green-light;

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.scss
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.scss
@@ -17,29 +17,27 @@
         }
     }
 
-    .bdl-Button:last-child,
-    .btn:last-child {
-        min-width: 80px;
-        margin: 0;
-        border-left: 0;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-        transition: background-color .5s ease, border-color .5s ease;
-    }
-
-    .bdl-Button:not(:last-child),
-    .btn:not(:last-child) {
+    .bdl-Button,
+    .btn {
         margin: 0;
         border-left: 0;
         border-radius: 0;
         transition: background-color .5s ease, border-color .5s ease;
     }
 
+    .bdl-Button:last-child,
+    .btn:last-child {
+        min-width: 80px;
+        margin: 0;
+        border-left: 0;
+        border-radius: 0 6px 6px 0;
+        transition: background-color .5s ease, border-color .5s ease;
+    }
+
     &.copy-success {
         .btn:last-child,
         .btn:last-child:hover,
-        .btn:last-child:active,
-        .btn:active:last-child:hover {
+        .btn:last-child:active {
             color: $white;
             background-color: $bdl-green-light;
             border-color: $bdl-green-light;


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

Possible usages (how it looks like with additional buttons and without):
don't pay a lot of attention on content and paddings in these 2 new buttons, you should provide yours to these Nodes, that's just an examples.

<img width="368" alt="Screenshot 2023-03-02 at 18 39 06" src="https://user-images.githubusercontent.com/126584114/222508722-59a967af-5bcc-439d-8153-ea4e09d1ea91.png">


<img width="438" alt="Screenshot 2023-03-02 at 18 40 43" src="https://user-images.githubusercontent.com/126584114/222508542-60441bf1-7e2b-4576-aa0b-1b04ddf253ba.png">

<img width="310" alt="Screenshot 2023-03-02 at 18 42 05" src="https://user-images.githubusercontent.com/126584114/222508892-24b8a9e4-b8f7-4efb-9664-e6c8b206518f.png">


how we will use it in Relay:
<img width="523" alt="Screenshot 2023-03-02 at 18 41 06" src="https://user-images.githubusercontent.com/126584114/222508644-a2788c8c-1ca3-45f1-8f89-e4c8e4e0563e.png">

_I have also just realised that this "copy" button has different paddings_ :thinking_face:

@tjuanitas am I right that it should be possible simply by passing `className` to `buttonProps`? 
