### PR TITLE
fix(react-intl): mock date in relative time unit tests

### DIFF
--- a/src/utils/__tests__/relativeTime.test.js
+++ b/src/utils/__tests__/relativeTime.test.js
@@ -9,7 +9,7 @@ const YEAR_IN_MS = 3.154e10;
 
 describe('timeFromNow function', () => {
     const originalDateNow = Date.now;
-    const fixedDate = 1629133900000; // Fixed timestamp for testing
+    const fixedDate = 1629133900000; // Fixed timestamp for testing.
     beforeAll(() => {
         Date.now = jest.fn(() => fixedDate);
     });

--- a/src/utils/__tests__/relativeTime.test.js
+++ b/src/utils/__tests__/relativeTime.test.js
@@ -8,38 +8,48 @@ const SEC_IN_MS = 1e3;
 const YEAR_IN_MS = 3.154e10;
 
 describe('timeFromNow function', () => {
-    it('should return correct year difference', () => {
-        const ms = Date.now() + YEAR_IN_MS * 4; // Four years in the future
+    const originalDateNow = Date.now;
+    const fixedDate = 1629133900000; // Fixed timestamp for testing
+    beforeAll(() => {
+        Date.now = jest.fn(() => fixedDate);
+    });
+
+    afterAll(() => {
+        Date.now = originalDateNow;
+    });
+
+    it('should return correct value and unit for time difference greater than a year', () => {
+        const ms = fixedDate + YEAR_IN_MS * 4;
         expect(timeFromNow(ms)).toEqual({ value: 4, unit: 'year' });
     });
 
-    it('should return correct week difference', () => {
-        const ms = Date.now() + WEEK_IN_MS * 2; // Two weeks in the future
+    it('should return correct value and unit for time difference greater than a week', () => {
+        const ms = fixedDate + WEEK_IN_MS * 2;
         expect(timeFromNow(ms)).toEqual({ value: 2, unit: 'week' });
     });
 
-    it('should return correct day difference', () => {
-        const ms = Date.now() + DAY_IN_MS * 2; // Two days in the future
+    it('should return correct value and unit for time difference greater than a day', () => {
+        const ms = fixedDate + DAY_IN_MS * 2;
         expect(timeFromNow(ms)).toEqual({ value: 2, unit: 'day' });
     });
 
-    it('should return correct hour difference', () => {
-        const ms = Date.now() + HOUR_IN_MS * 2; // Two hours in the future
+    it('should return correct value and unit for time difference greater than an hour', () => {
+        const ms = fixedDate + HOUR_IN_MS * 2;
         expect(timeFromNow(ms)).toEqual({ value: 2, unit: 'hour' });
     });
 
-    it('should return correct minute difference', () => {
-        const ms = Date.now() + MIN_IN_MS * 2; // Two minutes in the future
+    it('should return correct value and unit for time difference greater than a minute', () => {
+        const ms = fixedDate + MIN_IN_MS * 2;
         expect(timeFromNow(ms)).toEqual({ value: 2, unit: 'minute' });
     });
 
-    it('should return correct second difference', () => {
-        const ms = Date.now() + SEC_IN_MS * 2; // Two seconds in the future
+    it('should return correct value and unit for time difference greater than a second', () => {
+        const ms = fixedDate + SEC_IN_MS * 2;
         expect(timeFromNow(ms)).toEqual({ value: 2, unit: 'second' });
     });
 
     it('should return correct negative difference', () => {
-        const ms = Date.now() - DAY_IN_MS * 2; // Two days in the past
+        const ms = fixedDate - DAY_IN_MS * 2;
         expect(timeFromNow(ms)).toEqual({ value: -2, unit: 'day' });
     });
 });


### PR DESCRIPTION
It has been reported that the `relativeTime.test.js` test, created during the react-intl upgrade, has been failing inconsistently over the past couple of weeks when running the release pipeline.

I cannot reproduce this error locally; the tests always pass for me. I believe it may be related to Date.now() not being mocked for tests. I've mocked Date.now() within my tests to ensure consistent behavior. I think this should resolve the reported issue.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
