### PR TITLE
chore(ci): moved flow to its own job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,4 @@
 aliases:
-  - &curl-install
-    name: Install curl
-    command: apt-get update && apt-get install curl -y
-
   - &yarn
     name: Installing dependencies
     command: yarn install --non-interactive --frozen-lockfile --cache-folder ~/.cache/yarn
@@ -29,7 +25,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/buie
   docker:
-    - image: cypress/included:12.13.0
+    - image: cimg/node:18.18
 
 version: 2
 
@@ -43,16 +39,24 @@ jobs:
       - save-cache: *save-yarn-cache
       - run: *clean
       - run: *i18n
-      - run: *curl-install
       - run:
           name: Commit lint
           command: ./scripts/commitlint.sh
       - run:
           name: Code lint
           command: yarn lint
-      - run:
-          name: Flow
-          command: yarn flow check
+
+  flow:
+      <<: *defaults
+      steps:
+        - checkout
+        - restore-cache: *restore-yarn-cache
+        - run: *yarn
+        - save-cache: *save-yarn-cache
+        - run: *clean
+        - run:
+            name: Flow
+            command: yarn flow check
 
   build-unit-tests:
     resource_class: large
@@ -79,7 +83,9 @@ jobs:
           command: yarn test --maxWorkers=3
 
   e2e-tests:
-    <<: *defaults
+    working_directory: ~/buie
+    docker:
+      - image: cypress/included:12.13.0
     steps:
       - checkout
       - restore-cache: *restore-yarn-cache
@@ -94,5 +100,6 @@ workflows:
   lint_test_build:
     jobs:
       - lint
+      - flow
       - build-unit-tests
       - e2e-tests


### PR DESCRIPTION
Moved flow to its own job
Switch jobs to node images for non cypress jobs

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
