### PR TITLE
feat(types): migrating dropdown menu to typescript

### DIFF
--- a/src/components/category-selector/CategorySelectorComponent.tsx
+++ b/src/components/category-selector/CategorySelectorComponent.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import classnames from 'classnames';
 import PlainButton from '../plain-button/PlainButton';
-// @ts-ignore flow import
 import DropdownMenu, { MenuToggle } from '../dropdown-menu';
 import { Menu, SelectMenuItem } from '../menu';
 import messages from './messages';

--- a/src/components/dropdown-menu/DropdownMenu.js.flow
+++ b/src/components/dropdown-menu/DropdownMenu.js.flow
@@ -1,0 +1,285 @@
+// @flow
+import * as React from 'react';
+import TetherComponent from 'react-tether';
+import classNames from 'classnames';
+import noop from 'lodash/noop';
+import uniqueId from 'lodash/uniqueId';
+
+import { KEYS } from '../../constants';
+import './DropdownMenu.scss';
+
+type Props = {
+    bodyElement?: HTMLElement,
+    children: React.Node,
+    /** Forces menu to render within the scroll parent */
+    className?: string,
+    /** Forces menu to render within the visible window */
+    constrainToScrollParent: boolean,
+    /** Right aligns menu to button */
+    constrainToWindow: boolean,
+    /** Forces menu to render within the visible window and pins the dropdown if scrolled */
+    constrainToWindowWithPin?: boolean,
+    /** Enables responsive behaviors for this component */
+    isResponsive?: boolean,
+    /** Function called when menu is opened */
+    isRightAligned: boolean,
+    /** Handler for dropdown menu close events */
+    onMenuClose?: (event: SyntheticEvent<> | MouseEvent) => void,
+    /** Handler for dropdown menu open events */
+    onMenuOpen?: () => void,
+    /** "attachment" prop for the TetherComponent, will overwrite the default settings and ignore isRightAligned option */
+    tetherAttachment?: string,
+    /** "targetAttachment" prop for the TetherComponent, will overwrite the default settings and ignore isRightAligned option */
+    tetherTargetAttachment?: string,
+    /** Set true to close dropdown menu on event bubble instead of event capture */
+    useBubble?: boolean,
+};
+
+type State = {
+    initialFocusIndex: ?number,
+    isOpen: boolean,
+};
+
+class DropdownMenu extends React.Component<Props, State> {
+    static defaultProps = {
+        constrainToScrollParent: false,
+        constrainToWindow: false,
+        isResponsive: false,
+        isRightAligned: false,
+    };
+
+    menuID = uniqueId('menu');
+
+    menuButtonID = uniqueId('menubutton');
+
+    state = {
+        initialFocusIndex: null,
+        isOpen: false,
+    };
+
+    componentDidUpdate(prevProps: Props, prevState: State) {
+        const { useBubble } = this.props;
+        if (!prevState.isOpen && this.state.isOpen) {
+            // When menu is being opened
+            document.addEventListener('click', this.handleDocumentClick, !useBubble);
+            document.addEventListener('contextmenu', this.handleDocumentClick, !useBubble);
+
+            const { onMenuOpen } = this.props;
+            if (onMenuOpen) {
+                onMenuOpen();
+            }
+        } else if (prevState.isOpen && !this.state.isOpen) {
+            // When menu is being closed
+            document.removeEventListener('contextmenu', this.handleDocumentClick, !useBubble);
+            document.removeEventListener('click', this.handleDocumentClick, !useBubble);
+        }
+    }
+
+    componentWillUnmount() {
+        const { useBubble } = this.props;
+        if (this.state.isOpen) {
+            // Clean-up global click handlers
+            document.removeEventListener('contextmenu', this.handleDocumentClick, !useBubble);
+            document.removeEventListener('click', this.handleDocumentClick, !useBubble);
+        }
+    }
+
+    menuID: string;
+
+    menuButtonID: string;
+
+    openMenuAndSetFocusIndex = (initialFocusIndex: ?number) => {
+        this.setState({
+            initialFocusIndex,
+            isOpen: true,
+        });
+    };
+
+    closeMenu = (event: SyntheticEvent<> | MouseEvent) => {
+        const { onMenuClose = noop } = this.props;
+        this.setState(
+            {
+                isOpen: false,
+            },
+            () => onMenuClose(event),
+        );
+    };
+
+    focusButton = () => {
+        // @NOTE: This breaks encapsulation a bit, but the only other way is passing ref functions to unknown children components
+        const menuButtonEl = document.getElementById(this.menuButtonID);
+        if (menuButtonEl) {
+            menuButtonEl.focus();
+        }
+    };
+
+    handleButtonClick = (event: SyntheticEvent<>) => {
+        const { isOpen } = this.state;
+
+        event.stopPropagation();
+        event.preventDefault();
+
+        if (isOpen) {
+            this.closeMenu(event);
+        } else {
+            this.openMenuAndSetFocusIndex(null);
+        }
+    };
+
+    handleButtonKeyDown = (event: SyntheticKeyboardEvent<>) => {
+        const { isOpen } = this.state;
+
+        switch (event.key) {
+            case KEYS.space:
+            case KEYS.enter:
+            case KEYS.arrowDown:
+                event.stopPropagation();
+                event.preventDefault();
+
+                this.openMenuAndSetFocusIndex(0);
+                break;
+
+            case KEYS.arrowUp:
+                event.stopPropagation();
+                event.preventDefault();
+
+                this.openMenuAndSetFocusIndex(-1);
+                break;
+
+            case KEYS.escape:
+                if (isOpen) {
+                    event.stopPropagation();
+                }
+
+                event.preventDefault();
+                this.closeMenu(event);
+                break;
+
+            default:
+                break;
+        }
+    };
+
+    handleMenuClose = (isKeyboardEvent: boolean, event: SyntheticEvent<> | MouseEvent) => {
+        this.closeMenu(event);
+        this.focusButton();
+    };
+
+    handleDocumentClick = (event: MouseEvent) => {
+        const menuEl = document.getElementById(this.menuID);
+        const menuButtonEl = document.getElementById(this.menuButtonID);
+
+        // Some DOM magic to get global click handlers to close menu when not interacting with menu or associated button
+        if (
+            menuEl &&
+            menuButtonEl &&
+            event.target instanceof Node &&
+            !menuEl.contains(event.target) &&
+            !menuButtonEl.contains(event.target)
+        ) {
+            this.closeMenu(event);
+        }
+    };
+
+    render() {
+        const {
+            bodyElement,
+            children,
+            className,
+            constrainToScrollParent,
+            constrainToWindow,
+            constrainToWindowWithPin,
+            isResponsive,
+            isRightAligned,
+            tetherAttachment,
+            tetherTargetAttachment,
+        } = this.props;
+
+        const { isOpen, initialFocusIndex } = this.state;
+
+        const elements = React.Children.toArray(children);
+
+        if (elements.length !== 2) {
+            throw new Error('DropdownMenu must have exactly two children: A button component and a <Menu>');
+        }
+
+        const menuButton = elements[0];
+        const menu = elements[1];
+
+        const menuButtonProps: Object = {
+            id: this.menuButtonID,
+            key: this.menuButtonID,
+            onClick: this.handleButtonClick, // NOTE: Overrides button's handler
+            onKeyDown: this.handleButtonKeyDown, // NOTE: Overrides button's handler
+            'aria-expanded': isOpen ? 'true' : 'false',
+        };
+
+        if (menuButton.props['aria-haspopup'] === undefined) {
+            menuButtonProps['aria-haspopup'] = 'true';
+        }
+
+        // Add this only when its open, otherwise the menuID element isn't rendered
+        if (isOpen) {
+            menuButtonProps['aria-controls'] = this.menuID;
+        }
+
+        const menuProps = {
+            id: this.menuID,
+            key: this.menuID,
+            initialFocusIndex,
+            onClose: this.handleMenuClose,
+            'aria-labelledby': this.menuButtonID,
+        };
+
+        let attachment = 'top left';
+        let targetAttachment = 'bottom left';
+
+        if (isRightAligned) {
+            attachment = 'top right';
+            targetAttachment = 'bottom right';
+        }
+
+        const constraints = [];
+
+        if (constrainToScrollParent) {
+            constraints.push({
+                to: 'scrollParent',
+                attachment: 'together',
+            });
+        }
+
+        if (constrainToWindow) {
+            constraints.push({
+                to: 'window',
+                attachment: 'together',
+            });
+        }
+
+        if (constrainToWindowWithPin) {
+            constraints.push({
+                to: 'window',
+                attachment: 'together',
+                pin: true,
+            });
+        }
+
+        const bodyEl = bodyElement instanceof HTMLElement ? bodyElement : document.body;
+
+        return (
+            <TetherComponent
+                attachment={tetherAttachment || attachment}
+                bodyElement={bodyEl}
+                className={classNames({ 'bdl-DropdownMenu--responsive': isResponsive }, className)}
+                classPrefix="dropdown-menu"
+                constraints={constraints}
+                enabled={isOpen}
+                targetAttachment={tetherTargetAttachment || targetAttachment}
+            >
+                {React.cloneElement(menuButton, menuButtonProps)}
+                {isOpen && React.cloneElement(menu, menuProps)}
+            </TetherComponent>
+        );
+    }
+}
+
+export default DropdownMenu;

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -1,43 +1,44 @@
-// @flow
 import * as React from 'react';
 import TetherComponent from 'react-tether';
 import classNames from 'classnames';
+// @ts-ignore no types
 import noop from 'lodash/noop';
+// @ts-ignore no types
 import uniqueId from 'lodash/uniqueId';
 
 import { KEYS } from '../../constants';
 import './DropdownMenu.scss';
 
 type Props = {
-    bodyElement?: HTMLElement,
-    children: React.Node,
+    bodyElement?: HTMLElement;
+    children: React.ReactNode;
     /** Forces menu to render within the scroll parent */
-    className?: string,
+    className?: string;
     /** Forces menu to render within the visible window */
-    constrainToScrollParent: boolean,
+    constrainToScrollParent: boolean;
     /** Right aligns menu to button */
-    constrainToWindow: boolean,
+    constrainToWindow: boolean;
     /** Forces menu to render within the visible window and pins the dropdown if scrolled */
-    constrainToWindowWithPin?: boolean,
+    constrainToWindowWithPin?: boolean;
     /** Enables responsive behaviors for this component */
-    isResponsive?: boolean,
+    isResponsive?: boolean;
     /** Function called when menu is opened */
-    isRightAligned: boolean,
+    isRightAligned: boolean;
     /** Handler for dropdown menu close events */
-    onMenuClose?: (event: SyntheticEvent<> | MouseEvent) => void,
+    onMenuClose?: (event: React.SyntheticEvent | MouseEvent) => void;
     /** Handler for dropdown menu open events */
-    onMenuOpen?: () => void,
+    onMenuOpen?: () => void;
     /** "attachment" prop for the TetherComponent, will overwrite the default settings and ignore isRightAligned option */
-    tetherAttachment?: string,
+    tetherAttachment?: string;
     /** "targetAttachment" prop for the TetherComponent, will overwrite the default settings and ignore isRightAligned option */
-    tetherTargetAttachment?: string,
+    tetherTargetAttachment?: string;
     /** Set true to close dropdown menu on event bubble instead of event capture */
-    useBubble?: boolean,
+    useBubble?: boolean;
 };
 
 type State = {
-    initialFocusIndex: ?number,
-    isOpen: boolean,
+    initialFocusIndex?: number;
+    isOpen: boolean;
 };
 
 class DropdownMenu extends React.Component<Props, State> {
@@ -84,18 +85,14 @@ class DropdownMenu extends React.Component<Props, State> {
         }
     }
 
-    menuID: string;
-
-    menuButtonID: string;
-
-    openMenuAndSetFocusIndex = (initialFocusIndex: ?number) => {
+    openMenuAndSetFocusIndex = (initialFocusIndex?: number) => {
         this.setState({
             initialFocusIndex,
             isOpen: true,
         });
     };
 
-    closeMenu = (event: SyntheticEvent<> | MouseEvent) => {
+    closeMenu = (event: KeyboardEvent | MouseEvent) => {
         const { onMenuClose = noop } = this.props;
         this.setState(
             {
@@ -113,7 +110,7 @@ class DropdownMenu extends React.Component<Props, State> {
         }
     };
 
-    handleButtonClick = (event: SyntheticEvent<>) => {
+    handleButtonClick = (event: MouseEvent) => {
         const { isOpen } = this.state;
 
         event.stopPropagation();
@@ -126,7 +123,7 @@ class DropdownMenu extends React.Component<Props, State> {
         }
     };
 
-    handleButtonKeyDown = (event: SyntheticKeyboardEvent<>) => {
+    handleButtonKeyDown = (event: KeyboardEvent) => {
         const { isOpen } = this.state;
 
         switch (event.key) {
@@ -160,7 +157,7 @@ class DropdownMenu extends React.Component<Props, State> {
         }
     };
 
-    handleMenuClose = (isKeyboardEvent: boolean, event: SyntheticEvent<> | MouseEvent) => {
+    handleMenuClose = (isKeyboardEvent: boolean, event: KeyboardEvent | MouseEvent) => {
         this.closeMenu(event);
         this.focusButton();
     };
@@ -214,6 +211,7 @@ class DropdownMenu extends React.Component<Props, State> {
             'aria-expanded': isOpen ? 'true' : 'false',
         };
 
+        // @ts-ignore TODO: add proper types for MenuButton
         if (menuButton.props['aria-haspopup'] === undefined) {
             menuButtonProps['aria-haspopup'] = 'true';
         }
@@ -266,7 +264,9 @@ class DropdownMenu extends React.Component<Props, State> {
         const bodyEl = bodyElement instanceof HTMLElement ? bodyElement : document.body;
 
         return (
+            // @ts-ignore TODO: add proper types for TetherComponent
             <TetherComponent
+                // @ts-ignore TODO: add proper types for TetherComponent
                 attachment={tetherAttachment || attachment}
                 bodyElement={bodyEl}
                 className={classNames({ 'bdl-DropdownMenu--responsive': isResponsive }, className)}
@@ -275,7 +275,9 @@ class DropdownMenu extends React.Component<Props, State> {
                 enabled={isOpen}
                 targetAttachment={tetherTargetAttachment || targetAttachment}
             >
+                {/* @ts-ignore TODO: add proper types for MenuButton */}
                 {React.cloneElement(menuButton, menuButtonProps)}
+                {/* @ts-ignore TODO: add proper types for Menu */}
                 {isOpen && React.cloneElement(menu, menuProps)}
             </TetherComponent>
         );

--- a/src/components/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/dropdown-menu/DropdownMenu.tsx
@@ -6,6 +6,7 @@ import noop from 'lodash/noop';
 // @ts-ignore no types
 import uniqueId from 'lodash/uniqueId';
 
+// @ts-ignore no type declaration for the constants
 import { KEYS } from '../../constants';
 import './DropdownMenu.scss';
 
@@ -37,7 +38,7 @@ type Props = {
 };
 
 type State = {
-    initialFocusIndex?: number;
+    initialFocusIndex: number | null;
     isOpen: boolean;
 };
 
@@ -85,7 +86,7 @@ class DropdownMenu extends React.Component<Props, State> {
         }
     }
 
-    openMenuAndSetFocusIndex = (initialFocusIndex?: number) => {
+    openMenuAndSetFocusIndex = (initialFocusIndex: number | null) => {
         this.setState({
             initialFocusIndex,
             isOpen: true,
@@ -203,7 +204,15 @@ class DropdownMenu extends React.Component<Props, State> {
         const menuButton = elements[0];
         const menu = elements[1];
 
-        const menuButtonProps: Object = {
+        const menuButtonProps: {
+            id: string;
+            key: string;
+            onClick: (event: MouseEvent) => void;
+            onKeyDown: (event: KeyboardEvent) => void;
+            'aria-expanded': string;
+            'aria-haspopup'?: string;
+            'aria-controls'?: string;
+        } = {
             id: this.menuButtonID,
             key: this.menuButtonID,
             onClick: this.handleButtonClick, // NOTE: Overrides button's handler
@@ -275,10 +284,9 @@ class DropdownMenu extends React.Component<Props, State> {
                 enabled={isOpen}
                 targetAttachment={tetherTargetAttachment || targetAttachment}
             >
-                {/* @ts-ignore TODO: add proper types for MenuButton */}
-                {React.cloneElement(menuButton, menuButtonProps)}
-                {/* @ts-ignore TODO: add proper types for Menu */}
-                {isOpen && React.cloneElement(menu, menuProps)}
+                {/* TODO: fix the menuButton and menu types to avoid the casting */}
+                {React.cloneElement(menuButton as React.ReactElement, menuButtonProps)}
+                {isOpen && React.cloneElement(menu as React.ReactElement, menuProps)}
             </TetherComponent>
         );
     }

--- a/src/components/dropdown-menu/MenuToggle.js.flow
+++ b/src/components/dropdown-menu/MenuToggle.js.flow
@@ -1,0 +1,19 @@
+// @flow
+import * as React from 'react';
+
+import IconCaretDown from '../../icons/general/IconCaretDown';
+
+import './MenuToggle.scss';
+
+type Props = {
+    children?: React.Node,
+};
+
+const MenuToggle = ({ children }: Props) => (
+    <span className="menu-toggle">
+        {children}
+        <IconCaretDown className="toggle-arrow" width={7} />
+    </span>
+);
+
+export default MenuToggle;

--- a/src/components/dropdown-menu/MenuToggle.tsx
+++ b/src/components/dropdown-menu/MenuToggle.tsx
@@ -1,4 +1,3 @@
-// @flow
 import * as React from 'react';
 
 import IconCaretDown from '../../icons/general/IconCaretDown';
@@ -6,7 +5,7 @@ import IconCaretDown from '../../icons/general/IconCaretDown';
 import './MenuToggle.scss';
 
 type Props = {
-    children?: React.Node,
+    children?: React.ReactNode;
 };
 
 const MenuToggle = ({ children }: Props) => (

--- a/src/components/dropdown-menu/index.js.flow
+++ b/src/components/dropdown-menu/index.js.flow
@@ -1,0 +1,3 @@
+// @flow
+export { default } from './DropdownMenu';
+export { default as MenuToggle } from './MenuToggle';

--- a/src/components/dropdown-menu/index.ts
+++ b/src/components/dropdown-menu/index.ts
@@ -1,3 +1,2 @@
-// @flow
 export { default } from './DropdownMenu';
 export { default as MenuToggle } from './MenuToggle';

--- a/src/components/media/MediaMenu.tsx
+++ b/src/components/media/MediaMenu.tsx
@@ -6,7 +6,6 @@ import messages from './messages';
 import IconEllipsis from '../../icons/general/IconEllipsis';
 import { ButtonType } from '../button';
 import PlainButton, { PlainButtonProps } from '../plain-button';
-// @ts-ignore TODO: migrate DropdownMenu to typescript
 import DropdownMenu from '../dropdown-menu';
 import { Menu } from '../menu';
 import { bdlGray50 } from '../../styles/variables';


### PR DESCRIPTION
Migrating `DropdownMenu` to TypeScript. Adding a couple of ignores and castings that can be addressed in a separate PR to keep this one simple.