### PR TITLE
feat(threaded-replies): added resolve/unresolve for annotations

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -73,7 +73,7 @@ import type { Translations } from './flowTypes';
 import type { FeatureConfig } from '../common/feature-checking';
 import './ActivitySidebar.scss';
 
-import { type OnAnnotationEdit } from './activity-feed/comment/types';
+import type { OnAnnotationEdit, OnAnnotationStatusChange } from './activity-feed/comment/types';
 
 type ExternalProps = {
     activeFeedEntryId?: string,
@@ -224,7 +224,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         this.fetchFeedItems();
     };
 
-    handleAnnotationStatusChange = (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => {
+    handleAnnotationStatusChange: OnAnnotationStatusChange = ({ id, permissions, status }) => {
         const { api, emitAnnotationUpdateEvent, file } = this.props;
 
         emitAnnotationUpdateEvent({ id, status }, true);

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -1446,10 +1446,14 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             const instance = wrapper.instance();
             instance.fetchFeedItems = jest.fn();
 
-            wrapper.instance().handleAnnotationStatusChange('123', 'open', {
-                can_edit: true,
-                can_delete: true,
-                can_resolve: true,
+            wrapper.instance().handleAnnotationStatusChange({
+                id: '123',
+                status: 'open',
+                permissions: {
+                    can_edit: true,
+                    can_delete: true,
+                    can_resolve: true,
+                },
             });
 
             expect(mockEmitAnnotationUpdateEvent).toBeCalledWith({ id: '123', status: 'open' }, true);

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -109,7 +109,7 @@ const ActiveState = ({
     onAnnotationStatusChange,
     onAppActivityDelete,
     onCommentDelete,
-    onCommentEdit = noop,
+    onCommentEdit,
     onCommentSelect = noop,
     onHideReplies = noop,
     onReplyCreate = noop,
@@ -156,7 +156,9 @@ const ActiveState = ({
         permissions: AnnotationPermission | BoxCommentPermission,
         status: FeedItemStatus,
     }) => {
-        onCommentEdit({ hasMention: false, ...props });
+        if (onCommentEdit) {
+            onCommentEdit({ hasMention: false, ...props });
+        }
     };
 
     const hasMultipleVersions = item => item.versions || (shouldUseUAA && item.version_start !== item.version_end);

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActiveState.js
@@ -35,7 +35,12 @@ import type { SelectorItems, User } from '../../../../common/types/core';
 import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
 import type { Translations } from '../../flowTypes';
 
-import { type OnAnnotationEdit, type OnCommentEdit } from '../comment/types';
+import type {
+    OnAnnotationEdit,
+    OnAnnotationStatusChange,
+    OnCommentEdit,
+    OnCommentStatusChange,
+} from '../comment/types';
 import AnnotationActivityLinkProvider from './AnnotationActivityLinkProvider';
 
 type Props = {
@@ -56,7 +61,7 @@ type Props = {
     onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => void,
     onAnnotationEdit?: OnAnnotationEdit,
     onAnnotationSelect?: (annotation: Annotation) => void,
-    onAnnotationStatusChange?: (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => void,
+    onAnnotationStatusChange: OnAnnotationStatusChange,
     onAppActivityDelete?: Function,
     onCommentDelete?: Function,
     onCommentEdit?: OnCommentEdit,
@@ -104,7 +109,7 @@ const ActiveState = ({
     onAnnotationStatusChange,
     onAppActivityDelete,
     onCommentDelete,
-    onCommentEdit,
+    onCommentEdit = noop,
     onCommentSelect = noop,
     onHideReplies = noop,
     onReplyCreate = noop,
@@ -145,6 +150,13 @@ const ActiveState = ({
     };
     const onShowRepliesHandler = (id: string, type: CommentFeedItemType) => () => {
         onShowReplies(id, type);
+    };
+    const onCommentStatusChangeHandler: OnCommentStatusChange = (props: {
+        id: string,
+        permissions: AnnotationPermission | BoxCommentPermission,
+        status: FeedItemStatus,
+    }) => {
+        onCommentEdit({ hasMention: false, ...props });
     };
 
     const hasMultipleVersions = item => item.versions || (shouldUseUAA && item.version_start !== item.version_end);
@@ -204,6 +216,7 @@ const ActiveState = ({
                                         onReplyCreate={reply => onReplyCreate(item.id, FEED_ITEM_TYPE_COMMENT, reply)}
                                         onReplyDelete={onReplyDeleteHandler(item.id)}
                                         onShowReplies={() => onShowReplies(item.id, FEED_ITEM_TYPE_COMMENT)}
+                                        onStatusChange={onCommentStatusChangeHandler}
                                     />
                                 ) : (
                                     <ActivityThread
@@ -324,6 +337,7 @@ const ActiveState = ({
                                         onAnnotationEdit={onAnnotationEdit}
                                         onCommentEdit={onCommentEdit}
                                         onDelete={onAnnotationDelete}
+                                        onStatusChange={onAnnotationStatusChange}
                                         onReplyCreate={reply =>
                                             onReplyCreate(item.id, FEED_ITEM_TYPE_ANNOTATION, reply)
                                         }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.js
@@ -37,7 +37,7 @@ import type {
 import type { SelectorItems, User, GroupMini, BoxItem } from '../../../../common/types/core';
 import type { Errors, GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
 import type { Translations } from '../../flowTypes';
-import { type OnAnnotationEdit } from '../comment/types';
+import type { OnAnnotationEdit, OnAnnotationStatusChange } from '../comment/types';
 
 import './ActivityFeed.scss';
 
@@ -63,7 +63,7 @@ export type ActivityFeedProps = {
     onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => void,
     onAnnotationEdit?: OnAnnotationEdit,
     onAnnotationSelect?: (annotation: Annotation) => void,
-    onAnnotationStatusChange?: (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => void,
+    onAnnotationStatusChange: OnAnnotationStatusChange,
     onAppActivityDelete?: Function,
     onCommentCreate?: Function,
     onCommentDelete?: Function,

--- a/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/__tests__/ActiveState.test.js
@@ -199,4 +199,33 @@ describe('elements/content-sidebar/ActiveState/activity-feed/ActiveState', () =>
         const baseComment = wrapper.find('BaseComment');
         expect(baseComment.props().onCommentEdit).toEqual(onCommentEdit);
     });
+
+    test('Annotation BaseComment has onStatusChange from onAnnotationStatusChange', () => {
+        const onAnnotationStatusChange = () => {};
+        const wrapper = getShallowWrapper({
+            hasNewThreadedReplies: true,
+            items: [annotation],
+            onAnnotationStatusChange,
+        }).dive();
+        const baseComment = wrapper.find('BaseComment');
+        expect(baseComment.props().onStatusChange).toEqual(onAnnotationStatusChange);
+    });
+
+    test('Comment BaseComment has onStatusChange from onCommentEdit', () => {
+        const onCommentEdit = jest.fn();
+
+        const props = {
+            hasNewThreadedReplies: true,
+            items: [comment],
+            onCommentEdit,
+        };
+
+        const wrapper = getShallowWrapper(props).dive();
+        const baseComment = wrapper.find('BaseComment');
+        const onStatusChangeProp = baseComment.props().onStatusChange;
+        const expectedProps = { hasMention: false, ...props };
+
+        onStatusChangeProp(expectedProps);
+        expect(onCommentEdit).toHaveBeenCalledWith(expectedProps);
+    });
 });

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThreadContent.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/AnnotationThreadContent.js
@@ -18,7 +18,7 @@ import type { AnnotationThreadError } from './types';
 
 import './AnnotationThreadContent.scss';
 
-import type { OnAnnotationEdit } from '../comment/types';
+import type { OnAnnotationEdit, OnAnnotationStatusChange } from '../comment/types';
 
 type Props = {
     annotation?: Annotation,
@@ -31,7 +31,7 @@ type Props = {
     mentionSelectorContacts: SelectorItems<>,
     onAnnotationDelete?: ({ id: string, permissions: AnnotationPermission }) => any,
     onAnnotationEdit?: OnAnnotationEdit,
-    onAnnotationStatusChange?: (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => void,
+    onAnnotationStatusChange: OnAnnotationStatusChange,
     onReplyCreate?: (text: string) => void,
     onReplyDelete?: ({ id: string, permissions: BoxCommentPermission }) => void,
     onReplyEdit?: (

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/__tests__/useAnnotationThread.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/__tests__/useAnnotationThread.test.js
@@ -351,8 +351,10 @@ describe('src/elements/content-sidebar/activity-feed/useAnnotationThread', () =>
 
             const { result } = getHook();
             act(() => {
-                result.current.annotationActions.handleAnnotationStatusChange(annotation.id, 'resolved', {
-                    can_resolve: true,
+                result.current.annotationActions.handleAnnotationStatusChange({
+                    id: annotation.id,
+                    status: 'resolved',
+                    permissions: { can_resolve: true },
                 });
             });
 

--- a/src/elements/content-sidebar/activity-feed/annotation-thread/useAnnotationThread.js
+++ b/src/elements/content-sidebar/activity-feed/annotation-thread/useAnnotationThread.js
@@ -14,7 +14,7 @@ import type { BoxItem, User } from '../../../../common/types/core';
 import type { BoxCommentPermission, Comment, FeedItemStatus } from '../../../../common/types/feed';
 import type { ElementOrigin, ElementsXhrError } from '../../../../common/types/api';
 import type { AnnotationThreadError } from './types';
-import type { OnAnnotationEdit } from '../comment/types';
+import type { OnAnnotationEdit, OnAnnotationStatusChange } from '../comment/types';
 
 const normalizeReplies = (repliesArray?: Array<Comment>): { [string]: Comment } => {
     if (!repliesArray) {
@@ -54,7 +54,7 @@ type UseAnnotationThread = {
         handleAnnotationCreate: (text: string) => void,
         handleAnnotationDelete: ({ id: string, permissions: AnnotationPermission }) => void,
         handleAnnotationEdit: OnAnnotationEdit,
-        handleAnnotationStatusChange: (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => void,
+        handleAnnotationStatusChange: OnAnnotationStatusChange,
     },
     error?: AnnotationThreadError,
     isLoading: boolean,
@@ -323,11 +323,7 @@ const useAnnotationThread = ({
         });
     };
 
-    const handleAnnotationStatusChange = (
-        id: string,
-        status: FeedItemStatus,
-        permissions: AnnotationPermission,
-    ): void => {
+    const handleAnnotationStatusChange: OnAnnotationStatusChange = ({ id, permissions, status }): void => {
         setAnnotation(prevAnnotation => ({ ...prevAnnotation, isPending: true }));
 
         handleStatusChange({

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -27,7 +27,7 @@ import IconAnnotation from '../../../../icons/two-toned/IconAnnotation';
 
 import './AnnotationActivity.scss';
 
-import { type OnAnnotationEdit } from '../comment/types';
+import type { OnAnnotationEdit, OnAnnotationStatusChange } from '../comment/types';
 
 type Props = {
     currentUser?: User,
@@ -41,7 +41,7 @@ type Props = {
     onDelete?: ({ id: string, permissions: AnnotationPermission }) => any,
     onEdit?: OnAnnotationEdit,
     onSelect?: (annotation: Annotation) => any,
-    onStatusChange?: (id: string, status: FeedItemStatus, permissions: AnnotationPermission) => void,
+    onStatusChange?: OnAnnotationStatusChange,
 };
 
 const AnnotationActivity = ({
@@ -108,7 +108,7 @@ const AnnotationActivity = ({
     };
     const handleSelect = () => onSelect(item);
 
-    const handleStatusChange = (newStatus: FeedItemStatus) => onStatusChange(id, newStatus, permissions);
+    const handleStatusChange = (newStatus: FeedItemStatus) => onStatusChange({ id, status: newStatus, permissions });
 
     const createdAtTimestamp = new Date(created_at).getTime();
     const createdByUser = created_by || PLACEHOLDER_USER;

--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
@@ -22,7 +22,7 @@ import type {
     Comment as CommentType,
 } from '../../../../common/types/feed';
 import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../common/flowTypes';
-import type { OnAnnotationEdit, OnCommentEdit } from './types';
+import type { OnAnnotationEdit, OnCommentEdit, OnAnnotationStatusChange, OnCommentStatusChange } from './types';
 import type { SelectorItems, User } from '../../../../common/types/core';
 import type { Translations } from '../../flowTypes';
 
@@ -55,6 +55,7 @@ export type BaseCommentProps = {
     onReplyDelete?: ({ id: string, permissions?: BoxCommentPermission }) => void,
     onSelect: (isSelected: boolean) => void,
     onShowReplies?: () => void,
+    onStatusChange?: OnAnnotationStatusChange | OnCommentStatusChange,
     permissions: BoxCommentPermission,
     replies?: CommentType[],
     repliesTotalCount?: number,
@@ -88,6 +89,7 @@ export const BaseComment = ({
     onReplyDelete,
     onSelect,
     onShowReplies,
+    onStatusChange,
     permissions = {},
     replies = [],
     repliesTotalCount = 0,
@@ -176,10 +178,9 @@ export const BaseComment = ({
                             isEditing={isEditing}
                             isInputOpen={isInputOpen}
                             isResolved={isResolved}
-                            onAnnotationEdit={onAnnotationEdit}
-                            onCommentEdit={onCommentEdit}
                             onDelete={onDelete}
                             onSelect={onSelect}
+                            onStatusChange={onStatusChange}
                             permissions={permissions}
                             setIsEditing={setIsEditing}
                             setIsInputOpen={setIsInputOpen}

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
@@ -246,14 +246,13 @@ describe('elements/content-sidebar/ActivityFeed/comment/BaseComment', () => {
     `(
         `should allow user to resolve / unresolve if they have resolve permissions, edit handler is defined and given status is $status`,
         ({ status, menuItemTestId, expectedNewStatus }) => {
-            const mockOnEdit = jest.fn();
+            const mockOnStatusChange = jest.fn();
 
             getWrapper({
-                hasMention: false,
                 permissions: { can_resolve: true, can_edit: false, can_delete: false },
                 type: 'task',
                 status,
-                onCommentEdit: mockOnEdit,
+                onStatusChange: mockOnStatusChange,
             });
 
             const menuItem = screen.queryByTestId('comment-actions-menu');
@@ -265,8 +264,7 @@ describe('elements/content-sidebar/ActivityFeed/comment/BaseComment', () => {
 
             expect(screen.queryByTestId(menuItemTestId)).not.toBeInTheDocument();
 
-            expect(mockOnEdit).toBeCalledWith({
-                hasMention: false,
+            expect(mockOnStatusChange).toBeCalledWith({
                 id: '1',
                 permissions: {
                     can_delete: false,

--- a/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenuWrapper.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenuWrapper.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
 import type { BoxCommentPermission, FeedItemStatus } from '../../../../../common/types/feed';
-import type { OnAnnotationEdit, OnCommentEdit } from '../types';
 
 import { BaseCommentMenu } from './BaseCommentMenu';
+import type { OnAnnotationStatusChange, OnCommentStatusChange } from '../types';
 
 export interface BaseCommentMenuWrapperProps {
     canDelete: boolean;
@@ -13,10 +13,9 @@ export interface BaseCommentMenuWrapperProps {
     isEditing: boolean;
     isInputOpen: boolean;
     isResolved: boolean;
-    onAnnotationEdit?: OnAnnotationEdit | typeof undefined;
-    onCommentEdit: OnCommentEdit;
     onDelete: ({ id: string, permissions?: BoxCommentPermission }) => any;
     onSelect: (isSelected: boolean) => void;
+    onStatusChange?: OnAnnotationStatusChange | OnCommentStatusChange | typeof undefined;
     permissions: BoxCommentPermission;
     setIsEditing: ((boolean => boolean) | boolean) => void;
     setIsInputOpen: ((boolean => boolean) | boolean) => void;
@@ -30,10 +29,9 @@ export const BaseCommentMenuWrapper = ({
     isEditing,
     isInputOpen,
     isResolved,
-    onAnnotationEdit,
-    onCommentEdit,
     onDelete,
     onSelect,
+    onStatusChange,
     permissions,
     setIsEditing,
     setIsInputOpen,
@@ -69,10 +67,8 @@ export const BaseCommentMenuWrapper = ({
     };
 
     const handleStatusUpdate = (selectedStatus: FeedItemStatus): void => {
-        if (onAnnotationEdit) {
-            onAnnotationEdit({ id, permissions });
-        } else if (onCommentEdit) {
-            onCommentEdit({ id, status: selectedStatus, hasMention: false, permissions });
+        if (onStatusChange) {
+            onStatusChange({ id, status: selectedStatus, permissions });
         }
     };
 

--- a/src/elements/content-sidebar/activity-feed/comment/types.js
+++ b/src/elements/content-sidebar/activity-feed/comment/types.js
@@ -3,6 +3,12 @@ import type { AnnotationPermission, BoxCommentPermission, FeedItemStatus } from 
 
 export type OnAnnotationEdit = (args: { id: string, permissions: AnnotationPermission, text?: string }) => void;
 
+export type OnAnnotationStatusChange = (args: {
+    id: string,
+    permissions: AnnotationPermission,
+    status: FeedItemStatus,
+}) => void;
+
 export type OnCommentEdit = (args: {
     hasMention: boolean,
     id: string,
@@ -11,4 +17,11 @@ export type OnCommentEdit = (args: {
     permissions: BoxCommentPermission,
     status?: FeedItemStatus,
     text?: string,
+}) => void;
+
+export type OnCommentStatusChange = (args: {
+    hasMention?: boolean,
+    id: string,
+    permissions: BoxCommentPermission,
+    status: FeedItemStatus,
 }) => void;


### PR DESCRIPTION
### Overview
- Allows users to resolve/unresolve annotations when they have correct permissions
- Adds two new types for `onStatusChange` events (`OnCommentStatusChange` and `OnCommentStatusChange`)
- Refactored default properties in `OnCommentStatusChange` to be automatically appended in from the parent component instead of conditionally added in the child
- Updating status of comments was refactored but functionally unchanged

### Demo
![Screen Recording 2023-10-03 at 10 36 52 am](https://github.com/box/box-ui-elements/assets/13861069/aa785530-a1e2-4f89-b6f6-35b232932bea)

### Out of Scope
- Annotations are currently returning `can_resolve = false` regardless of comment owner on resolution. A separate ticket is tracking this bug