### PR TITLE
fix: Replace bdl-gray-62 for USM and Shared Link components

### DIFF
--- a/src/features/shared-link-settings-modal/SharedLinkSettingsModal.scss
+++ b/src/features/shared-link-settings-modal/SharedLinkSettingsModal.scss
@@ -26,11 +26,11 @@
     .password-section {
         .password-section-information {
             display: flex;
-            color: $bdl-gray-62;
+            color: $bdl-gray-65;
         }
 
         .password-section-information-icon path {
-            fill: $bdl-gray-62;
+            fill: $bdl-gray-65;
         }
 
         .password-section-information-text {
@@ -67,7 +67,7 @@
 
     .link-settings-modal-notice {
         margin: 0 0 ($bdl-grid-unit * 5);
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
     }
 }
 

--- a/src/features/shared-link-settings-modal/VanityNameSection.js
+++ b/src/features/shared-link-settings-modal/VanityNameSection.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
-import { bdlGray62 } from '../../styles/variables';
+import { bdlGray65 } from '../../styles/variables';
 
 import Checkbox from '../../components/checkbox';
 import TextInput from '../../components/text-input';
@@ -29,7 +29,7 @@ const VanityNameSection = ({
             <TextInput
                 description={
                     <span>
-                        <QuarantineBadge color={bdlGray62} />
+                        <QuarantineBadge color={bdlGray65} />
                         <FormattedMessage {...messages.vanityURLWarning} />
                     </span>
                 }

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -82,7 +82,7 @@
 // Menus are rendered at the root of the DOM, so this style is not nested
 .usm-menu-description {
     display: block;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-size: 12px;
 }
 
@@ -216,7 +216,7 @@
         }
 
         .text-area-container textarea::placeholder {
-            color: $bdl-gray-62;
+            color: $bdl-gray-65;
         }
 
         .bdl-PillSelector {
@@ -229,7 +229,7 @@
         border: 1px solid $bdl-gray-50;
 
         .bdl-PillSelector-input::placeholder {
-            color: $bdl-gray-62;
+            color: $bdl-gray-65;
         }
 
         &.bdl-is-disabled,
@@ -239,7 +239,7 @@
             box-shadow: none;
 
             .bdl-PillSelector-input::placeholder {
-                color: $bdl-gray-62;
+                color: $bdl-gray-65;
             }
 
             &:hover {
@@ -313,14 +313,14 @@
             margin-right: 10px;
 
             &.can-edit-btn {
-                color: $bdl-gray-62;
+                color: $bdl-gray-65;
             }
         }
     }
 
     .security-indicator-note {
         margin-top: 10px;
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
 
         .security-indicator-icon-globe {
             padding-right: 5px;


### PR DESCRIPTION
Gray 62 has issues where it barely meets the 4.5:1 color contrast ratio when used with a white background. If the component then changes background colors for different interaction states (hover, focus, etc), the contrast ratio no longer passes.

This is resolved by replacing usages of Gray 62 with Gray 65. Gray 62 is deprecated in our current design system.

**Before**
<img width="510" alt="Screen Shot 2023-03-22 at 6 11 41 PM" src="https://user-images.githubusercontent.com/7311041/227073295-c6fd3751-b058-402c-8e78-ba1eb929aa09.png">

**After**
<img width="516" alt="Screen Shot 2023-03-22 at 6 11 02 PM" src="https://user-images.githubusercontent.com/7311041/227073286-bb0ee289-b693-451f-9465-4af4fdfdc654.png">

^ the "Manage security [...]" text is slightly darker