### PR TITLE
fix(content-explorer): Update Share button border on selected row

### DIFF
--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -837,7 +837,7 @@ class ContentExplorer extends Component<Props, State> {
     /**
      * Sets state with currentCollection updated to have items.selected properties
      * set according to the given selected param. Also updates the selected item in the
-     * currentcollection. selectedItem will be set to the selected state
+     * currentCollection. selectedItem will be set to the selected state
      * item if it is in currentCollection, otherwise it will be set to undefined.
      *
      * @private

--- a/src/elements/content-explorer/ItemList.scss
+++ b/src/elements/content-explorer/ItemList.scss
@@ -55,10 +55,10 @@
 
         .bce-more-options {
             opacity: 1;
-        }
 
-        .bce-btn-more-options {
-            border-color: $grey-blue;
+            .btn {
+                border-color: $grey-blue;
+            }
         }
 
         .bce-item-column,


### PR DESCRIPTION
**Before**
<img width="586" alt="Screen Shot 2023-03-07 at 8 02 25 PM" src="https://user-images.githubusercontent.com/7311041/223617141-015e4895-9020-48b1-975c-6dd1e8ff8d06.png">

**After**
<img width="548" alt="Screen Shot 2023-03-07 at 8 02 51 PM" src="https://user-images.githubusercontent.com/7311041/223617131-46a6789c-7355-431d-9ce2-2815b2b367af.png">