### PR TITLE
feat(uaa-integration): Handle no comment permission

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -41,6 +41,7 @@ import {
     HTTP_STATUS_CODE_CONFLICT,
     IS_ERROR_DISPLAYED,
     PERMISSION_CAN_VIEW_ANNOTATIONS,
+    PERMISSION_CAN_COMMENT,
     TASK_NEW_APPROVED,
     TASK_NEW_COMPLETED,
     TASK_NEW_REJECTED,
@@ -595,17 +596,20 @@ class Feed extends Base {
         const appActivityActivityType = shouldShowAppActivity ? [FILE_ACTIVITY_TYPE_APP_ACTIVITY] : [];
         const taskActivityType = shouldShowTasks ? [FILE_ACTIVITY_TYPE_TASK] : [];
         const versionsActivityType = shouldShowVersions ? [FILE_ACTIVITY_TYPE_VERSION] : [];
+        const commentActivityType = permissions[PERMISSION_CAN_COMMENT] ? [FILE_ACTIVITY_TYPE_COMMENT] : [];
         const filteredActivityTypes = [
             ...annotationActivityType,
             ...appActivityActivityType,
-            FILE_ACTIVITY_TYPE_COMMENT,
+            ...commentActivityType,
             ...taskActivityType,
             ...versionsActivityType,
         ];
 
-        const fileActivitiesPromise = shouldUseUAA
-            ? this.fetchFileActivities(permissions, filteredActivityTypes, shouldShowReplies)
-            : Promise.resolve();
+        const fileActivitiesPromise =
+            // Only fetch when activity types are explicitly stated
+            shouldUseUAA && filteredActivityTypes.length
+                ? this.fetchFileActivities(permissions, filteredActivityTypes, shouldShowReplies)
+                : Promise.resolve();
 
         const handleFeedItems = (feedItems: FeedItems) => {
             if (!this.isDestroyed()) {


### PR DESCRIPTION
When comment permission is false, we don't want to block the file_activities call, so we exclude `comments` from the parameters.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
