### PR TITLE
fix(content-explorer): increase grid button style specificity

### DIFF
--- a/src/elements/common/sub-header/ViewModeChangeButton.scss
+++ b/src/elements/common/sub-header/ViewModeChangeButton.scss
@@ -1,4 +1,4 @@
-.bdl-ViewModeChangeButton {
+.btn.bdl-ViewModeChangeButton {
     padding: 5px 6px;
 
     svg {


### PR DESCRIPTION
If a developer is using the CDN links and multiple elements, then there can be conflicting styles based on the order of the stylesheets. e.g. order of `<link>` tags in https://codepen.io/box-platform/pen/rRZxYq

This is happening with the `ViewModeChangeButton` in ContentExplorer because it has the same specificity weight as the base BUIE button. The base button styles included in the other elements' stylesheets (like Sidebar, Preview, etc) are applied after the Explorer specific styles which means if they have the same specificity weight, then styles imported last take precedent.

**Before**
<img width="947" alt="Screen Shot 2023-05-10 at 11 46 09 AM" src="https://github.com/box/box-ui-elements/assets/7311041/cb3c8426-33b8-4f65-bdae-378b0e25d8bd">

**After**
<img width="952" alt="Screen Shot 2023-05-10 at 11 46 33 AM" src="https://github.com/box/box-ui-elements/assets/7311041/043dbc33-b386-4c2b-8c33-a4756d5d5b41">