### PR TITLE
fix(usm): make item prop optional

### DIFF
--- a/src/features/unified-share-modal/SharedLinkAccessDescription.js
+++ b/src/features/unified-share-modal/SharedLinkAccessDescription.js
@@ -13,7 +13,7 @@ import messages from './messages';
 type Props = {
     accessLevel?: accessLevelType,
     enterpriseName?: string,
-    item: itemtype,
+    item?: itemtype,
     itemType: ItemType,
 };
 
@@ -23,7 +23,7 @@ const SharedLinkAccessDescription = ({ accessLevel, enterpriseName, item, itemTy
     switch (accessLevel) {
         case ANYONE_WITH_LINK:
             // TODO: temporary change to support Canvas not being truly public
-            if (isBoxCanvas(convertToBoxItem(item))) {
+            if (item && isBoxCanvas(convertToBoxItem(item))) {
                 description = messages.canvasPeopleWithLinkDescription;
             } else {
                 description = messages.peopleWithLinkDescription;

--- a/src/features/unified-share-modal/SharedLinkAccessLabel.js
+++ b/src/features/unified-share-modal/SharedLinkAccessLabel.js
@@ -15,7 +15,7 @@ type Props = {
     accessLevel?: accessLevelType,
     enterpriseName?: string,
     hasDescription?: boolean,
-    item: itemtype,
+    item?: itemtype,
     itemType: ItemType,
 };
 

--- a/src/features/unified-share-modal/SharedLinkAccessMenu.js
+++ b/src/features/unified-share-modal/SharedLinkAccessMenu.js
@@ -33,7 +33,7 @@ type Props = {
     allowedAccessLevels: allowedAccessLevelsType,
     changeAccessLevel: (newAccessLevel: accessLevelType) => Promise<{ accessLevel: accessLevelType }>,
     enterpriseName?: string,
-    item: itemtype,
+    item?: itemtype,
     itemType: ItemType,
     onDismissTooltip: () => void,
     submitting: boolean,

--- a/src/features/unified-share-modal/__tests__/SharedLinkAccessDescription.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkAccessDescription.test.js
@@ -8,35 +8,35 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
         [
             {
                 itemType: 'file',
-                item: {
-                    extension: '',
-                },
-            },
-            {
-                itemType: 'file',
-                item: {
-                    extension: 'boxcanvas',
-                },
             },
             {
                 itemType: 'folder',
-                item: {
-                    extension: '',
-                },
             },
-        ].forEach(({ itemType, item }) => {
-            test('should render correct menu', () => {
-                const sharedLinkPermissionMenu = shallow(
+        ].forEach(({ itemType }) => {
+            test('should render correct description', () => {
+                const wrapper = shallow(
                     <SharedLinkAccessDescription
                         accessLevel={ANYONE_WITH_LINK}
                         enterpriseName="Box"
-                        item={item}
                         itemType={itemType}
                     />,
                 );
 
-                expect(sharedLinkPermissionMenu).toMatchSnapshot();
+                expect(wrapper).toMatchSnapshot();
             });
+        });
+
+        test('should render correct description for Canvas file', () => {
+            const wrapper = shallow(
+                <SharedLinkAccessDescription
+                    accessLevel={ANYONE_WITH_LINK}
+                    enterpriseName="Box"
+                    item={{ extension: 'boxcanvas' }}
+                    itemType="file"
+                />,
+            );
+
+            expect(wrapper.find('FormattedMessage').prop('defaultMessage')).toBe('Box sign-in required');
         });
     });
 
@@ -59,17 +59,16 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
                 name: 'Box',
             },
         ].forEach(({ itemType, name }) => {
-            test('should render correct menu', () => {
-                const sharedLinkPermissionMenu = shallow(
+            test('should render correct description', () => {
+                const wrapper = shallow(
                     <SharedLinkAccessDescription
                         accessLevel={ANYONE_IN_COMPANY}
                         enterpriseName={name}
-                        item={{ extension: '' }}
                         itemType={itemType}
                     />,
                 );
 
-                expect(sharedLinkPermissionMenu).toMatchSnapshot();
+                expect(wrapper).toMatchSnapshot();
             });
         });
     });
@@ -83,17 +82,16 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
                 itemType: 'folder',
             },
         ].forEach(({ itemType }) => {
-            test('should render correct menu', () => {
-                const sharedLinkPermissionMenu = shallow(
+            test('should render correct description', () => {
+                const wrapper = shallow(
                     <SharedLinkAccessDescription
                         accessLevel={PEOPLE_IN_ITEM}
                         enterpriseName="Box"
-                        item={{ extension: '' }}
                         itemType={itemType}
                     />,
                 );
 
-                expect(sharedLinkPermissionMenu).toMatchSnapshot();
+                expect(wrapper).toMatchSnapshot();
             });
         });
     });

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessDescription.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessDescription.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct menu 1`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct description 1`] = `
 <small
   className="usm-menu-description"
 >
@@ -16,7 +16,7 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in comp
 </small>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct menu 2`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct description 2`] = `
 <small
   className="usm-menu-description"
 >
@@ -32,7 +32,7 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in comp
 </small>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct menu 3`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct description 3`] = `
 <small
   className="usm-menu-description"
 >
@@ -48,7 +48,7 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in comp
 </small>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct menu 4`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct description 4`] = `
 <small
   className="usm-menu-description"
 >
@@ -64,7 +64,7 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in comp
 </small>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people in item should render correct menu 1`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in item should render correct description 1`] = `
 <small
   className="usm-menu-description"
 >
@@ -80,7 +80,7 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in item
 </small>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people in item should render correct menu 2`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in item should render correct description 2`] = `
 <small
   className="usm-menu-description"
 >
@@ -96,7 +96,7 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in item
 </small>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people with link should render correct menu 1`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people with link should render correct description 1`] = `
 <small
   className="usm-menu-description"
 >
@@ -112,23 +112,7 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people with li
 </small>
 `;
 
-exports[`features/unified-share-modal/SharedLinkAccessDescription people with link should render correct menu 2`] = `
-<small
-  className="usm-menu-description"
->
-  <FormattedMessage
-    defaultMessage="Box sign-in required"
-    id="boxui.unifiedShare.canvasPeopleWithLinkDescription"
-    values={
-      Object {
-        "company": "Box",
-      }
-    }
-  />
-</small>
-`;
-
-exports[`features/unified-share-modal/SharedLinkAccessDescription people with link should render correct menu 3`] = `
+exports[`features/unified-share-modal/SharedLinkAccessDescription people with link should render correct description 2`] = `
 <small
   className="usm-menu-description"
 >


### PR DESCRIPTION
the `item` prop was added for a Canvas use case in this PR: https://github.com/box/box-ui-elements/pull/3318

it was assumed that the component files in this features folder were only used by USM. however, there is a usage in the main webapp where only the `SharedLinkAccessLabel` component is imported and used in the sidebar when a folder is opened in the All Files page. When trying to bump BUIE in EUA, it is causing a type error because `item` is currently required.

This is setting `item` to optional instead of making a change in EUA to pass the `item` prop. The reasoning behind setting as optional instead of updating the component in EUA is so when Canvas is released, the changes in the above PR can be reverted without requiring another change in EUA.