### PR TITLE
fix(usm): hide link description when upsell shows

### DIFF
--- a/src/features/unified-share-modal/UnifiedShareForm.js
+++ b/src/features/unified-share-modal/UnifiedShareForm.js
@@ -438,6 +438,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             submitting,
             suggestedCollaborators,
             trackingProps,
+            upsellInlineNotice,
         } = this.props;
         const { type } = item;
         const { isFetchingJustificationReasons, isInviteSectionExpanded, justificationReasons } = this.state;
@@ -486,6 +487,7 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
             text: ftuxTooltipText,
             theme: 'callout',
         };
+        const showUpsellInlineNotice = !!upsellInlineNotice;
 
         return (
             <>
@@ -523,7 +525,10 @@ class UnifiedShareForm extends React.Component<USFProps, State> {
                             {...inviteCollabsEmailTracking}
                         >
                             {this.renderInviteePermissionsDropdown()}
-                            {showUpgradeOptions && !showUpgradeInlineNotice && this.renderUpgradeLinkDescription()}
+                            {showUpgradeOptions &&
+                                !showUpgradeInlineNotice &&
+                                !showUpsellInlineNotice &&
+                                this.renderUpgradeLinkDescription()}
                         </EmailForm>
                     </div>
                 </Tooltip>

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -212,17 +212,17 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
         });
 
         test.each([
-            [true, true, null],
-            [true, false, null],
-            [false, true, null],
-            [false, false, null],
-            [true, true, mockUpsellInlineNotice],
-            [true, false, mockUpsellInlineNotice],
-            [false, true, mockUpsellInlineNotice],
-            [false, false, mockUpsellInlineNotice],
+            [true, true, 'is not', null],
+            [true, false, 'is not', null],
+            [false, true, 'is not', null],
+            [false, false, 'is not', null],
+            [true, true, 'is', mockUpsellInlineNotice],
+            [true, false, 'is', mockUpsellInlineNotice],
+            [false, true, 'is', mockUpsellInlineNotice],
+            [false, false, 'is', mockUpsellInlineNotice],
         ])(
-            'should render a default component with upgrade CTA when showUpgradeInlineNotice is %s, showUpgradeOptions is %s, and upsellInlineNotice is %s',
-            (showUpgradeInlineNotice, showUpgradeOptions, upsellInlineNotice) => {
+            'should render a default component with upgrade CTA when showUpgradeInlineNotice is %s, showUpgradeOptions is %s, and upsellInlineNotice %s passed in',
+            (showUpgradeInlineNotice, showUpgradeOptions, upsellInlineNoticeDescription, upsellInlineNotice) => {
                 const wrapper = getWrapper({
                     canInvite: true,
                     isFetching: false,

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -243,6 +243,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
             expect(wrapper.exists('.upsell-inline-notice')).toBe(false);
             expect(wrapper.exists('.upsell-title')).toBe(false);
             expect(wrapper.exists('.upsell-body')).toBe(false);
+            expect(wrapper.exists('UpgradeBadge')).toBe(false);
         });
 
         test('should render a default component with correct Focus element and props when focusSharedLinkOnLoad is enabled', () => {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -221,7 +221,7 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
             [false, true, mockUpsellInlineNotice],
             [false, false, mockUpsellInlineNotice],
         ])(
-            'should render a default component with upgrade CTA with respect to showUpgradeInlineNotice, showUpgradeOptions, and upsellInlineNotice props',
+            'should render a default component with upgrade CTA when showUpgradeInlineNotice is %s, showUpgradeOptions is %s, and upsellInlineNotice is %s',
             (showUpgradeInlineNotice, showUpgradeOptions, upsellInlineNotice) => {
                 const wrapper = getWrapper({
                     canInvite: true,

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -243,7 +243,6 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
                 showUpgradeInlineNotice: true,
                 showUpgradeOptions: true,
             });
-            expect(wrapper.exists('UpgradeBadge')).toBe(false);
             expect(wrapper.exists('InlineNotice')).toBe(true);
         });
 
@@ -259,7 +258,6 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
             expect(wrapper.exists('.upsell-inline-notice')).toBe(false);
             expect(wrapper.exists('.upsell-title')).toBe(false);
             expect(wrapper.exists('.upsell-body')).toBe(false);
-            expect(wrapper.exists('UpgradeBadge')).toBe(false);
         });
 
         test('should render a default component with correct Focus element and props when focusSharedLinkOnLoad is enabled', () => {

--- a/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
+++ b/src/features/unified-share-modal/__tests__/UnifiedShareForm.test.js
@@ -211,14 +211,30 @@ describe('features/unified-share-modal/UnifiedShareForm', () => {
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should render a default component with upgrade CTA when showUpgradeOptions is enabled', () => {
-            const wrapper = getWrapper({
-                canInvite: true,
-                isFetching: false,
-                showUpgradeOptions: true,
-            });
-            expect(wrapper.exists('UpgradeBadge')).toBe(true);
-        });
+        test.each([
+            [true, true, null],
+            [true, false, null],
+            [false, true, null],
+            [false, false, null],
+            [true, true, mockUpsellInlineNotice],
+            [true, false, mockUpsellInlineNotice],
+            [false, true, mockUpsellInlineNotice],
+            [false, false, mockUpsellInlineNotice],
+        ])(
+            'should render a default component with upgrade CTA with respect to showUpgradeInlineNotice, showUpgradeOptions, and upsellInlineNotice props',
+            (showUpgradeInlineNotice, showUpgradeOptions, upsellInlineNotice) => {
+                const wrapper = getWrapper({
+                    canInvite: true,
+                    isFetching: false,
+                    showUpgradeInlineNotice,
+                    showUpgradeOptions,
+                    upsellInlineNotice,
+                });
+                expect(wrapper.exists('UpgradeBadge')).toBe(
+                    showUpgradeOptions && !showUpgradeInlineNotice && !upsellInlineNotice,
+                );
+            },
+        );
 
         test('should render correct upgrade inline notice when showUpgradeInlineNotice and showUpgradeOptions is enabled', () => {
             const wrapper = getWrapper({


### PR DESCRIPTION
### Overview
While our upsell inline notice is showing, we do not want redundant upgrade text to show (highlighted below).

<img width="510" alt="Screenshot 2024-05-08 at 1 20 41 PM" src="https://github.com/box/box-ui-elements/assets/5000110/936a5eb2-d202-4e45-88d5-67d7e8f64bf0">

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
