### PR TITLE
fix(accessibility): skip uploadsManager in voiceover if not visible

### DIFF
--- a/src/elements/content-uploader/UploadsManager.scss
+++ b/src/elements/content-uploader/UploadsManager.scss
@@ -6,6 +6,7 @@
     width: 100%;
     max-height: 0;
     transition: max-height .5s;
+    display: none;
 
     .bcu-progress-container {
         margin-right: 0;
@@ -23,6 +24,7 @@
 
     &.bcu-is-visible {
         max-height: 60px;
+        display: initial;
     }
 
     .bcu-uploads-manager-item-list {

--- a/src/elements/content-uploader/UploadsManager.scss
+++ b/src/elements/content-uploader/UploadsManager.scss
@@ -3,10 +3,10 @@
 .be.bcu-uploads-manager-container {
     position: fixed;
     bottom: 0;
+    display: none;
     width: 100%;
     max-height: 0;
     transition: max-height .5s;
-    display: none;
 
     .bcu-progress-container {
         margin-right: 0;
@@ -23,8 +23,8 @@
     }
 
     &.bcu-is-visible {
-        max-height: 60px;
         display: initial;
+        max-height: 60px;
     }
 
     .bcu-uploads-manager-item-list {


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

Without this change voiceover is detecting uploadManager even if it is not visible on the screen.