### PR TITLE
fix(share-form): map called on undefined object

### DIFF
--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -114,7 +114,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
         this.setState({ isFetchingJustificationReasons: true });
 
         return getJustificationReasons(item.typedID, checkpoint)
-            .then(({ classificationLabelId, options }: GetJustificationReasonsResponse) => {
+            .then(({ classificationLabelId, options = [] }: GetJustificationReasonsResponse) => {
                 this.setState({
                     classificationLabelId,
                     justificationReasons: options.map(({ id, title }) => ({

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -695,6 +695,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
                     defaultItem.typedID,
                     JUSTIFICATION_CHECKPOINT_EXTERNAL_COLLAB,
                 );
+                expect(wrapper.state('justificationReasons')).toEqual([]);
             },
         );
     });

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -208,7 +208,7 @@ export type justificationReasonType = {
 };
 export type getJustificationReasonsResponseType = {
     classificationLabelId: string,
-    options: Array<justificationReasonType>,
+    options?: Array<justificationReasonType>,
 };
 
 // Prop types used in the invite section of the Unified Share Form


### PR DESCRIPTION
BEFORE
A rejected promise occurs when `options.map` is called and `options` is undefined. The error does NOT result in a jest failure in node 14, but DOES result in a failure in node 18
```bash
nvm use 18.15
BABEL_ENV=test NODE_ENV=test yarn jest -c scripts/jest/jest.config.js src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js -t "justification is allowed"

...

 RUNS  src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
/.../box-ui-elements/src/features/unified-share-modal/UnifiedShareForm.js:119
          justificationReasons: options.map(function (_ref2) {
                                        ^

TypeError: Cannot read properties of undefined (reading 'map')
    at map (/.../box-ui-elements/src/features/unified-share-modal/UnifiedShareForm.js:120:51)

Node.js v18.15.0
error Command failed with exit code 1.

```
![before2](https://github.com/box/box-ui-elements/assets/37150601/44323492-caad-4676-aee7-5abc0ef361e9)
![before1](https://github.com/box/box-ui-elements/assets/37150601/78e8ee67-d86b-44bd-8da5-a19d5c144a6b)

CHANGE
Added a condition to default to empty array if options is undefined
Added a test to ensure `justificationReasons` is an empty array

AFTER
![after1](https://github.com/box/box-ui-elements/assets/37150601/65fdd115-562c-4f32-82dc-71d11f6d8683)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
