### PR TITLE
fix(content-explorer): Fix color contrast issue for item details

### DIFF
--- a/src/elements/common/breadcrumbs/InlineBreadcrumbs.scss
+++ b/src/elements/common/breadcrumbs/InlineBreadcrumbs.scss
@@ -3,7 +3,7 @@
 .be-inline-breadcrumbs {
     display: flex;
     min-width: 0;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-size: 11px;
 
     .be-breadcrumbs {
@@ -12,7 +12,7 @@
 
     .be-breadcrumb {
         &:first-child {
-            min-width: 43px;
+            min-width: auto;
         }
 
         .be & .btn-plain {

--- a/src/elements/common/item/ItemDetails.scss
+++ b/src/elements/common/item/ItemDetails.scss
@@ -2,7 +2,7 @@
 
 .be-item-name {
     .be-item-details {
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
         font-size: 11px;
     }
 }

--- a/src/elements/content-explorer/ItemList.js
+++ b/src/elements/content-explorer/ItemList.js
@@ -181,7 +181,7 @@ const ItemList = ({
                             />
                             {isSmall ? null : (
                                 <Column
-                                    className="bce-item-coloumn"
+                                    className="bce-item-column"
                                     disableSort={!hasSort}
                                     label={
                                         isRecents
@@ -197,7 +197,7 @@ const ItemList = ({
                             )}
                             {isSmall || isMedium ? null : (
                                 <Column
-                                    className="bce-item-coloumn"
+                                    className="bce-item-column"
                                     disableSort={!hasSort}
                                     label={intl.formatMessage(messages.size)}
                                     dataKey={FIELD_SIZE}

--- a/src/elements/content-explorer/ItemList.scss
+++ b/src/elements/content-explorer/ItemList.scss
@@ -14,7 +14,7 @@
     border-left: 2px solid transparent;
     outline: none;
 
-    .bce-item-coloumn {
+    .bce-item-column {
         color: $bdl-gray-62;
     }
 
@@ -42,7 +42,7 @@
             opacity: 1;
         }
 
-        .bce-item-coloumn,
+        .bce-item-column,
         .be & .btn-plain {
             color: $dark-cerulean;
             outline: none;
@@ -61,7 +61,7 @@
             border-color: $grey-blue;
         }
 
-        .bce-item-coloumn,
+        .bce-item-column,
         .be & .btn-plain {
             color: $dark-cerulean;
         }


### PR DESCRIPTION
**Changes**

- Improve color contrast for the item details text when the row is hovered
  - This is barely noticeable in screenshots
- Remove extra padding before "All Files" when only one breadcrumb item

**Before**
<img width="499" alt="Screen Shot 2023-03-03 at 5 15 31 PM" src="https://user-images.githubusercontent.com/7311041/222867108-7635107e-2331-4544-9107-78d7ea4c8ac6.png">

**After**
<img width="556" alt="Screen Shot 2023-03-03 at 5 15 13 PM" src="https://user-images.githubusercontent.com/7311041/222867091-62f81bb3-7fca-4ef6-b003-1ca75e81a831.png">