### PR TITLE
fix(content-explorer): detect if device supports downloading

### DIFF
--- a/src/elements/content-explorer/MoreOptions.js
+++ b/src/elements/content-explorer/MoreOptions.js
@@ -74,7 +74,7 @@ const MoreOptions = ({
     const allowShare = canShare && permissions[PERMISSION_CAN_SHARE];
     const allowRename = canRename && permissions[PERMISSION_CAN_RENAME];
     const allowDownload =
-        canDownload && permissions[PERMISSION_CAN_DOWNLOAD] && type === TYPE_FILE && !Browser.isMobile();
+        canDownload && permissions[PERMISSION_CAN_DOWNLOAD] && type === TYPE_FILE && Browser.canDownload();
     const allowed = allowDelete || allowRename || allowDownload || allowPreview || allowShare || allowOpen;
 
     if (!allowed) {

--- a/src/utils/Browser.js
+++ b/src/utils/Browser.js
@@ -83,6 +83,16 @@ class Browser {
     }
 
     /**
+     * Returns whether browser can download via HTML5.
+     *
+     * @see https://github.com/Modernizr/Modernizr/blob/master/feature-detects/a/download.js
+     * @return {boolean} Whether browser supports downloading
+     */
+    static canDownload() {
+        return !Browser.isMobile() || (!window.externalHost && 'download' in document.createElement('a'));
+    }
+
+    /**
      * Checks the browser for Dash support using H264 high.
      * Dash requires MediaSource extensions to exist and be applicable
      * to the H264 container (since we use H264 and not webm)

--- a/src/utils/__tests__/Browser.test.js
+++ b/src/utils/__tests__/Browser.test.js
@@ -96,6 +96,34 @@ describe('util/Browser/getUserAgent()', () => {
     });
 });
 
+describe('util/Browser/canDownload()', () => {
+    test('should return true if browser is not mobile', () => {
+        browser.isMobile = jest.fn().mockReturnValue(false);
+        expect(browser.canDownload()).toBe(true);
+    });
+
+    test('should return false if browser is mobile and externalHost is present', () => {
+        browser.isMobile = jest.fn().mockReturnValue(true);
+        window.externalHost = {};
+        expect(browser.canDownload()).toBe(false);
+        window.externalHost = undefined;
+    });
+
+    test("should return false if browser is mobile and doesn't support downloads", () => {
+        browser.isMobile = jest.fn().mockReturnValue(true);
+        window.externalHost = undefined;
+        global.document.createElement = jest.fn().mockReturnValue({});
+        expect(browser.canDownload()).toBe(false);
+    });
+
+    test('should return true if browser is mobile and supports downloads', () => {
+        browser.isMobile = jest.fn().mockReturnValue(true);
+        window.externalHost = undefined;
+        global.document.createElement = jest.fn().mockReturnValue({ download: true });
+        expect(browser.canDownload()).toBe(true);
+    });
+});
+
 describe('util/Browser/canPlayDash()', () => {
     test('should return false when there is no media source', () => {
         expect(browser.canPlayDash()).toBeFalsy();


### PR DESCRIPTION
Implementation of `canDownload` taken from box-content-preview for consistent downloading support:
https://github.com/box/box-content-preview/blob/master/src/lib/Browser.js

**Before**
<img width="324" alt="Screenshot 2023-12-29 at 2 54 37 PM" src="https://github.com/box/box-ui-elements/assets/7311041/12092a12-76ab-461c-b6b7-4a3f82e50acd">

**After**
<img width="324" alt="Screenshot 2023-12-29 at 2 53 44 PM" src="https://github.com/box/box-ui-elements/assets/7311041/4c8a40be-f425-4e7f-b31c-dad9f3281607">