### PR TITLE
chore(circleci): update wait-on command to use ipv4 explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "copy:styles": "copyfiles './src/**/*.scss' es --up 1",
         "cy:open": "yarn cy:wait; yarn cypress open",
         "cy:run": "yarn cy:wait; yarn cypress run --spec \"test/integration/**/*.test.js\"",
-        "cy:wait": "wait-on http-get://localhost:6060/#",
+        "cy:wait": "wait-on http-get://127.0.0.1:6060/#",
         "lint": "npm-run-all lint:*",
         "lint:js": "eslint --max-warnings=0 .",
         "lint:ts": "tsc && eslint --ext=.tsx,.ts --max-warnings=0 .",
@@ -83,10 +83,6 @@
         "test": "BABEL_ENV=test NODE_ENV=test yarn jest -c scripts/jest/jest.config.js",
         "test:e2e": "BROWSERSLIST_ENV=test npm-run-all -p -r start:examples cy:run",
         "test:e2e:open": "BROWSERSLIST_ENV=test npm-run-all -p -r start:examples cy:open",
-        "test:images": "BABEL_ENV=test NODE_ENV=test yarn jest -c scripts/jest/jest.images.config.js --maxWorkers=4",
-        "test:images:update": "BABEL_ENV=test NODE_ENV=test yarn jest -c scripts/jest/jest.images.config.js -u --maxWorkers=4",
-        "test:visuals": "start-server-and-test start:storybook:ci http-get://localhost:6061 test:images",
-        "test:visuals:update": "start-server-and-test start:storybook:ci http-get://localhost:6061 test:images:update",
         "ts:defs": "tsc --declaration --emitDeclarationOnly --declarationDir es --noEmit false"
     },
     "browserslist": {


### PR DESCRIPTION
localhost was refusing connection, when set to 127.0.0.1 it was able to connect

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
