### PR TITLE
fix(usm): Remove aria-label and add aria-haspopup

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1778,8 +1778,6 @@ boxui.unifiedShare.restrictedContactsError = Remove to continue
 boxui.unifiedShare.sendSharedLink = Send Shared Link
 # Field label for shared link recipient list (title-case)
 boxui.unifiedShare.sendSharedLinkFieldLabel = Email Shared Link
-# Accessible label for button that loads share settings popup
-boxui.unifiedShare.settingsButtonLabel = Open shared link settings popup
 # This tooltip appears over the shared link toggle, explaining what happens when it is clicked
 boxui.unifiedShare.sharedLinkDisabledTooltipCopy = Create and copy link for sharing
 # Text shown in share modal when shared link is editable and is open to public access

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -438,7 +438,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                 >
                     <PlainButton
                         {...sharedLinkSettingsButtonProps}
-                        aria-label={intl.formatMessage(messages.settingsButtonLabel)}
+                        aria-haspopup="dialog"
                         className="shared-link-settings-btn"
                         onClick={onSettingsClick}
                         type="button"

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -1278,7 +1278,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
 
 exports[`features/unified-share-modal/SharedLinkSection should render settings link when handler is provided and shared link is enabled 1`] = `
 <PlainButton
-  aria-label="Open shared link settings popup"
+  aria-haspopup="dialog"
   className="shared-link-settings-btn"
   data-resin-target="settings"
   onClick={

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -287,11 +287,11 @@ type SharedLinkSectionTypes = {
     onCopySuccess?: () => void,
     /** Handler function that gets called whenever the user dismisses a tooltip on the given component identifier */
     onDismissTooltip?: (componentIdentifier: tooltipComponentIdentifierType) => void,
-    /** Handler function for clicks on the settings icon. If not provided, the settings icon won't be rendered. */
+    /** Handler function for clicks on the settings button. If not provided, the settings button won't be rendered. */
     onSettingsClick?: Function,
     /** Shared link data */
     sharedLink: sharedLinkType,
-    /** Shows a callout tooltip next gear icon with info about what can be customized */
+    /** Shows a callout tooltip next to settings button with info about what can be customized */
     showSharedLinkSettingsCallout?: boolean,
     /** Mapping of components to the content that should be rendered in their tooltips */
     tooltips?: { [componentIdentifier: tooltipComponentIdentifierType]: React.Node },

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -118,11 +118,6 @@ const messages = defineMessages({
         description: 'Accessible label for shared link input field',
         id: 'boxui.share.sharedLinkURLLabel',
     },
-    settingsButtonLabel: {
-        defaultMessage: 'Open shared link settings popup',
-        description: 'Accessible label for button that loads share settings popup',
-        id: 'boxui.unifiedShare.settingsButtonLabel',
-    },
     linkShareOff: {
         defaultMessage: 'Create shared link',
         description: 'Call to action text for allowing the user to create a new shared link',


### PR DESCRIPTION
The `aria-label` is unnecessary and mismatched with the text. Recommendation is to remove and add `aria-haspopup`.

<img width="428" alt="Screen Shot 2023-03-16 at 11 35 38 AM" src="https://user-images.githubusercontent.com/7311041/225720116-8a47b981-cc00-4d25-a6e5-785b1ea95a19.png">

The "Link Settings" button is the element in question.
