### PR TITLE
fix(content-picker): use pagination component to import correct styles

### DIFF
--- a/src/elements/content-picker/ContentPicker.js
+++ b/src/elements/content-picker/ContentPicker.js
@@ -18,7 +18,7 @@ import UploadDialog from '../common/upload-dialog';
 import CreateFolderDialog from '../common/create-folder-dialog';
 import Internationalize from '../common/Internationalize';
 import makeResponsive from '../common/makeResponsive';
-import OffsetBasedPagination from '../../features/pagination/OffsetBasedPagination';
+import Pagination from '../../features/pagination';
 import { isFocusableElement, isInputElement, focus } from '../../utils/dom';
 import API from '../../api';
 import Content from './Content';
@@ -1289,7 +1289,7 @@ class ContentPicker extends Component<Props, State> {
                             renderCustomActionButtons={renderCustomActionButtons}
                         >
                             {isPaginationVisible ? (
-                                <OffsetBasedPagination
+                                <Pagination
                                     offset={offset}
                                     onOffsetChange={this.paginate}
                                     pageSize={currentPageSize}


### PR DESCRIPTION
The ContentPicker component is using `OffsetBasedPagination` directly: https://github.com/box/box-ui-elements/blob/1139bb0bf82a0c735fea88d00d773cae1e8b6792/src/elements/content-picker/ContentPicker.js#L21

The issue is that `OffsetBasedPagination` does not have it's own stylesheet. The styles are imported in the `Pagination` component: https://github.com/box/box-ui-elements/blob/1139bb0bf82a0c735fea88d00d773cae1e8b6792/src/features/pagination/Pagination.js#L10

Calling `Pagination` with the same props will forward everything to the inner `OffsetBasedPagination` component and apply the correct styles:
https://github.com/box/box-ui-elements/blob/1139bb0bf82a0c735fea88d00d773cae1e8b6792/src/features/pagination/Pagination.js#L22-L33

**Before**
<img width="892" alt="Screenshot 2023-12-04 at 1 21 24 PM" src="https://github.com/box/box-ui-elements/assets/7311041/65cc3128-f1e2-4de6-90cf-d85b713092fe">

**After**
<img width="894" alt="Screenshot 2023-12-04 at 1 22 15 PM" src="https://github.com/box/box-ui-elements/assets/7311041/1f95c393-4d93-484f-ae44-c86aec70f153">