### PR TITLE
fix(content-explorer): fix text ellipsis in breadcrumbs

### DIFF
--- a/src/features/content-explorer/content-explorer/ContentExplorer.scss
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.scss
@@ -162,6 +162,10 @@
     }
 }
 
+.bdl-ContentExplorerBreadcrumbs-crumbLink {
+    width: 100%;
+}
+
 .content-explorer .modal-actions .status-message {
     margin-right: auto;
 }

--- a/src/features/content-explorer/content-explorer/ContentExplorerBreadcrumbs.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorerBreadcrumbs.js
@@ -30,9 +30,11 @@ const ContentExplorerBreadcrumbs = ({
             <IconChevron direction="left" size="6px" color="#333" />
         </Button>
         <Breadcrumb label={formatMessage(messages.breadcrumb)} {...breadcrumbProps}>
+            {/* The outer div for each crumb prevents styling conflicts when the crumbs menu is active */}
             {foldersPath.map((folder, i) => (
                 <div key={folder.id} className="lnk">
                     <PlainButton
+                        className="bdl-ContentExplorerBreadcrumbs-crumbLink"
                         data-testid="breadcrumb-lnk"
                         onClick={event => onBreadcrumbClick(i, event)}
                         title={folder.name}


### PR DESCRIPTION
**Before**
<img width="578" alt="Screenshot 2023-12-29 at 6 39 31 PM" src="https://github.com/box/box-ui-elements/assets/7311041/203917a6-67cc-4f45-817c-dc344eff64da">

**After**
<img width="586" alt="Screenshot 2023-12-29 at 6 39 10 PM" src="https://github.com/box/box-ui-elements/assets/7311041/5833b6b8-57d1-4d99-917a-ff00bc391bfb">