### PR TITLE
fix(select-field): Add bottom margin when dropdown has top placement

### DIFF
--- a/src/components/select-field/SelectField.scss
+++ b/src/components/select-field/SelectField.scss
@@ -55,9 +55,16 @@
 .bdl-SelectFieldDropdown {
     z-index: 4;
     min-width: 100%;
-    margin-top: $bdl-grid-unit * 2;
     overflow-x: hidden;
     border-radius: $bdl-border-radius-size-med;
+
+    &[data-placement='bottom-start'] {
+        margin-top: $bdl-grid-unit * 2;
+    }
+
+    &[data-placement='top-start'] {
+        margin-bottom: $bdl-grid-unit * 2;
+    }
 }
 
 .bdl-SelectField-optionText {


### PR DESCRIPTION
Currently, the margin for the dropdown menu of `SelectFieldDropdown` is only applied when the dropdown is placed beneath the select field. The margin should be consistent between the top and bottom placements of the dropdown menu.

**Before**
<img width="202" alt="Screen Shot 2023-04-10 at 3 30 01 PM" src="https://user-images.githubusercontent.com/7311041/231011291-aa8d4c22-7a26-4324-8410-ef4325d64e20.png">

**After**
<img width="203" alt="Screen Shot 2023-04-10 at 3 30 13 PM" src="https://user-images.githubusercontent.com/7311041/231011310-d233fa34-77bc-49f0-bfcb-29a193bff031.png">
