### PR TITLE
fix(content-explorer): focus border on selected item row buttons

### DIFF
--- a/src/elements/content-explorer/ItemList.scss
+++ b/src/elements/content-explorer/ItemList.scss
@@ -58,6 +58,10 @@
 
             .btn {
                 border-color: $grey-blue;
+
+                &:focus {
+                    border-color: $bdl-gray;
+                }
             }
         }
 


### PR DESCRIPTION
Buttons with focus state should have `$bdl-gray` border. Due to specificity, the default `button:focus` border on this button was not being shown: https://github.com/box/box-ui-elements/blob/master/src/styles/common/_buttons.scss#L98

i.e. the border for buttons that are focused should be black but the border for this button is still blue because of the extra specificity added in this PR: https://github.com/box/box-ui-elements/pull/3278

**Before**
<img width="194" alt="Screen Shot 2023-04-20 at 3 22 52 PM" src="https://user-images.githubusercontent.com/7311041/233499857-7276fbed-977b-488d-884d-d58d5b2bbc9a.png">

**After**
<img width="196" alt="Screen Shot 2023-04-20 at 3 27 03 PM" src="https://user-images.githubusercontent.com/7311041/233500257-54300834-35b3-492c-8c73-3e1141263e7d.png">