### PR TITLE
feat(content-explorer): allow not using Portal when rendering modal

### DIFF
--- a/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
+++ b/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
@@ -145,7 +145,7 @@ class ContentExplorerModalContainer extends Component {
         listHeaderRenderer: PropTypes.func,
         /** Whether the new folder button should be shown */
         showCreateNewFolderButton: PropTypes.bool,
-        /** Whether the modal should be nested in a Portal or in a div */
+        /** Whether the modals should be nested in a Portal or in a div */
         shouldNotUsePortal: PropTypes.bool,
         /** Props for the search input */
         searchInputProps: PropTypes.object,

--- a/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
+++ b/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
@@ -145,6 +145,8 @@ class ContentExplorerModalContainer extends Component {
         listHeaderRenderer: PropTypes.func,
         /** Whether the new folder button should be shown */
         showCreateNewFolderButton: PropTypes.bool,
+        /** Whether the modal should be nested in a Portal or in a div */
+        shouldNotUsePortal: PropTypes.bool,
         /** Props for the search input */
         searchInputProps: PropTypes.object,
         /** Custom text for the choose button */
@@ -204,6 +206,7 @@ class ContentExplorerModalContainer extends Component {
             isCreatingFolder,
             createFolderError,
             initialFoldersPath,
+            shouldNotUsePortal,
             ...rest
         } = this.props;
         const { foldersPath, isNewFolderModalOpen } = this.state;
@@ -219,6 +222,7 @@ class ContentExplorerModalContainer extends Component {
                     isOpen
                     onEnterFolder={this.handleEnterFolder}
                     onCreateNewFolderButtonClick={this.handleCreateNewFolderButtonClick}
+                    shouldNotUsePortal={shouldNotUsePortal}
                     {...rest}
                 />
                 {isNewFolderModalOpen && (
@@ -230,6 +234,7 @@ class ContentExplorerModalContainer extends Component {
                         onCreateFolderInput={onCreateFolderInput}
                         isCreatingFolder={isCreatingFolder}
                         createFolderError={createFolderError}
+                        shouldNotUsePortal={shouldNotUsePortal}
                     />
                 )}
             </div>

--- a/src/features/content-explorer/content-explorer-modal-container/__tests__/ContentExplorerModalContainer.test.js
+++ b/src/features/content-explorer/content-explorer-modal-container/__tests__/ContentExplorerModalContainer.test.js
@@ -1,3 +1,4 @@
+import { shallow } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
 
@@ -6,8 +7,8 @@ import ContentExplorerModalContainer from '../ContentExplorerModalContainer';
 describe('features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer', () => {
     const sandbox = sinon.sandbox.create();
     const initialSelectedItems = { '123': { id: '123', name: 'folder123' } };
-    const renderComponent = props =>
-        shallow(
+    const renderComponent = (renderer = shallow, props) =>
+        renderer(
             <ContentExplorerModalContainer
                 onRequestClose={() => {}}
                 isOpen
@@ -42,7 +43,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
 
         test('should render component with class when specified', () => {
             const className = 'test';
-            const wrapper = renderComponent({ className });
+            const wrapper = renderComponent(shallow, { className });
 
             expect(wrapper.hasClass('content-explorer-modal-container')).toBe(true);
             expect(wrapper.hasClass(className)).toBe(true);
@@ -58,7 +59,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
         test('should render NewFolderModal when isNewFolderModalOpen is true', () => {
             const initialFoldersPath = [{ id: '0', name: 'folder' }];
             const parentFolderName = initialFoldersPath[0].name;
-            const wrapper = renderComponent({ initialFoldersPath });
+            const wrapper = renderComponent(shallow, { initialFoldersPath });
             wrapper.setState({ isNewFolderModalOpen: true });
 
             expect(wrapper.find('ContentExplorerModal').length).toBe(1);
@@ -71,7 +72,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
             const chooseButtonText = 'test';
             const onSelectedClick = () => {};
             const onSelectItem = () => {};
-            const wrapper = renderComponent({
+            const wrapper = renderComponent(shallow, {
                 searchInputProps,
                 chooseButtonText,
                 onSelectedClick,
@@ -83,12 +84,26 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
             expect(wrapper.find('ContentExplorerModal').prop('onSelectedClick')).toEqual(onSelectedClick);
             expect(wrapper.find('ContentExplorerModal').prop('onSelectItem')).toEqual(onSelectItem);
         });
+
+        test('should render ContentExplorerModal and NewFolderModal in Portal by default', () => {
+            const wrapper = renderComponent(mount);
+            wrapper.setState({ isNewFolderModalOpen: true });
+
+            expect(wrapper.find('Portal').length).toBe(4);
+        });
+
+        test('should not render ContentExplorerModal and NewFolderModal in Portal if shouldNotUsePortal=true', () => {
+            const wrapper = renderComponent(mount, { shouldNotUsePortal: true });
+            wrapper.setState({ isNewFolderModalOpen: true });
+
+            expect(wrapper.find('Portal').length).toBe(0);
+        });
     });
 
     describe('onNewFolderModalShown', () => {
         test('should call onNewFolderModalShown when new folder button is clicked', () => {
             const onNewFolderModalShownSpy = sandbox.spy();
-            const wrapper = renderComponent({
+            const wrapper = renderComponent(shallow, {
                 onNewFolderModalShown: onNewFolderModalShownSpy,
             });
             wrapper.find('ContentExplorerModal').prop('onCreateNewFolderButtonClick')();
@@ -100,7 +115,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
     describe('onNewFolderModalClosed', () => {
         test('should call onNewFolderModalClosed when new folder modal is closed', () => {
             const onNewFolderModalClosedSpy = sandbox.spy();
-            const wrapper = renderComponent({
+            const wrapper = renderComponent(shallow, {
                 onNewFolderModalClosed: onNewFolderModalClosedSpy,
             });
             wrapper.setState({ isNewFolderModalOpen: true });

--- a/src/features/content-explorer/content-explorer-modal-container/__tests__/ContentExplorerModalContainer.test.js
+++ b/src/features/content-explorer/content-explorer-modal-container/__tests__/ContentExplorerModalContainer.test.js
@@ -1,4 +1,3 @@
-import { shallow } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
 
@@ -7,7 +6,7 @@ import ContentExplorerModalContainer from '../ContentExplorerModalContainer';
 describe('features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer', () => {
     const sandbox = sinon.sandbox.create();
     const initialSelectedItems = { '123': { id: '123', name: 'folder123' } };
-    const renderComponent = (renderer = shallow, props) =>
+    const renderComponent = (props, renderer = shallow) =>
         renderer(
             <ContentExplorerModalContainer
                 onRequestClose={() => {}}
@@ -43,7 +42,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
 
         test('should render component with class when specified', () => {
             const className = 'test';
-            const wrapper = renderComponent(shallow, { className });
+            const wrapper = renderComponent({ className });
 
             expect(wrapper.hasClass('content-explorer-modal-container')).toBe(true);
             expect(wrapper.hasClass(className)).toBe(true);
@@ -59,7 +58,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
         test('should render NewFolderModal when isNewFolderModalOpen is true', () => {
             const initialFoldersPath = [{ id: '0', name: 'folder' }];
             const parentFolderName = initialFoldersPath[0].name;
-            const wrapper = renderComponent(shallow, { initialFoldersPath });
+            const wrapper = renderComponent({ initialFoldersPath });
             wrapper.setState({ isNewFolderModalOpen: true });
 
             expect(wrapper.find('ContentExplorerModal').length).toBe(1);
@@ -72,7 +71,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
             const chooseButtonText = 'test';
             const onSelectedClick = () => {};
             const onSelectItem = () => {};
-            const wrapper = renderComponent(shallow, {
+            const wrapper = renderComponent({
                 searchInputProps,
                 chooseButtonText,
                 onSelectedClick,
@@ -86,14 +85,14 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
         });
 
         test('should render ContentExplorerModal and NewFolderModal in Portal by default', () => {
-            const wrapper = renderComponent(mount);
+            const wrapper = renderComponent({}, mount);
             wrapper.setState({ isNewFolderModalOpen: true });
 
             expect(wrapper.find('Portal').length).toBe(4);
         });
 
         test('should not render ContentExplorerModal and NewFolderModal in Portal if shouldNotUsePortal=true', () => {
-            const wrapper = renderComponent(mount, { shouldNotUsePortal: true });
+            const wrapper = renderComponent({ shouldNotUsePortal: true }, mount);
             wrapper.setState({ isNewFolderModalOpen: true });
 
             expect(wrapper.find('Portal').length).toBe(0);
@@ -103,7 +102,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
     describe('onNewFolderModalShown', () => {
         test('should call onNewFolderModalShown when new folder button is clicked', () => {
             const onNewFolderModalShownSpy = sandbox.spy();
-            const wrapper = renderComponent(shallow, {
+            const wrapper = renderComponent({
                 onNewFolderModalShown: onNewFolderModalShownSpy,
             });
             wrapper.find('ContentExplorerModal').prop('onCreateNewFolderButtonClick')();
@@ -115,7 +114,7 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
     describe('onNewFolderModalClosed', () => {
         test('should call onNewFolderModalClosed when new folder modal is closed', () => {
             const onNewFolderModalClosedSpy = sandbox.spy();
-            const wrapper = renderComponent(shallow, {
+            const wrapper = renderComponent({
                 onNewFolderModalClosed: onNewFolderModalClosedSpy,
             });
             wrapper.setState({ isNewFolderModalOpen: true });

--- a/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
+++ b/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
@@ -33,6 +33,7 @@ type Props = {
     onSelectedClick?: () => void,
     onSelectedItemsUpdate?: Function,
     onViewSelectedClick?: Function,
+    shouldNotUsePortal?: boolean,
     title?: string,
 };
 
@@ -47,6 +48,7 @@ const ContentExplorerModal = ({
     onRequestClose,
     onSelectedClick,
     onSelectItem,
+    shouldNotUsePortal = false,
     ...rest
 }: Props) => (
     <Modal
@@ -56,6 +58,7 @@ const ContentExplorerModal = ({
         })}
         isOpen={isOpen}
         onRequestClose={onRequestClose}
+        shouldNotUsePortal={shouldNotUsePortal}
     >
         {description}
         <ContentExplorer

--- a/src/features/content-explorer/content-explorer-modal/__tests__/__snapshots__/ContentExplorerModal.test.js.snap
+++ b/src/features/content-explorer/content-explorer-modal/__tests__/__snapshots__/ContentExplorerModal.test.js.snap
@@ -4,6 +4,7 @@ exports[`features/content-explorer/content-explorer-modal/ContentExplorerModal r
 <Modal
   className="content-explorer-modal"
   isOpen={true}
+  shouldNotUsePortal={false}
   style={
     {
       "backdrop": {},

--- a/src/features/content-explorer/new-folder-modal/NewFolderModal.js
+++ b/src/features/content-explorer/new-folder-modal/NewFolderModal.js
@@ -39,6 +39,8 @@ class NewFolderModal extends Component {
         isCreatingFolder: PropTypes.bool,
         /** Message that will be shown when there was an error creating the folder. */
         createFolderError: PropTypes.string,
+        /** Whether the modal should be nested in a Portal or in a div */
+        shouldNotUsePortal: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -47,6 +49,7 @@ class NewFolderModal extends Component {
         parentFolderName: '',
         isCreatingFolder: false,
         createFolderError: null,
+        shouldNotUsePortal: false,
     };
 
     constructor(props) {
@@ -82,6 +85,7 @@ class NewFolderModal extends Component {
             parentFolderName,
             isCreatingFolder,
             createFolderError,
+            shouldNotUsePortal,
         } = this.props;
         const { folderNameInput } = this.state;
 
@@ -93,6 +97,7 @@ class NewFolderModal extends Component {
                 focusElementSelector=".folder-name-input input"
                 isOpen={isOpen}
                 onRequestClose={onRequestClose}
+                shouldNotUsePortal={shouldNotUsePortal}
                 title={
                     <FormattedMessage
                         {...messages.newFolderModalTitle}


### PR DESCRIPTION
Extended `ContentExplorerModalContainer` and `ContentExplorerModal` components to accept optional `shouldNotUsePortal` to that it's possible to render the modal within the parent, not only in the Portal.
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
