### PR TITLE
refactor: Use bdl-gray-65 for /elements

### DIFF
--- a/src/elements/common/_variables.scss
+++ b/src/elements/common/_variables.scss
@@ -45,7 +45,7 @@ $sidebarTabResponsiveSize: 48px;
 }
 
 @mixin placeholder {
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-weight: normal;
     font-family: $font;
     // Firefox sets opacity for placeholder to less than 100%

--- a/src/elements/common/breadcrumbs/Breadcrumb.scss
+++ b/src/elements/common/breadcrumbs/Breadcrumb.scss
@@ -10,7 +10,7 @@
     }
 
     .be & .btn-plain {
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
 
         &:last-child {
             color: $bdl-gray;

--- a/src/elements/common/breadcrumbs/BreadcrumbDropdown.scss
+++ b/src/elements/common/breadcrumbs/BreadcrumbDropdown.scss
@@ -1,7 +1,7 @@
 @import '../variables';
 
 .be .btn-plain.be-breadcrumbs-drop-down {
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     letter-spacing: 1.5px;
 
     &.be-breadcrumbs-condensed {

--- a/src/elements/common/share-access-select/ShareAccessSelect.scss
+++ b/src/elements/common/share-access-select/ShareAccessSelect.scss
@@ -9,7 +9,7 @@
         padding: 5px 25px 5px 10px;
         color: inherit;
         background: none;
-        background-image: sas-background-image-function($bdl-gray-62);
+        background-image: sas-background-image-function($bdl-gray-65);
         background-repeat: no-repeat;
         background-position: right 14px center, right 10px center;
         background-size: 4px 4px, 4px 4px;

--- a/src/elements/common/sub-header/AddButton.js
+++ b/src/elements/common/sub-header/AddButton.js
@@ -10,13 +10,13 @@ import Button from '../../../components/button';
 import IconAddThin from '../../../icons/general/IconAddThin';
 import messages from '../messages';
 import Tooltip from '../Tooltip';
-import { bdlGray62 } from '../../../styles/variables';
+import { bdlGray65 } from '../../../styles/variables';
 import './AddButton.scss';
 
 const AddButton = (props: ?Object) => (
     <Tooltip text={<FormattedMessage {...messages.add} />}>
         <Button className="be-btn-add" aria-label={messages.add.defaultMessage} type="button" {...props}>
-            <IconAddThin color={bdlGray62} />
+            <IconAddThin color={bdlGray65} />
         </Button>
     </Tooltip>
 );

--- a/src/elements/common/sub-header/SortButton.js
+++ b/src/elements/common/sub-header/SortButton.js
@@ -11,7 +11,7 @@ import type { IntlShape } from 'react-intl';
 import Button from '../../../components/button';
 import IconSort from '../../../icons/general/IconSort';
 import Tooltip from '../Tooltip';
-import { bdlGray62 } from '../../../styles/variables';
+import { bdlGray65 } from '../../../styles/variables';
 
 import messages from '../messages';
 
@@ -26,7 +26,7 @@ const SortButton = ({ intl, ...rest }: Props) => {
     return (
         <Tooltip text={sortMessage}>
             <Button aria-label={sortMessage} className="be-btn-sort" type="button" {...rest}>
-                <IconSort color={bdlGray62} />
+                <IconSort color={bdlGray65} />
             </Button>
         </Tooltip>
     );

--- a/src/elements/common/sub-header/ViewModeChangeButton.js
+++ b/src/elements/common/sub-header/ViewModeChangeButton.js
@@ -13,7 +13,7 @@ import messages from '../messages';
 import Tooltip from '../Tooltip';
 import type { ViewMode } from '../flowTypes';
 import { VIEW_MODE_GRID, VIEW_MODE_LIST } from '../../../constants';
-import { bdlGray62 } from '../../../styles/variables';
+import { bdlGray65 } from '../../../styles/variables';
 import './ViewModeChangeButton.scss';
 
 type Props = {
@@ -40,9 +40,9 @@ const ViewModeChangeButton = ({ className = '', onViewModeChange = noop, intl, v
                 {...rest}
             >
                 {isGridView ? (
-                    <IconListView color={bdlGray62} width={17} height={17} />
+                    <IconListView color={bdlGray65} width={17} height={17} />
                 ) : (
-                    <IconGridViewInverted color={bdlGray62} width={17} height={17} />
+                    <IconGridViewInverted color={bdlGray65} width={17} height={17} />
                 )}
             </Button>
         </Tooltip>

--- a/src/elements/content-explorer/ItemList.scss
+++ b/src/elements/content-explorer/ItemList.scss
@@ -15,7 +15,7 @@
     outline: none;
 
     .bce-item-column {
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
     }
 
     .bce-more-options {
@@ -91,7 +91,7 @@
     box-shadow: 0 4px 6px -2px $transparent-black;
 
     .ReactVirtualized__Table__headerColumn {
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
         font-weight: normal;
         text-transform: none;
     }

--- a/src/elements/content-picker/ItemList.scss
+++ b/src/elements/content-picker/ItemList.scss
@@ -79,7 +79,7 @@
         select {
             &.bcp-shared-access-select {
                 background-color: $white;
-                background-image: linear-gradient(45deg, transparent 50%, $bdl-gray-62 50%), linear-gradient(135deg, $bdl-gray-62 50%, transparent 50%);
+                background-image: linear-gradient(45deg, transparent 50%, $bdl-gray-65 50%), linear-gradient(135deg, $bdl-gray-65 50%, transparent 50%);
                 border-color: $bdl-gray-20;
             }
         }

--- a/src/elements/content-preview/preview-header/PreviewHeader.scss
+++ b/src/elements/content-preview/preview-header/PreviewHeader.scss
@@ -117,7 +117,7 @@
         color: $bdl-gray-10;
 
         .fill-color {
-            fill: $bdl-gray-62;
+            fill: $bdl-gray-65;
         }
     }
 }

--- a/src/elements/content-sidebar/AddTaskMenu.scss
+++ b/src/elements/content-sidebar/AddTaskMenu.scss
@@ -25,7 +25,7 @@ $bcs-AddTaskMenu-width: 256px;
 }
 
 .bcs-AddTaskMenu-description {
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-size: 11px;
     line-height: 14px;
 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplyForm.scss
@@ -3,7 +3,7 @@
 .bcs-ActivityThreadReplyForm-toggle {
     display: flex;
     align-items: center;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
 
     .bcs-ActivityThreadReplyForm-arrow {
         margin-right: $bdl-grid-unit;

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityLink.scss
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivityLink.scss
@@ -7,7 +7,7 @@
     font-weight: bold;
 
     &[aria-disabled='true'] {
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
     }
 
     .bcs-AnnotationActivityLink-message {

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.scss
@@ -37,7 +37,7 @@
 
     .bcs-CommentForm-tip {
         margin-top: 10px;
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
     }
 
     .bcs-CommentFormControls {

--- a/src/elements/content-sidebar/activity-feed/comment/CreateReply.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/CreateReply.scss
@@ -4,7 +4,7 @@
     .bcs-CreateReply-toggle {
         display: flex;
         align-items: center;
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
         font-weight: bold;
 
         .bcs-CreateReply-arrow {

--- a/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.scss
+++ b/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.scss
@@ -14,7 +14,7 @@
 }
 
 .bcs-ActivityMessage-edited {
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
 }
 
 .bcs-ActivityMessage-mention {

--- a/src/elements/content-sidebar/activity-feed/task-new/AssigneeDetails.scss
+++ b/src/elements/content-sidebar/activity-feed/task-new/AssigneeDetails.scss
@@ -12,5 +12,5 @@
 }
 
 .bcs-AssigneeDetails-status {
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
 }

--- a/src/elements/content-sidebar/skills/timeline/Timeline.scss
+++ b/src/elements/content-sidebar/skills/timeline/Timeline.scss
@@ -4,7 +4,7 @@
     display: flex;
     flex-direction: column;
     margin: 15px 0 0;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-size: 12px;
 
     &:last-child {

--- a/src/elements/content-sidebar/skills/transcript/Transcript.scss
+++ b/src/elements/content-sidebar/skills/transcript/Transcript.scss
@@ -42,7 +42,7 @@
 
     .be-transcript-edit-message {
         margin-bottom: 15px;
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
     }
 
     .be-transcript-content-collapsed {

--- a/src/elements/content-sidebar/versions/VersionsGroup.scss
+++ b/src/elements/content-sidebar/versions/VersionsGroup.scss
@@ -5,7 +5,7 @@
     margin-bottom: 0;
     padding-top: 20px;
     padding-bottom: 10px;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-size: 14px;
     line-height: 1;
 }

--- a/src/elements/content-sidebar/versions/VersionsItem.scss
+++ b/src/elements/content-sidebar/versions/VersionsItem.scss
@@ -52,7 +52,7 @@
 .bcs-VersionsItem-info {
     display: flex;
     align-items: center;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     white-space: nowrap;
 }
 
@@ -60,11 +60,11 @@
     display: flex;
     align-items: center;
     margin-top: 8px;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
 }
 
 .bcs-VersionsItem-footer {
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-size: 12px;
 }
 

--- a/src/features/content-insights/_mixins.scss
+++ b/src/features/content-insights/_mixins.scss
@@ -1,7 +1,7 @@
 @import '../../styles/variables';
 
 @mixin ContentInsightsHeaderText {
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     font-weight: bold;
     font-size: $bdl-fontSize-minimum;
 }

--- a/src/features/metadata-based-view/IconWithTooltip.js
+++ b/src/features/metadata-based-view/IconWithTooltip.js
@@ -10,7 +10,7 @@ import IconCheck from '../../icons/general/IconCheck';
 import IconClose from '../../icons/general/IconClose';
 import IconPencil from '../../icons/general/IconPencil';
 
-import { bdlGray62 } from '../../styles/variables';
+import { bdlGray65 } from '../../styles/variables';
 
 import { CANCEL_ICON_TYPE, EDIT_ICON_TYPE, SAVE_ICON_TYPE } from './constants';
 
@@ -36,21 +36,21 @@ const IconWithTooltip = ({
         case CANCEL_ICON_TYPE:
             iconBtn = (
                 <PlainButton className={className} type="button" onClick={onClick}>
-                    <IconClose color={bdlGray62} width={16} height={16} />
+                    <IconClose color={bdlGray65} width={16} height={16} />
                 </PlainButton>
             );
             break;
         case EDIT_ICON_TYPE:
             iconBtn = (
                 <PlainButton className={className} type="button" onClick={onClick}>
-                    <IconPencil color={bdlGray62} />
+                    <IconPencil color={bdlGray65} />
                 </PlainButton>
             );
             break;
         case SAVE_ICON_TYPE:
             iconBtn = (
                 <Button className={className} isLoading={isUpdating} type="button" onClick={onClick}>
-                    <IconCheck color={bdlGray62} width={16} height={16} />
+                    <IconCheck color={bdlGray65} width={16} height={16} />
                 </Button>
             );
             break;

--- a/src/features/metadata-based-view/MetadataBasedItemList.scss
+++ b/src/features/metadata-based-view/MetadataBasedItemList.scss
@@ -27,7 +27,7 @@ $bdl-MetadataBasedItemList-insetShadowRight: 3px 0 3px -2px $bdl-gray-10 inset;
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    color: $bdl-gray-62;
+    color: $bdl-gray-65;
     border-bottom: 1px solid $bdl-gray-10;
 
     & .icon-pencil {

--- a/src/features/metadata-based-view/__tests__/__snapshots__/IconWithTooltip.test.js.snap
+++ b/src/features/metadata-based-view/__tests__/__snapshots__/IconWithTooltip.test.js.snap
@@ -20,7 +20,7 @@ exports[`features/metadata-based-view/IconWithTooltip should get IconClose with 
     type="button"
   >
     <IconClose
-      color="#767676"
+      color="#6f6f6f"
       height={16}
       width={16}
     />
@@ -47,7 +47,7 @@ exports[`features/metadata-based-view/IconWithTooltip should get IconPencil with
     type="button"
   >
     <IconPencil
-      color="#767676"
+      color="#6f6f6f"
     />
   </PlainButton>
 </Tooltip>
@@ -75,7 +75,7 @@ exports[`features/metadata-based-view/IconWithTooltip should get IconSave with T
     type="button"
   >
     <IconCheck
-      color="#767676"
+      color="#6f6f6f"
       height={16}
       width={16}
     />

--- a/src/features/metadata-instance-editor/CascadePolicy.scss
+++ b/src/features/metadata-instance-editor/CascadePolicy.scss
@@ -26,7 +26,7 @@ $cascade-policy-background: #f1e2fd;
     }
 
     .metadata-operation-not-immediate {
-        color: $bdl-gray-62;
+        color: $bdl-gray-65;
         font-weight: bold;
 
         svg {


### PR DESCRIPTION
Similar to this PR: https://github.com/box/box-ui-elements/pull/3309, replacing usages of `$bdl-gray-62` with `$bdl-gray-65` except this is for files that are owned by Preview and UI Elements.