### PR TITLE
fix(dropdown-menu): add undefined event check for closeMenu

### DIFF
--- a/src/components/dropdown-menu/DropdownMenu.js
+++ b/src/components/dropdown-menu/DropdownMenu.js
@@ -97,11 +97,12 @@ class DropdownMenu extends React.Component<Props, State> {
 
     closeMenu = (event: SyntheticEvent<> | MouseEvent) => {
         const { onMenuClose = noop } = this.props;
+        const callback = event ? () => onMenuClose(event) : noop;
         this.setState(
             {
                 isOpen: false,
             },
-            () => onMenuClose(event),
+            callback,
         );
     };
 


### PR DESCRIPTION
An improvement to DropdownMenu to protect against undefined `event` arg which may break downstream message handlers