### PR TITLE
chore(preview): Fix ContentPreview unit test mock for global.performance

### DIFF
--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -28,13 +28,14 @@ describe('elements/content-preview/ContentPreview', () => {
             this.getThumbnail = jest.fn();
             this.updateContentInsightsOptions = jest.fn();
         };
-        global.performance = {
+        jest.spyOn(global, 'performance', 'get').mockReturnValue({
             now: jest.fn().mockReturnValue(PERFORMANCE_TIME),
-        };
+        });
     });
 
     afterEach(() => {
         delete global.Box;
+        jest.restoreAllMocks();
     });
 
     describe('constructor()', () => {


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
When bumping node to lts/hydrogen aka 18.16.0. the following error appear saying that `global.performance` is read only, after changing how we are mocking the object, it passes on 14 and 18 
 
![Screen Shot 2023-05-26 at 5 57 27 PM](https://github.com/box/box-ui-elements/assets/103291617/3672003d-f1ad-491b-8f16-6fdaba1fed71)


