### PR TITLE
fix(pill-selector-dropdown): pass showAvatars prop to RoundPill

### DIFF
--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -242,7 +242,7 @@ class PillSelectorBase extends React.Component<Props, State> {
                                       onRemove={onRemove.bind(this, option, index)}
                                       // $FlowFixMe option.text is for backwards compatibility
                                       text={option.displayText || option.text}
-                                      showAvatar
+                                      showAvatar={showAvatars}
                                       id={option.id}
                                       hasWarning={option.hasWarning}
                                       isExternal={option.isExternalUser}
@@ -278,9 +278,7 @@ class PillSelectorBase extends React.Component<Props, State> {
                         {...rest}
                         {...inputProps}
                         autoComplete="off"
-                        className={classNames('bdl-PillSelector-input', 'pill-selector-input', className, {
-                            'bdl-PillSelector-input--showAvatars': showAvatars,
-                        })}
+                        className={classNames('bdl-PillSelector-input', 'pill-selector-input', className)}
                         disabled={disabled}
                         onInput={onInput}
                         placeholder={this.getNumSelected() === 0 ? placeholder : ''}

--- a/src/components/pill-selector-dropdown/PillSelectorDropdown.js
+++ b/src/components/pill-selector-dropdown/PillSelectorDropdown.js
@@ -285,8 +285,8 @@ class PillSelectorDropdown extends React.Component<Props, State> {
                         onSuggestedPillAdd={onSuggestedPillAdd}
                         placeholder={placeholder}
                         selectedOptions={selectedOptions}
-                        showRoundedPills={showRoundedPills}
                         showAvatars={showAvatars && showRoundedPills}
+                        showRoundedPills={showRoundedPills}
                         suggestedPillsData={suggestedPillsData}
                         suggestedPillsFilter={suggestedPillsFilter}
                         suggestedPillsTitle={suggestedPillsTitle}

--- a/src/features/unified-share-modal/ContactsField.js
+++ b/src/features/unified-share-modal/ContactsField.js
@@ -209,6 +209,7 @@ class ContactsField extends React.Component<Props, State> {
                 placeholder={intl.formatMessage(commonMessages.pillSelectorPlaceholder)}
                 ref={fieldRef}
                 selectedOptions={selectedContacts}
+                showAvatars
                 showRoundedPills
                 selectorOptions={contacts}
                 validateForError={validateForError}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/ContactsField.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/ContactsField.test.js.snap
@@ -142,6 +142,7 @@ exports[`features/unified-share-modal/ContactsField render should have scrollabl
   }
   shouldClearUnmatchedInput={false}
   shouldSetActiveItemOnOpen={false}
+  showAvatars={true}
   showRoundedPills={true}
   validateForError={[MockFunction]}
   validator={[MockFunction]}
@@ -287,6 +288,7 @@ exports[`features/unified-share-modal/ContactsField render should render default
   selectorOptions={Array []}
   shouldClearUnmatchedInput={false}
   shouldSetActiveItemOnOpen={false}
+  showAvatars={true}
   showRoundedPills={true}
   validateForError={[MockFunction]}
   validator={[MockFunction]}


### PR DESCRIPTION
The `showAvatars` prop from `PillSelector` was not being passed to the `RoundPill` component so the avatars were always being shown. The prop was added in this PR: https://github.com/box/box-ui-elements/pull/2171 and the description says the avatars can be hidden.

**Intended Implementation**
https://user-images.githubusercontent.com/1657938/83594159-5d823f00-a513-11ea-9b78-e80fee8bd0b4.png

**Before**
<img width="278" alt="Screen Shot 2023-05-10 at 12 47 20 PM" src="https://github.com/box/box-ui-elements/assets/7311041/9570a200-fa26-41cf-a0d0-145220607501">

**After**
<img width="277" alt="Screen Shot 2023-05-10 at 12 46 48 PM" src="https://github.com/box/box-ui-elements/assets/7311041/ef374b69-80f2-4ea0-b921-88a6e1854748">
