### PR TITLE
fix(usm): Order person before icon in collaborator list DOM

### DIFF
--- a/src/features/collaborator-avatars/CollaboratorListItem.js
+++ b/src/features/collaborator-avatars/CollaboratorListItem.js
@@ -55,7 +55,11 @@ const CollaboratorListItem = (props: Props) => {
     return (
         <li>
             <div className="collaborator-list-item">
-                <div className="user">
+                <div className="bdl-CollaboratorListItem-user user">
+                    <div className="info">
+                        {userOrGroupNameContent}
+                        {emailContent}
+                    </div>
                     <CollaboratorAvatarItem
                         allowBadging
                         avatarUrl={imageURL}
@@ -66,10 +70,6 @@ const CollaboratorListItem = (props: Props) => {
                         isExternalCollab={isExternalCollab}
                         name={name}
                     />
-                    <div className="info">
-                        {userOrGroupNameContent}
-                        {emailContent}
-                    </div>
                 </div>
                 <div className="role">
                     {type === COLLAB_PENDING_TYPE ? (

--- a/src/features/collaborator-avatars/CollaboratorListItem.scss
+++ b/src/features/collaborator-avatars/CollaboratorListItem.scss
@@ -74,3 +74,7 @@
         }
     }
 }
+
+.bdl-CollaboratorListItem-user {
+    flex-direction: row-reverse;
+}

--- a/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorListItem.test.js.snap
+++ b/src/features/collaborator-avatars/__tests__/__snapshots__/CollaboratorListItem.test.js.snap
@@ -6,20 +6,8 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
     className="collaborator-list-item"
   >
     <div
-      className="user"
+      className="bdl-CollaboratorListItem-user user"
     >
-      <CollaboratorAvatarItem
-        allowBadging={true}
-        email="testc@example.com"
-        expiration={
-          Object {
-            "expiresAt": "Jan 1, 1966",
-          }
-        }
-        hasCustomAvatar={true}
-        id={1}
-        name="test c"
-      />
       <div
         className="info"
       >
@@ -46,6 +34,18 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
           </Link>
         </div>
       </div>
+      <CollaboratorAvatarItem
+        allowBadging={true}
+        email="testc@example.com"
+        expiration={
+          Object {
+            "expiresAt": "Jan 1, 1966",
+          }
+        }
+        hasCustomAvatar={true}
+        id={1}
+        name="test c"
+      />
     </div>
     <div
       className="role"
@@ -60,8 +60,17 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
     className="collaborator-list-item"
   >
     <div
-      className="user"
+      className="bdl-CollaboratorListItem-user user"
     >
+      <div
+        className="info"
+      >
+        <div
+          className="name group"
+        >
+          test c
+        </div>
+      </div>
       <CollaboratorAvatarItem
         allowBadging={true}
         email="testc@example.com"
@@ -74,15 +83,6 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
         id={1}
         name="test c"
       />
-      <div
-        className="info"
-      >
-        <div
-          className="name group"
-        >
-          test c
-        </div>
-      </div>
     </div>
     <div
       className="role"
@@ -97,20 +97,8 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
     className="collaborator-list-item"
   >
     <div
-      className="user"
+      className="bdl-CollaboratorListItem-user user"
     >
-      <CollaboratorAvatarItem
-        allowBadging={true}
-        email="testc@example.com"
-        expiration={
-          Object {
-            "expiresAt": "Jan 1, 1966",
-          }
-        }
-        hasCustomAvatar={true}
-        id={1}
-        name="test c"
-      />
       <div
         className="info"
       >
@@ -137,6 +125,18 @@ exports[`features/collaborator-avatars/CollaboratorListItem render() should rend
           </Link>
         </div>
       </div>
+      <CollaboratorAvatarItem
+        allowBadging={true}
+        email="testc@example.com"
+        expiration={
+          Object {
+            "expiresAt": "Jan 1, 1966",
+          }
+        }
+        hasCustomAvatar={true}
+        id={1}
+        name="test c"
+      />
     </div>
     <div
       className="role"


### PR DESCRIPTION
Recommendation from WebAIM is to order the persons name before the icon in the DOM. I will follow up with PM to confirm this is the approach we want to do.

Solution: move the `info` div before the `CollaboratorAvatarItem` component so that it appears first in the DOM and use `flex-direction: row-reverse` to fix the order in the UI.