### PR TITLE
fix(activity-feed-zoom): add a min-height prop to the items container

### DIFF
--- a/src/elements/common/_variables.scss
+++ b/src/elements/common/_variables.scss
@@ -6,6 +6,7 @@ $font: Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $minimumWidth: 300px;
 $sidebarHeaderHeight: 60px;
 $sidebarContentWidth: 340px;
+$sidebarContentMinHeight: 93px;
 $sidebarActivityFeedSpacingHorizontal: 20px;
 $sidebarActivityFeedSpacingVertical: 20px;
 $sidebarActivityFeedSelectedItemSpacing: 10px;

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -49,7 +49,7 @@
         flex: 1 1 auto;
         flex-direction: column;
         width: 100%; // Explicit width required since flex-direction is column
-        min-height: 93px;
+        min-height: $sidebarContentMinHeight;
         overflow-x: hidden;
         overflow-y: auto;
 
@@ -134,7 +134,7 @@
 
     .bcs-activity-feed-comment-input {
         flex: 0 0 auto;
-        min-height: 93px;
+        min-height: $sidebarContentMinHeight;
         max-height: 500px;
         overflow: hidden;
         background-color: $white;

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -49,6 +49,7 @@
         flex: 1 1 auto;
         flex-direction: column;
         width: 100%; // Explicit width required since flex-direction is column
+        min-height: 93px;
         overflow-x: hidden;
         overflow-y: auto;
 


### PR DESCRIPTION
The activity feed with comments list doesn't scale with zoom correctly. At 400% zoom, the top header and the comment form cover the whole screen making the comment history not visible and it's not possible to scroll it into a view.

This PR adds a min-height property to the comments container so it does not get squished to zero height. The min-height is the same as the comment form.

Before:
<img width="400" alt="zoom400before" src="https://github.com/box/box-ui-elements/assets/140608245/9e07ce76-5b3b-4750-ba78-e4e57bd2fa1f">
After:
<img width="400" alt="zoom400after" src="https://github.com/box/box-ui-elements/assets/140608245/d13c606a-cac1-4ef1-8628-79e29d6d7e99">

