### PR TITLE
fix: disable copy in textInputWithCopyButton when button is disabled

### DIFF
--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -26,6 +26,8 @@ type Props = {
     buttonProps?: Object,
     buttonSuccessText?: string | React.Node,
     className: string,
+    /** Disables copy function when copyDisabled is true */
+    copyDisabled?: boolean,
     disabled?: boolean,
     /** Label displayed for the text input */
     // TODO: Make label required
@@ -159,11 +161,15 @@ class TextInputWithCopyButton extends React.PureComponent<Props, State> {
     };
 
     handleCopyEvent = (event: SyntheticEvent<>) => {
-        this.animateCopyButton();
+        if (this.props.copyDisabled) {
+            event.preventDefault();
+        } else {
+            this.animateCopyButton();
 
-        const { onCopySuccess } = this.props;
-        if (onCopySuccess) {
-            onCopySuccess(event);
+            const { onCopySuccess } = this.props;
+            if (onCopySuccess) {
+                onCopySuccess(event);
+            }
         }
     };
 

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -159,12 +159,13 @@ class TextInputWithCopyButton extends React.PureComponent<Props, State> {
     };
 
     handleCopyEvent = (event: SyntheticEvent<>) => {
-        if (this.props.disabled) {
+        const { disabled, onCopySuccess } = this.props;
+
+        if (disabled) {
             event.preventDefault();
         } else {
             this.animateCopyButton();
 
-            const { onCopySuccess } = this.props;
             if (onCopySuccess) {
                 onCopySuccess(event);
             }

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -27,7 +27,6 @@ type Props = {
     buttonSuccessText?: string | React.Node,
     className: string,
     /** Disables copy function when copyDisabled is true */
-    copyDisabled?: boolean,
     disabled?: boolean,
     /** Label displayed for the text input */
     // TODO: Make label required
@@ -161,7 +160,7 @@ class TextInputWithCopyButton extends React.PureComponent<Props, State> {
     };
 
     handleCopyEvent = (event: SyntheticEvent<>) => {
-        if (this.props.copyDisabled) {
+        if (this.props.disabled) {
             event.preventDefault();
         } else {
             this.animateCopyButton();

--- a/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
+++ b/src/components/text-input-with-copy-button/TextInputWithCopyButton.js
@@ -26,7 +26,6 @@ type Props = {
     buttonProps?: Object,
     buttonSuccessText?: string | React.Node,
     className: string,
-    /** Disables copy function when copyDisabled is true */
     disabled?: boolean,
     /** Label displayed for the text input */
     // TODO: Make label required


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
Currently textInputWithCopyButton allows the user to use ctrl c to copy the text input even when button is disabled. This change adds a disableCopy prop that will completely disable the ability to copy when set to true.