### PR TITLE
fix(content-explorer): show pagination count for small devices

### DIFF
--- a/src/elements/content-picker/Footer.scss
+++ b/src/elements/content-picker/Footer.scss
@@ -62,6 +62,12 @@
         margin-right: 5px;
         margin-left: 5px;
     }
+
+    .be-is-small & {
+        .bdl-Pagination-count {
+            display: none;
+        }
+    }
 }
 
 @keyframes be_pulse {

--- a/src/features/pagination/Pagination.scss
+++ b/src/features/pagination/Pagination.scss
@@ -6,10 +6,6 @@
     .bdl-Pagination-count {
         display: flex;
         align-items: center;
-
-        .be-is-small & {
-            display: none;
-        }
     }
 
     .bdl-Pagination-toggle {


### PR DESCRIPTION
We got customer feedback that they'd like to see the pagination count on the footer on mobile devices for Content Explorer and Content Picker. We explained that the pagination count is intentionally hidden on small devices because of the lack space. We came to an agreement to show the pagination count on only Explorer since there is space at 300px.

**Before - Content Explorer**
<img width="498" alt="Screenshot 2024-01-23 at 2 51 05 PM" src="https://github.com/box/box-ui-elements/assets/7311041/49b80c48-6b82-4ae1-bb87-8cfcdd445bed">

**After - Content Explorer**
<img width="496" alt="Screenshot 2024-01-23 at 2 50 46 PM" src="https://github.com/box/box-ui-elements/assets/7311041/114dbe74-0881-4c55-a09a-05b8e94b4b5b">

**Unchanged - Content Picker**
<img width="498" alt="Screenshot 2024-01-23 at 2 52 40 PM" src="https://github.com/box/box-ui-elements/assets/7311041/28886aa2-53e0-487c-92a6-2232648a2ca3">
