### PR TITLE
fix(usm): fix item type hubs

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,7 +1,7 @@
 // @flow
 const ITEM_TYPE_FILE: 'file' = 'file';
 const ITEM_TYPE_FOLDER: 'folder' = 'folder';
-const ITEM_TYPE_HUB: 'hub' = 'hub';
+const ITEM_TYPE_HUBS: 'hubs' = 'hubs';
 const ITEM_TYPE_WEBLINK: 'web_link' = 'web_link';
 
 const JSON_PATCH_OP_ADD: 'add' = 'add';
@@ -15,7 +15,7 @@ const METADATA_FIELD_TYPE_MULTISELECT: 'multiSelect' = 'multiSelect';
 export {
     ITEM_TYPE_FILE,
     ITEM_TYPE_FOLDER,
-    ITEM_TYPE_HUB,
+    ITEM_TYPE_HUBS,
     ITEM_TYPE_WEBLINK,
     JSON_PATCH_OP_ADD,
     JSON_PATCH_OP_REMOVE,

--- a/src/common/types/core.js
+++ b/src/common/types/core.js
@@ -1,5 +1,5 @@
 // @flow
-import { ITEM_TYPE_FOLDER, ITEM_TYPE_FILE, ITEM_TYPE_HUB, ITEM_TYPE_WEBLINK } from '../constants';
+import { ITEM_TYPE_FOLDER, ITEM_TYPE_FILE, ITEM_TYPE_HUBS, ITEM_TYPE_WEBLINK } from '../constants';
 import {
     ACCESS_OPEN,
     ACCESS_COLLAB,
@@ -83,7 +83,7 @@ type InlineNoticeType = NoticeType | 'warning' | 'success' | 'generic';
 
 type NotificationType = NoticeType | 'default' | 'warn';
 
-type ItemType = typeof ITEM_TYPE_FOLDER | typeof ITEM_TYPE_FILE | typeof ITEM_TYPE_HUB | typeof ITEM_TYPE_WEBLINK;
+type ItemType = typeof ITEM_TYPE_FOLDER | typeof ITEM_TYPE_FILE | typeof ITEM_TYPE_HUBS | typeof ITEM_TYPE_WEBLINK;
 
 type FileMini = {
     id: string,

--- a/src/features/unified-share-modal/SharedLinkAccessDescription.js
+++ b/src/features/unified-share-modal/SharedLinkAccessDescription.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import type { ItemType } from '../../common/types/core';
 
 import { ANYONE_WITH_LINK, ANYONE_IN_COMPANY, PEOPLE_IN_ITEM } from './constants';
-import { ITEM_TYPE_FOLDER, ITEM_TYPE_HUB } from '../../common/constants';
+import { ITEM_TYPE_FOLDER, ITEM_TYPE_HUBS } from '../../common/constants';
 
 import type { accessLevelType } from './flowTypes';
 import messages from './messages';
@@ -19,7 +19,7 @@ type Props = {
 const SharedLinkAccessDescription = ({ accessLevel, enterpriseName, itemType }: Props) => {
     const getDescriptionForAnyoneWithLink = (type: ItemType) => {
         switch (type) {
-            case ITEM_TYPE_HUB:
+            case ITEM_TYPE_HUBS:
                 return messages.peopleWithLinkSignedInRequiredDescription;
             default:
                 return messages.peopleWithLinkDescription;
@@ -31,7 +31,7 @@ const SharedLinkAccessDescription = ({ accessLevel, enterpriseName, itemType }: 
                 return enterpriseName
                     ? messages.peopleInSpecifiedCompanyCanAccessFolder
                     : messages.peopleInCompanyCanAccessFolder;
-            case ITEM_TYPE_HUB:
+            case ITEM_TYPE_HUBS:
                 return enterpriseName
                     ? messages.peopleInSpecifiedCompanyCanAccessHub
                     : messages.peopleInCompanyCanAccessHub;
@@ -46,7 +46,7 @@ const SharedLinkAccessDescription = ({ accessLevel, enterpriseName, itemType }: 
         switch (type) {
             case ITEM_TYPE_FOLDER:
                 return messages.peopleInItemCanAccessFolder;
-            case ITEM_TYPE_HUB:
+            case ITEM_TYPE_HUBS:
                 return messages.peopleInItemCanAccessHub;
             default:
                 return messages.peopleInItemCanAccessFile;

--- a/src/features/unified-share-modal/__tests__/SharedLinkAccessDescription.test.js
+++ b/src/features/unified-share-modal/__tests__/SharedLinkAccessDescription.test.js
@@ -14,7 +14,7 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
                 itemType: 'folder',
             },
             {
-                itemType: 'hub',
+                itemType: 'hubs',
             },
         ].forEach(({ itemType }) => {
             test('should render correct description', () => {
@@ -50,11 +50,11 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
                 name: 'Box',
             },
             {
-                itemType: 'hub',
+                itemType: 'hubs',
                 name: '',
             },
             {
-                itemType: 'hub',
+                itemType: 'hubs',
                 name: 'Box',
             },
         ].forEach(({ itemType, name }) => {
@@ -81,7 +81,7 @@ describe('features/unified-share-modal/SharedLinkAccessDescription', () => {
                 itemType: 'folder',
             },
             {
-                itemType: 'hub',
+                itemType: 'hubs',
             },
         ].forEach(({ itemType }) => {
             test('should render correct description', () => {


### PR DESCRIPTION
Fix a typo in item type hubs. It should be `hubs` since it will be used as part of the collaborator page.


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
