### PR TITLE
feat(content-sidebar): enable responsiveness for Preview and Sidebar

### DIFF
--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -60,41 +60,26 @@
         }
     }
 
-    &.be-is-small {
-        .bcpr-body {
-            position: relative;
-        }
-
-        .bcs.bcs-is-open {
-            position: absolute;
-            right: 0;
-        }
+    &.bcpr-thumbnails-open .bcpr-navigate-left {
+        left: 191px;
     }
 }
 
-.bcpr.bcpr-thumbnails-open .bcpr-navigate-left {
-    left: 191px;
-}
+@include breakpoint($medium-screen) {
+    .bcpr {
+        position: relative;
 
-.is-responsive-web {
-    @include breakpoint($medium-screen) {
-        .be.bcpr {
-            position: relative;
+        .bcpr-body {
+            position: static;
+            flex-direction: column;
         }
 
-        .bcpr {
-            .bcpr-body {
-                position: static;
-                flex-direction: column;
-            }
+        .bcpr-container {
+            position: static;
+        }
 
-            .bcpr-container {
-                position: static;
-            }
-
-            &.bcpr-thumbnails-open .bcpr-navigate-left {
-                left: 0;
-            }
+        &.bcpr-thumbnails-open .bcpr-navigate-left {
+            left: 0;
         }
     }
 }

--- a/src/elements/content-sidebar/ContentSidebar.scss
+++ b/src/elements/content-sidebar/ContentSidebar.scss
@@ -29,9 +29,9 @@ $sidebarWidth: $sidebarTabsWidth + $sidebarContentWidth;
     }
 }
 
-.is-responsive-web {
-    @include breakpoint($medium-screen) {
-        .be.bcs {
+@include breakpoint($medium-screen) {
+    .be {
+        &.bcs {
             flex-basis: 100%;
             flex-direction: column;
             width: 100%;
@@ -39,13 +39,13 @@ $sidebarWidth: $sidebarTabsWidth + $sidebarContentWidth;
             max-width: none;
             max-height: 48px;
             transition: max-height .5s ease-in-out 0s;
+        }
 
-            &.bcs-is-open {
-                position: absolute;
-                bottom: 0;
-                z-index: 5; // Stack sidebar above annotations. See z-index values https://github.com/box/box-annotations/blob/master/src/common/BaseAnnotator.scss
-                max-height: 100%;
-            }
+        &.bcs-is-open {
+            position: absolute;
+            bottom: 0;
+            z-index: 5; // Stack sidebar above annotations. See z-index values https://github.com/box/box-annotations/blob/master/src/common/BaseAnnotator.scss
+            max-height: 100%;
         }
     }
 }

--- a/src/elements/content-sidebar/SidebarContent.scss
+++ b/src/elements/content-sidebar/SidebarContent.scss
@@ -39,15 +39,13 @@
     }
 }
 
-.is-responsive-web {
-    @include breakpoint($medium-screen) {
-        .bcs-content {
-            flex-basis: 100%;
-            width: auto;
+@include breakpoint($medium-screen) {
+    .bcs-content {
+        flex-basis: 100%;
+        width: auto;
 
-            .bcs-scroll-content {
-                width: auto;
-            }
+        .bcs-scroll-content {
+            width: auto;
         }
     }
 }

--- a/src/elements/content-sidebar/SidebarNav.scss
+++ b/src/elements/content-sidebar/SidebarNav.scss
@@ -64,17 +64,8 @@
     }
 }
 
-.is-responsive-web {
-    @include breakpoint($small-screen) {
-        .bcs .bcs-NavButton,
-        .bcs-SidebarNav-secondary .btn-plain,
-        .bdl-AdditionalTab {
-            width: $sidebarTabResponsiveSize - 2; //Reducing by 2px allows all the icons to fit on the smallest supported screen size (320px)
-            margin-right: 0;
-        }
-    }
-
-    @include breakpoint($medium-screen) {
+@include breakpoint($medium-screen) {
+    .bcs {
         .bcs-SidebarNav,
         .bcs-SidebarNav-tabs,
         .bcs-SidebarNav-main {
@@ -89,24 +80,24 @@
             margin-right: 12px;
         }
 
+        .bcs-SidebarNav-secondary > :last-child,
+        .bdl-AdditionalTabs > :last-child {
+            margin-right: 0;
+        }
+
         .bdl-AdditionalTab:not(.bdl-is-overflow),
         .bdl-AdditionalTabPlaceholder {
             display: none;
         }
 
-        .bdl-AdditionalTabs > :last-child,
-        .bcs-SidebarNav-secondary > :last-child {
-            margin-right: 0;
-        }
-
         .bcs-SidebarNav-overflow {
-            .bdl-AdditionalTabs {
-                padding: 0;
-            }
-
             &::after,
             &::before {
                 display: none;
+            }
+
+            .bdl-AdditionalTabs {
+                padding: 0;
             }
         }
 
@@ -124,6 +115,17 @@
             .btn-plain.bdl-SidebarToggleButton.bdl-is-collapsed {
                 background-color: $bdl-box-blue;
             }
+        }
+    }
+}
+
+@include breakpoint($small-screen) {
+    .bcs {
+        .bcs-NavButton,
+        .bcs-SidebarNav-secondary .btn-plain,
+        .bdl-AdditionalTab {
+            width: $sidebarTabResponsiveSize - 2; // Reducing by 2px allows all the icons to fit on the smallest supported screen size (320px)
+            margin-right: 0;
         }
     }
 }

--- a/src/elements/content-sidebar/SidebarNavButton.scss
+++ b/src/elements/content-sidebar/SidebarNavButton.scss
@@ -32,21 +32,19 @@
     }
 }
 
-.is-responsive-web {
-    @include breakpoint($medium-screen) {
-        .bcs-NavButton {
-            width: $sidebarTabResponsiveSize;
-            height: $sidebarTabResponsiveSize;
-            margin-right: $bdl-grid-unit * 3;
+@include breakpoint($medium-screen) {
+    .bcs .bcs-NavButton {
+        width: $sidebarTabResponsiveSize;
+        height: $sidebarTabResponsiveSize;
+        margin-right: $bdl-grid-unit * 3;
 
-            &::before {
-                top: $sidebarTabResponsiveSize;
-                right: 0;
-                bottom: 0;
-                left: 0;
-                width: auto;
-                height: 2px;
-            }
+        &::before {
+            top: $sidebarTabResponsiveSize;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            width: auto;
+            height: 2px;
         }
     }
 }

--- a/src/elements/content-sidebar/SidebarNavSignButton.scss
+++ b/src/elements/content-sidebar/SidebarNavSignButton.scss
@@ -14,14 +14,12 @@
     margin-top: 2px; //for visual alignment
 }
 
-.is-responsive-web {
-    @include breakpoint($medium-screen) {
-        .bcs-SidebarNavSignButton-icon {
-            display: none;
-        }
+@include breakpoint($medium-screen) {
+    .bcs-SidebarNavSignButton-icon {
+        display: none;
+    }
 
-        .bcs-SidebarNavSignButton-icon--grayscale {
-            display: inline;
-        }
+    .bcs-SidebarNavSignButton-icon--grayscale {
+        display: inline;
     }
 }

--- a/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
+++ b/src/elements/content-sidebar/activity-feed/activity-feed/ActivityFeed.scss
@@ -157,9 +157,10 @@
     }
 }
 
-.is-responsive-web {
-    @include breakpoint($medium-screen) {
-        .be .bcs-activity-feed,
+@include breakpoint($medium-screen) {
+    .be .bcs-activity-feed {
+        width: 100%;
+
         .bcs-activity-feed-comment-input {
             width: 100%;
         }


### PR DESCRIPTION
The main objective of this change was to remove the `is-responsive-web` class scope that wrapped the media queries enabling the responsive behavior.

In multiple cases, removing the `is-responsive-web` class lowered the specificity of the rules which no longer applied the appropriate responsive styles. In these cases, I reorganized the blocks to match the nesting and structure of the base (non-responsive) styles. If two selectors have the same specificity level, then the ones declared later are applied on the component which explains most of the restructure.