### PR TITLE
feat(collapsible-sidebar): add wrapperClassName prop

### DIFF
--- a/src/features/collapsible-sidebar/CollapsibleSidebar.js
+++ b/src/features/collapsible-sidebar/CollapsibleSidebar.js
@@ -39,6 +39,9 @@ type Props = {
 
     /** Optionally apply "aria-hidden": "true" to CollapsibleSidebar wrapper */
     isHidden?: boolean,
+
+    /** Optionally apply CSS to the CollapsibleSidebar wrapper */
+    wrapperClassName?: string,
 };
 
 class CollapsibleSidebar extends React.Component<Props> {
@@ -84,7 +87,7 @@ class CollapsibleSidebar extends React.Component<Props> {
     };
 
     render() {
-        const { children, className, expanded, isHidden, htmlAttributes } = this.props;
+        const { children, className, expanded, isHidden, htmlAttributes, wrapperClassName } = this.props;
         const navClasses = classNames(
             {
                 'is-expanded': expanded,
@@ -95,7 +98,7 @@ class CollapsibleSidebar extends React.Component<Props> {
         const ariaAttributes = { 'aria-hidden': isHidden ? 'true' : undefined };
         return (
             <div
-                className="bdl-CollapsibleSidebar-wrapper"
+                className={classNames('bdl-CollapsibleSidebar-wrapper', wrapperClassName)}
                 {...htmlAttributes}
                 {...ariaAttributes}
                 data-testid="CollapsibleSidebar-wrapper"

--- a/src/features/collapsible-sidebar/__tests__/CollapsibleSidebar.test.js
+++ b/src/features/collapsible-sidebar/__tests__/CollapsibleSidebar.test.js
@@ -14,6 +14,7 @@ describe('components/core/collapsible-sidebar/CollapsibleSidebar', () => {
             children: [<span key="1">abc</span>, <span key="2">def</span>],
             expanded: true,
             className: 'foo',
+            wrapperClassName: 'bar',
         });
 
         expect(sidebar).toMatchSnapshot();

--- a/src/features/collapsible-sidebar/__tests__/__snapshots__/CollapsibleSidebar.test.js.snap
+++ b/src/features/collapsible-sidebar/__tests__/__snapshots__/CollapsibleSidebar.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`components/core/collapsible-sidebar/CollapsibleSidebar render 1`] = `
 <div
-  className="bdl-CollapsibleSidebar-wrapper"
+  className="bdl-CollapsibleSidebar-wrapper bar"
   data-testid="CollapsibleSidebar-wrapper"
 >
   <CollapsibleSidebar__StyledNav


### PR DESCRIPTION
Adds a`wrapperClassName` prop to apply CSS to the `CollapsibleSidebar-wrapper` element.
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
