### PR TITLE
chore(i18n): Update README to be more clear on IntlProvider usage

### DIFF
--- a/src/elements/README.md
+++ b/src/elements/README.md
@@ -4,8 +4,43 @@ The Box UI Elements are designed to be agnostic of the authentication type. They
 _Note: When you are required to pass an access token to a Box Element Component, keep in mind that you can pass the access token as a string, or as a function. If you pass a function, it should return a string. Whenever the Box Element Component needs to make an API call to Box, it will use the accessToken you supplied, or invoke the access token function to get the access token._
 
 ## Internationalization (i18n)
-The UI Elements use [react-intl](https://github.com/formatjs/react-intl) for internationalization. In order for the UI Elements to render properly, they need to be wrapped in an i18n context via the [IntlProvider](https://github.com/formatjs/react-intl/blob/master/docs/Getting-Started.md#creating-an-i18n-context) and given a locale and translated messages to use. Each of the UI Element components optionally take in a `language` property and a `messages` property which is then delegated to our internal [IntlProvider](src/components/Internationalize.js). If either of these properties are not passed in, we do not use our internal `IntlProvider` and it is assumed that the parent react app (the react app that is importing in the UI Elements) has its own `IntlProvider`.
+The UI Elements use [react-intl](https://formatjs.io/docs/react-intl/) for internationalization. In order for the UI Elements to render properly, they need to be wrapped in an i18n context via the [IntlProvider](https://github.com/formatjs/formatjs/blob/main/website/docs/react-intl/components.md#intlprovider) and given a locale and translated messages to use. Each of the UI Element components optionally take in a `language` property and a `messages` property which is then delegated to our internal [IntlProvider](src/components/Internationalize.js). If either of these properties are not passed in, we do not use our internal `IntlProvider` and it is assumed that the parent react app (the react app that is importing in the UI Elements) has its own `IntlProvider`.
 
 The `language` property is a string that can be one of `en-AU`, `en-CA`, `en-GB`, `en-US`, `bn-IN`, `da-DK`, `de-DE`, `es-419`, `es-ES`, `fi-FI`, `fr-CA`, `fr-FR`, `hi-IN`, `it-IT`, `ja-JP`, `ko-KR`, `nb-NO`, `nl-NL`, `pl-PL`, `pt-BR`, `ru-RU`, `sv-SE`, `tr-TR`, `zh-CN`, `zh-TW`.
 
-The `messages` property is a map of message keys and translated strings. All the messages that the UI elements use can be found under the [i18n](i18n) folder. We distribute them as JS modules within the `box-ui-elements` npm package and they can be imported like any other module - `import box-ui-elements/i18n/[LANGUAGE FROM ABOVE]`. The code examples for each of the UI Elements assume `en-US` and show how the US english messages are imported in.
+The `messages` property is a map of message keys and translated strings. All the messages that the UI elements use can be found under the [i18n](https://github.com/box/box-ui-elements/tree/master/i18n) folder. We distribute them as JS modules within the `box-ui-elements` npm package and they can be imported like any other module - `import box-ui-elements/i18n/[LANGUAGE FROM ABOVE]`. The code examples for each of the UI Elements assume `en-US` and show how the US english messages are imported in.
+
+If you are using the CDNs, the i18n messages are included in the bundle.
+
+Example of using the `language` and `messages` properties:
+```jsx
+import messages from 'box-ui-elements/i18n/ja-JP';
+
+<ContentExplorer language="ja-JP" messages={messages} {...PROPS} />
+```
+
+_ContentExplorer will show in Japanese._
+
+Example `IntlProvider` with multiple elements
+```jsx
+import messages from 'box-ui-elements/i18n/ja-JP';
+
+<IntlProvider locale="ja-JP" messages={messages}>
+    <ContentExplorer {...PROPS} />
+    <ContentPicker {...PROPS} />
+</IntlProvider>
+```
+
+_Both ContentExplorer and ContentPicker will show in Japanese._
+
+Example of using different `language` and `messages` properties:
+
+```jsx
+import jaMessages from 'box-ui-elements/i18n/ja-JP';
+import deMessages from 'box-ui-elements/i18n/de-DE';
+
+<ContentExplorer language="ja-JP" messages={jaMessages} {...PROPS} />
+<ContentPicker language="de-DE" messages={deMessages} {...PROPS} />
+```
+
+_ContentExplorer will show in Japanese and ContentPicker will show in German._


### PR DESCRIPTION
Updated the README to be more clear on how to apply the localization. There was some confusion on only providing language or the message and that both were not require when they are. Included examples

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
