### PR TITLE
fix(content-sidebar): update to sidebar icon styles

### DIFF
--- a/src/elements/content-sidebar/additional-tabs/AdditionalTab.scss
+++ b/src/elements/content-sidebar/additional-tabs/AdditionalTab.scss
@@ -15,4 +15,6 @@
 .bdl-AdditionalTab-icon {
     @include bdl-openComponentAnimation(.5s);
     @include bdl-SidebarNavIcon;
+
+    border-radius: 5px;
 }


### PR DESCRIPTION
To bring it in line with current App Center styles

Before:
![Screenshot 2024-06-05 at 12 43 18](https://github.com/box/box-ui-elements/assets/7136553/53622710-c9b1-4ffa-a48d-d54d41c11add)

After:
![Screenshot 2024-06-05 at 12 43 37](https://github.com/box/box-ui-elements/assets/7136553/b2cf57a1-cc4d-4426-a57a-7bf0dc82d4ab)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
