### PR TITLE
fix(preview): update thumbnail sidebar width

### DIFF
--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -73,7 +73,7 @@
 }
 
 .bcpr.bcpr-thumbnails-open .bcpr-navigate-left {
-    left: 226px;
+    left: 191px;
 }
 
 .is-responsive-web {
@@ -90,6 +90,10 @@
 
             .bcpr-container {
                 position: static;
+            }
+
+            &.bcpr-thumbnails-open .bcpr-navigate-left {
+                left: 0;
             }
         }
     }


### PR DESCRIPTION
Note: This is the first part of the fix that needs to be merged and bumped before https://github.com/box/box-content-preview/pull/1483

## Summary of changes
- Update `left` of the left navigation arrow to **191px** to reflect the new thumbnail sidebar width
- Set `left` of the left navigation arrow to **0** when view size is below 768px (as the thumbnail sidebar will be hidden)

## Demo
### Before
![thumbnail_left_nav_before](https://github.com/box/box-ui-elements/assets/17888863/8ff0dfba-c59c-434f-8763-825e4edba55f)

### After
![thumbnail_left_nav_after](https://github.com/box/box-ui-elements/assets/17888863/66156e0e-3025-450f-8140-55612c43c1f1)

