### PR TITLE
feat(preview): Focus on comment form for replies and modifying

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -6,6 +6,7 @@
 import * as React from 'react';
 import noop from 'lodash/noop';
 import classNames from 'classnames';
+import { EditorState } from 'draft-js';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import type { InjectIntlProvidedProps } from 'react-intl';
 import Avatar from '../Avatar';
@@ -37,11 +38,17 @@ type Props = {
     onFocus?: Function,
     onSubmit?: Function,
     placeholder?: string,
+    shouldFocusOnOpen?: boolean,
     showTip?: boolean,
     tagged_message?: string,
     updateComment?: Function,
     user?: User,
 } & InjectIntlProvidedProps;
+
+const getEditorState = (shouldFocusOnOpen: boolean, message?: string): EditorState =>
+    shouldFocusOnOpen
+        ? EditorState.moveFocusToEnd(createMentionSelectorState(message))
+        : createMentionSelectorState(message);
 
 type State = {
     commentEditorState: any,
@@ -50,18 +57,19 @@ type State = {
 class CommentForm extends React.Component<Props, State> {
     static defaultProps = {
         isOpen: false,
+        shouldFocusOnOpen: false,
     };
 
     state = {
-        commentEditorState: createMentionSelectorState(this.props.tagged_message),
+        commentEditorState: getEditorState(this.props.shouldFocusOnOpen, this.props.tagged_message),
     };
 
     componentDidUpdate({ isOpen: prevIsOpen }: Props): void {
-        const { isOpen } = this.props;
+        const { isOpen, shouldFocusOnOpen } = this.props;
 
         if (isOpen !== prevIsOpen && !isOpen) {
             this.setState({
-                commentEditorState: createMentionSelectorState(),
+                commentEditorState: getEditorState(shouldFocusOnOpen),
             });
         }
     }
@@ -86,7 +94,7 @@ class CommentForm extends React.Component<Props, State> {
         }
 
         this.setState({
-            commentEditorState: createMentionSelectorState(),
+            commentEditorState: getEditorState(false),
         });
     };
 

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -38,7 +38,7 @@ type Props = {
     onFocus?: Function,
     onSubmit?: Function,
     placeholder?: string,
-    shouldFocusOnOpen?: boolean,
+    shouldFocusOnOpen: boolean,
     showTip?: boolean,
     tagged_message?: string,
     updateComment?: Function,

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -65,11 +65,11 @@ class CommentForm extends React.Component<Props, State> {
     };
 
     componentDidUpdate({ isOpen: prevIsOpen }: Props): void {
-        const { isOpen, shouldFocusOnOpen } = this.props;
+        const { isOpen } = this.props;
 
         if (isOpen !== prevIsOpen && !isOpen) {
             this.setState({
-                commentEditorState: getEditorState(shouldFocusOnOpen),
+                commentEditorState: getEditorState(false),
             });
         }
     }

--- a/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
-import { render as renderRTLFunc } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { EditorState } from 'draft-js';
 
 import Button from '../../../../../components/button/Button';
@@ -18,12 +18,12 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
         <CommentForm getMentionWithQuery={() => {}} intl={intlFake} user={{ id: 123, name: 'foo bar' }} {...props} />
     );
 
-    const render = props => mount(getComponent(props));
+    const getWrapper = props => mount(getComponent(props));
 
-    const renderRTL = props => renderRTLFunc(getComponent(props));
+    const getWrapperRTL = props => render(getComponent(props));
 
     test('should correctly render initial state', () => {
-        const wrapper = render();
+        const wrapper = getWrapper();
 
         expect(wrapper.find('[contentEditable]').length).toEqual(1);
         expect(wrapper.find('.bcs-CommentFormControls').length).toEqual(0);
@@ -33,7 +33,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     test('should call onFocus handler when input is focused', () => {
         const onFocusSpy = jest.fn();
 
-        const wrapper = render({ onFocus: onFocusSpy });
+        const wrapper = getWrapper({ onFocus: onFocusSpy });
 
         const mentionSelector = wrapper.find('[contentEditable]');
         mentionSelector.simulate('focus');
@@ -42,7 +42,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
 
     test('should call oncancel handler when input is canceled', () => {
         const onCancelSpy = jest.fn();
-        const wrapper = render({ isOpen: true, onCancel: onCancelSpy });
+        const wrapper = getWrapper({ isOpen: true, onCancel: onCancelSpy });
         const cancelButton = wrapper.find(Button).first();
 
         cancelButton.simulate('click');
@@ -50,7 +50,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     });
 
     test('should render open comment input when isOpen is true', () => {
-        const wrapper = render({ isOpen: true });
+        const wrapper = getWrapper({ isOpen: true });
 
         expect(wrapper.find(Media).hasClass('bcs-is-open')).toBe(true);
         expect(wrapper.find('.bcs-CommentFormControls').length).toEqual(1);
@@ -58,7 +58,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     });
 
     test('should set required to false on comment input when not open', () => {
-        const wrapper = render();
+        const wrapper = getWrapper();
 
         expect(
             wrapper
@@ -69,7 +69,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     });
 
     test('should set required to true on comment input when isOpen is true', () => {
-        const wrapper = render({ isOpen: true });
+        const wrapper = getWrapper({ isOpen: true });
 
         expect(
             wrapper
@@ -89,7 +89,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     `(`should call createComment $expectedCallCount times`, ({ commentText, expectedCallCount }) => {
         const createCommentSpy = jest.fn();
 
-        const wrapper = render({ createComment: createCommentSpy });
+        const wrapper = getWrapper({ createComment: createCommentSpy });
         const instance = wrapper.instance();
 
         instance.getFormattedCommentText = jest.fn().mockReturnValue(commentText);
@@ -103,7 +103,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     });
 
     test('should have editor state reflect tagged_message prop when not empty', () => {
-        const wrapper = render({ tagged_message: 'hey there' });
+        const wrapper = getWrapper({ tagged_message: 'hey there' });
 
         expect(
             wrapper
@@ -120,7 +120,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     });
 
     test('should have editor state reflect empty state when no tagged_message prop is passed', () => {
-        const wrapper = render();
+        const wrapper = getWrapper();
 
         expect(
             wrapper
@@ -137,7 +137,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     });
 
     test('should not display trigger @mention selector when getMentionQuery prop is empty', () => {
-        const wrapper = render({ getMentionWithQuery: null });
+        const wrapper = getWrapper({ getMentionWithQuery: null });
 
         expect(
             wrapper
@@ -148,13 +148,13 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
     });
 
     test('should not show mention tip is showTip is false', () => {
-        const wrapper = render({ showTip: false });
+        const wrapper = getWrapper({ showTip: false });
 
         expect(wrapper.find('.bcs-CommentForm-tip').length).toEqual(0);
     });
 
     test('should show custom placeholder when provided', () => {
-        const wrapper = render({ placeholder: 'Your comment goes here' });
+        const wrapper = getWrapper({ placeholder: 'Your comment goes here' });
 
         expect(
             wrapper
@@ -168,7 +168,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
         const mockFocusFunc = jest.fn();
         EditorState.moveFocusToEnd = mockFocusFunc;
 
-        renderRTL();
+        getWrapperRTL();
         expect(mockFocusFunc).not.toHaveBeenCalled();
     });
 
@@ -176,7 +176,7 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
         const mockFocusFunc = jest.fn();
         EditorState.moveFocusToEnd = mockFocusFunc;
 
-        renderRTL({ shouldFocusOnOpen: true });
+        getWrapperRTL({ shouldFocusOnOpen: true });
         expect(mockFocusFunc).toHaveBeenCalled();
     });
 });

--- a/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
+import { render as renderRTLFunc } from '@testing-library/react';
+import { EditorState } from 'draft-js';
 
 import Button from '../../../../../components/button/Button';
 import Media from '../../../../../components/media';
@@ -12,15 +14,13 @@ const intlFake = {
 };
 
 describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () => {
-    const render = props =>
-        mount(
-            <CommentForm
-                getMentionWithQuery={() => {}}
-                intl={intlFake}
-                user={{ id: 123, name: 'foo bar' }}
-                {...props}
-            />,
-        );
+    const getComponent = (props = {}) => (
+        <CommentForm getMentionWithQuery={() => {}} intl={intlFake} user={{ id: 123, name: 'foo bar' }} {...props} />
+    );
+
+    const render = props => mount(getComponent(props));
+
+    const renderRTL = props => renderRTLFunc(getComponent(props));
 
     test('should correctly render initial state', () => {
         const wrapper = render();
@@ -162,5 +162,21 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
                 .at(0)
                 .prop('placeholder'),
         ).toEqual('Your comment goes here');
+    });
+
+    test('should not focus on textbox when shouldFocusOnOpen is false', () => {
+        const mockFocusFunc = jest.fn();
+        EditorState.moveFocusToEnd = mockFocusFunc;
+
+        renderRTL();
+        expect(mockFocusFunc).not.toHaveBeenCalled();
+    });
+
+    test('should focus on textbox when shouldFocusOnOpen is true', () => {
+        const mockFocusFunc = jest.fn();
+        EditorState.moveFocusToEnd = mockFocusFunc;
+
+        renderRTL({ shouldFocusOnOpen: true });
+        expect(mockFocusFunc).toHaveBeenCalled();
     });
 });

--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
@@ -302,22 +302,23 @@ export const BaseComment = ({
                     <ActivityStatus status={status} />
                     {isEditing ? (
                         <CommentForm
-                            isDisabled={isDisabled}
                             className={classNames('bcs-Comment-editor', {
                                 'bcs-is-disabled': isDisabled,
                             })}
-                            updateComment={handleMessageUpdate}
+                            entityId={id}
+                            getAvatarUrl={getAvatarUrl}
+                            getMentionWithQuery={getMentionWithQuery}
+                            isDisabled={isDisabled}
+                            isEditing={isEditing}
                             isOpen={isInputOpen}
-                            // $FlowFixMe
-                            user={currentUser}
+                            mentionSelectorContacts={mentionSelectorContacts}
                             onCancel={commentFormCancelHandler}
                             onFocus={commentFormFocusHandler}
-                            isEditing={isEditing}
-                            entityId={id}
+                            shouldFocusOnOpen
                             tagged_message={tagged_message}
-                            getAvatarUrl={getAvatarUrl}
-                            mentionSelectorContacts={mentionSelectorContacts}
-                            getMentionWithQuery={getMentionWithQuery}
+                            updateComment={handleMessageUpdate}
+                            // $FlowFixMe
+                            user={currentUser}
                         />
                     ) : (
                         <ActivityMessage

--- a/src/elements/content-sidebar/activity-feed/comment/CreateReply.js
+++ b/src/elements/content-sidebar/activity-feed/comment/CreateReply.js
@@ -49,15 +49,16 @@ const CreateReply = ({
             {showReplyForm && !isDisabled ? (
                 <CommentForm
                     className="bcs-CreateReply-form"
+                    createComment={handleSubmit}
+                    getMentionWithQuery={getMentionWithQuery}
                     isOpen
                     isEditing
-                    showTip={false}
+                    mentionSelectorContacts={mentionSelectorContacts}
                     onCancel={onCancel}
                     onFocus={onFocus}
-                    createComment={handleSubmit}
-                    mentionSelectorContacts={mentionSelectorContacts}
-                    getMentionWithQuery={getMentionWithQuery}
                     placeholder={placeholder}
+                    shouldFocusOnOpen
+                    showTip={false}
                 />
             ) : (
                 <PlainButton className="bcs-CreateReply-toggle" onClick={onClick} type="button" isDisabled={isDisabled}>

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
@@ -55,6 +55,10 @@ export const getWrapper = props =>
     );
 
 describe('elements/content-sidebar/ActivityFeed/comment/BaseComment', () => {
+    beforeEach(() => {
+        EditorState.moveFocusToEnd = editor => editor;
+    });
+
     test.each`
         activityItem
         ${annotation}
@@ -402,5 +406,17 @@ describe('elements/content-sidebar/ActivityFeed/comment/BaseComment', () => {
 
         expect(showReplies).toBeCalledTimes(1);
         expect(hideReplies).not.toBeCalled();
+    });
+
+    test('should focus on the edit CommentForm when it is opened', () => {
+        const mockFocusFunc = jest.fn();
+        EditorState.moveFocusToEnd = mockFocusFunc;
+
+        getWrapper({ canEdit: true });
+        const menuItem = screen.getByTestId('comment-actions-menu');
+        fireEvent.click(menuItem);
+        const editButton = screen.getByTestId('edit-comment');
+        fireEvent.click(editButton);
+        expect(mockFocusFunc).toHaveBeenCalled();
     });
 });

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
@@ -55,9 +55,7 @@ export const getWrapper = props =>
     );
 
 describe('elements/content-sidebar/ActivityFeed/comment/BaseComment', () => {
-    beforeEach(() => {
-        EditorState.moveFocusToEnd = editor => editor;
-    });
+    EditorState.moveFocusToEnd = editor => editor;
 
     test.each`
         activityItem

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/CreateReply.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/CreateReply.test.js
@@ -37,6 +37,10 @@ const getWrapper = props =>
     );
 
 describe('elements/content-sidebar/ActivityFeed/comment/CreateReply', () => {
+    beforeEach(() => {
+        EditorState.moveFocusToEnd = editor => editor;
+    });
+
     afterEach(() => {
         jest.restoreAllMocks();
     });
@@ -123,5 +127,13 @@ describe('elements/content-sidebar/ActivityFeed/comment/CreateReply', () => {
         fireEvent.click(screen.getByText('Post'));
         expect(onSubmit).toBeCalledTimes(1);
         expect(onSubmit).toBeCalledWith('Batman');
+    });
+
+    test('reply form should be focused when opened', () => {
+        const mockFocusFunc = jest.fn();
+        EditorState.moveFocusToEnd = mockFocusFunc;
+
+        getWrapper({ showReplyForm: true });
+        expect(mockFocusFunc).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
- Used draft.js functionality in `EditorState` to force focus on the comment form when it is open from either initiating a new reply or modifying and existing comment/reply
- Added `shouldFocusOnOpen` prop to `CommentForm` which allows callers to opt in to this behavior

*Note regarding tests* -- While it would be better to simulate click events and check browser focus of the textbox element, the `EditorState.moveFocusToEnd` uses a lot of window functions which don't exist in our current version of jsdom. I tried upgrading jsdom which solved the issue but focusing on the text box still wasn't working correctly. Given that this function is part of draft.js, I opted to mock it and check that was called.


![focus on comment form](https://github.com/box/box-ui-elements/assets/4257589/b5d723ff-29db-4dbf-8add-c907010ad26e)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
