### PR TITLE
fix(makeselectable): Prevent arrow hotkeys on slider

### DIFF
--- a/src/components/table/__tests__/makeSelectable.test.js
+++ b/src/components/table/__tests__/makeSelectable.test.js
@@ -836,7 +836,7 @@ describe('components/table/makeSelectable', () => {
                     shortcut.handler({ preventDefault: sandbox.stub() });
                     expect(wrapper.state('focusedIndex')).toEqual(0);
                 });
-                test('should not set focus to first row target has role of slider', () => {
+                test('should not set focus to first row if target has role of slider', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,
                         isGridView: true,
@@ -875,7 +875,7 @@ describe('components/table/makeSelectable', () => {
             });
             describe('left', () => {
                 const hotKey = 'left';
-                test('should not set focus to first row target has role of slider', () => {
+                test('should not set focus to first row if target has role of slider', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,
                         isGridView: true,
@@ -938,7 +938,7 @@ describe('components/table/makeSelectable', () => {
                     shortcut.handler({ preventDefault: sandbox.stub() });
                     expect(wrapper.state('focusedIndex')).toEqual(0);
                 });
-                test('should not set focus to first row target has role of slider', () => {
+                test('should not set focus to first row if target has role of slider', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,
                         isGridView: true,
@@ -977,7 +977,7 @@ describe('components/table/makeSelectable', () => {
             });
             describe('up', () => {
                 const hotKey = 'up';
-                test('should not set focus to first row target has role of slider', () => {
+                test('should not set focus to first row if target has role of slider', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,
                         isGridView: true,

--- a/src/components/table/__tests__/makeSelectable.test.js
+++ b/src/components/table/__tests__/makeSelectable.test.js
@@ -836,6 +836,18 @@ describe('components/table/makeSelectable', () => {
                     shortcut.handler({ preventDefault: sandbox.stub() });
                     expect(wrapper.state('focusedIndex')).toEqual(0);
                 });
+                test('should not set focus to first row target has role of slider', () => {
+                    const wrapper = getWrapper({
+                        gridColumnCount,
+                        isGridView: true,
+                        selectedItems: ['a'],
+                    });
+                    wrapper.setState({ focusedIndex: undefined });
+                    const instance = wrapper.instance();
+                    const shortcut = instance.getHotkeyConfigs().find(h => h.get('key') === hotKey);
+                    shortcut.handler({ target: { role: 'slider' } });
+                    expect(wrapper.state('focusedIndex')).toEqual(undefined);
+                });
                 test('should call event.preventDefault() and set focus to next item', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,
@@ -863,6 +875,18 @@ describe('components/table/makeSelectable', () => {
             });
             describe('left', () => {
                 const hotKey = 'left';
+                test('should not set focus to first row target has role of slider', () => {
+                    const wrapper = getWrapper({
+                        gridColumnCount,
+                        isGridView: true,
+                        selectedItems: ['a'],
+                    });
+                    wrapper.setState({ focusedIndex: undefined });
+                    const instance = wrapper.instance();
+                    const shortcut = instance.getHotkeyConfigs().find(h => h.get('key') === hotKey);
+                    shortcut.handler({ target: { role: 'slider' } });
+                    expect(wrapper.state('focusedIndex')).toEqual(undefined);
+                });
                 test('should call event.preventDefault() and call onSelect with new focused item', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,
@@ -914,6 +938,18 @@ describe('components/table/makeSelectable', () => {
                     shortcut.handler({ preventDefault: sandbox.stub() });
                     expect(wrapper.state('focusedIndex')).toEqual(0);
                 });
+                test('should not set focus to first row target has role of slider', () => {
+                    const wrapper = getWrapper({
+                        gridColumnCount,
+                        isGridView: true,
+                        selectedItems: ['a'],
+                    });
+                    wrapper.setState({ focusedIndex: undefined });
+                    const instance = wrapper.instance();
+                    const shortcut = instance.getHotkeyConfigs().find(h => h.get('key') === hotKey);
+                    shortcut.handler({ target: { role: 'slider' } });
+                    expect(wrapper.state('focusedIndex')).toEqual(undefined);
+                });
                 test('should call event.preventDefault() and set focus to next row item', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,
@@ -941,6 +977,18 @@ describe('components/table/makeSelectable', () => {
             });
             describe('up', () => {
                 const hotKey = 'up';
+                test('should not set focus to first row target has role of slider', () => {
+                    const wrapper = getWrapper({
+                        gridColumnCount,
+                        isGridView: true,
+                        selectedItems: ['a'],
+                    });
+                    wrapper.setState({ focusedIndex: undefined });
+                    const instance = wrapper.instance();
+                    const shortcut = instance.getHotkeyConfigs().find(h => h.get('key') === hotKey);
+                    shortcut.handler({ target: { role: 'slider' } });
+                    expect(wrapper.state('focusedIndex')).toEqual(undefined);
+                });
                 test('should call event.preventDefault() and call onSelect with new focused item', () => {
                     const wrapper = getWrapper({
                         gridColumnCount,

--- a/src/components/table/makeSelectable.js
+++ b/src/components/table/makeSelectable.js
@@ -213,6 +213,10 @@ function makeSelectable(BaseTable) {
                     key: 'right',
                     description: <FormattedMessage {...messages.downDescription} />,
                     handler: event => {
+                        if (this.isTargetSlider(event)) {
+                            return;
+                        }
+
                         const { data } = this.props;
                         const { focusedIndex } = this.state;
 
@@ -228,6 +232,10 @@ function makeSelectable(BaseTable) {
                     key: 'left',
                     description: <FormattedMessage {...messages.upDescription} />,
                     handler: event => {
+                        if (this.isTargetSlider(event)) {
+                            return;
+                        }
+
                         const { focusedIndex = 0 } = this.state;
 
                         event.preventDefault();
@@ -241,6 +249,10 @@ function makeSelectable(BaseTable) {
                     key: 'down',
                     description: <FormattedMessage {...messages.downDescription} />,
                     handler: event => {
+                        if (this.isTargetSlider(event)) {
+                            return;
+                        }
+
                         const { data, gridColumnCount } = this.props;
                         const { focusedIndex } = this.state;
 
@@ -256,6 +268,10 @@ function makeSelectable(BaseTable) {
                     key: 'up',
                     description: <FormattedMessage {...messages.upDescription} />,
                     handler: event => {
+                        if (this.isTargetSlider(event)) {
+                            return;
+                        }
+
                         const { gridColumnCount } = this.props;
                         const { focusedIndex = 0 } = this.state;
 
@@ -585,6 +601,8 @@ function makeSelectable(BaseTable) {
                 this.selectToggle(index);
             }
         };
+
+        isTargetSlider = event => event.target.role === 'slider';
 
         render() {
             const { className, data } = this.props;

--- a/src/components/table/makeSelectable.js
+++ b/src/components/table/makeSelectable.js
@@ -602,7 +602,7 @@ function makeSelectable(BaseTable) {
             }
         };
 
-        isTargetSlider = event => event.target.role === 'slider';
+        isTargetSlider = event => event.target?.role === 'slider';
 
         render() {
             const { className, data } = this.props;


### PR DESCRIPTION
The library we use for hotkeys (mousetrap) prevents hotkeys on `input type=range` but not on elements with `role=slider`. This solves the scenario of using arrow hotkeys on the slider without focusing on the item list elements
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
