### PR TITLE
refactor(colors): Replace bdl-gray-62 with bdl-gray-65

### DIFF
--- a/src/styles/constants/_colors.scss
+++ b/src/styles/constants/_colors.scss
@@ -19,7 +19,8 @@ $bdl-box-blue-02: #fafcfe !default;
 // Box/Primary Grays
 $bdl-gray: #222 !default;
 $bdl-gray-80: #4e4e4e !default;
-$bdl-gray-62: #767676 !default;
+$bdl-gray-65: #6f6f6f !default;
+$bdl-gray-62: #767676 !default; // @deprecated Replaced in design system with $bdl-gray-65
 $bdl-gray-50: #909090 !default;
 $bdl-gray-40: #a7a7a7 !default;
 $bdl-gray-30: #bcbcbc !default;

--- a/src/styles/variables.js
+++ b/src/styles/variables.js
@@ -16,6 +16,7 @@ export const bdlBoxBlue05 = "#f2f7fd"; // bdl-box-blue-05
 export const bdlBoxBlue02 = "#fafcfe"; // bdl-box-blue-02
 export const bdlGray = "#222"; // bdl-gray
 export const bdlGray80 = "#4e4e4e"; // bdl-gray-80
+export const bdlGray65 = "#6f6f6f"; // bdl-gray-65
 export const bdlGray62 = "#767676"; // bdl-gray-62
 export const bdlGray50 = "#909090"; // bdl-gray-50
 export const bdlGray40 = "#a7a7a7"; // bdl-gray-40

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -13,6 +13,7 @@
     "bdl-box-blue-02": "#fafcfe",
     "bdl-gray": "#222",
     "bdl-gray-80": "#4e4e4e",
+    "bdl-gray-65": "#6f6f6f",
     "bdl-gray-62": "#767676",
     "bdl-gray-50": "#909090",
     "bdl-gray-40": "#a7a7a7",

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -13,6 +13,7 @@ export const bdlBoxBlue05 = '#f2f7fd'; // bdl-box-blue-05
 export const bdlBoxBlue02 = '#fafcfe'; // bdl-box-blue-02
 export const bdlGray = '#222'; // bdl-gray
 export const bdlGray80 = '#4e4e4e'; // bdl-gray-80
+export const bdlGray65 = '#6f6f6f'; // bdl-gray-65
 export const bdlGray62 = '#767676'; // bdl-gray-62
 export const bdlGray50 = '#909090'; // bdl-gray-50
 export const bdlGray40 = '#a7a7a7'; // bdl-gray-40


### PR DESCRIPTION
`bdl-gray-62` is replaced with `bdl-gray-65` in our design system but we cannot remove `bdl-gray-62` yet because the SASS and JS variables are used many parent apps