### PR TITLE
feat(usm): add inline notice as component

### DIFF
--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -713,7 +713,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             <div className={displayInModal ? '' : 'be bdl-UnifiedShareForm'}>
                 <LoadingIndicatorWrapper isLoading={isFetching} hideContent>
                     {!hasExpandedSections && allShareRestrictionWarning}
-                    {upsellInlineNotice && <div className="upsell-inline-notice">{upsellInlineNotice}</div>}
+                    {!!upsellInlineNotice && <div className="upsell-inline-notice">{upsellInlineNotice}</div>}
                     {showUpgradeOptions && showUpgradeInlineNotice && this.renderUpgradeInlineNotice()}
 
                     {!isEmailLinkSectionExpanded && !showCollaboratorList && this.renderInviteSection()}

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -699,6 +699,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             submitting,
             tooltips = {},
             trackingProps,
+            upsellInlineNotice = null,
         } = this.props;
         const { sharedLinkTracking, sharedLinkEmailTracking } = trackingProps;
         const { isEmailLinkSectionExpanded, isInviteSectionExpanded, showCollaboratorList } = this.state;
@@ -712,6 +713,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             <div className={displayInModal ? '' : 'be bdl-UnifiedShareForm'}>
                 <LoadingIndicatorWrapper isLoading={isFetching} hideContent>
                     {!hasExpandedSections && allShareRestrictionWarning}
+                    {upsellInlineNotice}
                     {showUpgradeOptions && showUpgradeInlineNotice && this.renderUpgradeInlineNotice()}
 
                     {!isEmailLinkSectionExpanded && !showCollaboratorList && this.renderInviteSection()}

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -713,7 +713,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             <div className={displayInModal ? '' : 'be bdl-UnifiedShareForm'}>
                 <LoadingIndicatorWrapper isLoading={isFetching} hideContent>
                     {!hasExpandedSections && allShareRestrictionWarning}
-                    {upsellInlineNotice}
+                    {upsellInlineNotice && <div className="upsell-inline-notice">{upsellInlineNotice}</div>}
                     {showUpgradeOptions && showUpgradeInlineNotice && this.renderUpgradeInlineNotice()}
 
                     {!isEmailLinkSectionExpanded && !showCollaboratorList && this.renderInviteSection()}

--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -713,7 +713,9 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             <div className={displayInModal ? '' : 'be bdl-UnifiedShareForm'}>
                 <LoadingIndicatorWrapper isLoading={isFetching} hideContent>
                     {!hasExpandedSections && allShareRestrictionWarning}
+
                     {!!upsellInlineNotice && <div className="upsell-inline-notice">{upsellInlineNotice}</div>}
+
                     {showUpgradeOptions && showUpgradeInlineNotice && this.renderUpgradeInlineNotice()}
 
                     {!isEmailLinkSectionExpanded && !showCollaboratorList && this.renderInviteSection()}

--- a/src/features/unified-share-modal/UnifiedShareModal.scss
+++ b/src/features/unified-share-modal/UnifiedShareModal.scss
@@ -289,6 +289,10 @@
         color: $bdl-box-blue;
         letter-spacing: normal;
     }
+
+    .upsell-inline-notice {
+        margin-bottom: $bdl-grid-unit * 5;
+    }
 }
 
 .bdl-UnifiedShareForm-container {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -74,7 +74,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
             />,
         );
     const mockUpsellInlineNotice = (
-        <div className="upsellInlineNotice" data-testid="upsellinlinenotice">
+        <div>
             <div className="title">Upsell Inline Notice</div>
             <div className="body">Lorem Ipsum</div>
         </div>
@@ -233,8 +233,14 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
 
         test('should render the upsell inline notice component when component is passed', () => {
             const wrapper = getWrapper({ upsellInlineNotice: mockUpsellInlineNotice });
-            const upsellInlineNotice = wrapper.find('[data-testid="upsellinlinenotice"]');
+            const upsellInlineNotice = wrapper.find('.upsell-inline-notice');
             expect(upsellInlineNotice).toHaveLength(1);
+        });
+
+        test('should not render the upsell inline notice div when component is passed', () => {
+            const wrapper = getWrapper();
+            const upsellInlineNotice = wrapper.find('.upsell-inline-notice');
+            expect(upsellInlineNotice).toHaveLength(0);
         });
 
         test('should render a default component with correct Focus element and props when focusSharedLinkOnLoad is enabled', () => {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -73,6 +73,12 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
                 {...props}
             />,
         );
+    const mockUpsellInlineNotice = (
+        <div className="upsellInlineNotice" data-testid="upsellinlinenotice">
+            <div className="title">Upsell Inline Notice</div>
+            <div className="body">Lorem Ipsum</div>
+        </div>
+    );
 
     describe('render()', () => {
         test('should render a default component with default props', () => {
@@ -223,6 +229,12 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
             });
             expect(wrapper.exists('UpgradeBadge')).toBe(false);
             expect(wrapper.exists('InlineNotice')).toBe(true);
+        });
+
+        test('should render the upsell inline notice component when component is passed', () => {
+            const wrapper = getWrapper({ upsellInlineNotice: mockUpsellInlineNotice });
+            const upsellInlineNotice = wrapper.find('[data-testid="upsellinlinenotice"]');
+            expect(upsellInlineNotice).toHaveLength(1);
         });
 
         test('should render a default component with correct Focus element and props when focusSharedLinkOnLoad is enabled', () => {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -75,8 +75,8 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
         );
     const mockUpsellInlineNotice = (
         <div>
-            <div className="title">Upsell Inline Notice</div>
-            <div className="body">Lorem Ipsum</div>
+            <div className="upsell-title">Upsell Inline Notice</div>
+            <div className="upsell-body">Lorem Ipsum</div>
         </div>
     );
 
@@ -234,11 +234,15 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
         test('should render the upsell inline notice component when component is passed', () => {
             const wrapper = getWrapper({ upsellInlineNotice: mockUpsellInlineNotice });
             expect(wrapper.exists('.upsell-inline-notice')).toBe(true);
+            expect(wrapper.exists('.upsell-title')).toBe(true);
+            expect(wrapper.exists('.upsell-body')).toBe(true);
         });
 
         test('should not render the upsell inline notice div when component is passed', () => {
             const wrapper = getWrapper();
             expect(wrapper.exists('.upsell-inline-notice')).toBe(false);
+            expect(wrapper.exists('.upsell-title')).toBe(false);
+            expect(wrapper.exists('.upsell-body')).toBe(false);
         });
 
         test('should render a default component with correct Focus element and props when focusSharedLinkOnLoad is enabled', () => {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -233,14 +233,12 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
 
         test('should render the upsell inline notice component when component is passed', () => {
             const wrapper = getWrapper({ upsellInlineNotice: mockUpsellInlineNotice });
-            const upsellInlineNotice = wrapper.find('.upsell-inline-notice');
-            expect(upsellInlineNotice).toHaveLength(1);
+            expect(wrapper.exists('.upsell-inline-notice')).toBe(true);
         });
 
         test('should not render the upsell inline notice div when component is passed', () => {
             const wrapper = getWrapper();
-            const upsellInlineNotice = wrapper.find('.upsell-inline-notice');
-            expect(upsellInlineNotice).toHaveLength(0);
+            expect(wrapper.exists('.upsell-inline-notice')).toBe(false);
         });
 
         test('should render a default component with correct Focus element and props when focusSharedLinkOnLoad is enabled', () => {

--- a/src/features/unified-share-modal/flowTypes.js
+++ b/src/features/unified-share-modal/flowTypes.js
@@ -409,8 +409,12 @@ export type USFProps = BaseUnifiedShareProps & {
     sharedLinkLoaded: boolean,
     /** Whether the FTUX tooltip should be rendered */
     shouldRenderFTUXTooltip: boolean,
-    /** Whether the upgrade inline notice should be rendered */
+    /** Whether the upgrade inline notice should be rendered
+     * NOTE (wyehdego): Remove this prop once we refactor legacy inline notice with upsellInlineNotice
+     */
     showUpgradeInlineNotice?: boolean,
+    /** Inline Notice component to render based on user */
+    upsellInlineNotice?: React.Node | null,
 };
 
 export type InviteCollaboratorsRequest = {


### PR DESCRIPTION
Example of new Business plan blueprint Inline Notice (purple) being passed into Unified Share Modal:
<img width="530" alt="Screenshot 2024-05-07 at 4 26 36 PM" src="https://github.com/box/box-ui-elements/assets/5000110/195e120c-c852-455d-9d29-e8db5d088bd5">


Example of new Freemium plan blueprint Inline Notice (blue) being passed into Unified Share Modal:
<img width="535" alt="Screenshot 2024-05-07 at 3 48 27 PM" src="https://github.com/box/box-ui-elements/assets/5000110/15b914f1-7ea8-4d79-a481-b3319f7afa0d">



<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
