### PR TITLE
feat(usm): Add access level label for hubs

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1800,16 +1800,22 @@ boxui.unifiedShare.modalTitle = Share ‘{itemName}’
 boxui.unifiedShare.peopleInCompanyCanAccessFile = Anyone in your company with the link or people invited to this file can access
 # Description of a company shared link for a folder.
 boxui.unifiedShare.peopleInCompanyCanAccessFolder = Anyone in your company with the link or people invited to this folder can access
+# Description of a company shared link for a hub.
+boxui.unifiedShare.peopleInCompanyCanAccessHub = Anyone in your company with the link or people invited to this hub can access
 # Label for "People in {enterpriseName}" option
 boxui.unifiedShare.peopleInEnterpriseName = People in {enterpriseName}
 # Description of a collaborator-only shared link for a file
 boxui.unifiedShare.peopleInItemCanAccessFile = Only invited people can access this file
 # Description of a collaborator-only shared link for a folder
 boxui.unifiedShare.peopleInItemCanAccessFolder = Only invited people can access this folder
+# Description of a collaborator-only shared link for a hub
+boxui.unifiedShare.peopleInItemCanAccessHub = Only invited people can access this hub
 # Description of a specific company shared link for a file. {company} is the company name
 boxui.unifiedShare.peopleInSpecifiedCompanyCanAccessFile = Anyone at {company} with the link or people invited to this file can access
 # Description of a specific company shared link for a folder. {company} is the company name
 boxui.unifiedShare.peopleInSpecifiedCompanyCanAccessFolder = Anyone at {company} with the link or people invited to this folder can access
+# Description of a specific company shared link for a hub. {company} is the company name
+boxui.unifiedShare.peopleInSpecifiedCompanyCanAccessHub = Anyone at {company} with the link or people invited to this hub can access
 # Label for "People in this file" option
 boxui.unifiedShare.peopleInThisFile = Invited people only
 # Label for "People in this folder" option
@@ -1818,6 +1824,8 @@ boxui.unifiedShare.peopleInThisFolder = Invited people only
 boxui.unifiedShare.peopleInYourCompany = People in your company
 # Description of an open shared link
 boxui.unifiedShare.peopleWithLinkDescription = Publicly accessible and no sign-in required
+# Description of an open shared link with signed required
+boxui.unifiedShare.peopleWithLinkSignedInRequiredDescription = Publicly accessible, sign-in required
 # Text to show that those having the link will have access
 boxui.unifiedShare.peopleWithTheLinkText = People with the link
 # Text used in button label to describe permission level - previewer

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,6 +1,7 @@
 // @flow
 const ITEM_TYPE_FILE: 'file' = 'file';
 const ITEM_TYPE_FOLDER: 'folder' = 'folder';
+const ITEM_TYPE_HUB: 'hub' = 'hub';
 const ITEM_TYPE_WEBLINK: 'web_link' = 'web_link';
 
 const JSON_PATCH_OP_ADD: 'add' = 'add';
@@ -14,6 +15,7 @@ const METADATA_FIELD_TYPE_MULTISELECT: 'multiSelect' = 'multiSelect';
 export {
     ITEM_TYPE_FILE,
     ITEM_TYPE_FOLDER,
+    ITEM_TYPE_HUB,
     ITEM_TYPE_WEBLINK,
     JSON_PATCH_OP_ADD,
     JSON_PATCH_OP_REMOVE,

--- a/src/common/types/core.js
+++ b/src/common/types/core.js
@@ -1,5 +1,5 @@
 // @flow
-import { ITEM_TYPE_FOLDER, ITEM_TYPE_FILE, ITEM_TYPE_WEBLINK } from '../constants';
+import { ITEM_TYPE_FOLDER, ITEM_TYPE_FILE, ITEM_TYPE_HUB, ITEM_TYPE_WEBLINK } from '../constants';
 import {
     ACCESS_OPEN,
     ACCESS_COLLAB,
@@ -83,7 +83,7 @@ type InlineNoticeType = NoticeType | 'warning' | 'success' | 'generic';
 
 type NotificationType = NoticeType | 'default' | 'warn';
 
-type ItemType = typeof ITEM_TYPE_FOLDER | typeof ITEM_TYPE_FILE | typeof ITEM_TYPE_WEBLINK;
+type ItemType = typeof ITEM_TYPE_FOLDER | typeof ITEM_TYPE_FILE | typeof ITEM_TYPE_HUB | typeof ITEM_TYPE_WEBLINK;
 
 type FileMini = {
     id: string,

--- a/src/features/unified-share-modal/SharedLinkAccessDescription.js
+++ b/src/features/unified-share-modal/SharedLinkAccessDescription.js
@@ -5,6 +5,8 @@ import { FormattedMessage } from 'react-intl';
 import type { ItemType } from '../../common/types/core';
 
 import { ANYONE_WITH_LINK, ANYONE_IN_COMPANY, PEOPLE_IN_ITEM } from './constants';
+import { ITEM_TYPE_FOLDER, ITEM_TYPE_HUB } from '../../common/constants';
+
 import type { accessLevelType } from './flowTypes';
 import messages from './messages';
 
@@ -15,26 +17,53 @@ type Props = {
 };
 
 const SharedLinkAccessDescription = ({ accessLevel, enterpriseName, itemType }: Props) => {
+    const getDescriptionForAnyoneWithLink = (type: ItemType) => {
+        switch (type) {
+            case ITEM_TYPE_HUB:
+                return messages.peopleWithLinkSignedInRequiredDescription;
+            default:
+                return messages.peopleWithLinkDescription;
+        }
+    };
+    const getDescriptionForAnyoneInCompany = (type: ItemType) => {
+        switch (type) {
+            case ITEM_TYPE_FOLDER:
+                return enterpriseName
+                    ? messages.peopleInSpecifiedCompanyCanAccessFolder
+                    : messages.peopleInCompanyCanAccessFolder;
+            case ITEM_TYPE_HUB:
+                return enterpriseName
+                    ? messages.peopleInSpecifiedCompanyCanAccessHub
+                    : messages.peopleInCompanyCanAccessHub;
+            default:
+                return enterpriseName
+                    ? messages.peopleInSpecifiedCompanyCanAccessFile
+                    : messages.peopleInCompanyCanAccessFile;
+        }
+    };
+
+    const getDescriptionForPeopleInItem = (type: ItemType) => {
+        switch (type) {
+            case ITEM_TYPE_FOLDER:
+                return messages.peopleInItemCanAccessFolder;
+            case ITEM_TYPE_HUB:
+                return messages.peopleInItemCanAccessHub;
+            default:
+                return messages.peopleInItemCanAccessFile;
+        }
+    };
+
     let description;
 
     switch (accessLevel) {
         case ANYONE_WITH_LINK:
-            description = messages.peopleWithLinkDescription;
+            description = getDescriptionForAnyoneWithLink(itemType);
             break;
         case ANYONE_IN_COMPANY:
-            if (itemType === 'folder') {
-                description = enterpriseName
-                    ? messages.peopleInSpecifiedCompanyCanAccessFolder
-                    : messages.peopleInCompanyCanAccessFolder;
-            } else {
-                description = enterpriseName
-                    ? messages.peopleInSpecifiedCompanyCanAccessFile
-                    : messages.peopleInCompanyCanAccessFile;
-            }
+            description = getDescriptionForAnyoneInCompany(itemType);
             break;
         case PEOPLE_IN_ITEM:
-            description =
-                itemType === 'folder' ? messages.peopleInItemCanAccessFolder : messages.peopleInItemCanAccessFile;
+            description = getDescriptionForPeopleInItem(itemType);
             break;
         default:
             return null;

--- a/src/features/unified-share-modal/__tests__/SharedLinkAccessDescription.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkAccessDescription.test.js
@@ -13,6 +13,9 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
             {
                 itemType: 'folder',
             },
+            {
+                itemType: 'hub',
+            },
         ].forEach(({ itemType }) => {
             test('should render correct description', () => {
                 const wrapper = shallow(
@@ -46,6 +49,14 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
                 itemType: 'folder',
                 name: 'Box',
             },
+            {
+                itemType: 'hub',
+                name: '',
+            },
+            {
+                itemType: 'hub',
+                name: 'Box',
+            },
         ].forEach(({ itemType, name }) => {
             test('should render correct description', () => {
                 const wrapper = shallow(
@@ -68,6 +79,9 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
             },
             {
                 itemType: 'folder',
+            },
+            {
+                itemType: 'hub',
             },
         ].forEach(({ itemType }) => {
             test('should render correct description', () => {

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessDescription.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessDescription.test.js.snap
@@ -64,6 +64,38 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in comp
 </small>
 `;
 
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct description 5`] = `
+<small
+  className="usm-menu-description"
+>
+  <FormattedMessage
+    defaultMessage="Anyone in your company with the link or people invited to this hub can access"
+    id="boxui.unifiedShare.peopleInCompanyCanAccessHub"
+    values={
+      {
+        "company": "",
+      }
+    }
+  />
+</small>
+`;
+
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in company should render correct description 6`] = `
+<small
+  className="usm-menu-description"
+>
+  <FormattedMessage
+    defaultMessage="Anyone at {company} with the link or people invited to this hub can access"
+    id="boxui.unifiedShare.peopleInSpecifiedCompanyCanAccessHub"
+    values={
+      {
+        "company": "Box",
+      }
+    }
+  />
+</small>
+`;
+
 exports[`features/unified-share-modal/SharedLinkAccessDescription people in item should render correct description 1`] = `
 <small
   className="usm-menu-description"
@@ -96,6 +128,22 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people in item
 </small>
 `;
 
+exports[`features/unified-share-modal/SharedLinkAccessDescription people in item should render correct description 3`] = `
+<small
+  className="usm-menu-description"
+>
+  <FormattedMessage
+    defaultMessage="Only invited people can access this hub"
+    id="boxui.unifiedShare.peopleInItemCanAccessHub"
+    values={
+      {
+        "company": "Box",
+      }
+    }
+  />
+</small>
+`;
+
 exports[`features/unified-share-modal/SharedLinkAccessDescription people with link should render correct description 1`] = `
 <small
   className="usm-menu-description"
@@ -119,6 +167,22 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people with li
   <FormattedMessage
     defaultMessage="Publicly accessible and no sign-in required"
     id="boxui.unifiedShare.peopleWithLinkDescription"
+    values={
+      {
+        "company": "Box",
+      }
+    }
+  />
+</small>
+`;
+
+exports[`features/unified-share-modal/SharedLinkAccessDescription people with link should render correct description 3`] = `
+<small
+  className="usm-menu-description"
+>
+  <FormattedMessage
+    defaultMessage="Publicly accessible, sign-in required"
+    id="boxui.unifiedShare.peopleWithLinkSignedInRequiredDescription"
     values={
       {
         "company": "Box",

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -291,6 +291,11 @@ const messages = defineMessages({
         description: 'Description of an open shared link',
         id: 'boxui.unifiedShare.peopleWithLinkDescription',
     },
+    peopleWithLinkSignedInRequiredDescription: {
+        defaultMessage: 'Publicly accessible, sign-in required',
+        description: 'Description of an open shared link with signed required',
+        id: 'boxui.unifiedShare.peopleWithLinkSignedInRequiredDescription',
+    },
     peopleInSpecifiedCompanyCanAccessFolder: {
         defaultMessage: 'Anyone at {company} with the link or people invited to this folder can access',
         description: 'Description of a specific company shared link for a folder. {company} is the company name',
@@ -311,6 +316,16 @@ const messages = defineMessages({
         description: 'Description of a company shared link for a file.',
         id: 'boxui.unifiedShare.peopleInCompanyCanAccessFile',
     },
+    peopleInSpecifiedCompanyCanAccessHub: {
+        defaultMessage: 'Anyone at {company} with the link or people invited to this hub can access',
+        description: 'Description of a specific company shared link for a hub. {company} is the company name',
+        id: 'boxui.unifiedShare.peopleInSpecifiedCompanyCanAccessHub',
+    },
+    peopleInCompanyCanAccessHub: {
+        defaultMessage: 'Anyone in your company with the link or people invited to this hub can access',
+        description: 'Description of a company shared link for a hub.',
+        id: 'boxui.unifiedShare.peopleInCompanyCanAccessHub',
+    },
     peopleInItemCanAccessFolder: {
         defaultMessage: 'Only invited people can access this folder',
         description: 'Description of a collaborator-only shared link for a folder',
@@ -320,6 +335,11 @@ const messages = defineMessages({
         defaultMessage: 'Only invited people can access this file',
         description: 'Description of a collaborator-only shared link for a file',
         id: 'boxui.unifiedShare.peopleInItemCanAccessFile',
+    },
+    peopleInItemCanAccessHub: {
+        defaultMessage: 'Only invited people can access this hub',
+        description: 'Description of a collaborator-only shared link for a hub',
+        id: 'boxui.unifiedShare.peopleInItemCanAccessHub',
     },
 
     // invite collabs levels


### PR DESCRIPTION
Adding new access label for `item type = hubs`.

<img width="527" alt="Screenshot 2024-04-02 at 6 19 22 PM" src="https://github.com/box/box-ui-elements/assets/17170105/116a06cf-46b8-4333-b95a-edeeb666b126">


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
