### PR TITLE
fix(modal-dialog): add aria-modal to ModalDialog

### DIFF
--- a/src/components/modal/ModalDialog.js
+++ b/src/components/modal/ModalDialog.js
@@ -143,6 +143,7 @@ class ModalDialog extends React.Component<Props> {
         const divProps = omit(rest, ['children', 'closeButtonProps', 'onRequestClose', 'intl']);
 
         divProps.role = isAlertType ? 'alertdialog' : 'dialog';
+        divProps['aria-modal'] = true;
         divProps['aria-labelledby'] = `${this.modalID}-label`;
         if (isAlertType) {
             divProps['aria-describedby'] = `${this.modalID}-desc`;

--- a/src/components/modal/__tests__/ModalDialog.test.js
+++ b/src/components/modal/__tests__/ModalDialog.test.js
@@ -37,6 +37,7 @@ describe('components/modal/ModalDialog', () => {
 
     test('should set aria props on modal dialog when rendered', () => {
         expect(wrapper.prop('role')).toEqual('dialog');
+        expect(wrapper.prop('aria-modal')).toEqual(true);
         expect(wrapper.prop('aria-labelledby')).toEqual(`${instance.modalID}-label`);
     });
 


### PR DESCRIPTION
It's possible to escape a modal with Accessibility Tools and a screen reader by using Control + Option + Arrow Keys.

This PR adds `aria-modal="true"` prop to ModalDialog div.