### PR TITLE
feat(label-primitive): pass properties to label

### DIFF
--- a/src/components/label/HiddenLabel.js.flow
+++ b/src/components/label/HiddenLabel.js.flow
@@ -8,10 +8,11 @@ const HIDDEN_CLASS_NAME = 'accessibility-hidden';
 type Props = {
     children: React.Node,
     labelContent: React.Node,
+    labelElProps?: React.Element<'label'>,
 };
 
-const HiddenLabel = ({ children, labelContent }: Props) => (
-    <LabelPrimitive className={HIDDEN_CLASS_NAME} labelContent={labelContent}>
+const HiddenLabel = ({ children, labelContent, labelElProps }: Props) => (
+    <LabelPrimitive className={HIDDEN_CLASS_NAME} labelContent={labelContent} labelElProps={labelElProps}>
         {children}
     </LabelPrimitive>
 );

--- a/src/components/label/HiddenLabel.tsx
+++ b/src/components/label/HiddenLabel.tsx
@@ -11,8 +11,8 @@ export interface HiddenLabelProps {
     labelElProps?: React.ComponentPropsWithoutRef<'label'>;
 }
 
-const HiddenLabel = ({ children, labelContent, labelElProps }: HiddenLabelProps) => (
-    <LabelPrimitive className="accessibility-hidden" labelContent={labelContent} labelElProps={labelElProps}>
+const HiddenLabel = ({ children, ...rest }: HiddenLabelProps) => (
+    <LabelPrimitive className="accessibility-hidden" {...rest}>
         {children}
     </LabelPrimitive>
 );

--- a/src/components/label/HiddenLabel.tsx
+++ b/src/components/label/HiddenLabel.tsx
@@ -7,10 +7,12 @@ export interface HiddenLabelProps {
     children: React.ReactElement;
     /** Text content of the label */
     labelContent: React.ReactNode;
+    /** Optional props for the label element */
+    labelElProps?: React.ComponentPropsWithoutRef<'label'>;
 }
 
-const HiddenLabel = ({ children, labelContent }: HiddenLabelProps) => (
-    <LabelPrimitive className="accessibility-hidden" labelContent={labelContent}>
+const HiddenLabel = ({ children, labelContent, labelElProps }: HiddenLabelProps) => (
+    <LabelPrimitive className="accessibility-hidden" labelContent={labelContent} labelElProps={labelElProps}>
         {children}
     </LabelPrimitive>
 );

--- a/src/components/label/Label.js.flow
+++ b/src/components/label/Label.js.flow
@@ -23,6 +23,8 @@ type Props = {
     infoIconProps?: Object,
     /** Tooltip text for the info icon */
     infoTooltip?: React.Node,
+    /** Optional props for the label element */
+    labelElProps?: React.Element<'label'>,
     /** Whether to show the `(Optional)` text next to the label for an optional field */
     showOptionalText?: boolean,
     /** The label text */
@@ -31,7 +33,7 @@ type Props = {
     tooltip?: React.Node,
 };
 
-const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hideLabel, children }: Props) => {
+const Label = ({ text, tooltip, infoTooltip, labelElProps, infoIconProps, showOptionalText, hideLabel, children }: Props) => {
     const labelContent = [
         <span key="labelText">{text}</span>,
         showOptionalText ? <OptionalFormattedMessage key="optionalMessage" /> : null,
@@ -48,11 +50,11 @@ const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hi
     }
 
     if (hideLabel) {
-        return <HiddenLabel labelContent={labelContent}>{children}</HiddenLabel>;
+        return <HiddenLabel labelContent={labelContent} labelElProps={labelElProps}>{children}</HiddenLabel>;
     }
 
     return (
-        <StandardLabel labelContent={labelContent} tooltip={tooltip}>
+        <StandardLabel labelContent={labelContent} labelElProps={labelElProps} tooltip={tooltip}>
             {children}
         </StandardLabel>
     );

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -42,7 +42,7 @@ const Label = ({
     showOptionalText,
     hideLabel,
     children,
-    labelElProps = {},
+    labelElProps,
 }: LabelProps) => {
     const labelContent = [
         <span key="labelText">{text}</span>,

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -30,9 +30,20 @@ export interface LabelProps {
     text: React.ReactNode;
     /** Optional tooltip text for the label */
     tooltip?: React.ReactNode;
+    /** Optional peopierties for label element */
+    labelElProps?: Object;
 }
 
-const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hideLabel, children }: LabelProps) => {
+const Label = ({
+    text,
+    tooltip,
+    infoTooltip,
+    infoIconProps,
+    showOptionalText,
+    hideLabel,
+    children,
+    labelElProps = {},
+}: LabelProps) => {
     const labelContent = [
         <span key="labelText">{text}</span>,
         showOptionalText ? <OptionalFormattedMessage key="optionalMessage" /> : null,
@@ -53,7 +64,7 @@ const Label = ({ text, tooltip, infoTooltip, infoIconProps, showOptionalText, hi
     }
 
     return (
-        <StandardLabel labelContent={labelContent} tooltip={tooltip}>
+        <StandardLabel labelContent={labelContent} tooltip={tooltip} labelElProps={labelElProps}>
             {children}
         </StandardLabel>
     );

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -24,14 +24,14 @@ export interface LabelProps {
     infoIconProps?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
     /** Tooltip text for the info icon */
     infoTooltip?: React.ReactNode;
+    /** Optional props for the label element */
+    labelElProps?: Object;
     /** Whether to show the `(Optional)` text next to the label for an optional field */
     showOptionalText?: boolean;
     /** The label text */
     text: React.ReactNode;
     /** Optional tooltip text for the label */
     tooltip?: React.ReactNode;
-    /** Optional peopierties for label element */
-    labelElProps?: Object;
 }
 
 const Label = ({

--- a/src/components/label/Label.tsx
+++ b/src/components/label/Label.tsx
@@ -25,7 +25,7 @@ export interface LabelProps {
     /** Tooltip text for the info icon */
     infoTooltip?: React.ReactNode;
     /** Optional props for the label element */
-    labelElProps?: Object;
+    labelElProps?: React.ComponentPropsWithoutRef<'label'>;
     /** Whether to show the `(Optional)` text next to the label for an optional field */
     showOptionalText?: boolean;
     /** The label text */
@@ -37,12 +37,12 @@ export interface LabelProps {
 const Label = ({
     text,
     tooltip,
+    labelElProps,
     infoTooltip,
     infoIconProps,
     showOptionalText,
     hideLabel,
     children,
-    labelElProps,
 }: LabelProps) => {
     const labelContent = [
         <span key="labelText">{text}</span>,
@@ -60,7 +60,11 @@ const Label = ({
     }
 
     if (hideLabel) {
-        return <HiddenLabel labelContent={labelContent}>{children}</HiddenLabel>;
+        return (
+            <HiddenLabel labelContent={labelContent} labelElProps={labelElProps}>
+                {children}
+            </HiddenLabel>
+        );
     }
 
     return (

--- a/src/components/label/LabelPrimitive.js.flow
+++ b/src/components/label/LabelPrimitive.js.flow
@@ -6,10 +6,11 @@ type Props = {
     children: React.Node,
     className?: string,
     labelContent: React.Node,
+    labelElProps?: React.Element<'label'>,
 };
 
-const LabelPrimitive = ({ children, className, labelContent, ...rest }: Props) => (
-    <label>
+const LabelPrimitive = ({ children, className, labelContent, labelElProps, ...rest }: Props) => (
+    <label {...labelElProps}>
         <span className={classNames('label bdl-Label', className)} {...rest}>
             {labelContent}
         </span>

--- a/src/components/label/LabelPrimitive.tsx
+++ b/src/components/label/LabelPrimitive.tsx
@@ -8,10 +8,12 @@ export interface LabelPrimitiveProps {
     className?: string;
     /** Text content of the label */
     labelContent: React.ReactNode;
+    /** Optional peopierties for label element */
+    labelElProps?: Object;
 }
 
-const LabelPrimitive = ({ children, className, labelContent, ...rest }: LabelPrimitiveProps) => (
-    <label>
+const LabelPrimitive = ({ children, className, labelContent, labelElProps, ...rest }: LabelPrimitiveProps) => (
+    <label {...labelElProps}>
         <span className={classNames('label bdl-Label', className)} {...rest}>
             {labelContent}
         </span>

--- a/src/components/label/LabelPrimitive.tsx
+++ b/src/components/label/LabelPrimitive.tsx
@@ -9,7 +9,7 @@ export interface LabelPrimitiveProps {
     /** Text content of the label */
     labelContent: React.ReactNode;
     /** Optional props for the label element */
-    labelElProps?: Object;
+    labelElProps?: React.ComponentPropsWithoutRef<'label'>;
 }
 
 const LabelPrimitive = ({ children, className, labelContent, labelElProps, ...rest }: LabelPrimitiveProps) => (

--- a/src/components/label/LabelPrimitive.tsx
+++ b/src/components/label/LabelPrimitive.tsx
@@ -8,7 +8,7 @@ export interface LabelPrimitiveProps {
     className?: string;
     /** Text content of the label */
     labelContent: React.ReactNode;
-    /** Optional peopierties for label element */
+    /** Optional props for the label element */
     labelElProps?: Object;
 }
 

--- a/src/components/label/StandardLabel.js.flow
+++ b/src/components/label/StandardLabel.js.flow
@@ -7,11 +7,12 @@ import LabelPrimitive from './LabelPrimitive';
 type Props = {
     children: React.Node,
     labelContent: React.Node,
+    labelElProps?: React.Element<'label'>,
     tooltip?: React.Node,
 };
 
-const StandardLabel = ({ children, labelContent, tooltip }: Props) => {
-    const label = <LabelPrimitive labelContent={labelContent}>{children}</LabelPrimitive>;
+const StandardLabel = ({ children, labelContent, labelElProps, tooltip }: Props) => {
+    const label = <LabelPrimitive labelContent={labelContent} labelElProps={labelElProps}>{children}</LabelPrimitive>;
 
     return tooltip ? (
         <Tooltip position="top-right" text={tooltip}>

--- a/src/components/label/StandardLabel.tsx
+++ b/src/components/label/StandardLabel.tsx
@@ -8,10 +8,10 @@ export interface StandardLabelProps {
     children: React.ReactElement;
     /** Text content of the label */
     labelContent: React.ReactNode;
+    /** Optional props for the label element */
+    labelElProps?: Object;
     /** Optional tooltip text for the label */
     tooltip?: React.ReactNode;
-    /** Optional peopierties for label element */
-    labelElProps?: Object;
 }
 
 const StandardLabel = ({ children, labelElProps, labelContent, tooltip }: StandardLabelProps) => {

--- a/src/components/label/StandardLabel.tsx
+++ b/src/components/label/StandardLabel.tsx
@@ -9,7 +9,7 @@ export interface StandardLabelProps {
     /** Text content of the label */
     labelContent: React.ReactNode;
     /** Optional props for the label element */
-    labelElProps?: Object;
+    labelElProps?: React.ComponentPropsWithoutRef<'label'>;
     /** Optional tooltip text for the label */
     tooltip?: React.ReactNode;
 }

--- a/src/components/label/StandardLabel.tsx
+++ b/src/components/label/StandardLabel.tsx
@@ -15,11 +15,7 @@ export interface StandardLabelProps {
 }
 
 const StandardLabel = ({ children, tooltip, ...rest }: StandardLabelProps) => {
-    const label = (
-        <LabelPrimitive {...rest}>
-            {children}
-        </LabelPrimitive>
-    );
+    const label = <LabelPrimitive {...rest}>{children}</LabelPrimitive>;
 
     return tooltip ? (
         <Tooltip position={TooltipPosition.TOP_RIGHT} text={tooltip}>

--- a/src/components/label/StandardLabel.tsx
+++ b/src/components/label/StandardLabel.tsx
@@ -14,9 +14,9 @@ export interface StandardLabelProps {
     tooltip?: React.ReactNode;
 }
 
-const StandardLabel = ({ children, labelElProps, labelContent, tooltip }: StandardLabelProps) => {
+const StandardLabel = ({ children, tooltip, ...rest }: StandardLabelProps) => {
     const label = (
-        <LabelPrimitive labelElProps={labelElProps} labelContent={labelContent}>
+        <LabelPrimitive {...rest}>
             {children}
         </LabelPrimitive>
     );

--- a/src/components/label/StandardLabel.tsx
+++ b/src/components/label/StandardLabel.tsx
@@ -10,10 +10,16 @@ export interface StandardLabelProps {
     labelContent: React.ReactNode;
     /** Optional tooltip text for the label */
     tooltip?: React.ReactNode;
+    /** Optional peopierties for label element */
+    labelElProps?: Object;
 }
 
-const StandardLabel = ({ children, labelContent, tooltip }: StandardLabelProps) => {
-    const label = <LabelPrimitive labelContent={labelContent}>{children}</LabelPrimitive>;
+const StandardLabel = ({ children, labelElProps, labelContent, tooltip }: StandardLabelProps) => {
+    const label = (
+        <LabelPrimitive labelElProps={labelElProps} labelContent={labelContent}>
+            {children}
+        </LabelPrimitive>
+    );
 
     return tooltip ? (
         <Tooltip position={TooltipPosition.TOP_RIGHT} text={tooltip}>

--- a/src/components/label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/src/components/label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`components/label/Label should correctly render default element 1`] = `
       null,
     ]
   }
+  labelElProps={Object {}}
 >
   <input
     type="text"

--- a/src/components/label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/src/components/label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`components/label/Label should correctly render default element 1`] = `
       null,
     ]
   }
-  labelElProps={Object {}}
 >
   <input
     type="text"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

This change is required to link Label with input/seelctor/date picker and have "name" under accessibility tab.
