### PR TITLE
refactor: Remove usage of the deprecated FormattedCompMessage component

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1630,6 +1630,8 @@ boxui.shareMenu.viewOnly = View Only
 boxui.timeInput.emptyTimeError = Required field. Enter a time in the format HH:MM A.
 # Error message for invalid time formats. "HH:MM A" should be localized.
 boxui.timeInput.invalidTimeError = Invalid time format. Enter a time in the format HH:MM A.
+# Used in a dialog box that urges the user to upgrade. This is substituted into the middle of the sentence in the string with id boxui.unifiedShare.levelOfCollabAccess
+boxui.unifiedShare.collabAccess = collaborator access
 # Text to display for a group of users who have accepted an invitation to collaborate
 boxui.unifiedShare.collaboration.groupCollabText = Group
 # Text to display for individual users who have accepted an invitation to collaborate
@@ -1716,6 +1718,8 @@ boxui.unifiedShare.justifiableContactRestrictionRemoveButtonLabel = Alternativel
 boxui.unifiedShare.justificationRequiredError = Select a justification or remove to continue
 # The placeholder text of the select field that allows selecting a business justification reason
 boxui.unifiedShare.justificationSelectPlaceholder = Select Justification
+# Used in a dialog box that urges the user to upgrade. The collaboratorAccess variable is replaced with the words "collaborator access" from the string with the id boxui.unifiedShare.collabAccess
+boxui.unifiedShare.levelOfCollabAccess = Set the level of {collaboratorAccess} and increase security through one of our paid plans.
 # Call to action text for allowing the user to create a new shared link
 boxui.unifiedShare.linkShareOff = Create shared link
 # Call to action text for allowing the user to remove an existing shared link

--- a/scripts/styleguide.config.js
+++ b/scripts/styleguide.config.js
@@ -50,7 +50,6 @@ const allSections = [
             '../src/components/hotkeys/HotkeyFriendlyModal.js',
             '../src/components/hotkeys/HotkeyLayer.js',
             '../src/components/hotkeys/Hotkeys.js',
-            '../src/components/i18n/FormattedCompMessage.js',
             '../src/components/infinite-scroll/InfiniteScroll.js',
             '../src/components/inline-error/InlineError.js',
             '../src/components/inline-notice/InlineNotice.js',

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -5,7 +5,6 @@ import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
-import FormattedCompMessage from '../../components/i18n/FormattedCompMessage';
 import LoadingIndicatorWrapper from '../../components/loading-indicator/LoadingIndicatorWrapper';
 import { Link } from '../../components/link';
 import Button from '../../components/button';
@@ -559,20 +558,20 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
         const { openUpgradePlanModal = () => {} } = this.props;
         return (
             <>
-                <FormattedCompMessage
-                    id="boxui.unifiedShare.upgradeCollaboratorAccessDescription"
-                    description="Description for cta to upgrade to get collaborator access controls"
-                >
-                    Set the level of{' '}
-                    <Link
-                        className="upgrade-link"
-                        href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
-                        target="_blank"
-                    >
-                        collaborator access
-                    </Link>{' '}
-                    and increase security through one of our paid plans.{' '}
-                </FormattedCompMessage>
+                <FormattedMessage
+                    values={{
+                        collaboratorAccess: (
+                            <Link
+                                className="upgrade-link"
+                                href="https://support.box.com/hc/en-us/articles/360044196413-Understanding-Collaborator-Permission-Levels"
+                                target="_blank"
+                            >
+                                <FormattedMessage {...messages.collabAccess} />
+                            </Link>
+                        ),
+                    }}
+                    {...messages.setLevelOfCollabAccess}
+                />
                 <PlainButton
                     className="upgrade-link"
                     data-resin-target={resinTarget}

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -545,6 +545,18 @@ const messages = defineMessages({
         description: 'Label for tooltips or other components that display expiration icons',
         id: 'boxui.unifiedShare.expiresMessage',
     },
+    setLevelOfCollabAccess: {
+        defaultMessage: 'Set the level of {collaboratorAccess} and increase security through one of our paid plans.',
+        description:
+            'Used in a dialog box that urges the user to upgrade. The collaboratorAccess variable is replaced with the words "collaborator access" from the string with the id boxui.unifiedShare.collabAccess',
+        id: 'boxui.unifiedShare.levelOfCollabAccess',
+    },
+    collabAccess: {
+        defaultMessage: 'collaborator access',
+        description:
+            'Used in a dialog box that urges the user to upgrade. This is substituted into the middle of the sentence in the string with id boxui.unifiedShare.levelOfCollabAccess',
+        id: 'boxui.unifiedShare.collabAccess',
+    },
 });
 
 export default messages;


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
- Remove usage of the deprecated FormattedCompMessage component because we are dropping support for it in the translation automation
- Later, this usage should be replaced with a rich text FormattedMessage component (react-intl v3+) in order to get the proper string to translate