### PR TITLE
fix(preview): Change focus indicator for actions in version panel

### DIFF
--- a/src/elements/content-sidebar/versions/VersionsItem.scss
+++ b/src/elements/content-sidebar/versions/VersionsItem.scss
@@ -1,4 +1,5 @@
 @import '../../common/variables';
+@import '../../../styles/constants/buttons';
 
 .bcs-VersionsItem {
     $bcs-VersionsItemButton-horizontal: 10px;
@@ -24,7 +25,7 @@
 
         &:focus {
             border: $bdl-btn-border-width solid $primary-color;
-            box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);
+            box-shadow: $bdl-btn-primary-box-shadow;
         }
     }
 }

--- a/src/elements/content-sidebar/versions/VersionsItem.scss
+++ b/src/elements/content-sidebar/versions/VersionsItem.scss
@@ -22,11 +22,9 @@
         top: $bcs-VersionsItemButton-vertical;
         right: $bcs-VersionsItemButton-horizontal;
 
-        &:not(.is-disabled) {
-            &:focus {
-                border: $bdl-btn-border-width solid $primary-color;
-                box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);
-            }
+        &:focus {
+            border: $bdl-btn-border-width solid $primary-color;
+            box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);
         }
     }
 }

--- a/src/elements/content-sidebar/versions/VersionsItem.scss
+++ b/src/elements/content-sidebar/versions/VersionsItem.scss
@@ -21,6 +21,13 @@
         position: absolute;
         top: $bcs-VersionsItemButton-vertical;
         right: $bcs-VersionsItemButton-horizontal;
+
+        &:not(.is-disabled) {
+            &:focus {
+                border: $bdl-btn-border-width solid $primary-color;
+                box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);
+            }
+        }
     }
 }
 

--- a/src/styles/common/_buttons.scss
+++ b/src/styles/common/_buttons.scss
@@ -176,7 +176,7 @@ button svg {
         &:focus {
             background-color: lighten($primary-color, 8%);
             border: $bdl-btn-border-width solid $primary-color;
-            box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);
+            box-shadow: $bdl-btn-primary-box-shadow;
         }
 
         &:hover {

--- a/src/styles/constants/_buttons.scss
+++ b/src/styles/constants/_buttons.scss
@@ -4,3 +4,4 @@ $bdl-btn-height-large: 40px;
 $bdl-btn-icon-size: 20px;
 $bdl-btn-text-icon-size: 16px;
 $bdl-btn-padding-horizontal: $bdl-grid-unit * 4;
+$bdl-btn-primary-box-shadow: inset 0 0 0 1px fade-out($white, .2), 0 1px 2px fade-out($black, .9);


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

Change focus indicator of actions button in version panel because the original one is difficult to be seen
Before:
![image](https://github.com/box/box-ui-elements/assets/141409011/334bd5e8-2c3a-4e8a-ba20-440796ee0c19)
After:
![image](https://github.com/box/box-ui-elements/assets/141409011/3ad6f1af-b6e5-4b17-a9c8-940e19d3a3bb)

