### PR TITLE
chore(ci): openssl-legacy-provider yarn test

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "start:storybook": "LANGUAGE=en-US REACT=true BABEL_ENV=development NODE_ENV=development NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6061",
         "start:storybook:ci": "yarn start:storybook --ci",
         "start:storybook:legacy": "BROWSERSLIST_ENV=production yarn start:storybook",
-        "test": "BABEL_ENV=test NODE_ENV=test yarn jest -c scripts/jest/jest.config.js",
+        "test": "BABEL_ENV=test NODE_ENV=test NODE_OPTIONS=--openssl-legacy-provider yarn jest -c scripts/jest/jest.config.js",
         "test:e2e": "BROWSERSLIST_ENV=test npm-run-all -p -r start:examples cy:run",
         "test:e2e:open": "BROWSERSLIST_ENV=test npm-run-all -p -r start:examples cy:open",
         "test:images": "BABEL_ENV=test NODE_ENV=test yarn jest -c scripts/jest/jest.images.config.js --maxWorkers=4",

--- a/scripts/cut_release.sh
+++ b/scripts/cut_release.sh
@@ -10,8 +10,8 @@ blue=$"\n\e[1;34m(ℹ) "
 end=$"\e[0m\n"
 
 # While running yarn, the registry changes to registry.yarnpkg.com which is a mirror to the public NPM registry
-YARN_PUBLIC_REGISTRY_REGEX="^https://registry\.yarnpkg\.com\/?$"
-NPM_PUBLIC_REGISTRY_REGEX="^https://registry\.npmjs\.org\/?$"
+YARN_PUBLIC_REGISTRY_REGEX="^https:\/\/registry\.yarnpkg\.com\/?$"
+NPM_PUBLIC_REGISTRY_REGEX="^https:\/\/registry\.npmjs\.org\/?$"
 NPM_PUBLIC_REGISTRY="https://registry.npmjs.org"
 
 check_release_scripts_changed() {


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
