### PR TITLE
feat(uaa-integration): Filter activity types for UAA

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -35,6 +35,7 @@ import {
     FILE_ACTIVITY_TYPE_TASK,
     HTTP_STATUS_CODE_CONFLICT,
     IS_ERROR_DISPLAYED,
+    PERMISSION_CAN_VIEW_ANNOTATIONS,
     TASK_NEW_APPROVED,
     TASK_NEW_COMPLETED,
     TASK_NEW_REJECTED,
@@ -518,13 +519,17 @@ class Feed extends Base {
 
         const versionsPromise = shouldShowVersions ? this.fetchVersions() : Promise.resolve();
         const currentVersionPromise = shouldShowVersions ? this.fetchCurrentVersion() : Promise.resolve();
+
+        const filteredActivityTypes = [];
+        if (shouldShowAnnotations && permissions[PERMISSION_CAN_VIEW_ANNOTATIONS]) {
+            filteredActivityTypes.push(FILE_ACTIVITY_TYPE_ANNOTATION);
+        }
+        if (shouldShowAppActivity) filteredActivityTypes.push(FILE_ACTIVITY_TYPE_APP_ACTIVITY);
+        filteredActivityTypes.push(FILE_ACTIVITY_TYPE_COMMENT);
+        if (shouldShowTasks) filteredActivityTypes.push(FILE_ACTIVITY_TYPE_TASK);
+
         const fileActivitiesPromise = shouldUseUAA
-            ? this.fetchFileActivities(permissions, [
-                  FILE_ACTIVITY_TYPE_ANNOTATION,
-                  FILE_ACTIVITY_TYPE_APP_ACTIVITY,
-                  FILE_ACTIVITY_TYPE_COMMENT,
-                  FILE_ACTIVITY_TYPE_TASK,
-              ])
+            ? this.fetchFileActivities(permissions, filteredActivityTypes, shouldShowReplies)
             : Promise.resolve();
 
         const handleFeedItems = (feedItems: FeedItems) => {
@@ -677,7 +682,11 @@ class Feed extends Base {
      * @param {FileActivityTypes[]} activityTypes - the activity types to filter by
      * @return {Promise} - the file comments
      */
-    fetchFileActivities(permissions: BoxItemPermission, activityTypes: FileActivityTypes[]): Promise<Object> {
+    fetchFileActivities(
+        permissions: BoxItemPermission,
+        activityTypes: FileActivityTypes[],
+        shouldShowReplies,
+    ): Promise<Object> {
         this.fileActivitiesAPI = new FileActivitiesAPI(this.options);
         return new Promise(resolve => {
             this.fileActivitiesAPI.getActivities({
@@ -686,6 +695,7 @@ class Feed extends Base {
                 permissions,
                 successCallback: resolve,
                 activityTypes,
+                shouldShowReplies,
             });
         });
     }

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -520,13 +520,18 @@ class Feed extends Base {
         const versionsPromise = shouldShowVersions ? this.fetchVersions() : Promise.resolve();
         const currentVersionPromise = shouldShowVersions ? this.fetchCurrentVersion() : Promise.resolve();
 
-        const filteredActivityTypes = [];
-        if (shouldShowAnnotations && permissions[PERMISSION_CAN_VIEW_ANNOTATIONS]) {
-            filteredActivityTypes.push(FILE_ACTIVITY_TYPE_ANNOTATION);
-        }
-        if (shouldShowAppActivity) filteredActivityTypes.push(FILE_ACTIVITY_TYPE_APP_ACTIVITY);
-        filteredActivityTypes.push(FILE_ACTIVITY_TYPE_COMMENT);
-        if (shouldShowTasks) filteredActivityTypes.push(FILE_ACTIVITY_TYPE_TASK);
+        const annotationActivityType =
+            shouldShowAnnotations && permissions[PERMISSION_CAN_VIEW_ANNOTATIONS]
+                ? [FILE_ACTIVITY_TYPE_ANNOTATION]
+                : [];
+        const appActivityActivityType = shouldShowAppActivity ? [FILE_ACTIVITY_TYPE_APP_ACTIVITY] : [];
+        const taskActivityType = shouldShowTasks ? [FILE_ACTIVITY_TYPE_TASK] : [];
+        const filteredActivityTypes = [
+            ...annotationActivityType,
+            ...appActivityActivityType,
+            FILE_ACTIVITY_TYPE_COMMENT,
+            ...taskActivityType,
+        ];
 
         const fileActivitiesPromise = shouldUseUAA
             ? this.fetchFileActivities(permissions, filteredActivityTypes, shouldShowReplies)

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -686,7 +686,7 @@ class Feed extends Base {
     fetchFileActivities(
         permissions: BoxItemPermission,
         activityTypes: FileActivityTypes[],
-        shouldShowReplies: boolean,
+        shouldShowReplies?: boolean = false,
     ): Promise<Object> {
         this.fileActivitiesAPI = new FileActivitiesAPI(this.options);
         return new Promise(resolve => {

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -680,12 +680,13 @@ class Feed extends Base {
      *
      * @param {BoxItemPermission} permissions - the file permissions
      * @param {FileActivityTypes[]} activityTypes - the activity types to filter by
+     * @param {boolean} shouldShowReplies - specify if replies should be included in the response
      * @return {Promise} - the file comments
      */
     fetchFileActivities(
         permissions: BoxItemPermission,
         activityTypes: FileActivityTypes[],
-        shouldShowReplies,
+        shouldShowReplies: boolean,
     ): Promise<Object> {
         this.fileActivitiesAPI = new FileActivitiesAPI(this.options);
         return new Promise(resolve => {

--- a/src/api/FileActivities.js
+++ b/src/api/FileActivities.js
@@ -8,6 +8,7 @@ import Base from './Base';
 import {
     ERROR_CODE_FETCH_ACTIVITY,
     FILE_ACTIVITY_TYPE_ANNOTATION,
+    FILE_ACTIVITY_TYPE_COMMENT,
     PERMISSION_CAN_COMMENT,
     PERMISSION_CAN_VIEW_ANNOTATIONS,
 } from '../constants';
@@ -80,7 +81,9 @@ class FileActivities extends Base {
                 throw new Error('Missing file id!');
             }
 
-            this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileID);
+            if (activityTypes.includes(FILE_ACTIVITY_TYPE_COMMENT)) {
+                this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileID);
+            }
             if (activityTypes.includes(FILE_ACTIVITY_TYPE_ANNOTATION)) {
                 this.checkApiCallValidity(PERMISSION_CAN_VIEW_ANNOTATIONS, permissions, fileID);
             }

--- a/src/api/FileActivities.js
+++ b/src/api/FileActivities.js
@@ -5,7 +5,12 @@
  */
 
 import Base from './Base';
-import { PERMISSION_CAN_COMMENT, ERROR_CODE_FETCH_ACTIVITY } from '../constants';
+import {
+    ERROR_CODE_FETCH_ACTIVITY,
+    FILE_ACTIVITY_TYPE_ANNOTATION,
+    PERMISSION_CAN_COMMENT,
+    PERMISSION_CAN_VIEW_ANNOTATIONS,
+} from '../constants';
 import type { BoxItemPermission } from '../common/types/core';
 import type { ElementsXhrError } from '../common/types/api';
 import type { FileActivity, FileActivityTypes } from '../common/types/feed';
@@ -20,8 +25,7 @@ const getFileActivityQueryParams = (
 ) => {
     const baseEndpoint = `/file_activities?file_id=${fileID}`;
     const hasActivityTypes = !!activityTypes && !!activityTypes.length;
-    const enableReplies = shouldShowReplies ? 'true' : 'false';
-    const enabledRepliesQueryParam = `&enable_replies=${enableReplies}&reply_limit=${REPLY_LIMIT}`;
+    const enabledRepliesQueryParam = `&enable_replies=${shouldShowReplies}&reply_limit=${REPLY_LIMIT}`;
     const activityTypeQueryParam = hasActivityTypes ? `&activity_types=${activityTypes.join()}` : '';
 
     return `${baseEndpoint}${activityTypeQueryParam}${enabledRepliesQueryParam}`;
@@ -76,6 +80,9 @@ class FileActivities extends Base {
             }
 
             this.checkApiCallValidity(PERMISSION_CAN_COMMENT, permissions, fileID);
+            if (activityTypes.includes(FILE_ACTIVITY_TYPE_ANNOTATION)) {
+                this.checkApiCallValidity(PERMISSION_CAN_VIEW_ANNOTATIONS, permissions, fileID);
+            }
         } catch (e) {
             errorCallback(e, this.errorCode);
             return;

--- a/src/api/FileActivities.js
+++ b/src/api/FileActivities.js
@@ -33,6 +33,7 @@ class FileActivities extends Base {
      *
      * @param {string} [id] - a box file id
      * @param {Array<FileActivityTypes>} activityTypes - optional. Array of File Activity types to filter by, returns all Activity Types if omitted.
+     * @param {boolean} shouldShowReplies - optional. Specify if replies should be included in the response
      * @return {string} base url for files
      */
     getFilteredUrl(id: string, activityTypes?: FileActivityTypes[], shouldShowReplies?: boolean): string {
@@ -47,6 +48,7 @@ class FileActivities extends Base {
      * @param {string} fileId - the file id
      * @param {BoxItemPermission} permissions - the permissions for the file
      * @param {number} repliesCount - number of replies to return, by default all replies are returned
+     * @param {boolean} shouldShowReplies - specify if replies should be included in the response
      * @param {Function} successCallback - the success callback
      * @returns {void}
      */

--- a/src/api/FileActivities.js
+++ b/src/api/FileActivities.js
@@ -25,7 +25,8 @@ const getFileActivityQueryParams = (
 ) => {
     const baseEndpoint = `/file_activities?file_id=${fileID}`;
     const hasActivityTypes = !!activityTypes && !!activityTypes.length;
-    const enabledRepliesQueryParam = `&enable_replies=${shouldShowReplies}&reply_limit=${REPLY_LIMIT}`;
+    const enableReplies = shouldShowReplies ? 'true' : 'false';
+    const enabledRepliesQueryParam = `&enable_replies=${enableReplies}&reply_limit=${REPLY_LIMIT}`;
     const activityTypeQueryParam = hasActivityTypes ? `&activity_types=${activityTypes.join()}` : '';
 
     return `${baseEndpoint}${activityTypeQueryParam}${enabledRepliesQueryParam}`;

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -606,14 +606,24 @@ describe('api/Feed', () => {
         });
 
         test('should use the file activities api if shouldUseUAA is true', done => {
-            feed.feedItems(file, false, successCb, errorCb, errorCb, { shouldUseUAA: true });
+            feed.feedItems(file, false, successCb, errorCb, errorCb, {
+                shouldUseUAA: true,
+                shouldShowAnnotations: true,
+                shouldShowAppActivity: true,
+                shouldShowTasks: true,
+                shouldShowReplies: true,
+            });
             setImmediate(() => {
-                expect(feed.fetchFileActivities).toBeCalledWith(file.permissions, [
-                    FILE_ACTIVITY_TYPE_ANNOTATION,
-                    FILE_ACTIVITY_TYPE_APP_ACTIVITY,
-                    FILE_ACTIVITY_TYPE_COMMENT,
-                    FILE_ACTIVITY_TYPE_TASK,
-                ]);
+                expect(feed.fetchFileActivities).toBeCalledWith(
+                    file.permissions,
+                    [
+                        FILE_ACTIVITY_TYPE_ANNOTATION,
+                        FILE_ACTIVITY_TYPE_APP_ACTIVITY,
+                        FILE_ACTIVITY_TYPE_COMMENT,
+                        FILE_ACTIVITY_TYPE_TASK,
+                    ],
+                    true,
+                );
                 expect(feed.fetchComments).not.toBeCalled();
                 expect(feed.fetchThreadedComments).not.toBeCalled();
                 done();

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -852,7 +852,7 @@ describe('api/Feed', () => {
             });
 
             test('should return a promise and call the file activities api', () => {
-                const permissions = { can_edit: true, can_delete: true, can_resolve: true };
+                const permissions = { can_edit: true, can_delete: true, can_resolve: true, can_view_annotations: true };
                 const fileActivityItems = feed.fetchFileActivities(permissions, [
                     FILE_ACTIVITY_TYPE_ANNOTATION,
                     FILE_ACTIVITY_TYPE_APP_ACTIVITY,

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -870,6 +870,7 @@ describe('api/Feed', () => {
                     errorCallback: expect.any(Function),
                     fileID: feed.file.id,
                     permissions,
+                    shouldShowReplies: false,
                     successCallback: expect.any(Function),
                 });
                 expect(fileActivityItems).resolves.toEqual({ entries: mockFileActivities });

--- a/src/api/__tests__/FileActivities.test.js
+++ b/src/api/__tests__/FileActivities.test.js
@@ -74,11 +74,15 @@ describe('api/FileActivities', () => {
             });
         });
 
-        test('should reject with an error code for calls with can_comment as false', () => {
+        test.each([
+            { can_comment: true, can_view_annotations: false },
+            { can_comment: false, can_view_annotations: true },
+            { can_comment: false, can_view_annotations: false },
+        ])('should reject with an error code for calls with invalid permissions %s', permissions => {
             fileActivities.getActivities({
                 fileID: '123',
-                activityTypes: ['comment', 'task'],
-                permissions: [{ can_comment: false }],
+                activityTypes: ['annotation', 'comment', 'task'],
+                permissions,
                 successCallback,
                 errorCallback,
             });


### PR DESCRIPTION
This filters the call to file_activities depending on the parameters passed into the feed. Specifically for annotations, we previously threw an error if the specific file doesn't have the ability to add annotations. No call to file_activities would occur because of this. So now we just check if there's the proper permissions, if not, we filter annotations out.

![image](https://github.com/box/box-ui-elements/assets/11734293/3b795f72-2fbd-4bc7-8193-aed557552f26)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
