### PR TITLE
fix(content-answers): scope styles to content answers modal

### DIFF
--- a/src/features/content-answers/Answer.scss
+++ b/src/features/content-answers/Answer.scss
@@ -1,4 +1,6 @@
-.bdl-Answer {
-    font-size: 15px;
-    white-space: pre-wrap;
+.bdl-ContentAnswersModal {
+    .bdl-Answer {
+        font-size: 15px;
+        white-space: pre-wrap;
+    }
 }

--- a/src/features/content-answers/ContentAnswersGridCard.scss
+++ b/src/features/content-answers/ContentAnswersGridCard.scss
@@ -1,26 +1,28 @@
 @import '../../styles/variables';
 
-.bdl-ContentAnswersGridCard {
-    margin-top: $bdl-grid-unit * 4;
+.bdl-ContentAnswersModal {
+    .bdl-ContentAnswersGridCard {
+        margin-top: $bdl-grid-unit * 4;
 
-    .bdl-ContentAnswersGridCard-icon {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: $bdl-grid-unit * 8;
-        height: $bdl-grid-unit * 8;
-        background: $bdl-light-blue-20;
-        border-radius: 50%;
-    }
+        .bdl-ContentAnswersGridCard-icon {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: $bdl-grid-unit * 8;
+            height: $bdl-grid-unit * 8;
+            background: $bdl-light-blue-20;
+            border-radius: 50%;
+        }
 
-    .bdl-ContentAnswersGridCard-body {
-        padding: $bdl-grid-unit * 4;
-        background-color: $white;
-        border: 1px solid $bdl-gray-10;
-        border-radius: $bdl-border-radius-size-xlarge;
-    }
+        .bdl-ContentAnswersGridCard-body {
+            padding: $bdl-grid-unit * 4;
+            background-color: $white;
+            border: 1px solid $bdl-gray-10;
+            border-radius: $bdl-border-radius-size-xlarge;
+        }
 
-    .bdl-Media-figure {
-        margin: $bdl-grid-unit * 4 $bdl-grid-unit * 3 0 0;
+        .bdl-Media-figure {
+            margin: $bdl-grid-unit * 4 $bdl-grid-unit * 3 0 0;
+        }
     }
 }

--- a/src/features/content-answers/ContentAnswersModal.scss
+++ b/src/features/content-answers/ContentAnswersModal.scss
@@ -1,10 +1,13 @@
 @import '../../styles/variables';
 
 .bdl-ContentAnswersModal {
-    .modal-dialog-container {
+    .bdl-ContentAnswersModal-content {
         display: flex;
-        flex-basis: 0;
-        width: 100%;
+        flex-direction: column;
+        background-color: $bdl-gray-05;
+    }
+
+    .modal-dialog-container {
         height: 100%;
         max-height: 702px;
     }
@@ -12,17 +15,14 @@
     .modal-dialog {
         width: 768px;
         height: 100%;
-        max-height: 702px;
         padding: 0;
-        background-color: $bdl-gray-05;
+        overflow: hidden;
     }
 
     .modal-header-container {
         z-index: 1;
         margin: 0;
         padding: $bdl-grid-unit * 4 $bdl-grid-unit * 5;
-        background-color: white;
-        border-radius: $bdl-border-radius-size-xlarge $bdl-border-radius-size-xlarge 0 0;
         box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 1px 0 $bdl-gray-10;
 
         .modal-title {
@@ -36,16 +36,9 @@
     }
 
     .modal-content {
-        display: flex;
-        flex-direction: column;
         flex-grow: 1;
-        max-height: 638px;
         margin-top: 0;
         overflow: hidden;
-    }
-
-    .modal-close-button {
-        top: 20px;
     }
 
     .bdl-ContentAnswersModalFooter-submitButton {

--- a/src/features/content-answers/ContentAnswersModal.scss
+++ b/src/features/content-answers/ContentAnswersModal.scss
@@ -1,7 +1,7 @@
 @import '../../styles/variables';
 
 .bdl-ContentAnswersModal {
-    .bdl-ContentAnswersModal-content {
+    .be {
         display: flex;
         flex-direction: column;
         background-color: $bdl-gray-05;
@@ -23,6 +23,7 @@
         z-index: 1;
         margin: 0;
         padding: $bdl-grid-unit * 4 $bdl-grid-unit * 5;
+        background-color: $white;
         box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 1px 0 $bdl-gray-10;
 
         .modal-title {

--- a/src/features/content-answers/ContentAnswersModal.tsx
+++ b/src/features/content-answers/ContentAnswersModal.tsx
@@ -114,7 +114,7 @@ const ContentAnswersModal = ({ api, currentUser, file, isOpen, onAsk, onRequestC
                 </>
             }
         >
-            <div className="be bdl-ContentAnswersModal-content">
+            <div className="be">
                 <ContentAnswersModalContent
                     currentUser={currentUser}
                     data-testid="content-answers-modal-content"

--- a/src/features/content-answers/ContentAnswersModal.tsx
+++ b/src/features/content-answers/ContentAnswersModal.tsx
@@ -98,7 +98,7 @@ const ContentAnswersModal = ({ api, currentUser, file, isOpen, onAsk, onRequestC
 
     return (
         <Modal
-            className="bdl-ContentAnswersModal"
+            className="be-modal bdl-ContentAnswersModal"
             data-testid="content-answers-modal"
             isOpen={isOpen}
             onRequestClose={onRequestClose}
@@ -114,21 +114,23 @@ const ContentAnswersModal = ({ api, currentUser, file, isOpen, onAsk, onRequestC
                 </>
             }
         >
-            <ContentAnswersModalContent
-                currentUser={currentUser}
-                data-testid="content-answers-modal-content"
-                fileName={fileName}
-                isLoading={isLoading}
-                questions={questions}
-            />
-            <ContentAnswersModalFooter
-                currentUser={currentUser}
-                data-testid="content-answers-modal-footer"
-                hasError={hasError}
-                isLoading={isLoading}
-                onAsk={handleAsk}
-                onRetry={handleRetry}
-            />
+            <div className="be bdl-ContentAnswersModal-content">
+                <ContentAnswersModalContent
+                    currentUser={currentUser}
+                    data-testid="content-answers-modal-content"
+                    fileName={fileName}
+                    isLoading={isLoading}
+                    questions={questions}
+                />
+                <ContentAnswersModalFooter
+                    currentUser={currentUser}
+                    data-testid="content-answers-modal-footer"
+                    hasError={hasError}
+                    isLoading={isLoading}
+                    onAsk={handleAsk}
+                    onRetry={handleRetry}
+                />
+            </div>
         </Modal>
     );
 };

--- a/src/features/content-answers/ContentAnswersModalContent.scss
+++ b/src/features/content-answers/ContentAnswersModalContent.scss
@@ -1,12 +1,14 @@
 @import '../../styles/variables';
 
-.bdl-ContentAnswersModalContent {
-    flex: 1 1 auto;
-    width: auto;
-    padding: 0 $bdl-grid-unit * 5 $bdl-grid-unit * 5 $bdl-grid-unit * 5;
-    overflow: auto;
+.bdl-ContentAnswersModal {
+    .bdl-ContentAnswersModalContent {
+        flex: 1 1 auto;
+        width: auto;
+        padding: 0 $bdl-grid-unit * 5 $bdl-grid-unit * 5 $bdl-grid-unit * 5;
+        overflow: auto;
 
-    ul {
-        margin: 0;
+        ul {
+            margin: 0;
+        }
     }
 }

--- a/src/features/content-answers/ContentAnswersModalError.scss
+++ b/src/features/content-answers/ContentAnswersModalError.scss
@@ -1,28 +1,30 @@
 @import '../../styles/variables';
 
-.bdl-ContentAnswersModalError {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    text-align: center;
+.bdl-ContentAnswersModal {
+    .bdl-ContentAnswersModalError {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        text-align: center;
 
-    .bdl-ContentAnswersModalError-illustration {
-        margin-block-end: 1.5rem;
-    }
+        .bdl-ContentAnswersModalError-illustration {
+            margin-block-end: 1.5rem;
+        }
 
-    h2 {
-        margin: 0;
-        font-weight: bold;
-        font-size: 1rem;
-        margin-block-end: .75rem;
-    }
+        h2 {
+            margin: 0;
+            font-weight: bold;
+            font-size: 1rem;
+            margin-block-end: .75rem;
+        }
 
-    p {
-        margin: 0;
-        font-weight: normal;
-        font-size: .875rem;
-        letter-spacing: .01875rem;
+        p {
+            margin: 0;
+            font-weight: normal;
+            font-size: .875rem;
+            letter-spacing: .01875rem;
+        }
     }
 }

--- a/src/features/content-answers/ContentAnswersModalFooter.scss
+++ b/src/features/content-answers/ContentAnswersModalFooter.scss
@@ -1,42 +1,44 @@
 @import '../../styles/variables';
 
-.bdl-ContentAnswersModalFooter-questionInput {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    align-items: end;
-    padding: $bdl-grid-unit * 4 $bdl-grid-unit * 5;
-    background: $white;
-    border-radius: 0 0 $bdl-border-radius-size-xlarge $bdl-border-radius-size-xlarge;
-    box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 -1px 0 $bdl-gray-10;
+.bdl-ContentAnswersModal {
+    .bdl-ContentAnswersModalFooter-questionInput {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        align-items: end;
+        padding: $bdl-grid-unit * 4 $bdl-grid-unit * 5;
+        background: $white;
+        border-radius: 0 0 $bdl-border-radius-size-xlarge $bdl-border-radius-size-xlarge;
+        box-shadow: 0 0 8px rgba(0, 0, 0, .05), 0 -1px 0 $bdl-gray-10;
 
-    .bdl-ContentAnswersModalFooter-avatar {
-        height: $bdl-grid-unit * 8;
-        margin-bottom: $bdl-grid-unit;
-    }
+        .bdl-ContentAnswersModalFooter-avatar {
+            height: $bdl-grid-unit * 8;
+            margin-bottom: $bdl-grid-unit;
+        }
 
-    .text-area-container {
-        width: 100%;
-        margin: 0 $bdl-grid-unit * 4;
-    }
+        .text-area-container {
+            width: 100%;
+            margin: 0 $bdl-grid-unit * 4;
+        }
 
-    textarea {
-        width: 100%;
-        height: $bdl-grid-unit * 10;
-        margin: 0;
-        padding: 0;
-        overflow: hidden;
-        font-size: 14px;
-        line-height: 1.25rem;
-        letter-spacing: .01875rem;
-        border: none;
-        border-radius: $bdl-border-radius-size-med;
-        box-shadow: 0 0 0 .0625rem $bdl-gray-50;
-        padding-block: .625rem;
-        padding-inline: .75rem;
-    }
+        textarea {
+            width: 100%;
+            height: $bdl-grid-unit * 10;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+            font-size: 14px;
+            line-height: 1.25rem;
+            letter-spacing: .01875rem;
+            border: none;
+            border-radius: $bdl-border-radius-size-med;
+            box-shadow: 0 0 0 .0625rem $bdl-gray-50;
+            padding-block: .625rem;
+            padding-inline: .75rem;
+        }
 
-    textarea:focus {
-        border: 1.5px solid $bdl-box-blue;
+        textarea:focus {
+            border: 1.5px solid $bdl-box-blue;
+        }
     }
 }

--- a/src/features/content-answers/ContentAnswersModalFooterActions.scss
+++ b/src/features/content-answers/ContentAnswersModalFooterActions.scss
@@ -1,17 +1,19 @@
 @import '../../styles/variables';
 
-.bdl-ContentAnswersModalFooterActions {
-    position: relative;
-    top: -$bdl-grid-unit * 4;
-    display: flex;
-    padding: $bdl-grid-unit * 3 0 0 0;
-}
+.bdl-ContentAnswersModal {
+    .bdl-ContentAnswersModalFooterActions {
+        position: relative;
+        top: -$bdl-grid-unit * 4;
+        display: flex;
+        padding: $bdl-grid-unit * 3 0 0 0;
+    }
 
-.bdl-ContentAnswersModalFooterActions-button {
-    margin: auto;
+    .bdl-ContentAnswersModalFooterActions-button {
+        margin: auto;
 
-    &:not(.bdl-is-disabled):focus {
-        border: 1px solid #bcbcbc;
-        box-shadow: 0 0 0 1px $white, 0 0 0 3px $bdl-light-blue;
+        &:not(.bdl-is-disabled):focus {
+            border: 1px solid #bcbcbc;
+            box-shadow: 0 0 0 1px $white, 0 0 0 3px $bdl-light-blue;
+        }
     }
 }

--- a/src/features/content-answers/ContentAnswersOpenButton.scss
+++ b/src/features/content-answers/ContentAnswersOpenButton.scss
@@ -10,7 +10,7 @@
     border: 1px solid #2222224d;
 }
 
-.bdl-ContentAnswersOpenButton {
+.btn.bdl-ContentAnswersOpenButton {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/features/content-answers/InlineError.scss
+++ b/src/features/content-answers/InlineError.scss
@@ -1,39 +1,41 @@
 @import '../../styles/variables';
 
-.bdl-InlineError {
-    margin-top: $bdl-grid-unit * 4;
+.bdl-ContentAnswersModal {
+    .bdl-InlineError {
+        margin-top: $bdl-grid-unit * 4;
 
-    .bdl-InlineError-icon {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: $bdl-grid-unit * 8;
-        height: $bdl-grid-unit * 8;
-        background: $bdl-light-blue-20;
-        border-radius: 50%;
-    }
+        .bdl-InlineError-icon {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: $bdl-grid-unit * 8;
+            height: $bdl-grid-unit * 8;
+            background: $bdl-light-blue-20;
+            border-radius: 50%;
+        }
 
-    .bdl-InlineError-text {
-        flex-grow: 1;
-        margin: 0 $bdl-grid-unit * 3;
-        font-size: $bdl-fontSize--dejaBlue;
-    }
+        .bdl-InlineError-text {
+            flex-grow: 1;
+            margin: 0 $bdl-grid-unit * 3;
+            font-size: $bdl-fontSize--dejaBlue;
+        }
 
-    .bdl-InlineError-alertIcon {
-        width: 20px;
-        height: 20px;
-    }
+        .bdl-InlineError-alertIcon {
+            width: 20px;
+            height: 20px;
+        }
 
-    .bdl-Media-figure {
-        margin: $bdl-grid-unit * 4 $bdl-grid-unit * 3 0 0;
-    }
+        .bdl-Media-figure {
+            margin: $bdl-grid-unit * 4 $bdl-grid-unit * 3 0 0;
+        }
 
-    .bdl-Media-body {
-        display: flex;
-        align-items: center;
-        padding: $bdl-grid-unit * 3 $bdl-grid-unit * 4;
-        background-color: $bdl-watermelon-red-10;
-        border: 2px solid $bdl-watermelon-red-50;
-        border-radius: $bdl-grid-unit * 3;
+        .bdl-Media-body {
+            display: flex;
+            align-items: center;
+            padding: $bdl-grid-unit * 3 $bdl-grid-unit * 4;
+            background-color: $bdl-watermelon-red-10;
+            border: 2px solid $bdl-watermelon-red-50;
+            border-radius: $bdl-grid-unit * 3;
+        }
     }
 }

--- a/src/features/content-answers/LoadingElement.scss
+++ b/src/features/content-answers/LoadingElement.scss
@@ -1,4 +1,5 @@
-.bdl-LoadingElement-LoadingIndicator {
-    position: relative;
-    display: inline-flex;
+.bdl-ContentAnswersModal {
+    .bdl-LoadingElement-loadingIndicator {
+        display: inline-flex;
+    }
 }

--- a/src/features/content-answers/LoadingElement.tsx
+++ b/src/features/content-answers/LoadingElement.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import LoadingIndicator, { LoadingIndicatorSize } from '../../components/loading-indicator';
+import LoadingIndicator from '../../components/loading-indicator';
 import ContentAnswersGridCard from './ContentAnswersGridCard';
 
 import './LoadingElement.scss';
@@ -8,7 +8,7 @@ const LoadingElement = () => {
     return (
         <div className="bdl-LoadingElement" data-testid="LoadingElement">
             <ContentAnswersGridCard>
-                <LoadingIndicator className="bdl-LoadingElement-LoadingIndicator" size={LoadingIndicatorSize.MEDIUM} />
+                <LoadingIndicator className="bdl-LoadingElement-loadingIndicator" />
             </ContentAnswersGridCard>
         </div>
     );

--- a/src/features/content-answers/Question.scss
+++ b/src/features/content-answers/Question.scss
@@ -1,16 +1,18 @@
 @import '../../styles/variables';
 
-.bdl-Question {
-    margin-top: 1rem;
-    white-space: pre-wrap;
+.bdl-ContentAnswersModal {
+    .bdl-Question {
+        margin-top: 1rem;
+        white-space: pre-wrap;
 
-    .bdl-Media-figure {
-        margin-right: $bdl-grid-unit * 3;
-    }
+        .bdl-Media-figure {
+            margin-right: $bdl-grid-unit * 3;
+        }
 
-    .bdl-Media {
-        align-items: center;
-        color: black;
-        font-size: 15px;
+        .bdl-Media {
+            align-items: center;
+            color: $bdl-gray;
+            font-size: 15px;
+        }
     }
 }

--- a/src/features/content-answers/WelcomeMessage.scss
+++ b/src/features/content-answers/WelcomeMessage.scss
@@ -1,25 +1,27 @@
 @import '../../styles/variables';
 
-.bdl-WelcomeMessage {
-    .ContentAnswersGridCard {
-        margin-top: $bdl-grid-unit * 5;
-    }
+.bdl-ContentAnswersModal {
+    .bdl-WelcomeMessage {
+        .bdl-ContentAnswersGridCard {
+            margin-top: $bdl-grid-unit * 5;
+        }
 
-    .bdl-WelcomeMessage-title {
-        margin: 0;
-        font-weight: bold;
-        font-size: 15px;
-        line-height: 20px;
-    }
+        .bdl-WelcomeMessage-title {
+            margin: 0;
+            font-weight: bold;
+            font-size: 15px;
+            line-height: 20px;
+        }
 
-    .bdl-WelcomeMessage-askQuestionText {
-        margin: $bdl-grid-unit * 3 0;
-        font-size: 15px;
-    }
+        .bdl-WelcomeMessage-askQuestionText {
+            margin: $bdl-grid-unit * 3 0;
+            font-size: 15px;
+        }
 
-    .bdl-WelcomeMessage-clearChatText {
-        margin: 0;
-        color: $bdl-gray-65;
-        font-size: 13px;
+        .bdl-WelcomeMessage-clearChatText {
+            margin: 0;
+            color: $bdl-gray-65;
+            font-size: 13px;
+        }
     }
 }


### PR DESCRIPTION
When running a custom app, the UI for Content Answers is not appearing as expected. There are a couple reasons for this:

1. Storybook and our internal apps (EUA, AC) have styles applied to the `body` element which gives us a false assumption of base styles during development. When the component is then used in a customer app, we are missing these base styles. To resolve this, we need to add the `be-modal` class to the outer modal component and the `be` class to the inner content so that the correct styles are applied.
2. Depending on how the customer imports our CSS stylesheets, component styles may be incorrectly applied if they have the same level of specificity as the lower level components. For example, the styles for `bdl-ContentAnswersOpenButton` has the same specificity as the base button `btn` component and thus the styles are not always applied correctly. Adding an outer `.bdl-ContentAnswersModal` to the stylesheets will increase the specificity as well as prevent the styles from these components with common names from leaking into other areas.

**Before**
<img width="1008" alt="Screenshot 2024-05-06 at 4 06 58 PM" src="https://github.com/box/box-ui-elements/assets/7311041/3ec3c284-48a6-4cae-b3a3-5433e7f2fa97">

**After**
<img width="1008" alt="Screenshot 2024-05-06 at 4 04 36 PM" src="https://github.com/box/box-ui-elements/assets/7311041/943290fd-e3ae-4c89-9df0-eefde7b72ce9">