### PR TITLE
feat(aci): add ACI config to features prop

### DIFF
--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -110,9 +110,10 @@ describe('elements/content-preview/ContentPreview', () => {
             file = { id: '123' };
 
             props = {
-                advancedContentInsights: {
-                    enabled: true,
-                    isActive: false,
+                features: {
+                    advancedContentInsights: {
+                        isActive: false,
+                    },
                 },
             };
 
@@ -123,9 +124,9 @@ describe('elements/content-preview/ContentPreview', () => {
             instance.destroyPreview = jest.fn();
             instance.fetchFile = jest.fn();
 
-            const updatedContentInsightsOptions = { enabled: true, isActive: true };
+            const updatedContentInsightsOptions = { isActive: true };
 
-            wrapper.setProps({ advancedContentInsights: updatedContentInsightsOptions });
+            wrapper.setProps({ features: { advancedContentInsights: updatedContentInsightsOptions } });
 
             expect(instance.preview.updateContentInsightsOptions).toHaveBeenCalledWith(updatedContentInsightsOptions);
         });


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
