### PR TITLE
fix(content-picker): check share permission for default shared links

### DIFF
--- a/src/api/Folder.js
+++ b/src/api/Folder.js
@@ -208,7 +208,7 @@ class Folder extends Item {
     /**
      * Does the network request for fetching a folder
      *
-     * @param {Array<String>} fields Array of field strings
+     * @param {Array<string>|void} fields - Optionally include specific fields
      * @return {Promise}
      */
     folderRequest(

--- a/src/api/WebLink.js
+++ b/src/api/WebLink.js
@@ -8,7 +8,6 @@ import Item from './Item';
 import { CACHE_PREFIX_WEBLINK, ERROR_CODE_FETCH_WEBLINK } from '../constants';
 import { findMissingProperties } from '../utils/fields';
 import type { RequestOptions } from '../common/types/api';
-import type { BoxItem } from '../common/types/core';
 import type APICache from '../utils/Cache';
 
 class WebLink extends Item {
@@ -37,14 +36,14 @@ class WebLink extends Item {
      * Gets a Box weblink
      *
      * @param {string} id - Weblink id
-     * @param {(newItem: BoxItem) => void} successCallback - Function to call with results
+     * @param {Function} successCallback - Function to call with results
      * @param {Function} errorCallback - Function to call with errors
-     * @param {Array<String>} fields - Array of field strings
+     * @param {Array<string>|void} fields - Optionally include specific fields
      * @returns {Promise}
      */
     async getWeblink(
         id: string,
-        successCallback: (newItem: BoxItem) => void,
+        successCallback: Function,
         errorCallback: Function,
         { fields }: RequestOptions = {},
     ): Promise<void> {

--- a/src/constants.js
+++ b/src/constants.js
@@ -94,7 +94,6 @@ export const FIELD_PARENT = 'parent';
 export const FIELD_EXTENSION = 'extension';
 export const FIELD_ITEM_EXPIRATION = 'expires_at';
 export const FIELD_PERMISSIONS = 'permissions';
-export const FIELD_PERMISSIONS_CAN_SHARE = `${FIELD_PERMISSIONS}.can_share`;
 export const FIELD_PERMISSIONS_CAN_UPLOAD = `${FIELD_PERMISSIONS}.can_upload`;
 export const FIELD_ITEM_COLLECTION = 'item_collection';
 export const FIELD_PATH_COLLECTION = 'path_collection';

--- a/src/constants.js
+++ b/src/constants.js
@@ -94,6 +94,7 @@ export const FIELD_PARENT = 'parent';
 export const FIELD_EXTENSION = 'extension';
 export const FIELD_ITEM_EXPIRATION = 'expires_at';
 export const FIELD_PERMISSIONS = 'permissions';
+export const FIELD_PERMISSIONS_CAN_SHARE = `${FIELD_PERMISSIONS}.can_share`;
 export const FIELD_PERMISSIONS_CAN_UPLOAD = `${FIELD_PERMISSIONS}.can_upload`;
 export const FIELD_ITEM_COLLECTION = 'item_collection';
 export const FIELD_PATH_COLLECTION = 'path_collection';

--- a/src/elements/content-explorer/Content.js
+++ b/src/elements/content-explorer/Content.js
@@ -61,6 +61,7 @@ type Props = {
 
 const Content = ({
     currentCollection,
+    fieldsToShow = [],
     focusedRow,
     gridColumnCount = 1,
     isMedium,
@@ -68,7 +69,6 @@ const Content = ({
     tableRef,
     view,
     viewMode = VIEW_MODE_LIST,
-    fieldsToShow = [],
     ...rest
 }: Props) => {
     const isViewEmpty = isEmpty(view, currentCollection, fieldsToShow);

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -1282,6 +1282,7 @@ class ContentExplorer extends Component<Props, State> {
         if (!item[FIELD_SHARED_LINK] && getProp(item, FIELD_PERMISSIONS_CAN_SHARE, false)) {
             // create a shared link with default access, and update the collection
             const access = undefined;
+            // $FlowFixMe
             this.api.getAPI(item.type).share(item, access, (updatedItem: BoxItem) => {
                 this.updateCollection(currentCollection, updatedItem, () => this.setState({ isShareModalOpen: true }));
             });
@@ -1690,7 +1691,6 @@ class ContentExplorer extends Component<Props, State> {
                             canDownload={canDownload}
                             canPreview={canPreview}
                             canRename={canRename}
-                            canSetShareAccess={canSetShareAccess}
                             canShare={canShare}
                             currentCollection={currentCollection}
                             focusedRow={focusedRow}

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -43,6 +43,7 @@ import {
     DEFAULT_SEARCH_DEBOUNCE,
     SORT_ASC,
     FIELD_NAME,
+    FIELD_PERMISSIONS_CAN_SHARE,
     FIELD_SHARED_LINK,
     DEFAULT_ROOT,
     VIEW_SEARCH,
@@ -1275,20 +1276,19 @@ class ContentExplorer extends Component<Props, State> {
      * @param {Object} item file or folder
      * @returns {void}
      */
-    handleSharedLinkSuccess = (item: BoxItem) => {
+    handleSharedLinkSuccess = async (item: BoxItem) => {
         const { currentCollection } = this.state;
+        let updatedItem = item;
 
-        if (!item[FIELD_SHARED_LINK]) {
-            // create a shared link with default access, and update the collection
-            const access = undefined;
+        // if there is no shared link, create one with enterprise default access
+        if (!item[FIELD_SHARED_LINK] && getProp(item, FIELD_PERMISSIONS_CAN_SHARE, false)) {
             // $FlowFixMe
-            this.api.getAPI(item.type).share(item, access, (updatedItem: BoxItem) => {
-                this.updateCollection(currentCollection, updatedItem, () => this.setState({ isShareModalOpen: true }));
+            await this.api.getAPI(item.type).share(item, undefined, (sharedItem: BoxItem) => {
+                updatedItem = sharedItem;
             });
-        } else {
-            // update collection with existing shared link
-            this.updateCollection(currentCollection, item, () => this.setState({ isShareModalOpen: true }));
         }
+
+        this.updateCollection(currentCollection, updatedItem, () => this.setState({ isShareModalOpen: true }));
     };
 
     /**

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -43,6 +43,7 @@ import {
     DEFAULT_SEARCH_DEBOUNCE,
     SORT_ASC,
     FIELD_NAME,
+    FIELD_PERMISSIONS_CAN_SHARE,
     FIELD_SHARED_LINK,
     DEFAULT_ROOT,
     VIEW_SEARCH,
@@ -1278,7 +1279,7 @@ class ContentExplorer extends Component<Props, State> {
     handleSharedLinkSuccess = (item: BoxItem) => {
         const { currentCollection } = this.state;
 
-        if (item.type && !item[FIELD_SHARED_LINK]) {
+        if (!item[FIELD_SHARED_LINK] && getProp(item, FIELD_PERMISSIONS_CAN_SHARE, false)) {
             // create a shared link with default access, and update the collection
             const access = undefined;
             this.api.getAPI(item.type).share(item, access, (updatedItem: BoxItem) => {
@@ -1304,8 +1305,8 @@ class ContentExplorer extends Component<Props, State> {
             return;
         }
 
-        const { permissions } = selected;
-        if (!permissions) {
+        const { permissions, type } = selected;
+        if (!permissions || !type) {
             return;
         }
 

--- a/src/elements/content-explorer/ContentExplorer.js
+++ b/src/elements/content-explorer/ContentExplorer.js
@@ -43,7 +43,6 @@ import {
     DEFAULT_SEARCH_DEBOUNCE,
     SORT_ASC,
     FIELD_NAME,
-    FIELD_PERMISSIONS_CAN_SHARE,
     FIELD_SHARED_LINK,
     DEFAULT_ROOT,
     VIEW_SEARCH,
@@ -1279,7 +1278,7 @@ class ContentExplorer extends Component<Props, State> {
     handleSharedLinkSuccess = (item: BoxItem) => {
         const { currentCollection } = this.state;
 
-        if (!item[FIELD_SHARED_LINK] && getProp(item, FIELD_PERMISSIONS_CAN_SHARE, false)) {
+        if (!item[FIELD_SHARED_LINK]) {
             // create a shared link with default access, and update the collection
             const access = undefined;
             // $FlowFixMe

--- a/src/elements/content-explorer/PreviewDialog.js
+++ b/src/elements/content-explorer/PreviewDialog.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @file Content Explorer Preview dialog
+ * @file Content Explorer Preview Dialog
  * @author Box
  */
 

--- a/src/elements/content-explorer/ShareDialog.js
+++ b/src/elements/content-explorer/ShareDialog.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @file Content Explorer Delete Confirmation Dialog
+ * @file Content Explorer Share Dialog
  * @author Box
  */
 

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.js
@@ -589,16 +589,16 @@ describe('elements/content-explorer/ContentExplorer', () => {
             updateCollectionMock.mockClear();
         });
 
-        test('should create shared link if it does not exist', () => {
-            instance.handleSharedLinkSuccess({ ...boxItem, shared_link: null });
+        test('should create shared link if it does not exist', async () => {
+            await instance.handleSharedLinkSuccess({ ...boxItem, shared_link: null });
 
             expect(getApiMock).toBeCalledTimes(1);
             expect(getApiShareMock).toBeCalledTimes(1);
             expect(updateCollectionMock).toBeCalledTimes(1);
         });
 
-        test('should not create shared link if it already exists', () => {
-            instance.handleSharedLinkSuccess(boxItem);
+        test('should not create shared link if it already exists', async () => {
+            await instance.handleSharedLinkSuccess(boxItem);
 
             expect(getApiMock).not.toBeCalled();
             expect(getApiShareMock).not.toBeCalled();

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.js
@@ -566,15 +566,18 @@ describe('elements/content-explorer/ContentExplorer', () => {
 
         const boxItem = {
             shared_link: 'not null',
-            permissions: 'not null',
-            type: 'not null',
+            permissions: {
+                can_share: true,
+                can_set_share_access: false,
+            },
+            type: 'file',
         };
 
         let wrapper;
         let instance;
 
         beforeEach(() => {
-            wrapper = getWrapper({ canShare: true, canSetShareAccess: true });
+            wrapper = getWrapper();
             instance = wrapper.instance();
             instance.api = { getAPI: getApiMock };
             instance.updateCollection = updateCollectionMock;
@@ -586,7 +589,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
             updateCollectionMock.mockClear();
         });
 
-        test('should create shared link when it doesnt exist yet', () => {
+        test('should create shared link if it does not exist', () => {
             instance.handleSharedLinkSuccess({ ...boxItem, shared_link: null });
 
             expect(getApiMock).toBeCalledTimes(1);
@@ -594,7 +597,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
             expect(updateCollectionMock).toBeCalledTimes(1);
         });
 
-        test('should not create shared link when one already exists', () => {
+        test('should not create shared link if it already exists', () => {
             instance.handleSharedLinkSuccess(boxItem);
 
             expect(getApiMock).not.toBeCalled();

--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';
-import getProp from 'lodash/get';
 import uniqueid from 'lodash/uniqueId';
 import noop from 'lodash/noop';
 import Header from '../common/header';
@@ -37,7 +36,6 @@ import {
     ERROR_CODE_ITEM_NAME_INVALID,
     ERROR_CODE_ITEM_NAME_TOO_LONG,
     FIELD_NAME,
-    FIELD_PERMISSIONS_CAN_SHARE,
     FIELD_SHARED_LINK,
     SORT_ASC,
     TYPE_FILE,
@@ -938,7 +936,7 @@ class ContentPicker extends Component<Props, State> {
      */
     handleSharedLinkSuccess = (item: BoxItem) => {
         // if no shared link currently exists, create a shared link with enterprise default
-        if (!item[FIELD_SHARED_LINK] && getProp(item, FIELD_PERMISSIONS_CAN_SHARE, false)) {
+        if (!item[FIELD_SHARED_LINK]) {
             this.changeShareAccess(undefined, item);
         } else {
             const { selected } = this.state;
@@ -972,8 +970,8 @@ class ContentPicker extends Component<Props, State> {
             return;
         }
 
-        const { can_set_share_access }: BoxItemPermission = permissions;
-        if (access !== undefined && !can_set_share_access) {
+        const { can_share, can_set_share_access }: BoxItemPermission = permissions;
+        if (access === undefined ? !can_share : !can_set_share_access) {
             return;
         }
 

--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import type { Node } from 'react';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';
+import getProp from 'lodash/get';
 import uniqueid from 'lodash/uniqueId';
 import noop from 'lodash/noop';
 import Header from '../common/header';
@@ -36,6 +37,7 @@ import {
     ERROR_CODE_ITEM_NAME_INVALID,
     ERROR_CODE_ITEM_NAME_TOO_LONG,
     FIELD_NAME,
+    FIELD_PERMISSIONS_CAN_SHARE,
     FIELD_SHARED_LINK,
     SORT_ASC,
     TYPE_FILE,
@@ -936,7 +938,7 @@ class ContentPicker extends Component<Props, State> {
      */
     handleSharedLinkSuccess = (item: BoxItem) => {
         // if no shared link currently exists, create a shared link with enterprise default
-        if (!item[FIELD_SHARED_LINK]) {
+        if (!item[FIELD_SHARED_LINK] && getProp(item, FIELD_PERMISSIONS_CAN_SHARE, false)) {
             this.changeShareAccess(undefined, item);
         } else {
             const { selected } = this.state;

--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -952,8 +952,8 @@ class ContentPicker extends Component<Props, State> {
         }
 
         this.updateItemInCollection(updatedItem);
-        if (item.selected && item !== selected[cacheKey]) {
-            this.select(item, { forceSharedLink: false });
+        if (updatedItem.selected && updatedItem !== selected[cacheKey]) {
+            this.select(updatedItem, { forceSharedLink: false });
         }
     };
 

--- a/test/fixtures/content-picker/create-sharedlink.json
+++ b/test/fixtures/content-picker/create-sharedlink.json
@@ -19,7 +19,7 @@
         "can_comment": true,
         "can_rename": false,
         "can_delete": false,
-        "can_share": false,
+        "can_share": true,
         "can_set_share_access": true,
         "can_invite_collaborator": false,
         "can_annotate": false,


### PR DESCRIPTION
Check if the item has the `can_share` permission before trying to create a shared link with default access level. There's a bug for roles that do not have permission to generate shared links such as Previewer.