### PR TITLE
fix(content-sidebar): increase z-index to stack above annotations

### DIFF
--- a/src/elements/content-sidebar/ContentSidebar.scss
+++ b/src/elements/content-sidebar/ContentSidebar.scss
@@ -43,7 +43,7 @@ $sidebarWidth: $sidebarTabsWidth + $sidebarContentWidth;
             &.bcs-is-open {
                 position: absolute;
                 bottom: 0;
-                z-index: 2;
+                z-index: 5; // Stack sidebar above annotations. See z-index values https://github.com/box/box-annotations/blob/master/src/common/BaseAnnotator.scss
                 max-height: 100%;
             }
         }


### PR DESCRIPTION
### Context
When the sidebar is opened on medium sized screens, annotations on the file will render above the sidebar.

Updating the `z-index` value of `.bcs.bcs-is-open` will layer the sidebar above the annotations. See [BaseAnnotator.scss](https://github.com/box/box-annotations/blob/master/src/common/BaseAnnotator.scss) for `z-index` values.

<img width="300" alt="Screenshot 2023-12-20 at 10 30 54 AM" src="https://github.com/box/box-ui-elements/assets/7311041/9e0d7b79-f19b-48da-86bf-3e0c8472c1c1">

---

### Before

Closed sidebar

<img width="300" alt="Screenshot 2023-12-20 at 9 58 43 AM" src="https://github.com/box/box-ui-elements/assets/7311041/10dcb04d-1d0f-4b90-8ca1-3a5c363d80ca">

Opened sidebar

<img width="300" alt="Screenshot 2023-12-20 at 9 58 29 AM" src="https://github.com/box/box-ui-elements/assets/7311041/75571ead-72b0-4638-9921-3e593136260d">

---

### After

<img width="300" alt="Screenshot 2023-12-20 at 11 07 14 AM" src="https://github.com/box/box-ui-elements/assets/7311041/a40eef1b-ed1c-44a0-b971-fc36d5170706">
