### PR TITLE
feat(activityitems): new layout

### DIFF
--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -41,7 +41,7 @@ import { type OnAnnotationEdit } from '../comment/types';
 
 import './ActivityFeed.scss';
 
-type Props = {
+export type ActivityFeedProps = {
     activeFeedEntryId?: string,
     activeFeedEntryType?: FocusableFeedItemType,
     activityFeedError: ?Errors,
@@ -49,6 +49,7 @@ type Props = {
     contactsLoaded?: boolean,
     currentUser?: User,
     feedItems?: FeedItems,
+    // $FlowFixMe file.file_version (BoxItem[BoxItemVersion]) has many apparently long-standing type errors
     file: BoxItem,
     getApproverWithQuery?: Function,
     getAvatarUrl: GetAvatarUrlCallback,
@@ -104,7 +105,7 @@ type State = {
     selectedItemId: string | null,
 };
 
-class ActivityFeed extends React.Component<Props, State> {
+class ActivityFeed extends React.Component<ActivityFeedProps, State> {
     state = {
         isScrolled: false,
         isInputOpen: false,
@@ -119,7 +120,7 @@ class ActivityFeed extends React.Component<Props, State> {
         this.resetFeedScroll();
     }
 
-    componentDidUpdate(prevProps: Props, prevState: State) {
+    componentDidUpdate(prevProps: ActivityFeedProps, prevState: State) {
         const {
             activeFeedEntryId: prevActiveFeedEntryId,
             currentUser: prevCurrentUser,
@@ -168,7 +169,7 @@ class ActivityFeed extends React.Component<Props, State> {
      * @param {object} currentUser - The user that is logged into the account
      * @param {object} feedItems - Items in the activity feed
      */
-    isEmpty = ({ feedItems, shouldUseUAA }: Props = this.props): boolean => {
+    isEmpty = ({ feedItems, shouldUseUAA }: ActivityFeedProps = this.props): boolean => {
         if (feedItems === undefined) {
             return false;
         }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityItem.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityItem.scss
@@ -6,7 +6,7 @@
 
         // This brittle selector is here in order to only select the parent BaseComment and not the BaseComments which constitute its replies.
         & > div {
-            padding: 6px 12px $bdl-grid-unit * 5;
+            padding: 6px $bdl-grid-unit * 3 $bdl-grid-unit * 5;
         }
 
         &.bcs-is-hoverable:hover {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityItem.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityItem.scss
@@ -4,9 +4,9 @@
     &.hasNewThreadedReplies {
         padding: 2px $bdl-grid-unit * 2;
 
+        // This brittle selector is here in order to only select the parent BaseComment and not the BaseComments which constitute its replies.
         & > div {
-            padding: $bdl-grid-unit * 2;
-            padding-right: $bdl-grid-unit * 4;
+            padding: 6px 12px $bdl-grid-unit * 5;
         }
 
         &.bcs-is-hoverable:hover {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityItem.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityItem.scss
@@ -6,7 +6,7 @@
 
         // This brittle selector is here in order to only select the parent BaseComment and not the BaseComments which constitute its replies.
         & > div {
-            padding: 6px $bdl-grid-unit * 3 $bdl-grid-unit * 5;
+            padding: $bdl-grid-unit * 3 $bdl-grid-unit * 3 $bdl-grid-unit * 5;
         }
 
         &.bcs-is-hoverable:hover {

--- a/src/elements/content-sidebar/activity-feed/activity-feed/stories/ActivityFeed.stories.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/stories/ActivityFeed.stories.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from 'react';
+
+import { IntlProvider } from 'react-intl';
+
+import ActivityFeed, { type ActivityFeedProps } from '../ActivityFeed';
+import {
+    TIME_STRING_SEPT_27_2017,
+    TIME_STRING_SEPT_28_2017,
+    currentUser,
+    comment,
+    replies,
+    repliesProps,
+} from '../../comment/stories/common';
+import { FEED_ITEM_TYPE_VERSION } from '../../../../../constants';
+
+import type { FeedItems, Comment } from '../../../../../common/types/feed';
+
+const file = {
+    id: '12345',
+    permissions: {
+        can_comment: true,
+    },
+    created_at: TIME_STRING_SEPT_27_2017,
+    modified_at: TIME_STRING_SEPT_28_2017,
+    file_version: {
+        id: 987,
+        type: FEED_ITEM_TYPE_VERSION,
+        created_at: TIME_STRING_SEPT_28_2017,
+        modified_at: null,
+        modified_by: null,
+        trashed_at: null,
+        version_number: 1,
+    },
+    version_number: '3',
+};
+
+const activityFeedComment: Comment = {
+    ...comment,
+    replies,
+};
+
+const comments = {
+    total_count: 1,
+    entries: [activityFeedComment],
+};
+
+const feedItems: FeedItems = [...comments.entries];
+
+const getTemplate = customProps => (props: ActivityFeedProps) => (
+    <IntlProvider locale="en">
+        <ActivityFeed
+            currentUser={currentUser}
+            feedItems={feedItems}
+            file={file}
+            {...repliesProps}
+            {...props}
+            {...customProps}
+        />
+    </IntlProvider>
+);
+
+export const LegacyComment = getTemplate({ hasNewThreadedReplies: false });
+
+export const ThreadedRepliesComment = getTemplate({ hasNewThreadedReplies: true });
+
+export default {
+    title: 'Components|ActivityFeed',
+    component: ActivityFeed,
+};

--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.scss
@@ -44,7 +44,6 @@ $repliesPaddingLeft: 40px;
     display: flex;
     justify-content: space-between;
     width: 100%;
-    padding: 2;
 }
 
 .bcs-BaseComment-content {

--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.scss
@@ -3,28 +3,51 @@
 $repliesPaddingLeft: 40px;
 
 .bcs-BaseComment {
-    .bcs-Comment-timestamp {
-        margin-bottom: $bdl-grid-unit * 4;
-    }
-
-    .bcs-ActivityTimestamp {
-        color: $bdl-gray-65;
-    }
+    font-size: $bdl-fontSize--dejaBlue;
 
     .bcs-CommentForm-input {
         background-color: $white;
+    }
+
+    .bcs-CommentFormControls {
+        display: flex;
+        flex-direction: row-reverse;
+
+        .btn {
+            margin: $bdl-grid-unit * 3 0 0 $bdl-grid-unit * 3;
+        }
     }
 
     .btn-plain:focus-visible {
         outline: auto;
     }
 
-    .bcs-Replies {
-        margin: $bdl-grid-unit * 3 0;
-        padding-left: $repliesPaddingLeft;
+    .bcs-Comment-media {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        width: 100%;
+        margin-bottom: $bdl-grid-unit * 4;
     }
 
-    .bcs-Comment-media {
-        margin-bottom: $bdl-grid-unit * 3;
+    .mention-selector-wrapper {
+        margin: 0;
     }
+
+    .public-DraftEditor-content {
+        width: 100%;
+        min-height: $bdl-grid-unit * 12;
+    }
+}
+
+.bcs-BaseComment-header {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    padding: 2;
+}
+
+.bcs-BaseComment-content {
+    width: 100%;
+    margin-top: 4 * $bdl-grid-unit;
 }

--- a/src/elements/content-sidebar/activity-feed/comment/Replies.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/Replies.scss
@@ -1,9 +1,11 @@
 @import '../../../common/variables';
 
 .bcs-Replies {
+    margin-top: $bdl-grid-unit * 3;
+
     .bcs-Replies-content {
         position: relative;
-        margin-bottom: $bdl-grid-unit * 6;
+        margin-bottom: $bdl-grid-unit * 4;
         padding-left: $bdl-grid-unit * 5;
 
         .bcs-Replies-list {
@@ -16,7 +18,7 @@
         }
 
         li:not(:last-child) {
-            margin-bottom: $bdl-grid-unit * 7;
+            margin-bottom: $bdl-grid-unit * 4;
         }
     }
 

--- a/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentInfo.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentInfo.js
@@ -1,0 +1,72 @@
+// @flow
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import { ACTIVITY_TARGETS } from '../../../../common/interactionTargets';
+import { PLACEHOLDER_USER } from '../../../../../constants';
+import ActivityTimestamp from '../../common/activity-timestamp';
+import Avatar from '../../Avatar';
+import IconAnnotation from '../../../../../icons/two-toned/IconAnnotation';
+import UserLink from '../../common/user-link';
+
+import type { FeedItemStatus } from '../../../../../common/types/feed';
+import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../../common/flowTypes';
+import type { User } from '../../../../../common/types/core';
+
+import messages from '../messages';
+
+import './BaseCommentInfo.scss';
+
+export interface BaseCommentInfoProps {
+    annotationActivityLink?: React.Element<any> | typeof undefined;
+    created_at: string | number;
+    created_by: User;
+    getAvatarUrl: GetAvatarUrlCallback;
+    getUserProfileUrl?: GetProfileUrlCallback | typeof undefined;
+    status?: FeedItemStatus | typeof undefined;
+}
+
+export const BaseCommentInfo = ({
+    annotationActivityLink,
+    created_at,
+    created_by,
+    getAvatarUrl,
+    getUserProfileUrl,
+}: BaseCommentInfoProps) => {
+    const createdByUser = created_by || PLACEHOLDER_USER;
+    const createdAtTimestamp = new Date(created_at).getTime();
+
+    return (
+        <div className="bcs-BaseCommentInfo">
+            <div className="bcs-BaseCommentInfo-avatar">
+                <Avatar
+                    badgeIcon={
+                        annotationActivityLink && (
+                            <IconAnnotation
+                                title={<FormattedMessage {...messages.inlineCommentAnnotationIconTitle} />}
+                            />
+                        )
+                    }
+                    getAvatarUrl={getAvatarUrl}
+                    user={createdByUser}
+                />
+            </div>
+            <div className="bcs-BaseCommentInfo-data">
+                <div className="bcs-Comment-headline">
+                    <UserLink
+                        data-resin-target={ACTIVITY_TARGETS.PROFILE}
+                        getUserProfileUrl={getUserProfileUrl}
+                        id={createdByUser.id}
+                        name={createdByUser.name}
+                    />
+                </div>
+                <div className="bcs-BaseCommentInfo-data-timestamp">
+                    <ActivityTimestamp date={createdAtTimestamp} />
+                    {annotationActivityLink && (
+                        <div className="bcs-BaseComment-AnnotationActivityLink">{annotationActivityLink}</div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentInfo.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentInfo.scss
@@ -1,0 +1,38 @@
+@import '../../../../common/variables';
+
+.bcs-BaseCommentInfo {
+    display: flex;
+    align-items: 'bottom';
+    justify-content: flex-start;
+    padding: 2;
+    font-size: $bdl-fontSize--dejaBlue;
+
+    .bdl-Media-figure {
+        line-height: 0;
+    }
+}
+
+.bcs-BaseCommentInfo-avatar {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.bcs-BaseCommentInfo-data {
+    display: flex;
+    flex-direction: column;
+    margin-left: 10px;
+
+    .bcs-ActivityTimestamp {
+        color: $bdl-gray-65;
+    }
+
+    .bcs-Comment-headline {
+        font-weight: bold;
+    }
+}
+
+.bcs-BaseCommentInfo-data-timestamp {
+    display: flex;
+    color: $bdl-gray;
+}

--- a/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenu.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenu.js
@@ -1,0 +1,125 @@
+// @flow
+import * as React from 'react';
+
+import { FormattedMessage } from 'react-intl';
+import TetherComponent from 'react-tether';
+
+import { ACTIVITY_TARGETS } from '../../../../common/interactionTargets';
+import { COMMENT_STATUS_OPEN, COMMENT_STATUS_RESOLVED } from '../../../../../constants';
+import { MenuItem } from '../../../../../components/menu';
+
+import Checkmark16 from '../../../../../icon/line/Checkmark16';
+import DeleteConfirmation from '../../common/delete-confirmation';
+import Media from '../../../../../components/media';
+import messages from '../messages';
+import Pencil16 from '../../../../../icon/line/Pencil16';
+import Trash16 from '../../../../../icon/line/Trash16';
+import X16 from '../../../../../icon/fill/X16';
+
+import type { FeedItemStatus } from '../../../../../common/types/feed';
+
+import './BaseCommentMenu.scss';
+
+export interface BaseCommentMenuProps {
+    canDelete: boolean;
+    canEdit: boolean;
+    canResolve: boolean;
+    handleDeleteCancel: () => void;
+    handleDeleteClick: () => void;
+    handleDeleteConfirm: () => void;
+    handleEditClick: () => void;
+    handleMenuClose: () => void;
+    handleStatusUpdate: (selectedStatus: FeedItemStatus) => void;
+    isConfirmingDelete: boolean;
+    isResolved: boolean;
+    onSelect: (isSelected: boolean) => void;
+}
+export const BaseCommentMenu = ({
+    canDelete,
+    canEdit,
+    canResolve,
+    handleDeleteCancel,
+    handleDeleteClick,
+    handleDeleteConfirm,
+    handleEditClick,
+    handleMenuClose,
+    handleStatusUpdate,
+    isConfirmingDelete,
+    isResolved,
+    onSelect,
+}: BaseCommentMenuProps) => {
+    return (
+        <TetherComponent
+            attachment="top right"
+            className="bcs-Comment-deleteConfirmationModal"
+            constraints={[{ to: 'scrollParent', attachment: 'together' }]}
+            targetAttachment="bottom right"
+        >
+            <Media.Menu
+                data-testid="comment-actions-menu"
+                dropdownProps={{
+                    onMenuOpen: () => onSelect(true),
+                    onMenuClose: handleMenuClose,
+                }}
+                className="BaseCommentMenu"
+                isDisabled={isConfirmingDelete}
+                menuProps={{
+                    'data-resin-component': ACTIVITY_TARGETS.COMMENT_OPTIONS,
+                }}
+            >
+                {canResolve && isResolved && (
+                    <MenuItem
+                        className="bcs-Comment-unresolveComment"
+                        data-resin-target={ACTIVITY_TARGETS.COMMENT_OPTIONS_EDIT}
+                        data-testid="unresolve-comment"
+                        onClick={() => handleStatusUpdate(COMMENT_STATUS_OPEN)}
+                    >
+                        <X16 />
+                        <FormattedMessage {...messages.commentUnresolveMenuItem} />
+                    </MenuItem>
+                )}
+                {canResolve && !isResolved && (
+                    <MenuItem
+                        data-resin-target={ACTIVITY_TARGETS.COMMENT_OPTIONS_EDIT}
+                        data-testid="resolve-comment"
+                        onClick={() => handleStatusUpdate(COMMENT_STATUS_RESOLVED)}
+                    >
+                        <Checkmark16 />
+                        <FormattedMessage {...messages.commentResolveMenuItem} />
+                    </MenuItem>
+                )}
+                {canEdit && (
+                    <MenuItem
+                        data-resin-target={ACTIVITY_TARGETS.COMMENT_OPTIONS_EDIT}
+                        data-testid="edit-comment"
+                        onClick={handleEditClick}
+                    >
+                        <Pencil16 />
+                        <FormattedMessage {...messages.commentEditMenuItem} />
+                    </MenuItem>
+                )}
+                {canDelete && (
+                    <MenuItem
+                        aria-label={messages.commentDeleteMenuItem.defaultMessage}
+                        data-resin-target={ACTIVITY_TARGETS.COMMENT_OPTIONS_DELETE}
+                        data-testid="delete-comment"
+                        onClick={handleDeleteClick}
+                    >
+                        <Trash16 />
+                        <FormattedMessage {...messages.commentDeleteMenuItem} />
+                    </MenuItem>
+                )}
+            </Media.Menu>
+
+            {isConfirmingDelete && (
+                <DeleteConfirmation
+                    data-resin-component={ACTIVITY_TARGETS.COMMENT_OPTIONS}
+                    isOpen={isConfirmingDelete}
+                    message={messages.commentDeletePrompt}
+                    onDeleteCancel={handleDeleteCancel}
+                    onDeleteConfirm={handleDeleteConfirm}
+                />
+            )}
+        </TetherComponent>
+    );
+};

--- a/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenu.scss
+++ b/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenu.scss
@@ -1,0 +1,4 @@
+.BaseCommentMenu.bdl-Media-menu {
+    // to override float:right from .bdl-Media-menu
+    float: none;
+}

--- a/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenuWrapper.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenuWrapper.js
@@ -1,0 +1,95 @@
+// @flow
+import React from 'react';
+import type { BoxCommentPermission, FeedItemStatus } from '../../../../../common/types/feed';
+import type { OnAnnotationEdit, OnCommentEdit } from '../types';
+
+import { BaseCommentMenu } from './BaseCommentMenu';
+
+export interface BaseCommentMenuWrapperProps {
+    canDelete: boolean;
+    canEdit: boolean;
+    canResolve: boolean;
+    id: string;
+    isEditing: boolean;
+    isInputOpen: boolean;
+    isResolved: boolean;
+    onAnnotationEdit?: OnAnnotationEdit | typeof undefined;
+    onCommentEdit: OnCommentEdit;
+    onDelete: ({ id: string, permissions?: BoxCommentPermission }) => any;
+    onSelect: (isSelected: boolean) => void;
+    permissions: BoxCommentPermission;
+    setIsEditing: ((boolean => boolean) | boolean) => void;
+    setIsInputOpen: ((boolean => boolean) | boolean) => void;
+}
+
+export const BaseCommentMenuWrapper = ({
+    canDelete,
+    canEdit,
+    canResolve,
+    id,
+    isEditing,
+    isInputOpen,
+    isResolved,
+    onAnnotationEdit,
+    onCommentEdit,
+    onDelete,
+    onSelect,
+    permissions,
+    setIsEditing,
+    setIsInputOpen,
+}: BaseCommentMenuWrapperProps) => {
+    const [isConfirmingDelete, setIsConfirmingDelete] = React.useState<boolean>(false);
+
+    const handleDeleteConfirm = (): void => {
+        onDelete({ id, permissions });
+        onSelect(false);
+    };
+
+    const handleDeleteCancel = (): void => {
+        setIsConfirmingDelete(false);
+        onSelect(false);
+    };
+
+    const handleDeleteClick = (): void => {
+        setIsConfirmingDelete(true);
+        onSelect(true);
+    };
+
+    const handleEditClick = (): void => {
+        setIsEditing(true);
+        setIsInputOpen(true);
+        onSelect(true);
+    };
+
+    const handleMenuClose = (): void => {
+        if (isConfirmingDelete || isEditing || isInputOpen) {
+            return;
+        }
+        onSelect(false);
+    };
+
+    const handleStatusUpdate = (selectedStatus: FeedItemStatus): void => {
+        if (onAnnotationEdit) {
+            onAnnotationEdit({ id, permissions });
+        } else if (onCommentEdit) {
+            onCommentEdit({ id, status: selectedStatus, hasMention: false, permissions });
+        }
+    };
+
+    return (
+        <BaseCommentMenu
+            canDelete={canDelete}
+            canEdit={canEdit}
+            canResolve={canResolve}
+            handleDeleteCancel={handleDeleteCancel}
+            handleDeleteClick={handleDeleteClick}
+            handleDeleteConfirm={handleDeleteConfirm}
+            handleEditClick={handleEditClick}
+            handleMenuClose={handleMenuClose}
+            handleStatusUpdate={handleStatusUpdate}
+            isConfirmingDelete={isConfirmingDelete}
+            isResolved={isResolved}
+            onSelect={onSelect}
+        />
+    );
+};

--- a/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentInfo.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentInfo.test.js
@@ -40,12 +40,12 @@ describe('elements/content-sidebar/ActivityFeed/comment/BaseCommentInfo', () => 
         // This could fail for some locales, but I was unable to use the ReadableTime component to get the properly-formatted time programmatically
         expect(wrapper.getByText('Sep 27, 2017')).toBeInTheDocument();
 
-        expect(wrapper.queryByText(localize(messages.annotationBadge.id))).not.toBeInTheDocument();
+        expect(wrapper.queryByText(localize(messages.inlineCommentAnnotationIconTitle.id))).not.toBeInTheDocument();
     });
     test('should render an annotation badge if annotationActivityLink is defined', () => {
         const wrapper = getWrapper({
             annotationActivityLink: <AnnotationActivityLinkProvider {...annotationActivityLinkProviderProps} />,
         });
-        expect(wrapper.getByText('Annotation Badge')).toBeInTheDocument();
+        expect(wrapper.getByText(localize(messages.inlineCommentAnnotationIconTitle.id))).toBeInTheDocument();
     });
 });

--- a/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentInfo.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentInfo.test.js
@@ -1,0 +1,51 @@
+// @flow
+
+import React from 'react';
+
+import { IntlProvider } from 'react-intl';
+import { render } from '@testing-library/react';
+
+import { BaseCommentInfo } from '../BaseCommentInfo';
+import localize from '../../../../../../../test/support/i18n';
+
+import { annotationActivityLinkProviderProps, user1 } from '../../stories/common';
+import { baseCommmentInfoDefaultProps } from '../stories/common';
+import AnnotationActivityLinkProvider from '../../../activity-feed/AnnotationActivityLinkProvider';
+
+import messages from '../../messages';
+
+jest.mock('react-intl', () => ({
+    ...jest.requireActual('react-intl'),
+    FormattedMessage: ({ defaultMessage }: { defaultMessage: string }) => <span>{defaultMessage}</span>,
+}));
+
+const getWrapper = props =>
+    render(
+        <IntlProvider locale="en">
+            <BaseCommentInfo {...baseCommmentInfoDefaultProps} {...props} />
+        </IntlProvider>,
+    );
+
+describe('elements/content-sidebar/ActivityFeed/comment/BaseCommentInfo', () => {
+    test('should render appropriate contents if annotationActivityLink is undefined', () => {
+        const wrapper = getWrapper();
+        expect(wrapper.getByText(user1.name)).toBeInTheDocument();
+
+        const userInitials = user1.name
+            .split(' ')
+            .map(word => word[0])
+            .join('');
+        expect(wrapper.getByText(userInitials)).toBeInTheDocument();
+
+        // This could fail for some locales, but I was unable to use the ReadableTime component to get the properly-formatted time programmatically
+        expect(wrapper.getByText('Sep 27, 2017')).toBeInTheDocument();
+
+        expect(wrapper.queryByText(localize(messages.annotationBadge.id))).not.toBeInTheDocument();
+    });
+    test('should render an annotation badge if annotationActivityLink is defined', () => {
+        const wrapper = getWrapper({
+            annotationActivityLink: <AnnotationActivityLinkProvider {...annotationActivityLinkProviderProps} />,
+        });
+        expect(wrapper.getByText('Annotation Badge')).toBeInTheDocument();
+    });
+});

--- a/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentMenu.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentMenu.test.js
@@ -1,0 +1,85 @@
+// @flow
+
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { fireEvent, render, type RenderResult } from '@testing-library/react';
+
+import { BaseCommentMenu } from '../BaseCommentMenu';
+import { baseCommmentMenuDefaultProps } from '../stories/common';
+import localize from '../../../../../../../test/support/i18n';
+
+import messages from '../../messages';
+
+jest.mock('react-intl', () => ({
+    ...jest.requireActual('react-intl'),
+    FormattedMessage: ({ defaultMessage }: { defaultMessage: string }) => <span>{defaultMessage}</span>,
+}));
+
+const openMenu = (wrapper: RenderResult) => {
+    fireEvent.click(wrapper.queryByTestId('comment-actions-menu'));
+};
+
+const getWrapper = props =>
+    render(
+        <IntlProvider locale="en">
+            <BaseCommentMenu {...baseCommmentMenuDefaultProps} {...props} />
+        </IntlProvider>,
+    );
+
+describe('elements/content-sidebar/ActivityFeed/comment/BaseCommentMenu', () => {
+    test.each`
+        prop            | value    | message
+        ${'canResolve'} | ${true}  | ${localize(messages.commentResolveMenuItem.id)}
+        ${'canResolve'} | ${false} | ${localize(messages.commentResolveMenuItem.id)}
+        ${'canEdit'}    | ${true}  | ${localize(messages.commentEditMenuItem.id)}
+        ${'canEdit'}    | ${false} | ${localize(messages.commentEditMenuItem.id)}
+        ${'canDelete'}  | ${true}  | ${localize(messages.commentDeleteMenuItem.id)}
+        ${'canDelete'}  | ${false} | ${localize(messages.commentDeleteMenuItem.id)}
+    `(`should render appropriate menu items when $prop is $value`, ({ prop, value, message }) => {
+        const wrapper = getWrapper({ [prop]: value });
+        openMenu(wrapper);
+        if (value) {
+            expect(wrapper.getByText(message)).toBeInTheDocument();
+        } else {
+            expect(wrapper.queryByText(message)).not.toBeInTheDocument();
+        }
+    });
+
+    test.each`
+        canResolve | isResolved | should
+        ${true}    | ${true}    | ${'should'}
+        ${false}   | ${true}    | ${'should NOT'}
+        ${true}    | ${false}   | ${'should NOT'}
+        ${false}   | ${false}   | ${'should NOT'}
+    `(
+        `$should render unresolve menu item when canResolve us $canResolve and isResolved is $isResolved`,
+        ({ canResolve, isResolved, should }) => {
+            const wrapper = getWrapper({ canResolve, isResolved });
+            const message = localize(messages.commentUnresolveMenuItem.id);
+            openMenu(wrapper);
+            if (should === 'should') {
+                expect(wrapper.getByText(message)).toBeInTheDocument();
+            } else {
+                expect(wrapper.queryByText(message)).not.toBeInTheDocument();
+            }
+        },
+    );
+
+    test.each`
+        isConfirmingDelete | should
+        ${true}            | ${'should'}
+        ${false}           | ${'should NOT'}
+    `(
+        `$should render delete confirmation modal when isConfirmingDelete is $isConfirmingDelete`,
+        ({ isConfirmingDelete, should }) => {
+            const wrapper = getWrapper({ isConfirmingDelete });
+            const message = localize(messages.commentDeletePrompt.id);
+            openMenu(wrapper);
+            if (should === 'should') {
+                expect(wrapper.getByText(message)).toBeInTheDocument();
+            } else {
+                expect(wrapper.queryByText(message)).not.toBeInTheDocument();
+            }
+        },
+    );
+});

--- a/src/elements/content-sidebar/activity-feed/comment/components/stories/BaseCommentInfo.stories.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/stories/BaseCommentInfo.stories.js
@@ -1,0 +1,25 @@
+// @flow
+import * as React from 'react';
+
+import { IntlProvider } from 'react-intl';
+import { BaseCommentInfo, type BaseCommentInfoProps } from '../BaseCommentInfo';
+import AnnotationActivityLinkProvider from '../../../activity-feed/AnnotationActivityLinkProvider';
+import { annotationActivityLinkProviderProps } from '../../stories/common';
+import { baseCommmentInfoDefaultProps } from './common';
+
+const getTemplate = customProps => (props: BaseCommentInfoProps) => (
+    <IntlProvider locale="en">
+        <BaseCommentInfo {...baseCommmentInfoDefaultProps} {...customProps} {...props} />
+    </IntlProvider>
+);
+
+export const Annotation = getTemplate({
+    annotationActivityLink: <AnnotationActivityLinkProvider {...annotationActivityLinkProviderProps} />,
+});
+export const Comment = getTemplate();
+
+export default {
+    title: 'Components|BaseCommentInfo',
+    component: BaseCommentInfo,
+    parameters: { layout: 'centered' },
+};

--- a/src/elements/content-sidebar/activity-feed/comment/components/stories/BaseCommentMenu.stories.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/stories/BaseCommentMenu.stories.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+
+import { IntlProvider } from 'react-intl';
+import { BaseCommentMenu, type BaseCommentMenuProps } from '../BaseCommentMenu';
+import { baseCommmentMenuDefaultProps } from './common';
+
+const getTemplate = customProps => (props: BaseCommentMenuProps) => (
+    <div style={{ marginLeft: '12rem', marginTop: '10.5rem' }}>
+        <IntlProvider locale="en">
+            <BaseCommentMenu {...baseCommmentMenuDefaultProps} {...customProps} {...props} />
+        </IntlProvider>
+    </div>
+);
+
+export const AllPermissions = getTemplate();
+export const CannotDelete = getTemplate({ canDelete: false });
+export const CannotResolve = getTemplate({ canResolve: false });
+export const CannotModify = getTemplate({ canEdit: false });
+export const ConfirmingDelete = getTemplate({ isConfirmingDelete: true });
+
+export default {
+    title: 'Components|BaseCommentMenu',
+    component: BaseCommentMenu,
+    parameters: { layout: 'centered' },
+};

--- a/src/elements/content-sidebar/activity-feed/comment/components/stories/common.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/stories/common.js
@@ -1,0 +1,28 @@
+// @flow
+import { TIME_STRING_SEPT_27_2017, user1 } from '../../stories/common';
+
+import { type BaseCommentMenuProps } from '../BaseCommentMenu';
+import { type BaseCommentInfoProps } from '../BaseCommentInfo';
+
+export const baseCommmentMenuDefaultProps: BaseCommentMenuProps = {
+    canDelete: true,
+    canEdit: true,
+    canResolve: true,
+    handleDeleteCancel: () => undefined,
+    handleDeleteClick: () => undefined,
+    handleDeleteConfirm: () => undefined,
+    handleEditClick: () => undefined,
+    handleMenuClose: () => undefined,
+    // eslint-disable-next-line no-unused-vars
+    handleStatusUpdate: args => undefined,
+    isConfirmingDelete: false,
+    isResolved: false,
+    // eslint-disable-next-line no-unused-vars
+    onSelect: args => undefined,
+};
+
+export const baseCommmentInfoDefaultProps: BaseCommentInfoProps = {
+    created_at: TIME_STRING_SEPT_27_2017,
+    created_by: user1,
+    getAvatarUrl: (str: string) => new Promise(() => str),
+};

--- a/src/elements/content-sidebar/activity-feed/comment/stories/common.js
+++ b/src/elements/content-sidebar/activity-feed/comment/stories/common.js
@@ -95,7 +95,7 @@ export const annotationBase: Annotation = {
     type: 'annotation',
 };
 
-const annotationActivityLinkProviderProps = {
+export const annotationActivityLinkProviderProps = {
     isCurrentVersion: true,
     item: annotationBase,
     onSelect: () => {

--- a/src/elements/content-sidebar/activity-feed/common/delete-confirmation/DeleteConfirmation.scss
+++ b/src/elements/content-sidebar/activity-feed/common/delete-confirmation/DeleteConfirmation.scss
@@ -2,7 +2,7 @@
 @import '../../../../../styles/mixins/overlay';
 
 .bcs-DeleteConfirmation {
-    width: 212px;
+    width: 214px;
 
     .overlay {
         @include bdl-Overlay-container;


### PR DESCRIPTION
The purpose of this task is to bring `BaseComment` into alignment with the layout for TR comments in [designs](https://www.figma.com/file/EyW24R6Bg9IkiQ33urle5l/Preview-Threaded-Replies-and-Annotations?node-id=1169%3A189350&mode=dev). The nesting of wrappers to apply the new layout prompted a request to break `BaseComment` down into its constituent components. That is the content of this PR.

Please note that bringing activity item styles into full alignment with the designs is beyond the scope of this PR. I did only what I subjectively considered to be the minimum to accommodate the new layout. (See [this document](https://cloud.box.com/s/04xkqx19dfkj5v4v069waqwh7locfzt3) for an attempt at cataloguing all incoming UI diffs).

legacy (on dev pod)
![Screenshot 2023-09-27 at 12 45 55 PM](https://github.com/box/box-ui-elements/assets/5461045/26b3f12f-fa2d-45f1-9310-e858bf205515)

new layout (on dev pod)
![TR-new-layout](https://github.com/box/box-ui-elements/assets/5461045/a7372091-26cb-45c9-8a99-bebdc87744fb)

If helpful, some screenshots of stories:
![Screenshot 2023-09-26 at 3 46 53 PM](https://github.com/box/box-ui-elements/assets/5461045/9360269e-6c57-461f-8e9e-7be4107124a8)
![Screenshot 2023-09-26 at 3 46 58 PM](https://github.com/box/box-ui-elements/assets/5461045/6cba5dda-1c1c-419d-8857-17221bfc7c7e)
![Screenshot 2023-09-26 at 3 47 32 PM](https://github.com/box/box-ui-elements/assets/5461045/88a2f856-2b25-4f7c-89a9-df1277fda675)
![Screenshot 2023-09-26 at 4 05 03 PM](https://github.com/box/box-ui-elements/assets/5461045/ae268222-6d22-4bef-9878-ac25531ff308)
![Screenshot 2023-09-26 at 3 47 42 PM](https://github.com/box/box-ui-elements/assets/5461045/8b8c9937-4200-49e6-8a0d-672f43be38af)
![Screenshot 2023-09-26 at 3 47 45 PM](https://github.com/box/box-ui-elements/assets/5461045/d6a85a37-db78-4825-a8d8-1f40e02a86ea)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
