### PR TITLE
chore(circleci): update config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,13 @@ aliases:
 
   - &restore-yarn-cache
     keys:
-      - yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum ".circleci/config.yml" }}
+        - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
+        - yarn-packages-v1-{{ .Branch }}-
 
   - &save-yarn-cache
     paths:
-      - node_modules
-      - ~/.npm
-      - ~/.cache
-    key: yarn-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum ".circleci/config.yml" }}
+      - ~/.cache/yarn
+    key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
 defaults: &defaults
   resource_class: large
@@ -37,6 +36,9 @@ jobs:
       - checkout
       - restore-cache: *restore-yarn-cache
       - run: *yarn
+      - run:
+            name: cache dir
+            command: yarn cache dir
       - save-cache: *save-yarn-cache
       - run: *clean
       - run: *i18n
@@ -106,7 +108,14 @@ jobs:
         - run: *i18n
         - run:
             name: Chromatic
-            command: yarn chromatic
+            command: |
+                if [ "{.Environment.CIRCLE_BRANCH}" = "master" ]; then
+                  echo "{.Environment.CIRCLE_BRANCH} branch detected, auto-accepting changes"
+                  yarn chromatic --auto-accept-changes
+                else
+                  echo "Pull request detected, validating changes"
+                  yarn chromatic
+                fi
 
 workflows:
   version: 2


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
