### PR TITLE
fix(activity-thread): Hide Modify option on comment if resolved

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenu.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/BaseCommentMenu.js
@@ -88,7 +88,7 @@ export const BaseCommentMenu = ({
                         <FormattedMessage {...messages.commentResolveMenuItem} />
                     </MenuItem>
                 )}
-                {canEdit && (
+                {canEdit && !isResolved && (
                     <MenuItem
                         data-resin-target={ACTIVITY_TARGETS.COMMENT_OPTIONS_EDIT}
                         data-testid="edit-comment"

--- a/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentMenu.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/components/__tests__/BaseCommentMenu.test.js
@@ -66,6 +66,24 @@ describe('elements/content-sidebar/ActivityFeed/comment/BaseCommentMenu', () => 
     );
 
     test.each`
+        canEdit | isResolved | should
+        ${true} | ${false}   | ${'should'}
+        ${true} | ${true}    | ${'should NOT'}
+    `(
+        `$should render modify menu item when isResolved is $isResolved and canEdit is $canEdit`,
+        ({ canEdit, isResolved, should }) => {
+            const wrapper = getWrapper({ canEdit, isResolved });
+            const message = localize(messages.commentEditMenuItem.id);
+            openMenu(wrapper);
+            if (should === 'should') {
+                expect(wrapper.getByText(message)).toBeInTheDocument();
+            } else {
+                expect(wrapper.queryByText(message)).not.toBeInTheDocument();
+            }
+        },
+    );
+
+    test.each`
         isConfirmingDelete | should
         ${true}            | ${'should'}
         ${false}           | ${'should NOT'}


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
