### PR TITLE
fix(modify-reply): Map object to params

### DIFF
--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import noop from 'lodash/noop';
 import Comment from '../comment';
 import LoadingIndicator from '../../../../components/loading-indicator';
 import { BaseComment } from '../comment/BaseComment';
@@ -65,7 +66,7 @@ const ActivityThreadReplies = ({
                     getUserProfileUrl={getUserProfileUrl}
                     mentionSelectorContacts={mentionSelectorContacts}
                     onDelete={onDelete}
-                    onCommentEdit={handleOnEdit}
+                    onCommentEdit={onEdit ? handleOnEdit : noop}
                     onSelect={onSelect}
                     permissions={getReplyPermissions(reply)}
                     translations={translations}
@@ -83,7 +84,7 @@ const ActivityThreadReplies = ({
                 getUserProfileUrl={getUserProfileUrl}
                 mentionSelectorContacts={mentionSelectorContacts}
                 onDelete={onDelete}
-                onEdit={handleOnEdit}
+                onEdit={onEdit ? handleOnEdit : noop}
                 onSelect={onSelect}
                 permissions={getReplyPermissions(reply)}
                 translations={translations}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import noop from 'lodash/noop';
 import Comment from '../comment';
 import LoadingIndicator from '../../../../components/loading-indicator';
 import { BaseComment } from '../comment/BaseComment';
@@ -51,7 +50,9 @@ const ActivityThreadReplies = ({
     };
 
     const handleOnEdit = ({ hasMention, id, onError, onSuccess, permissions, status, text }): void => {
-        onEdit(id, text, status, hasMention, permissions, onSuccess, onError);
+        if (onEdit) {
+            onEdit(id, text, status, hasMention, permissions, onSuccess, onError);
+        }
     };
 
     const renderComment = (reply: CommentType) => {
@@ -66,7 +67,7 @@ const ActivityThreadReplies = ({
                     getUserProfileUrl={getUserProfileUrl}
                     mentionSelectorContacts={mentionSelectorContacts}
                     onDelete={onDelete}
-                    onCommentEdit={onEdit ? handleOnEdit : noop}
+                    onCommentEdit={handleOnEdit}
                     onSelect={onSelect}
                     permissions={getReplyPermissions(reply)}
                     translations={translations}
@@ -84,7 +85,7 @@ const ActivityThreadReplies = ({
                 getUserProfileUrl={getUserProfileUrl}
                 mentionSelectorContacts={mentionSelectorContacts}
                 onDelete={onDelete}
-                onEdit={onEdit ? handleOnEdit : noop}
+                onEdit={handleOnEdit}
                 onSelect={onSelect}
                 permissions={getReplyPermissions(reply)}
                 translations={translations}

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityThreadReplies.js
@@ -49,6 +49,10 @@ const ActivityThreadReplies = ({
         };
     };
 
+    const handleOnEdit = ({ hasMention, id, onError, onSuccess, permissions, status, text }): void => {
+        onEdit(id, text, status, hasMention, permissions, onSuccess, onError);
+    };
+
     const renderComment = (reply: CommentType) => {
         if (hasNewThreadedReplies) {
             return (
@@ -61,7 +65,7 @@ const ActivityThreadReplies = ({
                     getUserProfileUrl={getUserProfileUrl}
                     mentionSelectorContacts={mentionSelectorContacts}
                     onDelete={onDelete}
-                    onCommentEdit={onEdit}
+                    onCommentEdit={handleOnEdit}
                     onSelect={onSelect}
                     permissions={getReplyPermissions(reply)}
                     translations={translations}
@@ -79,7 +83,7 @@ const ActivityThreadReplies = ({
                 getUserProfileUrl={getUserProfileUrl}
                 mentionSelectorContacts={mentionSelectorContacts}
                 onDelete={onDelete}
-                onEdit={onEdit}
+                onEdit={handleOnEdit}
                 onSelect={onSelect}
                 permissions={getReplyPermissions(reply)}
                 translations={translations}


### PR DESCRIPTION
* Fix bug with modifying a reply to a comment by mapping the single param to the multiple params used in props above

Notes
* See below for help tracing props
* `Comment.js and BaseComment.js` <- `ActivityThreadReplies.js` <- `ActivityThread.js`
* The props is continued to passed but ActivityThread shows the definition for the onEdit function params expected in components above it.

Issue
* The issue was introduced in this commit: https://github.com/box/box-ui-elements/commit/4f65525e0b502b809332717e537ca075f7a40321
* Before: https://cloud.box.com/s/pmgbtcg04fqjnvf38yok5dmk3wp3z6b2
* After: https://cloud.box.com/s/bwakotinhvlveplrosnpztpjzdz74ju1

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
