### PR TITLE
feat(cloud-game): Adjust cloud game visual

### DIFF
--- a/src/features/security-cloud-game/SecurityCloudGame.js
+++ b/src/features/security-cloud-game/SecurityCloudGame.js
@@ -3,6 +3,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import FocusTrap from '../../components/focus-trap';
+import Tooltip from '../../components/tooltip';
 
 import DragCloud from './DragCloud';
 import DropCloud from './DropCloud';
@@ -12,8 +13,8 @@ import { checkOverlap, getGridPosition, getRandomCloudPosition } from './utils';
 import './SecurityCloudGame.scss';
 
 // pick these numbers to balance accessibility and game complexity
-const CLOUD_SIZE_RATIO = 5;
-const GRID_TRACK_SIZE_RATIO = 20;
+const CLOUD_SIZE_RATIO = 4;
+const GRID_TRACK_SIZE_RATIO = 16;
 
 const SecurityCloudGame = ({ height, intl: { formatMessage }, onValidDrop, width }) => {
     const [dropCloudPosition, setDropCloudPosition] = useState(null);
@@ -43,7 +44,7 @@ const SecurityCloudGame = ({ height, intl: { formatMessage }, onValidDrop, width
             gridTrackSize: minGameBoardLength / GRID_TRACK_SIZE_RATIO,
         });
 
-        messageElement.focus();
+        messageElement.focus({ preventScroll: true });
     }, [height, width]);
 
     useEffect(() => {
@@ -197,6 +198,11 @@ const SecurityCloudGame = ({ height, intl: { formatMessage }, onValidDrop, width
         return <FormattedMessage {...messages.instructions} />;
     };
 
+    const hideMessageTooltip = () => {
+        const { current: messageElement } = messageElementRef;
+        return document.activeElement !== messageElement;
+    };
+
     /**
      * Renders the cloud game
      * @returns {JSX}
@@ -207,14 +213,22 @@ const SecurityCloudGame = ({ height, intl: { formatMessage }, onValidDrop, width
                 {liveText}
             </div>
             <div className="bdl-SecurityCloudGame" style={{ height: `${height}px`, width: `${width}px` }}>
-                <div
-                    ref={messageElementRef}
-                    className="bdl-SecurityCloudGame-message"
-                    aria-label={getAccessibilityInstructions()}
-                    tabIndex={-1}
+                <Tooltip
+                    className="bdl-SecurityCloudGame-tooltip"
+                    constrainToWindow={false}
+                    isShown={hideMessageTooltip() ? false : undefined}
+                    position="bottom-center"
+                    text={renderMessage()}
                 >
-                    {renderMessage()}
-                </div>
+                    <div
+                        ref={messageElementRef}
+                        className="bdl-SecurityCloudGame-message"
+                        aria-label={getAccessibilityInstructions()}
+                        tabIndex={-1}
+                    >
+                        {renderMessage()}
+                    </div>
+                </Tooltip>
                 <div className="bdl-SecurityCloudGame-board">
                     {renderDropCloud()}
                     {renderDragCloud()}

--- a/src/features/security-cloud-game/SecurityCloudGame.scss
+++ b/src/features/security-cloud-game/SecurityCloudGame.scss
@@ -30,10 +30,14 @@
 
     .bdl-SecurityCloudGame-message {
         flex: none;
+        max-height: 40px;
         padding: 10px;
+        overflow: hidden;
         color: $white;
         font-size: 16px;
+        white-space: nowrap;
         text-align: center;
+        text-overflow: ellipsis;
         background-color: rgba(0, 0, 0, .1);
     }
 
@@ -47,6 +51,10 @@
 .bdl-SecurityCloudGame-liveText {
     position: absolute;
     left: -9999px;
+}
+
+.bdl-SecurityCloudGame-tooltip.bdl-Tooltip {
+    max-width: 100%;
 }
 
 .bdl-DragCloud {

--- a/src/features/security-cloud-game/__tests__/SecurityCloudGame.test.js
+++ b/src/features/security-cloud-game/__tests__/SecurityCloudGame.test.js
@@ -37,13 +37,13 @@ describe('features/security-cloud-game/SecurityCloudGame', () => {
 
         const dropCloud = wrapper.find(DropCloud);
         expect(dropCloud.prop('position')).toEqual({
-            x: 79,
-            y: 79,
+            x: 74,
+            y: 74,
         });
         const dragCloud = wrapper.find(DragCloud);
         expect(dragCloud.prop('position')).toEqual({
-            x: 395,
-            y: 395,
+            x: 370,
+            y: 370,
         });
     });
 


### PR DESCRIPTION
## Summary of changes

- Make cloud objects bigger to accommodate small screens
- Add a max height of 40px to the message header and show tooltip on hover
- Prevent auto-scroll into view on load

## Demo
![adjust_cloud_game_visual](https://github.com/box/box-ui-elements/assets/17888863/f2315f09-a14f-4880-bcf7-5e35aa39a9b7)
