### PR TITLE
feat(annotations): editing an annotation reply

### DIFF
--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -322,6 +322,7 @@ const ActiveState = ({
                                             />
                                         }
                                         onAnnotationEdit={onAnnotationEdit}
+                                        onCommentEdit={onCommentEdit}
                                         onDelete={onAnnotationDelete}
                                         onReplyCreate={reply =>
                                             onReplyCreate(item.id, FEED_ITEM_TYPE_ANNOTATION, reply)

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
@@ -193,7 +193,7 @@ describe('elements/content-sidebar/ActiveState/activity-feed/ActiveState', () =>
         expect(wrapper.find('AnnotationActivity')).toHaveLength(hasNewThreadedReplies ? 0 : 1);
     });
 
-    test('Annotationq BaseComment has onCommentEdit to edit replies', () => {
+    test('Annotation BaseComment has onCommentEdit to edit replies', () => {
         const onCommentEdit = () => {};
         const wrapper = getShallowWrapper({ hasNewThreadedReplies: true, items: [annotation], onCommentEdit }).dive();
         const baseComment = wrapper.find('BaseComment');

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
@@ -192,4 +192,11 @@ describe('elements/content-sidebar/ActiveState/activity-feed/ActiveState', () =>
         expect(wrapper.find('Comment')).toHaveLength(hasNewThreadedReplies ? 0 : 1);
         expect(wrapper.find('AnnotationActivity')).toHaveLength(hasNewThreadedReplies ? 0 : 1);
     });
+
+    test('Annotationq BaseComment has onCommentEdit to edit replies', () => {
+        const onCommentEdit = () => {};
+        const wrapper = getShallowWrapper({ hasNewThreadedReplies: true, items: [annotation], onCommentEdit }).dive();
+        const baseComment = wrapper.find('BaseComment');
+        expect(baseComment.props().onCommentEdit).toEqual(onCommentEdit);
+    });
 });


### PR DESCRIPTION
- Editing replies of an annotation should hit the comment edit endpoint to successfully work. Therefore, `onCommentEdit` must be passed to the Annotations BaseComment component so that it can ultimately be passed down to the Replies component and correctly called on a reply edit
- There is a known bug where the page must be refreshed to view a reply edit. This has been ticketed for a fix

![annotation reply edit](https://github.com/box/box-ui-elements/assets/4257589/ba3dec0e-d389-491b-bd01-42576c728891)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
