### PR TITLE
feat(activitysidebar): collapse replies on resolve

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1143,8 +1143,9 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     hideRepliesForFeedItem = (feedItemId: string) => {
         const { feedItems } = this.state;
         const feedItem = feedItems.find((item: FeedItem) => item.id === feedItemId);
-        const lastReply = feedItem.replies.slice(-1);
-        if (lastReply.length > 1) {
+        const { replies } = feedItem;
+        if (replies.length > 1) {
+            const lastReply = feedItem.replies.slice(-1);
             this.updateReplies(feedItemId, lastReply);
         }
     };

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1144,7 +1144,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         const { feedItems } = this.state;
         const feedItem = feedItems.find((item: FeedItem) => item.id === feedItemId);
         const { replies } = feedItem;
-        if (replies.length > 1) {
+        if (replies && replies.length > 1) {
             const lastReply = feedItem.replies.slice(-1);
             this.updateReplies(feedItemId, lastReply);
         }

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -33,6 +33,7 @@ import {
     ACTIVITY_FILTER_OPTION_RESOLVED,
     ACTIVITY_FILTER_OPTION_TASKS,
     ACTIVITY_FILTER_OPTION_UNRESOLVED,
+    COMMENT_STATUS_RESOLVED,
     DEFAULT_COLLAB_DEBOUNCE,
     ERROR_CODE_FETCH_ACTIVITY,
     FEED_ITEM_TYPE_ANNOTATION,
@@ -237,6 +238,10 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             (annotation: Annotation) => {
                 emitAnnotationUpdateEvent(annotation);
                 this.feedSuccessCallback();
+
+                if (status === COMMENT_STATUS_RESOLVED) {
+                    this.hideRepliesForFeedItem(id);
+                }
             },
             this.feedErrorCallback,
         );
@@ -468,6 +473,10 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                 onSuccess();
             }
             onCommentUpdate();
+
+            if (status === COMMENT_STATUS_RESOLVED) {
+                this.hideRepliesForFeedItem(id);
+            }
         };
 
         if (hasReplies) {
@@ -1129,6 +1138,15 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                 item.type === feedItemsStatusFilter
             );
         });
+    };
+
+    hideRepliesForFeedItem = (feedItemId: string) => {
+        const { feedItems } = this.state;
+        const feedItem = feedItems.find((item: FeedItem) => item.id === feedItemId);
+        const lastReply = feedItem.replies.slice(-1);
+        if (lastReply.length) {
+            this.updateReplies(feedItemId, lastReply);
+        }
     };
 
     onTaskModalClose = () => {

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1144,7 +1144,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         const { feedItems } = this.state;
         const feedItem = feedItems.find((item: FeedItem) => item.id === feedItemId);
         const lastReply = feedItem.replies.slice(-1);
-        if (lastReply.length) {
+        if (lastReply.length > 1) {
             this.updateReplies(feedItemId, lastReply);
         }
     };

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1141,10 +1141,12 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     };
 
     hideRepliesForFeedItem = (feedItemId: string) => {
-        const { feedItems } = this.state;
-        const feedItem = feedItems.find((item: FeedItem) => item.id === feedItemId);
-        const { replies } = feedItem || {};
-        if (replies && replies.length > 1) {
+        const { feedItems = [] } = this.state;
+        // unfortunately, casting to any is the only way to avoid flow issues resulting
+        // from replies not existing on certain FeedItem types
+        const feedItem: any = feedItems.find(item => item.id === feedItemId);
+        const { replies = [] } = feedItem || {};
+        if (replies.length > 1) {
             const lastReply = replies.slice(-1);
             this.updateReplies(feedItemId, lastReply);
         }

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1143,9 +1143,9 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     hideRepliesForFeedItem = (feedItemId: string) => {
         const { feedItems } = this.state;
         const feedItem = feedItems.find((item: FeedItem) => item.id === feedItemId);
-        const { replies } = feedItem;
+        const { replies } = feedItem || {};
         if (replies && replies.length > 1) {
-            const lastReply = feedItem.replies.slice(-1);
+            const lastReply = replies.slice(-1);
             this.updateReplies(feedItemId, lastReply);
         }
     };

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -1569,7 +1569,12 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
     });
 
     describe('hideRepliesForFeedItem()', () => {
-        test('should not call updateReplies if there are no replies', () => {
+        test.each`
+            replies
+            ${undefined}
+            ${[]}
+            ${[{ id: 123 }]}
+        `('should not call updateReplies when replies is $replies', ({ replies }) => {
             const wrapper = getWrapper();
             const updateReplies = jest.fn();
             const instance = wrapper.instance();
@@ -1578,24 +1583,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             const itemId = '999';
 
             wrapper.setState({
-                feedItems: [{ id: itemId, replies: [], type: 'comment' }],
-            });
-
-            instance.hideRepliesForFeedItem(itemId);
-
-            expect(updateReplies).not.toBeCalled();
-        });
-
-        test('should not call updateReplies if there is one reply', () => {
-            const wrapper = getWrapper();
-            const updateReplies = jest.fn();
-            const instance = wrapper.instance();
-            instance.updateReplies = updateReplies;
-
-            const itemId = '999';
-
-            wrapper.setState({
-                feedItems: [{ id: itemId, replies: [{ id: 123 }], type: 'comment' }],
+                feedItems: [{ id: itemId, replies, type: 'comment' }],
             });
 
             instance.hideRepliesForFeedItem(itemId);

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -1591,6 +1591,19 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             expect(updateReplies).not.toBeCalled();
         });
 
+        test('should not call updateReplies when the feedItem does not exist for the given feedItemId', () => {
+            const wrapper = getWrapper();
+            const updateReplies = jest.fn();
+            const instance = wrapper.instance();
+            instance.updateReplies = updateReplies;
+
+            wrapper.setState({ feedItems: [] });
+
+            instance.hideRepliesForFeedItem(123);
+
+            expect(updateReplies).not.toBeCalled();
+        });
+
         test('should call updateReplies with lastReply and feedItemId if there are replies', () => {
             const wrapper = getWrapper();
             const updateReplies = jest.fn();

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -1568,6 +1568,60 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
         );
     });
 
+    describe('hideRepliesForFeedItem()', () => {
+        test('should not call updateReplies if there are no replies', () => {
+            const wrapper = getWrapper();
+            const updateReplies = jest.fn();
+            const instance = wrapper.instance();
+            instance.updateReplies = updateReplies;
+
+            const itemId = '999';
+
+            wrapper.setState({
+                feedItems: [{ id: itemId, replies: [], type: 'comment' }],
+            });
+
+            instance.hideRepliesForFeedItem(itemId);
+
+            expect(updateReplies).not.toBeCalled();
+        });
+
+        test('should not call updateReplies if there is one reply', () => {
+            const wrapper = getWrapper();
+            const updateReplies = jest.fn();
+            const instance = wrapper.instance();
+            instance.updateReplies = updateReplies;
+
+            const itemId = '999';
+
+            wrapper.setState({
+                feedItems: [{ id: itemId, replies: [{ id: 123 }], type: 'comment' }],
+            });
+
+            instance.hideRepliesForFeedItem(itemId);
+
+            expect(updateReplies).not.toBeCalled();
+        });
+
+        test('should call updateReplies with lastReply and feedItemId if there are replies', () => {
+            const wrapper = getWrapper();
+            const updateReplies = jest.fn();
+            const instance = wrapper.instance();
+            instance.updateReplies = updateReplies;
+
+            const itemId = '999';
+            const lastReplyId = '456';
+            const expectedReplies = [{ id: lastReplyId }];
+
+            wrapper.setState({
+                feedItems: [{ id: itemId, replies: [{ id: 123 }, { id: lastReplyId }], type: 'comment' }],
+            });
+
+            instance.hideRepliesForFeedItem(itemId);
+            expect(updateReplies).toBeCalledWith(itemId, expectedReplies);
+        });
+    });
+
     describe('renderAddTaskButton()', () => {
         test('should return null when hasTasks is false', () => {
             const wrapper = getWrapper({ hasTasks: false });


### PR DESCRIPTION
- Collapse replies on comment/annotation resolve to show only one comment

![comment resolve collapse](https://github.com/box/box-ui-elements/assets/4257589/884e1bee-53c5-4e1a-ba8a-5faec6f695a4)

![annotation resolve collapse](https://github.com/box/box-ui-elements/assets/4257589/3ce70952-138b-42ff-8221-4f8cee484e25)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
