### PR TITLE
fix(usm): Removing redundant button element

### DIFF
--- a/src/features/collaborator-avatars/CollaboratorList.js
+++ b/src/features/collaborator-avatars/CollaboratorList.js
@@ -4,7 +4,6 @@ import { FormattedMessage } from 'react-intl';
 
 import { ModalActions } from '../../components/modal';
 import Button from '../../components/button';
-import PlainButton from '../../components/plain-button';
 import { Link } from '../../components/link';
 import CollaborationBadge from '../../icons/badges/CollaborationBadge';
 import type {
@@ -51,9 +50,9 @@ class CollaboratorList extends React.Component<Props> {
         const { collaborators, onDoneClick, maxCollaboratorListSize, trackingProps } = this.props;
         const { usernameProps, emailProps, manageLinkProps, viewAdditionalProps, doneButtonProps } = trackingProps;
         const manageAllBtn = (
-            <PlainButton className="manage-all-btn" type="button">
+            <span className="manage-all-btn">
                 <FormattedMessage {...messages.manageAllLinkText} />
-            </PlainButton>
+            </span>
         );
         const maxListSizeToRender = Math.min(maxCollaboratorListSize, MAX_COLLABORATOR_LIST_SIZE);
 

--- a/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorList.test.js.snap
+++ b/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorList.test.js.snap
@@ -13,15 +13,14 @@ exports[`features/collaborator-avatars/CollaboratorList render() should render d
       rel="noopener"
       target="_blank"
     >
-      <PlainButton
+      <span
         className="manage-all-btn"
-        type="button"
       >
         <FormattedMessage
           defaultMessage="Manage All"
           id="boxui.collaboratorAvatars.manageAllLinkText"
         />
-      </PlainButton>
+      </span>
     </Link>
   </div>
   <ul
@@ -118,15 +117,14 @@ exports[`features/collaborator-avatars/CollaboratorList render() should render e
       rel="noopener"
       target="_blank"
     >
-      <PlainButton
+      <span
         className="manage-all-btn"
-        type="button"
       >
         <FormattedMessage
           defaultMessage="Manage All"
           id="boxui.collaboratorAvatars.manageAllLinkText"
         />
-      </PlainButton>
+      </span>
     </Link>
   </div>
   <ul

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -366,6 +366,7 @@
 
         float: right;
         color: $bdl-box-blue;
+        letter-spacing: normal;
     }
 }
 


### PR DESCRIPTION
The "Manage All" button is wrapped by both a link and a button. This causes it to be focused twice (using keyboard) and is distracting to screen readers. The button is replaced with a span and added `letter-spacing` to mimic the other "link" styled buttons on the main USM component.

**Before**
<img width="428" alt="Screen Shot 2023-03-16 at 4 11 55 PM" src="https://user-images.githubusercontent.com/7311041/225772831-70257ecb-c215-41e6-979f-53e87e34c99c.png">

**After**
<img width="434" alt="Screen Shot 2023-03-16 at 4 12 08 PM" src="https://user-images.githubusercontent.com/7311041/225772851-5bdc4845-9f8d-44ff-ac2b-bb510b342c8c.png">

^ i.e. no difference. verified in Chrome, Safari, and Firefox