### PR TITLE
feat(threaded-replies): Collapse replies on resolve v2

### DIFF
--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
@@ -101,6 +101,21 @@ export const BaseComment = ({
     const [isEditing, setIsEditing] = React.useState<boolean>(false);
     const [isInputOpen, setIsInputOpen] = React.useState<boolean>(false);
 
+    const prevStatus = React.useRef<FeedItemStatus | undefined>(status);
+
+    React.useEffect(() => {
+        if (
+            onHideReplies &&
+            status === COMMENT_STATUS_RESOLVED &&
+            status !== prevStatus.current &&
+            repliesTotalCount === replies.length
+        ) {
+            onHideReplies(replies.splice(-1));
+        }
+
+        prevStatus.current = status;
+    }, [onHideReplies, replies, repliesTotalCount, status]);
+
     const commentFormFocusHandler = (): void => {
         setIsInputOpen(true);
         onSelect(true);

--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
@@ -101,7 +101,7 @@ export const BaseComment = ({
     const [isEditing, setIsEditing] = React.useState<boolean>(false);
     const [isInputOpen, setIsInputOpen] = React.useState<boolean>(false);
 
-    const prevStatus = React.useRef<FeedItemStatus | undefined>(status);
+    const prevStatus = React.useRef<?FeedItemStatus>(status);
 
     React.useEffect(() => {
         if (

--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
@@ -104,13 +104,11 @@ export const BaseComment = ({
     const prevStatus = React.useRef<?FeedItemStatus>(status);
 
     React.useEffect(() => {
-        if (
-            onHideReplies &&
-            status === COMMENT_STATUS_RESOLVED &&
-            status !== prevStatus.current &&
-            replies.length > 1 &&
-            repliesTotalCount === replies.length
-        ) {
+        const isStatusChangedToResolved = status === COMMENT_STATUS_RESOLVED && status !== prevStatus.current;
+
+        const isRepliesExpanded = replies.length > 1 && repliesTotalCount === replies.length;
+
+        if (onHideReplies && isStatusChangedToResolved && isRepliesExpanded) {
             onHideReplies(replies.slice(-1));
         }
 

--- a/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
+++ b/src/elements/content-sidebar/activity-feed/comment/BaseComment.js
@@ -108,9 +108,10 @@ export const BaseComment = ({
             onHideReplies &&
             status === COMMENT_STATUS_RESOLVED &&
             status !== prevStatus.current &&
+            replies.length > 1 &&
             repliesTotalCount === replies.length
         ) {
-            onHideReplies(replies.splice(-1));
+            onHideReplies(replies.slice(-1));
         }
 
         prevStatus.current = status;

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
@@ -422,7 +422,7 @@ describe('elements/content-sidebar/ActivityFeed/comment/BaseComment', () => {
         expect(mockFocusFunc).toHaveBeenCalled();
     });
 
-    test('should hide replies when status changes to resolved, hideOnReplies is defined, there is more than one reply, and replies are not collapsed', () => {
+    test('should hide replies when status changes to resolved, onHideReplies is defined, there is more than one reply, and replies are not collapsed', () => {
         const { rerender } = getWrapper({ ...repliesProps, repliesTotalCount: replies.length });
         rerender(getComponent({ ...repliesProps, repliesTotalCount: replies.length, status: COMMENT_STATUS_RESOLVED }));
         expect(hideReplies).toHaveBeenCalledWith(replies.slice(-1));


### PR DESCRIPTION
- Collapse replies on comment/annotation resolve to show only one comment

![comment resolve collapse](https://github.com/box/box-ui-elements/assets/4257589/884e1bee-53c5-4e1a-ba8a-5faec6f695a4)

![annotation resolve collapse](https://github.com/box/box-ui-elements/assets/4257589/3ce70952-138b-42ff-8221-4f8cee484e25)
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
