### PR TITLE
fix: remove core-js from examples wrapper

### DIFF
--- a/examples/Wrapper.js
+++ b/examples/Wrapper.js
@@ -2,7 +2,6 @@
 /**
  * Wrapper component for styleguidist examples
  */
-import 'core-js'; // For IE11
 import * as React from 'react';
 import { IntlProvider } from 'react-intl';
 


### PR DESCRIPTION
I need a quick change to re-run the release pipeline.

This is removing a `core-js` import which says is used for IE11. I can't figure out where `Wrapper.js` is actually being used. I don't see references in `/examples/src` or in any of the elements. but I tested styleguidist in Chrome, Firefox, and Safari and everything seemed to work 🤷 