### PR TITLE
fix(css): remove IE7 CSS hack to fix Parcel support

### DIFF
--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -118,7 +118,6 @@ textarea,
 select {
     font-weight: inherit;
     font-size: inherit;
-    *font-size: 100%; /* to enable resizing for IE */
     font-family: inherit;
 }
 


### PR DESCRIPTION
Removing CSS hack to target IE7 and below because that's superrrr outdated

https://www.geeksforgeeks.org/what-is-the-use-of-star-preceded-property-in-css/