### PR TITLE
feat(pill-selector): added more options for text input

### DIFF
--- a/src/components/pill-selector-dropdown/PillSelector.js
+++ b/src/components/pill-selector-dropdown/PillSelector.js
@@ -31,6 +31,10 @@ type Props = {
     getPillImageUrl?: (data: { id: string | number, [key: string]: any }) => string,
     innerRef?: React.Ref<any>,
     inputProps: Object,
+    /** Allows disabling the textarea element without disabling the whole PillSelector */
+    isInputDisabled?: boolean,
+    /** Whether to show textarea in next line when focused */
+    isInputFocusedNextLine?: boolean,
     onInput: Function,
     onRemove: Function,
     onSuggestedPillAdd?: Function,
@@ -194,6 +198,8 @@ class PillSelectorBase extends React.Component<Props, State> {
             getPillClassName,
             getPillImageUrl,
             inputProps,
+            isInputDisabled,
+            isInputFocusedNextLine,
             onInput,
             onRemove,
             onSuggestedPillAdd,
@@ -284,8 +290,10 @@ class PillSelectorBase extends React.Component<Props, State> {
                         {...rest}
                         {...inputProps}
                         autoComplete="off"
-                        className={classNames('bdl-PillSelector-input', 'pill-selector-input', className)}
-                        disabled={disabled}
+                        className={classNames('bdl-PillSelector-input', 'pill-selector-input', className, {
+                            'bdl-PillSelector-input--nextLine': isInputFocusedNextLine,
+                        })}
+                        disabled={disabled || isInputDisabled}
                         onInput={onInput}
                         placeholder={this.getNumSelected() === 0 ? placeholder : ''}
                         ref={input => {

--- a/src/components/pill-selector-dropdown/PillSelector.scss
+++ b/src/components/pill-selector-dropdown/PillSelector.scss
@@ -50,6 +50,10 @@
             border-color: $primary-color;
             outline: 0;
             box-shadow: none;
+
+            .bdl-PillSelector-input--nextLine {
+                flex: 1 1 100%;
+            }
         }
 
         &.show-error {

--- a/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
+++ b/src/components/pill-selector-dropdown/__tests__/PillSelector.test.js
@@ -41,6 +41,13 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
+        test('should render with disabled input', () => {
+            const wrapper = shallow(<PillSelector isInputDisabled onInput={onInputStub} onRemove={onRemoveStub} />);
+            const input = wrapper.find('textarea');
+
+            expect(input.prop('disabled')).toBe(true);
+        });
+
         test('should add is-focused class when input is focused', () => {
             const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
             wrapper.setState({ isFocused: true });
@@ -53,6 +60,20 @@ describe('components/pill-selector-dropdown/PillSelector', () => {
             wrapper.setState({ isFocused: false });
 
             expect(wrapper.find('.is-focused').length).toBe(0);
+        });
+
+        test('should add bdl-PillSelector-input--nextLine class when prop is set to true', () => {
+            const wrapper = shallow(
+                <PillSelector onInput={onInputStub} onRemove={onRemoveStub} isInputFocusedNextLine />,
+            );
+
+            expect(wrapper.find('.bdl-PillSelector-input--nextLine').length).toBe(1);
+        });
+
+        test('should not add bdl-PillSelector-input--nextLine class when prop is not given', () => {
+            const wrapper = shallow(<PillSelector onInput={onInputStub} onRemove={onRemoveStub} />);
+
+            expect(wrapper.find('.bdl-PillSelector-input--nextLine').length).toBe(0);
         });
 
         test('should add show-error class when error is given', () => {


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

This PR adds two new props to the `PillSelector` component. The two props are needed for the `PillSelectorDropdown` component. For now, they can be supplied to `PillSelector` through the `inputProps` prop.
## `isInputDisabled`
Allows disabling the `textarea` element without disabling the whole `PillSelector`. Usecase: our application needs to be able to set a maximum number of pills so that the user cannot add more than this number but can add less. The plan is to use this prop to disable the input once the maximum number of pills is reached. The user cannot then add new pills, but can still remove existing pills. Once the number of pills goes below the maximum, we enable the input again.

## `isInputFocusedNextLine`
Gives the `textarea` its own separate line when the user focuses the component to input text. The new line disappears when you focus away. This is very useful when the component is used in a limited width (as the case in our application). See the GIFs below:

| Before | After |
| ------ | ----- |
| ![before](https://github.com/box/box-ui-elements/assets/37188590/5e38a21e-118a-45c6-b35b-beec0c1f35cb) | ![after](https://github.com/box/box-ui-elements/assets/37188590/c593c851-ced7-417b-83ee-d8d343e1f1e0) | 



