### PR TITLE
fix(content-explorer): select all checkbox in empty folder

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -203,7 +203,7 @@ class ContentExplorer extends Component {
         const { items } = this.props;
         const { selectedItems } = this.state;
 
-        return items.every(item => selectedItems[item.id]);
+        return items.length > 0 && items.every(item => selectedItems[item.id]);
     };
 
     isLoadingItems = () => {

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
@@ -99,7 +99,7 @@ describe('features/content-explorer/content-explorer/ContentExplorer', () => {
         });
 
         test('should pass isSelectAllChecked to ContentExplorerSelectAll', () => {
-            const isSelectAllChecked = true;
+            const isSelectAllChecked = false;
             const wrapper = renderComponent({ isSelectAllAllowed: true });
             wrapper.setState({ isSelectAllChecked });
 


### PR DESCRIPTION
Select All checkbox was automatically getting checked in an empty folder. This was because of logic with .every where an empty item list will return true still as there is no item unchecked. 
This new change makes it so that in an empty folder, the Select All checkbox is permanently unchecked, and it cannot be checked. This is because with no items, it is impossible to have any items checked.

Before:
<img width="666" alt="Screen Shot 2023-05-09 at 10 48 10 AM" src="https://github.com/box/box-ui-elements/assets/56702540/df7382cc-4eda-4a16-9d5c-9fe45be2edb2">

After:
<img width="637" alt="Screen Shot 2023-05-09 at 10 45 44 AM" src="https://github.com/box/box-ui-elements/assets/56702540/63a01f0d-0cf6-4ac2-95cf-d231e998dd3c">


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
