### PR TITLE
fix(flyout): set default role for Flyout to 'dialog'

### DIFF
--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -54,6 +54,13 @@ const positions = {
 };
 
 /**
+ * The set of container's aria-haspopup attribute values which are compatible with popup's role attribute according to MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup
+ */
+const ARIA_HASPOPUP_COMPATIBLE_ROLES = ['menu', 'listbox', 'tree', 'grid', 'dialog'];
+
+const getAriaHaspopupFromRole = (role: string) => (ARIA_HASPOPUP_COMPATIBLE_ROLES.includes(role) ? role : 'false');
+
+/**
  * Checks if there is a clickable ancestor or self
  * @param {Node} rootNode The base node we should stop at
  * @param {Node} targetNode The target node of the event
@@ -151,6 +158,10 @@ export type FlyoutProps = {
      * Time in milliseconds that the button should wait before opening and closing the flyout
      */
     openOnHoverDelayTimeout?: number,
+    /**
+     * Set custom 'role' for overlay and 'aria-haspopup' for overlay button. 'dialog' by default
+     */
+    overlayRole?: string,
     /** An array of CSS classes for portaled elements in the overlay, used to check whether a click is inside the overlay */
     portaledClasses: Array<string>,
     /**
@@ -394,6 +405,7 @@ class Flyout extends React.Component<Props, State> {
 
         const overlayButton = elements[0];
         const overlayContent = elements[1];
+        const overlayRole = this.props.overlayRole || 'dialog';
 
         const overlayButtonProps: Object = {
             id: this.overlayButtonID,
@@ -404,7 +416,7 @@ class Flyout extends React.Component<Props, State> {
             onMouseLeave: this.handleButtonHoverLeave,
             role: 'button',
             tabIndex: '0',
-            'aria-haspopup': 'true',
+            'aria-haspopup': getAriaHaspopupFromRole(overlayRole),
             'aria-expanded': isVisible ? 'true' : 'false',
         };
 
@@ -415,7 +427,7 @@ class Flyout extends React.Component<Props, State> {
         const overlayProps = {
             id: this.overlayID,
             key: this.overlayID,
-            role: 'dialog',
+            role: overlayRole,
             onClick: this.handleOverlayClick,
             onClose: this.handleOverlayClose,
             onMouseEnter: this.handleButtonHover,

--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -53,12 +53,7 @@ const positions = {
     },
 };
 
-/**
- * The set of container's aria-haspopup attribute values which are compatible with popup's role attribute according to MDN: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup
- */
-const ARIA_HASPOPUP_COMPATIBLE_ROLES = ['menu', 'listbox', 'tree', 'grid', 'dialog'];
-
-const getAriaHaspopupFromRole = (role: string) => (ARIA_HASPOPUP_COMPATIBLE_ROLES.includes(role) ? role : 'false');
+const OVERLAY_ROLE = 'dialog';
 
 /**
  * Checks if there is a clickable ancestor or self
@@ -158,10 +153,6 @@ export type FlyoutProps = {
      * Time in milliseconds that the button should wait before opening and closing the flyout
      */
     openOnHoverDelayTimeout?: number,
-    /**
-     * Set custom 'role' for overlay and 'aria-haspopup' for overlay button. 'dialog' by default
-     */
-    overlayRole?: string,
     /** An array of CSS classes for portaled elements in the overlay, used to check whether a click is inside the overlay */
     portaledClasses: Array<string>,
     /**
@@ -405,7 +396,6 @@ class Flyout extends React.Component<Props, State> {
 
         const overlayButton = elements[0];
         const overlayContent = elements[1];
-        const overlayRole = this.props.overlayRole || 'dialog';
 
         const overlayButtonProps: Object = {
             id: this.overlayButtonID,
@@ -416,7 +406,7 @@ class Flyout extends React.Component<Props, State> {
             onMouseLeave: this.handleButtonHoverLeave,
             role: 'button',
             tabIndex: '0',
-            'aria-haspopup': getAriaHaspopupFromRole(overlayRole),
+            'aria-haspopup': OVERLAY_ROLE,
             'aria-expanded': isVisible ? 'true' : 'false',
         };
 
@@ -427,7 +417,7 @@ class Flyout extends React.Component<Props, State> {
         const overlayProps = {
             id: this.overlayID,
             key: this.overlayID,
-            role: overlayRole,
+            role: OVERLAY_ROLE,
             onClick: this.handleOverlayClick,
             onClose: this.handleOverlayClose,
             onMouseEnter: this.handleButtonHover,

--- a/src/components/flyout/__tests__/Flyout.test.js
+++ b/src/components/flyout/__tests__/Flyout.test.js
@@ -24,12 +24,7 @@ describe('components/flyout/Flyout', () => {
     );
     FakeButton.displayName = 'FakeButton';
     /* eslint-disable */
-    const FakeOverlay = ({
-        onClick = () => {},
-        onClose = () => {},
-        shouldDefaultFocus = false,
-        ...rest
-    }) => (
+    const FakeOverlay = ({ onClick = () => {}, onClose = () => {}, shouldDefaultFocus = false, ...rest }) => (
         <div {...rest} className="overlay-wrapper is-visible">
             <div className="overlay">
                 <input type="text" />
@@ -82,7 +77,7 @@ describe('components/flyout/Flyout', () => {
 
             expect(button.prop('id')).toEqual(instance.overlayButtonID);
             expect(button.key()).toEqual(instance.overlayButtonID);
-            expect(button.prop('aria-haspopup')).toEqual('true');
+            expect(button.prop('aria-haspopup')).toEqual('dialog');
             expect(button.prop('aria-expanded')).toEqual('false');
             expect(button.prop('aria-controls')).toBeFalsy();
         });
@@ -290,6 +285,37 @@ describe('components/flyout/Flyout', () => {
                 );
                 expect(wrapper.prop('offset')).toEqual(offset);
             });
+        });
+
+        ['menu', 'listbox', 'tree', 'grid', 'dialog'].forEach(role => {
+            test('should match overlay "role" with button "aria-haspopup" if compatible', () => {
+                const wrapper = mount(
+                    <Flyout overlayRole={role}>
+                        <FakeButton />
+                        <FakeOverlay />
+                    </Flyout>,
+                );
+
+                wrapper.setState({
+                    isVisible: true,
+                });
+                expect(wrapper.find(FakeOverlay).prop('role')).toEqual(wrapper.find(FakeButton).prop('aria-haspopup'));
+            });
+        });
+
+        test('should set "aria-haspopup" to "false" if "role" is not compatible', () => {
+            const wrapper = mount(
+                <Flyout overlayRole="tab">
+                    <FakeButton />
+                    <FakeOverlay />
+                </Flyout>,
+            );
+
+            wrapper.setState({
+                isVisible: true,
+            });
+            expect(wrapper.find(FakeOverlay).prop('role')).toEqual('tab');
+            expect(wrapper.find(FakeButton).prop('aria-haspopup')).toEqual('false');
         });
     });
 

--- a/src/components/flyout/__tests__/Flyout.test.js
+++ b/src/components/flyout/__tests__/Flyout.test.js
@@ -286,37 +286,6 @@ describe('components/flyout/Flyout', () => {
                 expect(wrapper.prop('offset')).toEqual(offset);
             });
         });
-
-        ['menu', 'listbox', 'tree', 'grid', 'dialog'].forEach(role => {
-            test('should match overlay "role" with button "aria-haspopup" if compatible', () => {
-                const wrapper = mount(
-                    <Flyout overlayRole={role}>
-                        <FakeButton />
-                        <FakeOverlay />
-                    </Flyout>,
-                );
-
-                wrapper.setState({
-                    isVisible: true,
-                });
-                expect(wrapper.find(FakeOverlay).prop('role')).toEqual(wrapper.find(FakeButton).prop('aria-haspopup'));
-            });
-        });
-
-        test('should set "aria-haspopup" to "false" if "role" is not compatible', () => {
-            const wrapper = mount(
-                <Flyout overlayRole="tab">
-                    <FakeButton />
-                    <FakeOverlay />
-                </Flyout>,
-            );
-
-            wrapper.setState({
-                isVisible: true,
-            });
-            expect(wrapper.find(FakeOverlay).prop('role')).toEqual('tab');
-            expect(wrapper.find(FakeButton).prop('aria-haspopup')).toEqual('false');
-        });
     });
 
     describe('handleOverlayClick()', () => {


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
~This PR extends `Flyout` component with `overlayRole` prop in order to pass a custom role for popup content. It includes updates for both overlay `role` attribute as well as `aria-haspopup` attribute for button container.~
This PR fixes `Flyout` container component attribute `aria-haspopup` to `dialog` to match the role of the overlay component.