### PR TITLE
fix: update modal buttons alignments in element dialogs

### DIFF
--- a/scripts/styleguide.styles.scss
+++ b/scripts/styleguide.styles.scss
@@ -2,6 +2,10 @@
     &.bce,
     &.bcp {
         height: 600px;
+
+        .bcu {
+            height: 100%;
+        }
     }
 
     &.bcpr {

--- a/src/components/i18n/FormattedCompMessage.js
+++ b/src/components/i18n/FormattedCompMessage.js
@@ -184,7 +184,7 @@ class FormattedCompMessage extends React.Component<Props, State> {
         // the reviewer finds and submit translation tickets to Jira and/or fixed
         // translations directly back to Mojito.
         // 3. It can be used by the planned "text experiment framework" to identify
-        // whole strings in the UI that can be A/B tested in various langauges without
+        // whole strings in the UI that can be A/B tested in various languages without
         // publishing new versions of the code.
         return React.createElement(
             tagName,

--- a/src/elements/common/base.scss
+++ b/src/elements/common/base.scss
@@ -12,7 +12,6 @@
     line-height: 20px;
     letter-spacing: .3px;
 
-    // TODO: Remove when border-color in src/styles/_inputs.scss is accessible
     input[type='text'],
     input[type='date'],
     input[type='password'],
@@ -23,7 +22,8 @@
     input[type='number'],
     div[contentEditable='true'],
     textarea {
-        border-color: $bdl-gray-50;
+        width: 100%;
+        border-color: $bdl-gray-50; // TODO: Remove when border-color in src/styles/_inputs.scss is accessible
     }
 
     /* stylelint-disable */

--- a/src/elements/common/create-folder-dialog/CreateFolderDialog.js
+++ b/src/elements/common/create-folder-dialog/CreateFolderDialog.js
@@ -109,9 +109,6 @@ const CreateFolderDialog = ({
                 <input ref={ref} onKeyDown={onKeyDown} required type="text" />
             </label>
             <div className="be-modal-btns">
-                <PrimaryButton data-testid="be-btn-create-folder" isLoading={isLoading} onClick={create} type="button">
-                    <FormattedMessage {...messages.create} />
-                </PrimaryButton>
                 <Button
                     data-testid="be-btn-create-folder-cancel"
                     isDisabled={isLoading}
@@ -120,6 +117,9 @@ const CreateFolderDialog = ({
                 >
                     <FormattedMessage {...messages.cancel} />
                 </Button>
+                <PrimaryButton data-testid="be-btn-create-folder" isLoading={isLoading} onClick={create} type="button">
+                    <FormattedMessage {...messages.create} />
+                </PrimaryButton>
             </div>
         </Modal>
     );

--- a/src/elements/common/header/Header.scss
+++ b/src/elements/common/header/Header.scss
@@ -1,6 +1,6 @@
 @import '../variables';
 
-.be .be-header {
+.be-header {
     display: flex;
     flex: 0 0 70px;
     align-items: center;
@@ -15,11 +15,5 @@
     .be-search {
         flex: 1;
         padding-left: 20px;
-    }
-
-    input[type='search'] {
-        width: 100%;
-        font: inherit;
-        -webkit-appearance: none;
     }
 }

--- a/src/elements/common/modal.scss
+++ b/src/elements/common/modal.scss
@@ -3,13 +3,18 @@
 .be-modal {
     .be-modal-btns {
         display: flex;
-        justify-content: center;
+        justify-content: flex-end;
         padding: 15px 0 0;
 
         .btn {
             @include bdl-Button--large;
 
-            margin-left: 8px;
+            margin-top: 0;
+            margin-bottom: 0;
+
+            &:last-of-type {
+                margin-right: 0;
+            }
         }
     }
 

--- a/src/elements/content-explorer/DeleteConfirmationDialog.js
+++ b/src/elements/content-explorer/DeleteConfirmationDialog.js
@@ -50,12 +50,12 @@ const DeleteConfirmationDialog = ({
         >
             <FormattedMessage {...message} values={{ name: item.name }} />
             <div className="be-modal-btns">
-                <PrimaryButton isLoading={isLoading} onClick={onDelete} type="button">
-                    <FormattedMessage {...messages.delete} />
-                </PrimaryButton>
                 <Button autoFocus isDisabled={isLoading} onClick={onCancel} type="button">
                     <FormattedMessage {...messages.cancel} />
                 </Button>
+                <PrimaryButton isLoading={isLoading} onClick={onDelete} type="button">
+                    <FormattedMessage {...messages.delete} />
+                </PrimaryButton>
             </div>
         </Modal>
     );

--- a/src/elements/content-explorer/RenameDialog.js
+++ b/src/elements/content-explorer/RenameDialog.js
@@ -120,12 +120,12 @@ const RenameDialog = ({
                 <input ref={ref} defaultValue={nameWithoutExt} onKeyDown={onKeyDown} required type="text" />
             </label>
             <div className="be-modal-btns">
-                <PrimaryButton isLoading={isLoading} onClick={rename} type="button">
-                    <FormattedMessage {...messages.rename} />
-                </PrimaryButton>
                 <Button isDisabled={isLoading} onClick={onCancel} type="button">
                     <FormattedMessage {...messages.cancel} />
                 </Button>
+                <PrimaryButton isLoading={isLoading} onClick={rename} type="button">
+                    <FormattedMessage {...messages.rename} />
+                </PrimaryButton>
             </div>
         </Modal>
     );

--- a/src/elements/content-preview/README.md
+++ b/src/elements/content-preview/README.md
@@ -1,5 +1,5 @@
 ### Demo ([Documentation](https://developer.box.com/docs/box-content-preview))
-***IMPORTANT:*** The Content Preview UI Element works differently from the other UI Elements above. The React component is a wrapper for the [Preview library](https://developer.box.com/docs/box-content-preview). It also requires a langauge (defaults to en-US) to be passed in since the preview library bundles are localized. Providing a language will automatically pull in the corresponding preview.js bundle and dynamically load it by adding a script tag. It will also dynamically load the additional required preview.css file by adding a link tag.
+***IMPORTANT:*** The Content Preview UI Element works differently from the other UI Elements above. The React component is a wrapper for the [Preview library](https://developer.box.com/docs/box-content-preview). It also requires a language (defaults to en-US) to be passed in since the preview library bundles are localized. Providing a language will automatically pull in the corresponding preview.js bundle and dynamically load it by adding a script tag. It will also dynamically load the additional required preview.css file by adding a link tag.
 
 ```jsx
 var ContentPreview = require('./ContentPreview').default;

--- a/src/styles/common/_forms.scss
+++ b/src/styles/common/_forms.scss
@@ -16,7 +16,7 @@ input[type='tel'],
 input[type='number'],
 div[contentEditable='true'],
 textarea {
-    width: 262px;
+    width: 100%;
 
     @include box-inputs;
 }

--- a/src/styles/common/_forms.scss
+++ b/src/styles/common/_forms.scss
@@ -16,7 +16,7 @@ input[type='tel'],
 input[type='number'],
 div[contentEditable='true'],
 textarea {
-    width: 100%;
+    width: 262px;
 
     @include box-inputs;
 }


### PR DESCRIPTION
This is updating the designs of the modals used in Content Explorer and Content Picker. There are three modal components that this is specifically targeting: `CreateFolderDialog.js`, `DeleteConfirmationDialog.js`, and `RenameDialog.js`

I decided to add `width: 100%;` to all text fields in the base elements stylesheet since `100%` seems to be the most ideal value for `width` in majority of cases for input.

At the moment, components are inheriting `width: 262px` from the [base components stylesheet](https://github.com/box/box-ui-elements/blob/master/src/styles/common/_forms.scss#L9-L22) but this seems to be an arbitrary value and components are overriding it. e.g.

- Task modal in Sidebar: https://github.com/box/box-ui-elements/blob/b9d196fcf330d38de87890ca8ccf4a5c8433d313/src/elements/content-sidebar/activity-feed/task-form/TaskForm.scss#L14
- Description in File Properties section in Sidebar: https://github.com/box/box-ui-elements/blob/b9d196fcf330d38de87890ca8ccf4a5c8433d313/src/features/item-details/ItemProperties.scss#L16
- Content Sharing / USM: https://github.com/box/box-ui-elements/blob/b9d196fcf330d38de87890ca8ccf4a5c8433d313/src/features/unified-share-modal/UnifiedShareModal.scss#L181

**Before**
<img width="840" alt="Screenshot 2023-07-05 at 11 19 50 AM" src="https://github.com/box/box-ui-elements/assets/7311041/f24afd8e-020c-4cf6-a527-e644aa72b45c">

**After**
<img width="840" alt="Screenshot 2023-07-05 at 11 19 35 AM" src="https://github.com/box/box-ui-elements/assets/7311041/6520836c-875f-4783-b402-932ddfe66d70">
