### PR TITLE
feat(unified-share-modal): added targeting attribute

### DIFF
--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -6,6 +6,8 @@ import './Toggle.scss';
 
 type Props = {
     className?: string,
+    /** Optional attribute used for targeting */
+    'data-target-id'?: string,
     /** Description of the input */
     description?: React.Node,
     isDisabled?: boolean, // @TODO: eventually call this `disabled`
@@ -35,6 +37,7 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
     (
         {
             className = '',
+            'data-target-id': dataTargetId,
             description,
             isDisabled,
             isOn,
@@ -64,8 +67,6 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
             toggleElements.reverse();
         }
 
-        const { 'data-target-id': dataTargetId, ...inputProps } = rest;
-
         return (
             <div className={classes} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                 {/* eslint-disable-next-line jsx-a11y/label-has-for */}
@@ -81,7 +82,7 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
                         ref={ref}
                         role="switch"
                         type="checkbox"
-                        {...inputProps}
+                        {...rest}
                     />
                     {toggleElements}
                 </label>

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -64,10 +64,12 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
             toggleElements.reverse();
         }
 
+        const { 'data-target-id': dataTargetId, ...inputProps } = rest;
+
         return (
             <div className={classes} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                 {/* eslint-disable-next-line jsx-a11y/label-has-for */}
-                <label className="toggle-simple">
+                <label className="toggle-simple" data-target-id={dataTargetId}>
                     <input
                         checked={isOn}
                         className="toggle-simple-input"
@@ -79,7 +81,7 @@ const Toggle = React.forwardRef<Props, HTMLInputElement>(
                         ref={ref}
                         role="switch"
                         type="checkbox"
-                        {...rest}
+                        {...inputProps}
                     />
                     {toggleElements}
                 </label>

--- a/src/features/unified-share-modal/ContactsField.js
+++ b/src/features/unified-share-modal/ContactsField.js
@@ -197,6 +197,7 @@ class ContactsField extends React.Component<Props, State> {
                 getPillImageUrl={getContactAvatarUrl}
                 inputProps={{
                     autoFocus: true,
+                    'data-target-id': 'PillSelectorDropdown-AddNamesOrEmailAddresses',
                     onChange: noop,
                 }}
                 label={label}

--- a/src/features/unified-share-modal/InviteePermissionsMenu.js
+++ b/src/features/unified-share-modal/InviteePermissionsMenu.js
@@ -92,6 +92,7 @@ class InviteePermissionsMenu extends Component<Props> {
                     'is-disabled': disabled,
                     'bdl-is-disabled': disabled,
                 })}
+                data-target-id="PlainButton-InviteePermissionsMenuToggle"
                 disabled={disabled}
                 type="button"
                 {...inviteePermissionsButtonProps}

--- a/src/features/unified-share-modal/SharedLinkSection.js
+++ b/src/features/unified-share-modal/SharedLinkSection.js
@@ -261,14 +261,14 @@ class SharedLinkSection extends React.Component<Props, State> {
         } = sharedLink;
 
         const {
-            copyButtonProps,
+            copyButtonProps: copyButtonTrackingProps,
             onChangeSharedLinkAccessLevel,
             onChangeSharedLinkPermissionLevel,
             onSharedLinkAccessMenuOpen,
             onSharedLinkCopy = noop,
             sendSharedLinkButtonProps,
-            sharedLinkAccessMenuButtonProps,
-            sharedLinkPermissionsMenuButtonProps,
+            sharedLinkAccessMenuButtonProps: sharedLinkAccessMenuButtonTrackingProps,
+            sharedLinkPermissionsMenuButtonProps: sharedLinkPermissionsMenuButtonTrackingProps,
         } = trackingProps;
 
         const shouldTriggerCopyOnLoad = !!triggerCopyOnLoad && !!isCopySuccessful;
@@ -281,6 +281,21 @@ class SharedLinkSection extends React.Component<Props, State> {
 
         const isEditableBoxNote = isBoxNote(convertToBoxItem(item)) && isEditAllowed;
         const allowedPermissionLevels = this.getAllowedPermissionLevels();
+
+        const copyButtonProps = {
+            ...copyButtonTrackingProps,
+            'data-target-id': 'Button-CopySharedLink',
+        };
+
+        const sharedLinkAccessMenuButtonProps = {
+            ...sharedLinkAccessMenuButtonTrackingProps,
+            'data-target-id': 'Button-SharedLinkAccessMenuLabel',
+        };
+
+        const sharedLinkPermissionsMenuButtonProps = {
+            ...sharedLinkPermissionsMenuButtonTrackingProps,
+            'data-target-id': 'Button-SharedLinkPermissionsMenuLabel',
+        };
 
         return (
             <>
@@ -312,6 +327,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                             <Button
                                 aria-label={intl.formatMessage(messages.sendSharedLink)}
                                 className="email-shared-link-btn"
+                                data-target-id="Button-SendSharedLink"
                                 isDisabled={submitting}
                                 onClick={onEmailSharedLinkClick}
                                 type="button"
@@ -441,6 +457,7 @@ class SharedLinkSection extends React.Component<Props, State> {
                         {...sharedLinkSettingsButtonProps}
                         aria-haspopup="dialog"
                         className="shared-link-settings-btn"
+                        data-target-id="PlainButton-SharedLinkSettings"
                         onClick={onSettingsClick}
                         type="button"
                     >
@@ -489,6 +506,7 @@ class SharedLinkSection extends React.Component<Props, State> {
 
         const toggleComponent = (
             <Toggle
+                data-target-id="Toggle-CreateSharedLink"
                 isDisabled={!isToggleEnabled}
                 isOn={isSharedLinkEnabled}
                 label={linkText}

--- a/src/features/unified-share-modal/__tests__/__snapshots__/ContactsField.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/ContactsField.test.js.snap
@@ -47,6 +47,7 @@ exports[`features/unified-share-modal/ContactsField render should have scrollabl
   inputProps={
     {
       "autoFocus": true,
+      "data-target-id": "PillSelectorDropdown-AddNamesOrEmailAddresses",
       "onChange": [Function],
     }
   }
@@ -250,6 +251,7 @@ exports[`features/unified-share-modal/ContactsField render should render default
   inputProps={
     {
       "autoFocus": true,
+      "data-target-id": "PillSelectorDropdown-AddNamesOrEmailAddresses",
       "onChange": [Function],
     }
   }

--- a/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/InviteePermissionsMenu.test.js.snap
@@ -28,6 +28,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
       >
         <PlainButton
           className="lnk is-disabled bdl-is-disabled"
+          data-target-id="PlainButton-InviteePermissionsMenuToggle"
           disabled={true}
           type="button"
         >
@@ -139,6 +140,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
   >
     <PlainButton
       className="lnk"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={false}
       type="button"
     >
@@ -264,6 +266,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
       >
         <PlainButton
           className="lnk is-disabled bdl-is-disabled"
+          data-target-id="PlainButton-InviteePermissionsMenuToggle"
           disabled={true}
           type="button"
         >
@@ -375,6 +378,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
   >
     <PlainButton
       className="lnk"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={false}
       type="button"
     >
@@ -500,6 +504,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
       >
         <PlainButton
           className="lnk is-disabled bdl-is-disabled"
+          data-target-id="PlainButton-InviteePermissionsMenuToggle"
           disabled={true}
           type="button"
         >
@@ -611,6 +616,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
   >
     <PlainButton
       className="lnk"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={false}
       type="button"
     >
@@ -736,6 +742,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
       >
         <PlainButton
           className="lnk is-disabled bdl-is-disabled"
+          data-target-id="PlainButton-InviteePermissionsMenuToggle"
           disabled={true}
           type="button"
         >
@@ -847,6 +854,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
   >
     <PlainButton
       className="lnk"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={false}
       type="button"
     >
@@ -972,6 +980,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
       >
         <PlainButton
           className="lnk is-disabled bdl-is-disabled"
+          data-target-id="PlainButton-InviteePermissionsMenuToggle"
           disabled={true}
           type="button"
         >
@@ -1083,6 +1092,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
   >
     <PlainButton
       className="lnk"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={false}
       type="button"
     >
@@ -1208,6 +1218,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
       >
         <PlainButton
           className="lnk is-disabled bdl-is-disabled"
+          data-target-id="PlainButton-InviteePermissionsMenuToggle"
           disabled={true}
           type="button"
         >
@@ -1319,6 +1330,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
   >
     <PlainButton
       className="lnk"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={false}
       type="button"
     >
@@ -1428,6 +1440,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
   >
     <PlainButton
       className="lnk"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={false}
       type="button"
     >
@@ -1553,6 +1566,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() it should 
       >
         <PlainButton
           className="lnk is-disabled bdl-is-disabled"
+          data-target-id="PlainButton-InviteePermissionsMenuToggle"
           disabled={true}
           type="button"
         >
@@ -1671,6 +1685,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() should ren
   >
     <PlainButton
       className="lnk is-disabled bdl-is-disabled"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={true}
       type="button"
     >
@@ -1705,6 +1720,7 @@ exports[`features/unified-share-modal/InviteePermissionsMenu render() should ren
   >
     <PlainButton
       className="lnk is-disabled bdl-is-disabled"
+      data-target-id="PlainButton-InviteePermissionsMenuToggle"
       disabled={true}
       type="button"
     >

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkSection.test.js.snap
@@ -21,6 +21,7 @@ exports[`features/unified-share-modal/SharedLinkSection should match snapshot wh
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={false}
       isOn={true}
       label={
@@ -75,7 +76,11 @@ exports[`features/unified-share-modal/SharedLinkSection should match snapshot wh
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -104,6 +109,7 @@ exports[`features/unified-share-modal/SharedLinkSection should match snapshot wh
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -128,7 +134,9 @@ exports[`features/unified-share-modal/SharedLinkSection should match snapshot wh
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -151,7 +159,9 @@ exports[`features/unified-share-modal/SharedLinkSection should match snapshot wh
         trackingProps={
           {
             "onChangeSharedLinkPermissionLevel": undefined,
-            "sharedLinkPermissionsMenuButtonProps": undefined,
+            "sharedLinkPermissionsMenuButtonProps": {
+              "data-target-id": "Button-SharedLinkPermissionsMenuLabel",
+            },
           }
         }
       />
@@ -190,6 +200,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
       theme="default"
     >
       <Toggle
+        data-target-id="Toggle-CreateSharedLink"
         isDisabled={true}
         isOn={true}
         label={
@@ -225,7 +236,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -254,6 +269,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -278,7 +294,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -297,7 +315,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render a default 
         trackingProps={
           {
             "onChangeSharedLinkPermissionLevel": undefined,
-            "sharedLinkPermissionsMenuButtonProps": undefined,
+            "sharedLinkPermissionsMenuButtonProps": {
+              "data-target-id": "Button-SharedLinkPermissionsMenuLabel",
+            },
           }
         }
       />
@@ -335,6 +355,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       theme="default"
     >
       <Toggle
+        data-target-id="Toggle-CreateSharedLink"
         isDisabled={false}
         isOn={false}
         label={
@@ -371,6 +392,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={false}
       isOn={true}
       label={
@@ -405,7 +427,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -434,6 +460,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -458,7 +485,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -481,7 +510,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
         trackingProps={
           {
             "onChangeSharedLinkPermissionLevel": undefined,
-            "sharedLinkPermissionsMenuButtonProps": undefined,
+            "sharedLinkPermissionsMenuButtonProps": {
+              "data-target-id": "Button-SharedLinkPermissionsMenuLabel",
+            },
           }
         }
       />
@@ -511,6 +542,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render default co
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={true}
       isOn={false}
       label={
@@ -536,6 +568,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled c
   theme="default"
 >
   <Toggle
+    data-target-id="Toggle-CreateSharedLink"
     isDisabled={true}
     isOn={false}
     label={
@@ -560,6 +593,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render disabled r
   theme="default"
 >
   <Toggle
+    data-target-id="Toggle-CreateSharedLink"
     isDisabled={true}
     isOn={true}
     label={
@@ -603,6 +637,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
       theme="default"
     >
       <Toggle
+        data-target-id="Toggle-CreateSharedLink"
         isDisabled={true}
         isOn={true}
         label={
@@ -638,7 +673,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -667,6 +706,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -689,7 +729,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper dro
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -736,6 +778,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={false}
       isOn={true}
       label={
@@ -770,7 +813,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -799,6 +846,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -823,7 +871,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -847,7 +897,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         trackingProps={
           {
             "onChangeSharedLinkPermissionLevel": undefined,
-            "sharedLinkPermissionsMenuButtonProps": undefined,
+            "sharedLinkPermissionsMenuButtonProps": {
+              "data-target-id": "Button-SharedLinkPermissionsMenuLabel",
+            },
           }
         }
       />
@@ -877,6 +929,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={false}
       isOn={true}
       label={
@@ -911,7 +964,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -940,6 +997,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -964,7 +1022,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -987,7 +1047,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         trackingProps={
           {
             "onChangeSharedLinkPermissionLevel": undefined,
-            "sharedLinkPermissionsMenuButtonProps": undefined,
+            "sharedLinkPermissionsMenuButtonProps": {
+              "data-target-id": "Button-SharedLinkPermissionsMenuLabel",
+            },
           }
         }
       />
@@ -1017,6 +1079,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={false}
       isOn={true}
       label={
@@ -1051,7 +1114,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -1080,6 +1147,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -1104,7 +1172,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -1127,7 +1197,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         trackingProps={
           {
             "onChangeSharedLinkPermissionLevel": undefined,
-            "sharedLinkPermissionsMenuButtonProps": undefined,
+            "sharedLinkPermissionsMenuButtonProps": {
+              "data-target-id": "Button-SharedLinkPermissionsMenuLabel",
+            },
           }
         }
       />
@@ -1157,6 +1229,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={false}
       isOn={true}
       label={
@@ -1191,7 +1264,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -1220,6 +1297,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -1244,7 +1322,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />
@@ -1267,7 +1347,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render proper lis
         trackingProps={
           {
             "onChangeSharedLinkPermissionLevel": undefined,
-            "sharedLinkPermissionsMenuButtonProps": undefined,
+            "sharedLinkPermissionsMenuButtonProps": {
+              "data-target-id": "Button-SharedLinkPermissionsMenuLabel",
+            },
           }
         }
       />
@@ -1281,6 +1363,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render settings l
   aria-haspopup="dialog"
   className="shared-link-settings-btn"
   data-resin-target="settings"
+  data-target-id="PlainButton-SharedLinkSettings"
   onClick={
     [MockFunction] {
       "calls": [
@@ -1324,6 +1407,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
     className="shared-link-toggle-row"
   >
     <Toggle
+      data-target-id="Toggle-CreateSharedLink"
       isDisabled={false}
       isOn={true}
       label={
@@ -1358,7 +1442,11 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
             id="boxui.core.copy"
           />
         }
-        buttonProps={{}}
+        buttonProps={
+          {
+            "data-target-id": "Button-CopySharedLink",
+          }
+        }
         buttonSuccessText={
           <FormattedMessage
             defaultMessage="Copied"
@@ -1387,6 +1475,7 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
       <Button
         aria-label="Send Shared Link"
         className="email-shared-link-btn"
+        data-target-id="Button-SendSharedLink"
         isLoading={false}
         showRadar={false}
         type="button"
@@ -1411,7 +1500,9 @@ exports[`features/unified-share-modal/SharedLinkSection should render without Sh
         {
           "onChangeSharedLinkAccessLevel": undefined,
           "onSharedLinkAccessMenuOpen": undefined,
-          "sharedLinkAccessMenuButtonProps": undefined,
+          "sharedLinkAccessMenuButtonProps": {
+            "data-target-id": "Button-SharedLinkAccessMenuLabel",
+          },
         }
       }
     />


### PR DESCRIPTION
Added `data-target-id` attribute to various elements of `unified-share-modal`. It will be used for targeting purposes.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
