### PR TITLE
fix: hide uploads manager progress bar for screen-readers if not visible

### DIFF
--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -88,13 +88,13 @@ const OverallUploadsProgressBar = ({
 
     return (
         <div
+            aria-hidden={!isVisible}
             className="bcu-overall-progress-bar"
             data-resin-target={isExpanded ? 'uploadcollapse' : 'uploadexpand'}
             onClick={onClick}
             onKeyDown={onKeyDown}
             role="button"
             tabIndex={isVisible ? '0' : '-1'}
-            aria-hidden={!isVisible}
         >
             <span className="bcu-upload-status">{status}</span>
             <ProgressBar percent={updatedPercent} />

--- a/src/elements/content-uploader/OverallUploadsProgressBar.js
+++ b/src/elements/content-uploader/OverallUploadsProgressBar.js
@@ -94,6 +94,7 @@ const OverallUploadsProgressBar = ({
             onKeyDown={onKeyDown}
             role="button"
             tabIndex={isVisible ? '0' : '-1'}
+            aria-hidden={!isVisible}
         >
             <span className="bcu-upload-status">{status}</span>
             <ProgressBar percent={updatedPercent} />

--- a/src/elements/content-uploader/__tests__/OverallUploadsProgressBar.test.js
+++ b/src/elements/content-uploader/__tests__/OverallUploadsProgressBar.test.js
@@ -92,4 +92,12 @@ describe('elements/content-uploader/OverallUploadsProgressBar', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should be invisible for assistive technologies when hidden', () => {
+        const wrapper = getWrapper({
+            isVisible: false,
+        });
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/src/elements/content-uploader/__tests__/OverallUploadsProgressBar.test.js
+++ b/src/elements/content-uploader/__tests__/OverallUploadsProgressBar.test.js
@@ -100,4 +100,12 @@ describe('elements/content-uploader/OverallUploadsProgressBar', () => {
 
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('should be visible for assistive technologies when displayed', () => {
+        const wrapper = getWrapper({
+            isVisible: true,
+        });
+
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/src/elements/content-uploader/__tests__/__snapshots__/OverallUploadsProgressBar.test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/OverallUploadsProgressBar.test.js.snap
@@ -1,7 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`elements/content-uploader/OverallUploadsProgressBar should be invisible for assistive technologies when hidden 1`] = `
+<div
+  aria-hidden={true}
+  className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  role="button"
+  tabIndex="-1"
+>
+  <span
+    className="bcu-upload-status"
+  >
+    <FormattedMessage
+      defaultMessage="Drop files on this page to upload them into this folder."
+      id="be.uploadsManagerUploadPrompt"
+    />
+  </span>
+  <ProgressBar
+    percent={0}
+  />
+  <span
+    className="bcu-uploads-manager-toggle"
+  />
+</div>
+`;
+
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isDragging is true 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -28,6 +56,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isResumeVisible is false 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -54,6 +83,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isResumeVisible is true and hasMultipleFailedUploads is false 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -83,6 +113,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isResumeVisible is true and hasMultipleFailedUploads is true 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -112,6 +143,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isVisible is false 1`] = `
 <div
+  aria-hidden={true}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -138,6 +170,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_ERROR 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -164,6 +197,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_UPLOAD_EMPTY 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -190,6 +224,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_UPLOAD_IN_PROGRESS 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}
@@ -216,6 +251,7 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should render corre
 
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when view is VIEW_UPLOAD_SUCCESS 1`] = `
 <div
+  aria-hidden={false}
   className="bcu-overall-progress-bar"
   data-resin-target="uploadcollapse"
   onClick={[Function]}

--- a/src/elements/content-uploader/__tests__/__snapshots__/OverallUploadsProgressBar.test.js.snap
+++ b/src/elements/content-uploader/__tests__/__snapshots__/OverallUploadsProgressBar.test.js.snap
@@ -27,6 +27,33 @@ exports[`elements/content-uploader/OverallUploadsProgressBar should be invisible
 </div>
 `;
 
+exports[`elements/content-uploader/OverallUploadsProgressBar should be visible for assistive technologies when displayed 1`] = `
+<div
+  aria-hidden={false}
+  className="bcu-overall-progress-bar"
+  data-resin-target="uploadcollapse"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  <span
+    className="bcu-upload-status"
+  >
+    <FormattedMessage
+      defaultMessage="Drop files on this page to upload them into this folder."
+      id="be.uploadsManagerUploadPrompt"
+    />
+  </span>
+  <ProgressBar
+    percent={0}
+  />
+  <span
+    className="bcu-uploads-manager-toggle"
+  />
+</div>
+`;
+
 exports[`elements/content-uploader/OverallUploadsProgressBar should render correctly when isDragging is true 1`] = `
 <div
   aria-hidden={false}


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
This PR fixes the issue of `OverallUploadsProgressBar` being accessible for screen readers when it's visually hidden