### PR TITLE
feat(feat-option): PoC for options.features in Preview SDK

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -822,6 +822,14 @@ class ContentPreview extends React.PureComponent<Props, State> {
             showProgress: false,
             skipServerUpdate: true,
             useHotkeys: false,
+            /* NOTES:
+             - Add features option to pass to box-content-preview like is done when passing feature configurations to BUIE
+            */
+            features: {
+                newPlainText: {
+                    enabled: true,
+                },
+            },
         };
         const { Preview } = global.Box;
         this.preview = new Preview();


### PR DESCRIPTION
Example of how to use options.features for box-content-preview.