### PR TITLE
fix: update source paths for test pages

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -128,7 +128,7 @@ class Metadata extends File {
     /**
      * Returns the custom properties template
      *
-     * @return {Object} temaplte for custom properties
+     * @return {Object} template for custom properties
      */
     getCustomPropertiesTemplate(): MetadataTemplate {
         return {

--- a/test/explorer-no-react.html
+++ b/test/explorer-no-react.html
@@ -33,7 +33,7 @@
                 display: flex;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/explorer.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/explorer.css" />
     </head>
     <body>
         <div class="inputs">
@@ -62,7 +62,7 @@
         </div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.1/umd/react.development.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.1/umd/react-dom.development.js"></script>
-        <script src="../dist/dev/en-US/explorer.no.react.js"></script>
+        <script src="../dev/en-US/explorer.no.react.js"></script>
         <script>
             function load() {
                 const { ContentExplorer } = Box;

--- a/test/explorer-picker-uploader.html
+++ b/test/explorer-picker-uploader.html
@@ -32,9 +32,9 @@
                 display: flex;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/explorer.css" />
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/picker.css" />
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/uploader.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/explorer.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/picker.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/uploader.css" />
     </head>
     <body>
         <div class="inputs">
@@ -66,9 +66,9 @@
             <h1>Content Uploader</h1>
             <div class="uploader1"></div>
         </div>
-        <script src="../dist/dev/en-US/explorer.js"></script>
-        <script src="../dist/dev/en-US/picker.js"></script>
-        <script src="../dist/dev/en-US/uploader.js"></script>
+        <script src="../dev/en-US/explorer.js"></script>
+        <script src="../dev/en-US/picker.js"></script>
+        <script src="../dev/en-US/uploader.js"></script>
         <script>
             function load() {
                 const { ContentExplorer, FolderPicker, FilePicker, ContentUploader } = Box;

--- a/test/explorer.html
+++ b/test/explorer.html
@@ -46,7 +46,7 @@
                 vertical-align: middle;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/explorer.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/explorer.css" />
     </head>
     <body>
         <div class="inputs">
@@ -72,7 +72,7 @@
             <h1>Content Explorer (grid view)</h1>
             <div class="explorer4"></div>
         </div>
-        <script src="../dist/dev/en-US/explorer.js"></script>
+        <script src="../dev/en-US/explorer.js"></script>
         <script>
             function load() {
                 const { ContentExplorer } = Box;

--- a/test/openwith.html
+++ b/test/openwith.html
@@ -25,9 +25,9 @@
                 margin: 20px;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/openwith.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/openwith.css" />
         <script src="https://cdn.polyfill.io/v2/polyfill.js?features=es6,Intl"></script>
-        <script src="../dist/dev/en-US/openwith.js"></script>
+        <script src="../dev/en-US/openwith.js"></script>
     </head>
     <body>
         <div class="container">

--- a/test/pickers-no-react.html
+++ b/test/pickers-no-react.html
@@ -37,7 +37,7 @@
                 display: flex;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/picker.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/picker.css" />
     </head>
     <body>
         <div class="inputs">
@@ -78,7 +78,7 @@
         </div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.1/umd/react.development.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.1/umd/react-dom.development.js"></script>
-        <script src="../dist/dev/en-US/picker.no.react.js"></script>
+        <script src="../dev/en-US/picker.no.react.js"></script>
         <script>
             function load() {
                 const { FilePicker, FolderPicker } = Box;

--- a/test/pickers.html
+++ b/test/pickers.html
@@ -39,7 +39,7 @@
                 display: flex;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/picker.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/picker.css" />
     </head>
     <body>
         <div class="inputs">
@@ -82,7 +82,7 @@
             <h1>Folder Picker (max 3 items / token generator / no upload)</h1>
             <div class="folderPicker2"></div>
         </div>
-        <script src="../dist/dev/en-US/picker.js"></script>
+        <script src="../dev/en-US/picker.js"></script>
         <script>
             function load() {
                 const { FilePicker, FolderPicker, ContentPicker } = Box;

--- a/test/popups.html
+++ b/test/popups.html
@@ -48,8 +48,8 @@
                 background: red;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/picker.css" />
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/uploader.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/picker.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/uploader.css" />
     </head>
     <body>
         <div class="inputs">
@@ -100,8 +100,8 @@
             <h1>Folder Picker (max 3 items / token generator / no upload)</h1>
             <div class="folderPicker2"></div>
         </div>
-        <script src="../dist/dev/en-US/picker.js"></script>
-        <script src="../dist/dev/en-US/uploader.js"></script>
+        <script src="../dev/en-US/picker.js"></script>
+        <script src="../dev/en-US/uploader.js"></script>
         <script>
             function load() {
                 const { FilePicker, FolderPicker, ContentPicker, ContentUploader } = Box;

--- a/test/preview-react-with-sidebar.html
+++ b/test/preview-react-with-sidebar.html
@@ -29,8 +29,8 @@
                 width: 100%;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/preview.css" />
-        <script src="../dist/dev/en-US/preview.js"></script>
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/preview.css" />
+        <script src="../dev/en-US/preview.js"></script>
     </head>
     <body>
         <div class="inputs">

--- a/test/preview-react.html
+++ b/test/preview-react.html
@@ -30,8 +30,8 @@
                 width: 800px;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/preview.css" />
-        <script src="../dist/dev/en-US/preview.js"></script>
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/preview.css" />
+        <script src="../dev/en-US/preview.js"></script>
     </head>
     <body>
         <div class="inputs">

--- a/test/preview.html
+++ b/test/preview.html
@@ -33,8 +33,8 @@
                 flex-grow: 1;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/explorer.css" />
-        <script src="../dist/dev/en-US/explorer.js"></script>
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/explorer.css" />
+        <script src="../dev/en-US/explorer.js"></script>
     </head>
 
     <body>

--- a/test/pseudo.html
+++ b/test/pseudo.html
@@ -28,9 +28,9 @@
                 display: flex;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-x-pseudo/explorer.css" />
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-x-pseudo/picker.css" />
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-x-pseudo/uploader.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-x-pseudo/explorer.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-x-pseudo/picker.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-x-pseudo/uploader.css" />
     </head>
     <body>
         <div class="inputs">

--- a/test/sharing-no-react.html
+++ b/test/sharing-no-react.html
@@ -17,12 +17,12 @@
             }
         </style>
 
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/sharing.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/sharing.css" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.1/umd/react.development.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.1/umd/react-dom.development.js"></script>
     </head>
     <body>
-        <script src="../dist/dev/en-US/sharing.no.react.js"></script>
+        <script src="../dev/en-US/sharing.no.react.js"></script>
 
         <div>
             <form class="inputs">

--- a/test/sharing.html
+++ b/test/sharing.html
@@ -17,10 +17,10 @@
             }
         </style>
 
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/sharing.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/sharing.css" />
     </head>
     <body>
-        <script src="../dist/dev/en-US/sharing.js"></script>
+        <script src="../dev/en-US/sharing.js"></script>
 
         <div>
             <form class="inputs">

--- a/test/sidebar-additional-tabs.html
+++ b/test/sidebar-additional-tabs.html
@@ -29,9 +29,9 @@
                 margin-bottom: 10px;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/sidebar.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/sidebar.css" />
         <script src="https://unpkg.com/react/umd/react.development.js"></script>
-        <script src="../dist/dev/en-US/sidebar.js"></script>
+        <script src="../dev/en-US/sidebar.js"></script>
     </head>
     <body>
         <div class="sidebar">

--- a/test/sidebar.html
+++ b/test/sidebar.html
@@ -51,8 +51,8 @@
                 <button type="button" onclick="load(true)">Submit</button>
             </div>
         </div>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/sidebar.css" />
-        <script src="../dist/dev/en-US/sidebar.js"></script>
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/sidebar.css" />
+        <script src="../dev/en-US/sidebar.js"></script>
     </head>
 
     <body>

--- a/test/uploader-no-react.html
+++ b/test/uploader-no-react.html
@@ -34,7 +34,7 @@
                 display: flex;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/uploader.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/uploader.css" />
     </head>
 
     <body>
@@ -57,7 +57,7 @@
         </div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.1/umd/react.development.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.1/umd/react-dom.development.js"></script>
-        <script src="../dist/dev/en-US/uploader.no.react.js"></script>
+        <script src="../dev/en-US/uploader.no.react.js"></script>
         <script>
             // Set token and folder ID to locally stored values if available
             (function() {

--- a/test/uploader-window-view.html
+++ b/test/uploader-window-view.html
@@ -41,7 +41,7 @@
                 width: 100%;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/uploader.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/uploader.css" />
     </head>
 
     <body>
@@ -69,7 +69,7 @@
             <div class="drop-zone"><h2>Drop Files/Folders Here</h2></div>
             <div class="uploader1"></div>
         </div>
-        <script src="../dist/dev/en-US/uploader.js"></script>
+        <script src="../dev/en-US/uploader.js"></script>
         <script>
             let resetTimeout;
             // Set token and folder ID to locally stored values if available

--- a/test/uploader.html
+++ b/test/uploader.html
@@ -31,7 +31,7 @@
                 display: flex;
             }
         </style>
-        <link rel="stylesheet" type="text/css" href="../dist/dev/en-US/uploader.css" />
+        <link rel="stylesheet" type="text/css" href="../dev/en-US/uploader.css" />
     </head>
 
     <body>
@@ -56,7 +56,7 @@
             </div>
             <div class="uploader1"></div>
         </div>
-        <script src="../dist/dev/en-US/uploader.js"></script>
+        <script src="../dev/en-US/uploader.js"></script>
         <script>
             // Set token and folder ID to locally stored values if available
             (function() {


### PR DESCRIPTION
I made a mistake by adding `dist` to the relative paths for the test pages in this PR: https://github.com/box/box-ui-elements/pull/3350

These files are intended to be tested with the `yarn start:dev` command and adding `dist` to the paths will cause issues because the sources will not be found.

<sup>i.e. everything breaks :(</sup>