### PR TITLE
feat(content-answers): add contentAnswers Modal header and footer

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -902,10 +902,18 @@ boxui.collaboratorAvatars.viewAdditionalPeopleText = View additional people
 boxui.collapsiblesidebar.collapseBtnLabel = Collapse
 # Aria label for toggle button that expands/collapses sidebar (collapsed state)
 boxui.collapsiblesidebar.expandBtnLabel = Expand
+# Content Answers submit input button text
+boxui.contentAnswers.ask = Ask
+# Content Answers submit input button disabled tooltip text when answer is generating
+boxui.contentAnswers.askDisabledTooltip = You can submit another question once Box AI has finished responding
+# Content Answers modal input placeholder
+boxui.contentAnswers.askQuestionPlaceholder = Ask anything about this document
 # Content Answers feature name shown on menu item and modal title
 boxui.contentAnswers.contentAnswersTitle = Box AI
 # Default tooltip message for Content Answers entry point button
 boxui.contentAnswers.defaultTooltip = Get instant answers about this document using Box AI
+# Error tooltip to show inside text area if the user reached the character limit
+boxui.contentAnswers.maxCharactersReachedError = Maximum of {characterLimit} characters reached
 # Aria label for the folder breadcrumb
 boxui.contentExplorer.breadcrumb = Breadcrumb
 # Text shown on button used to close the content explorer

--- a/src/features/content-answers/ContentAnswers.tsx
+++ b/src/features/content-answers/ContentAnswers.tsx
@@ -11,7 +11,7 @@ const ContentAnswers = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     const handleClick = () => {
-        setIsModalOpen(prevState => !prevState);
+        setIsModalOpen(true);
     };
 
     const handleClose = () => {
@@ -19,9 +19,9 @@ const ContentAnswers = () => {
     };
 
     return (
-        <div>
+        <div className="ContentAnswers">
             <ContentAnswersOpenButton onClick={handleClick} />
-            {isModalOpen && <ContentAnswersModal onRequestClose={handleClose} />}
+            <ContentAnswersModal isModalOpen={isModalOpen} onRequestClose={handleClose} />
         </div>
     );
 };

--- a/src/features/content-answers/ContentAnswers.tsx
+++ b/src/features/content-answers/ContentAnswers.tsx
@@ -21,7 +21,7 @@ const ContentAnswers = () => {
     return (
         <div className="ContentAnswers">
             <ContentAnswersOpenButton onClick={handleClick} />
-            <ContentAnswersModal isModalOpen={isModalOpen} onRequestClose={handleClose} />
+            <ContentAnswersModal isOpen={isModalOpen} onRequestClose={handleClose} />
         </div>
     );
 };

--- a/src/features/content-answers/ContentAnswers.tsx
+++ b/src/features/content-answers/ContentAnswers.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import ContentAnswersModal from './ContentAnswersModal';
 import ContentAnswersOpenButton from './ContentAnswersOpenButton';
 
 type ExternalProps = {
@@ -10,12 +11,17 @@ const ContentAnswers = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     const handleClick = () => {
-        setIsModalOpen(!isModalOpen);
+        setIsModalOpen(prevState => !prevState);
+    };
+
+    const handleClose = () => {
+        setIsModalOpen(false);
     };
 
     return (
         <div>
             <ContentAnswersOpenButton onClick={handleClick} />
+            {isModalOpen && <ContentAnswersModal onRequestClose={handleClose} />}
         </div>
     );
 };

--- a/src/features/content-answers/ContentAnswersModal.scss
+++ b/src/features/content-answers/ContentAnswersModal.scss
@@ -1,0 +1,51 @@
+.ContentAnswersModal {
+    .modal-dialog-containter {
+        display: flex;
+        flex-basis: 0;
+        width: 100%;
+        height: 100%;
+        max-height: 702px;
+    }
+
+    .modal-dialog {
+        width: 768px;
+        height: 100%;
+        max-height: 702px;
+        padding: 0;
+        background-color: #f4f4f4;
+    }
+
+    .modal-header-container {
+        z-index: 1;
+        margin: 0;
+        padding: 16px 20px;
+        background-color: white;
+        border-radius: 12px 12px 0 0;
+        box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 1px 0 #e8e8e8;
+
+        .modal-title {
+            display: flex;
+            align-items: center;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .BoxAiLogo {
+            margin-right: 12px;
+        }
+    }
+
+    .modal-content {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        max-height: 638px;
+        margin-top: 0;
+    }
+
+    .modal-close-button {
+        top: 20px;
+    }
+}

--- a/src/features/content-answers/ContentAnswersModal.scss
+++ b/src/features/content-answers/ContentAnswersModal.scss
@@ -1,5 +1,7 @@
+@import '../../styles/variables';
+
 .ContentAnswersModal {
-    .modal-dialog-containter {
+    .modal-dialog-container {
         display: flex;
         flex-basis: 0;
         width: 100%;
@@ -12,7 +14,7 @@
         height: 100%;
         max-height: 702px;
         padding: 0;
-        background-color: #f4f4f4;
+        background-color: $bdl-gray-05;
     }
 
     .modal-header-container {
@@ -20,16 +22,12 @@
         margin: 0;
         padding: 16px 20px;
         background-color: white;
-        border-radius: 12px 12px 0 0;
-        box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 1px 0 #e8e8e8;
+        border-radius: $bdl-border-radius-size-xlarge $bdl-border-radius-size-xlarge 0 0;
+        box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 1px 0 $bdl-gray-10;
 
         .modal-title {
             display: flex;
             align-items: center;
-        }
-
-        p {
-            margin: 0;
         }
 
         .BoxAiLogo {

--- a/src/features/content-answers/ContentAnswersModal.tsx
+++ b/src/features/content-answers/ContentAnswersModal.tsx
@@ -12,16 +12,16 @@ import messages from './messages';
 import './ContentAnswersModal.scss';
 
 type Props = {
-    isModalOpen: boolean;
+    isOpen: boolean;
     onRequestClose: () => void;
 };
 
-const ContentAnswersModal = ({ isModalOpen, onRequestClose }: Props) => {
+const ContentAnswersModal = ({ isOpen, onRequestClose }: Props) => {
     return (
         <Modal
             className="ContentAnswersModal"
             data-testid="content-answers-modal"
-            isOpen={isModalOpen}
+            isOpen={isOpen}
             onRequestClose={onRequestClose}
             title={
                 <>

--- a/src/features/content-answers/ContentAnswersModal.tsx
+++ b/src/features/content-answers/ContentAnswersModal.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import BoxAiLogo from '../../icon/logo/BoxAiLogo';
+import ContentAnswersModalContent from './ContentAnswersModalContent';
+import ContentAnswersModalFooter from './ContentAnswersModalFooter';
+// @ts-ignore flow import
+import Modal from '../../components/modal/Modal';
+
+import messages from './messages';
+
+import './ContentAnswersModal.scss';
+
+type Props = {
+    onRequestClose: () => void;
+};
+
+const ContentAnswersModal = ({ onRequestClose }: Props) => {
+    return (
+        <Modal
+            isOpen
+            className="ContentAnswersModal"
+            data-testid="content-answers-modal"
+            onRequestClose={onRequestClose}
+            title={
+                <>
+                    <BoxAiLogo className="BoxAiLogo" data-testid="content-answers-icon-color" width={32} height={32} />
+                    <p>
+                        <span>
+                            <FormattedMessage {...messages.contentAnswersTitle} />
+                        </span>
+                    </p>
+                </>
+            }
+        >
+            <ContentAnswersModalContent />
+            <ContentAnswersModalFooter />
+        </Modal>
+    );
+};
+
+export default ContentAnswersModal;

--- a/src/features/content-answers/ContentAnswersModal.tsx
+++ b/src/features/content-answers/ContentAnswersModal.tsx
@@ -19,9 +19,9 @@ type Props = {
 const ContentAnswersModal = ({ isModalOpen, onRequestClose }: Props) => {
     return (
         <Modal
-            isOpen={isModalOpen}
             className="ContentAnswersModal"
             data-testid="content-answers-modal"
+            isOpen={isModalOpen}
             onRequestClose={onRequestClose}
             title={
                 <>

--- a/src/features/content-answers/ContentAnswersModal.tsx
+++ b/src/features/content-answers/ContentAnswersModal.tsx
@@ -12,24 +12,21 @@ import messages from './messages';
 import './ContentAnswersModal.scss';
 
 type Props = {
+    isModalOpen: boolean;
     onRequestClose: () => void;
 };
 
-const ContentAnswersModal = ({ onRequestClose }: Props) => {
+const ContentAnswersModal = ({ isModalOpen, onRequestClose }: Props) => {
     return (
         <Modal
-            isOpen
+            isOpen={isModalOpen}
             className="ContentAnswersModal"
             data-testid="content-answers-modal"
             onRequestClose={onRequestClose}
             title={
                 <>
                     <BoxAiLogo className="BoxAiLogo" data-testid="content-answers-icon-color" width={32} height={32} />
-                    <p>
-                        <span>
-                            <FormattedMessage {...messages.contentAnswersTitle} />
-                        </span>
-                    </p>
+                    <FormattedMessage {...messages.contentAnswersTitle} />
                 </>
             }
         >

--- a/src/features/content-answers/ContentAnswersModalContent.scss
+++ b/src/features/content-answers/ContentAnswersModalContent.scss
@@ -1,0 +1,11 @@
+@import '../../styles/variables';
+
+.ContentAnswersModalContent {
+    flex: 1 1 auto;
+    width: auto;
+    // TODO: remove fixed height
+    height: 566px;
+    max-height: 566px;
+    padding: 0 20px 20px 20px;
+    overflow: auto;
+}

--- a/src/features/content-answers/ContentAnswersModalContent.scss
+++ b/src/features/content-answers/ContentAnswersModalContent.scss
@@ -3,9 +3,6 @@
 .ContentAnswersModalContent {
     flex: 1 1 auto;
     width: auto;
-    // TODO: remove fixed height
-    height: 566px;
-    max-height: 566px;
     padding: 0 20px 20px 20px;
     overflow: auto;
 }

--- a/src/features/content-answers/ContentAnswersModalContent.tsx
+++ b/src/features/content-answers/ContentAnswersModalContent.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import './ContentAnswersModalContent.scss';
+
+const ContentAnswersModalContent = () => {
+    // TODO: Add Modal Content Detail
+    return <div className="ContentAnswersModalContent">Modal Content</div>;
+};
+
+export default ContentAnswersModalContent;

--- a/src/features/content-answers/ContentAnswersModalFooter.scss
+++ b/src/features/content-answers/ContentAnswersModalFooter.scss
@@ -4,12 +4,11 @@
     position: relative;
     z-index: 1;
     display: flex;
-    flex: 1 1 auto;
     align-items: end;
     padding: 16px 20px;
-    background: white;
-    border-radius: 0 0 12px 12px;
-    box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 -1px 0 #e8e8e8;
+    background: $white;
+    border-radius: 0 0 $bdl-border-radius-size-xlarge $bdl-border-radius-size-xlarge;
+    box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 -1px 0 $bdl-gray-10;
 
     .ContentAnswersModalFooter-avatar {
         height: 32px;
@@ -17,7 +16,7 @@
     }
 
     .ContentAnswersModalFooter-submitButton {
-        height: 40px;
+        height: $bdl-btn-height-large;
         margin: 0;
         font-size: 14px;
     }
@@ -34,11 +33,11 @@
         margin: 0;
         overflow: hidden;
         font-size: 14px;
-        border: 1px solid #6f6f6f;
-        border-radius: 6px;
+        border: 1px solid $bdl-gray-65;
+        border-radius: $bdl-border-radius-size-med;
     }
 
     textarea:focus {
-        border: 1.5px solid rgb(36, 124, 252);
+        border: 1.5px solid $bdl-box-blue;
     }
 }

--- a/src/features/content-answers/ContentAnswersModalFooter.scss
+++ b/src/features/content-answers/ContentAnswersModalFooter.scss
@@ -1,0 +1,44 @@
+@import '../../styles/variables';
+
+.ContentAnswersModalFooter {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex: 1 1 auto;
+    align-items: end;
+    padding: 16px 20px;
+    background: white;
+    border-radius: 0 0 12px 12px;
+    box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 -1px 0 #e8e8e8;
+
+    .ContentAnswersModalFooter-avatar {
+        height: 32px;
+        margin-bottom: 4px;
+    }
+
+    .ContentAnswersModalFooter-submitButton {
+        height: 40px;
+        margin: 0;
+        font-size: 14px;
+    }
+
+    .text-area-container {
+        width: 100%;
+        margin: 0 16px;
+    }
+
+    textarea {
+        display: flex;
+        width: 100%;
+        height: 40px;
+        margin: 0;
+        overflow: hidden;
+        font-size: 14px;
+        border: 1px solid #6f6f6f;
+        border-radius: 6px;
+    }
+
+    textarea:focus {
+        border: 1.5px solid rgb(36, 124, 252);
+    }
+}

--- a/src/features/content-answers/ContentAnswersModalFooter.tsx
+++ b/src/features/content-answers/ContentAnswersModalFooter.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { injectIntl, FormattedMessage, IntlShape } from 'react-intl';
+
+import Avatar from '../../components/avatar';
+import PrimaryButton from '../../components/primary-button';
+// @ts-ignore flow import
+import TextArea from '../../components/text-area';
+import { TEXT_AREA } from './constants';
+
+import './ContentAnswersModalFooter.scss';
+
+import messages from './messages';
+
+type Props = {
+    intl: IntlShape;
+};
+
+const ContentAnswersModalFooter = ({ intl }: Props) => {
+    const [inputMessage, setInputMessage] = useState('');
+    const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
+    const [hasMaxCharacterError, setHasMaxCharacterError] = useState(false);
+
+    const handleInputChange = (event: React.FormEvent<HTMLInputElement>) => {
+        let currentInput = event.currentTarget.value;
+        if (currentInput.length > TEXT_AREA.MAX_LENGTH) {
+            currentInput = currentInput.slice(0, TEXT_AREA.MAX_LENGTH);
+        }
+        setInputMessage(currentInput);
+        setHasMaxCharacterError(currentInput.length >= TEXT_AREA.MAX_LENGTH);
+        setIsSubmitDisabled(currentInput.trim().length === 0);
+    };
+
+    return (
+        <div className="ContentAnswersModalFooter">
+            <div className="ContentAnswersModalFooter-avatar">
+                <Avatar />
+            </div>
+            <TextArea
+                data-testid="content-answers-question-input"
+                error={
+                    hasMaxCharacterError &&
+                    intl.formatMessage(messages.maxCharactersReachedError, {
+                        characterLimit: TEXT_AREA.MAX_LENGTH,
+                    })
+                }
+                hideLabel
+                label={intl.formatMessage(messages.askQuestionPlaceholder)}
+                maxLength={TEXT_AREA.MAX_LENGTH}
+                onChange={handleInputChange}
+                placeholder={intl.formatMessage(messages.askQuestionPlaceholder)}
+                value={inputMessage}
+            />
+            <PrimaryButton
+                className="ContentAnswersModalFooter-submitButton"
+                data-testid="content-answers-submit-button"
+                isDisabled={isSubmitDisabled}
+            >
+                <FormattedMessage {...messages.ask} />
+            </PrimaryButton>
+        </div>
+    );
+};
+
+export default injectIntl(ContentAnswersModalFooter);

--- a/src/features/content-answers/ContentAnswersModalFooter.tsx
+++ b/src/features/content-answers/ContentAnswersModalFooter.tsx
@@ -16,6 +16,7 @@ type Props = {
 };
 
 const ContentAnswersModalFooter = ({ intl }: Props) => {
+    const { formatMessage } = intl;
     const [inputMessage, setInputMessage] = useState('');
     const [isSubmitDisabled, setIsSubmitDisabled] = useState(true);
     const [hasMaxCharacterError, setHasMaxCharacterError] = useState(false);
@@ -39,15 +40,15 @@ const ContentAnswersModalFooter = ({ intl }: Props) => {
                 data-testid="content-answers-question-input"
                 error={
                     hasMaxCharacterError &&
-                    intl.formatMessage(messages.maxCharactersReachedError, {
+                    formatMessage(messages.maxCharactersReachedError, {
                         characterLimit: TEXT_AREA.MAX_LENGTH,
                     })
                 }
                 hideLabel
-                label={intl.formatMessage(messages.askQuestionPlaceholder)}
+                label={formatMessage(messages.askQuestionPlaceholder)}
                 maxLength={TEXT_AREA.MAX_LENGTH}
                 onChange={handleInputChange}
-                placeholder={intl.formatMessage(messages.askQuestionPlaceholder)}
+                placeholder={formatMessage(messages.askQuestionPlaceholder)}
                 value={inputMessage}
             />
             <PrimaryButton

--- a/src/features/content-answers/ContentAnswersOpenButton.scss
+++ b/src/features/content-answers/ContentAnswersOpenButton.scss
@@ -5,7 +5,7 @@
     align-items: center;
     justify-content: center;
     width: 40px;
-    height: 40px;
+    height: $bdl-btn-height-large;
     background-color: $bdl-gray-02;
     border: none;
 

--- a/src/features/content-answers/__tests__/ContentAnswersModal.test.tsx
+++ b/src/features/content-answers/__tests__/ContentAnswersModal.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ContentAnswersModal from '../ContentAnswersModal';
+
+describe('features/content-answers/ContentAnswersModal', () => {
+    const renderComponent = (props?: {}) => render(<ContentAnswersModal onRequestClose={jest.fn()} {...props} />);
+
+    test('should render the header icon', () => {
+        renderComponent();
+
+        const headerIcon = screen.queryByTestId('content-answers-icon-color');
+        expect(headerIcon).toBeInTheDocument();
+    });
+});

--- a/src/features/content-answers/__tests__/ContentAnswersModal.test.tsx
+++ b/src/features/content-answers/__tests__/ContentAnswersModal.test.tsx
@@ -4,7 +4,8 @@ import { render, screen } from '@testing-library/react';
 import ContentAnswersModal from '../ContentAnswersModal';
 
 describe('features/content-answers/ContentAnswersModal', () => {
-    const renderComponent = (props?: {}) => render(<ContentAnswersModal onRequestClose={jest.fn()} {...props} />);
+    const renderComponent = (props?: {}) =>
+        render(<ContentAnswersModal isModalOpen onRequestClose={jest.fn()} {...props} />);
 
     test('should render the header icon', () => {
         renderComponent();

--- a/src/features/content-answers/__tests__/ContentAnswersModal.test.tsx
+++ b/src/features/content-answers/__tests__/ContentAnswersModal.test.tsx
@@ -5,7 +5,7 @@ import ContentAnswersModal from '../ContentAnswersModal';
 
 describe('features/content-answers/ContentAnswersModal', () => {
     const renderComponent = (props?: {}) =>
-        render(<ContentAnswersModal isModalOpen onRequestClose={jest.fn()} {...props} />);
+        render(<ContentAnswersModal isOpen onRequestClose={jest.fn()} {...props} />);
 
     test('should render the header icon', () => {
         renderComponent();

--- a/src/features/content-answers/__tests__/ContentAnswersModalFooter.test.tsx
+++ b/src/features/content-answers/__tests__/ContentAnswersModalFooter.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 // @ts-ignore flow import
 import localize from '../../../../test/support/i18n';
 import ContentAnswersModalFooter from '../ContentAnswersModalFooter';
-import { mockLongPrompt, TEXT_AREA } from '../constants';
+import { MOCK_LONG_PROMPT, TEXT_AREA } from '../constants';
 
 import messages from '../messages';
 
@@ -30,7 +30,7 @@ describe('features/content-answers/ContentAnswersModalFooter', () => {
         renderComponent();
         const input = screen.getByTestId('content-answers-question-input');
 
-        fireEvent.change(input, { target: { value: mockLongPrompt } });
+        fireEvent.change(input, { target: { value: MOCK_LONG_PROMPT } });
 
         const error = screen.queryAllByText(
             localize(messages.maxCharactersReachedError.id, { characterLimit: TEXT_AREA.MAX_LENGTH }),

--- a/src/features/content-answers/__tests__/ContentAnswersModalFooter.test.tsx
+++ b/src/features/content-answers/__tests__/ContentAnswersModalFooter.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// @ts-ignore flow import
+import localize from '../../../../test/support/i18n';
+import ContentAnswersModalFooter from '../ContentAnswersModalFooter';
+import { mockLongPrompt, TEXT_AREA } from '../constants';
+
+import messages from '../messages';
+
+describe('features/content-answers/ContentAnswersModalFooter', () => {
+    const renderComponent = (props?: {}) => render(<ContentAnswersModalFooter {...props} />);
+
+    test('should disable submit button if input is empty', () => {
+        renderComponent();
+        const submitButton = screen.getByTestId('content-answers-submit-button');
+        expect(submitButton).toHaveClass('is-disabled');
+    });
+
+    test('should enable submit button if there is any input', () => {
+        renderComponent();
+        const submitButton = screen.getByTestId('content-answers-submit-button');
+        const input = screen.getByTestId('content-answers-question-input');
+
+        fireEvent.change(input, { target: { value: 'Test' } });
+        expect(submitButton).not.toHaveClass('is-disabled');
+    });
+
+    test('should show an error if the character limit is reached', () => {
+        renderComponent();
+        const input = screen.getByTestId('content-answers-question-input');
+
+        fireEvent.change(input, { target: { value: mockLongPrompt } });
+
+        const error = screen.queryAllByText(
+            localize(messages.maxCharactersReachedError.id, { characterLimit: TEXT_AREA.MAX_LENGTH }),
+        );
+        expect(error.length).not.toBe(0);
+    });
+});

--- a/src/features/content-answers/constants.ts
+++ b/src/features/content-answers/constants.ts
@@ -1,0 +1,6 @@
+export const mockLongPrompt =
+    'What is the significance of the character limit in the text area, and why is it important to ensure that users are notified when they exceed it? Additionally, what steps can be taken to prevent users from exceeding the character limit, and how can errors related to the character limit be handled in a user-friendly manner?';
+
+export const TEXT_AREA = {
+    MAX_LENGTH: 300,
+};

--- a/src/features/content-answers/constants.ts
+++ b/src/features/content-answers/constants.ts
@@ -1,4 +1,4 @@
-export const mockLongPrompt =
+export const MOCK_LONG_PROMPT =
     'What is the significance of the character limit in the text area, and why is it important to ensure that users are notified when they exceed it? Additionally, what steps can be taken to prevent users from exceeding the character limit, and how can errors related to the character limit be handled in a user-friendly manner?';
 
 export const TEXT_AREA = {

--- a/src/features/content-answers/messages.ts
+++ b/src/features/content-answers/messages.ts
@@ -1,6 +1,21 @@
 import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
+    ask: {
+        defaultMessage: 'Ask',
+        description: 'Content Answers submit input button text',
+        id: 'boxui.contentAnswers.ask',
+    },
+    askDisabledTooltip: {
+        defaultMessage: 'You can submit another question once Box AI has finished responding',
+        description: 'Content Answers submit input button disabled tooltip text when answer is generating',
+        id: 'boxui.contentAnswers.askDisabledTooltip',
+    },
+    askQuestionPlaceholder: {
+        defaultMessage: 'Ask anything about this document',
+        description: 'Content Answers modal input placeholder',
+        id: 'boxui.contentAnswers.askQuestionPlaceholder',
+    },
     contentAnswersTitle: {
         defaultMessage: 'Box AI',
         description: 'Content Answers feature name shown on menu item and modal title',
@@ -10,6 +25,11 @@ const messages = defineMessages({
         defaultMessage: 'Get instant answers about this document using Box AI',
         description: 'Default tooltip message for Content Answers entry point button',
         id: 'boxui.contentAnswers.defaultTooltip',
+    },
+    maxCharactersReachedError: {
+        defaultMessage: 'Maximum of {characterLimit} characters reached',
+        description: 'Error tooltip to show inside text area if the user reached the character limit',
+        id: 'boxui.contentAnswers.maxCharactersReachedError',
     },
 });
 


### PR DESCRIPTION
**Initial Modal**
<img width="793" alt="Screenshot 2023-09-20 at 11 59 15 AM" src="https://github.com/box/box-ui-elements/assets/41510767/8ead133b-f302-410c-8aae-4bd2d8a06dc5">

**Modal with question input**
<img width="780" alt="Screenshot 2023-09-20 at 11 59 34 AM" src="https://github.com/box/box-ui-elements/assets/41510767/f7b88746-73a2-44dd-9a12-36038ce2ca51">

**Modal with input exceeds limitation**
<img width="782" alt="Screenshot 2023-09-20 at 12 00 06 PM" src="https://github.com/box/box-ui-elements/assets/41510767/778c0ea4-212f-4bb0-b5d1-a3889f0eff89">

