### PR TITLE
feat(api): Extend getMetadata in Metadata API

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -455,7 +455,11 @@ class Metadata extends File {
      */
     async getMetadata(
         file: BoxItem,
-        successCallback: ({ editors: Array<MetadataEditor>, templates: Array<MetadataTemplate> }) => void,
+        successCallback: ({
+            editors: Array<MetadataEditor>,
+            templateInstances: Array<MetadataTemplateInstance>,
+            templates: Array<MetadataTemplate>,
+        }) => void,
         errorCallback: ElementsErrorCallback,
         hasMetadataFeature: boolean,
         options: RequestOptions = {},

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -42,7 +42,6 @@ import type {
     MetadataFields,
     MetadataSuggestion,
     MetadataTemplateInstance,
-    MetadataInstanceTemplateFields,
 } from '../common/types/metadata';
 import type { BoxItem } from '../common/types/core';
 import type APICache from '../utils/Cache';
@@ -364,13 +363,13 @@ class Metadata extends File {
      * @return {Object} metadata template instance
      */
     createTemplateInstance(instance: MetadataInstanceV2, template: MetadataTemplate): MetadataTemplateInstance {
-        const metadataFields: MetadataInstanceTemplateFields = {};
+        const metadataFields: MetadataInstanceTemplateField[] = [];
 
         if (template.templateKey !== METADATA_TEMPLATE_PROPERTIES) {
             // Get Metadata Fields for Instances created from predefinied template
             const templateFields = template.fields || [];
             templateFields.map(async field => {
-                metadataFields[field.key] = {
+                metadataFields.push({
                     description: field.description,
                     displayName: field.displayName,
                     hidden: field.hidden || field.isHidden,
@@ -379,18 +378,18 @@ class Metadata extends File {
                     options: field.options,
                     type: field.type,
                     value: instance[field.key],
-                };
+                });
             });
         } else {
             // Get Metadata Fields for Custom Instances
             Object.keys(instance).forEach(key => {
                 if (!key.startsWith('$')) {
                     // $FlowFixMe
-                    metadataFields[key] = {
+                    metadataFields.push({
                         key,
                         type: 'string',
                         value: instance[key],
-                    };
+                    });
                 }
             });
         }

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -393,9 +393,13 @@ class Metadata extends File {
         }
 
         return {
-            ...template,
             canEdit: instance.$canEdit && canEdit,
+            displayName: template.displayName,
+            hidden: template.hidden,
+            id: template.id,
             fields,
+            scope: template.scope,
+            templateKey: template.templateKey,
         };
     }
 

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -42,7 +42,7 @@ import type {
     MetadataFields,
     MetadataSuggestion,
     MetadataTemplateInstance,
-    MetadataInstanceTemplateField,
+    MetadataTemplateInstanceField,
 } from '../common/types/metadata';
 import type { BoxItem } from '../common/types/core';
 import type APICache from '../utils/Cache';
@@ -360,23 +360,17 @@ class Metadata extends File {
      * @return {Object} metadata template instance
      */
     createTemplateInstance(instance: MetadataInstanceV2, template: MetadataTemplate): MetadataTemplateInstance {
-        const metadataFields: MetadataInstanceTemplateField[] = [];
+        const fields: MetadataTemplateInstanceField[] = [];
 
         // templateKey is unique identifier for the template,
         // but its value is set to 'properties' if instance was created using Custom Metadata option instead of template
-        const isCustomMetadataInstance = template.templateKey !== METADATA_TEMPLATE_PROPERTIES;
-        if (isCustomMetadataInstance) {
-            // Get Metadata Fields for Instances created from predefinied template
+        const isInstanceFromTemplate = template.templateKey !== METADATA_TEMPLATE_PROPERTIES;
+        if (isInstanceFromTemplate) {
+            // Get Metadata Fields for Instances created from predefined template
             const templateFields = template.fields || [];
-            templateFields.forEach(async field => {
-                metadataFields.push({
-                    description: field.description,
-                    displayName: field.displayName,
-                    hidden: field.hidden,
-                    id: field.id,
-                    key: field.key,
-                    options: field.options,
-                    type: field.type,
+            templateFields.forEach(field => {
+                fields.push({
+                    ...field,
                     value: instance[field.key],
                 });
             });
@@ -384,8 +378,7 @@ class Metadata extends File {
             // Get Metadata Fields for Custom Instances
             Object.keys(instance).forEach(key => {
                 if (!key.startsWith('$')) {
-                    // $FlowFixMe
-                    metadataFields.push({
+                    fields.push({
                         key,
                         type: 'string',
                         value: instance[key],
@@ -395,12 +388,8 @@ class Metadata extends File {
         }
 
         return {
-            displayName: template.displayName,
-            hidden: template.hidden,
-            id: template.id,
-            metadataFields,
-            scope: template.scope,
-            templateKey: template.templateKey,
+            ...template,
+            fields,
         };
     }
 
@@ -445,7 +434,7 @@ class Metadata extends File {
     /**
      * API for getting metadata editors
      *
-     * @param file
+     * @param {Object} file
      * @param {Function} successCallback - Success callback
      * @param {Function} errorCallback - Error callback
      * @param {boolean} hasMetadataFeature - metadata feature check

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -339,14 +339,10 @@ class Metadata extends File {
             globalTemplates,
         );
 
-        // Filter out skills and classification
-        // let filteredInstances = this.extractSkills(id, instances);
-        const filteredInstances = this.extractClassification(id, instances);
-
         // Create editors from each instance
         const editors: Array<MetadataEditor> = [];
         await Promise.all(
-            filteredInstances.map(async instance => {
+            instances.map(async instance => {
                 const template: ?MetadataTemplate = await this.getTemplateForInstance(id, instance, templates);
                 if (template) {
                     editors.push(this.createEditor(instance, template, canEdit));
@@ -431,14 +427,11 @@ class Metadata extends File {
             globalTemplates,
         );
 
-        // Filter out classification
-        const filteredInstances = this.extractClassification(id, instances);
-
         // Create Metadata Template Instance from each instance
         const templateInstances: Array<MetadataTemplateInstance> = [];
 
         await Promise.all(
-            filteredInstances.map(async instance => {
+            instances.map(async instance => {
                 const template: ?MetadataTemplate = await this.getTemplateForInstance(id, instance, templates);
                 if (template) {
                     templateInstances.push(this.createTemplateInstance(instance, template));
@@ -504,10 +497,13 @@ class Metadata extends File {
                 hasMetadataFeature ? this.getTemplates(id, METADATA_SCOPE_ENTERPRISE) : Promise.resolve([]),
             ]);
 
+            // Filter out classification
+            const filteredInstances = this.extractClassification(id, instances);
+
             const templateInstances = isMetadataRedesign
                 ? await this.getTemplateInstances(
                       id,
-                      instances,
+                      filteredInstances,
                       customPropertiesTemplate,
                       enterpriseTemplates,
                       globalTemplates,
@@ -516,7 +512,7 @@ class Metadata extends File {
             const editors = !isMetadataRedesign
                 ? await this.getEditors(
                       id,
-                      instances,
+                      filteredInstances,
                       customPropertiesTemplate,
                       enterpriseTemplates,
                       globalTemplates,

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -357,9 +357,14 @@ class Metadata extends File {
      *
      * @param {Object} instance - metadata instance
      * @param {Object} template - metadata template
+     * @param {boolean} canEdit - can user edit item
      * @return {Object} metadata template instance
      */
-    createTemplateInstance(instance: MetadataInstanceV2, template: MetadataTemplate): MetadataTemplateInstance {
+    createTemplateInstance(
+        instance: MetadataInstanceV2,
+        template: MetadataTemplate,
+        canEdit: boolean,
+    ): MetadataTemplateInstance {
         const fields: MetadataTemplateInstanceField[] = [];
 
         // templateKey is unique identifier for the template,
@@ -389,6 +394,7 @@ class Metadata extends File {
 
         return {
             ...template,
+            canEdit: instance.$canEdit && canEdit,
             fields,
         };
     }
@@ -401,6 +407,7 @@ class Metadata extends File {
      * @param {Object} customPropertiesTemplate - custom properties template
      * @param {Array} enterpriseTemplates - enterprise templates
      * @param {Array} globalTemplates - global templates
+     * @param {boolean} canEdit
      * @return {Array} metadata editors
      */
     async getTemplateInstances(
@@ -409,6 +416,7 @@ class Metadata extends File {
         customPropertiesTemplate: MetadataTemplate,
         enterpriseTemplates: Array<MetadataTemplate>,
         globalTemplates: Array<MetadataTemplate>,
+        canEdit: boolean,
     ): Promise<Array<MetadataTemplateInstance>> {
         // Get all usable templates for metadata instances
         const templates: Array<MetadataTemplate> = [customPropertiesTemplate].concat(
@@ -423,7 +431,7 @@ class Metadata extends File {
             instances.map(async instance => {
                 const template: ?MetadataTemplate = await this.getTemplateForInstance(id, instance, templates);
                 if (template) {
-                    templateInstances.push(this.createTemplateInstance(instance, template));
+                    templateInstances.push(this.createTemplateInstance(instance, template, canEdit));
                 }
             }),
         );
@@ -500,6 +508,7 @@ class Metadata extends File {
                       customPropertiesTemplate,
                       enterpriseTemplates,
                       globalTemplates,
+                      !!permissions.can_upload,
                   )
                 : [];
             const editors = !isMetadataRedesign

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -368,7 +368,7 @@ class Metadata extends File {
 
         if (template.templateKey !== METADATA_TEMPLATE_PROPERTIES) {
             // Get Metadata Fields for Instances created from predefinied template
-            const templateFields = template.fields;
+            const templateFields = template.fields || [];
             templateFields.map(async field => {
                 metadataFields[field.key] = {
                     description: field.description,

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -400,6 +400,7 @@ class Metadata extends File {
             fields,
             scope: template.scope,
             templateKey: template.templateKey,
+            type: instance.$type,
         };
     }
 

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -168,6 +168,7 @@ describe('api/Metadata', () => {
                     {
                         $id: '321',
                         $template: '',
+                        $canEdit: true,
                         testStringField: 'This is string',
                         testFloatField: '2.1',
                     },
@@ -192,8 +193,10 @@ describe('api/Metadata', () => {
                         id: '123456',
                         templateKey: 'instance_from_template',
                     },
+                    true,
                 ),
             ).toEqual({
+                canEdit: true,
                 displayName: 'Test template',
                 hidden: undefined,
                 id: '123456',
@@ -224,6 +227,7 @@ describe('api/Metadata', () => {
             expect(
                 metadata.createTemplateInstance(
                     {
+                        $canEdit: true,
                         $id: '321',
                         $template: '',
                         testCustomField: 'This is string',
@@ -234,8 +238,10 @@ describe('api/Metadata', () => {
                         id: '123456',
                         templateKey: 'properties',
                     },
+                    false,
                 ),
             ).toEqual({
+                canEdit: false,
                 displayName: 'Test template',
                 hidden: undefined,
                 id: '123456',
@@ -669,7 +675,7 @@ describe('api/Metadata', () => {
                 .mockResolvedValueOnce('template4')
                 .mockResolvedValueOnce();
 
-            const templateInstances = await metadata.getTemplateInstances('id', instances, {}, [], []);
+            const templateInstances = await metadata.getTemplateInstances('id', instances, {}, [], [], true);
             expect(templateInstances).toEqual([
                 'templateInstance1',
                 'templateInstance2',
@@ -862,6 +868,7 @@ describe('api/Metadata', () => {
                 'custom',
                 'enterprise',
                 'global',
+                true,
             );
             expect(metadata.getUserAddableTemplates).toHaveBeenCalledWith('custom', 'enterprise', true, true);
             expect(metadata.successHandler).toHaveBeenCalledWith({

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -197,7 +197,7 @@ describe('api/Metadata', () => {
                 displayName: 'Test template',
                 hidden: undefined,
                 id: '123456',
-                metadataFields: [
+                fields: [
                     {
                         description: 'Test description',
                         displayName: 'Test string field',
@@ -239,7 +239,7 @@ describe('api/Metadata', () => {
                 displayName: 'Test template',
                 hidden: undefined,
                 id: '123456',
-                metadataFields: [
+                fields: [
                     {
                         key: 'testCustomField',
                         type: 'string',
@@ -788,10 +788,7 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest
-                .fn()
-                .mockResolvedValueOnce('global')
-                .mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
             metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true);
@@ -846,10 +843,7 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest
-                .fn()
-                .mockResolvedValueOnce('global')
-                .mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
             metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, {}, true);
@@ -905,10 +899,7 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest
-                .fn()
-                .mockResolvedValueOnce('global')
-                .mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
             metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, { refreshCache: true });
@@ -966,10 +957,7 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest
-                .fn()
-                .mockResolvedValueOnce('global')
-                .mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
             metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, { forceFetch: true });
@@ -1026,10 +1014,7 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest
-                .fn()
-                .mockResolvedValueOnce('global')
-                .mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
             metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), false);
@@ -1124,10 +1109,7 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest
-                .fn()
-                .mockResolvedValueOnce('global')
-                .mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
             metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, { forceFetch: true });

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -197,16 +197,8 @@ describe('api/Metadata', () => {
                 displayName: 'Test template',
                 hidden: undefined,
                 id: '123456',
-                metadataFields: {
-                    testFloatField: {
-                        description: 'Test description',
-                        displayName: 'Test float field',
-                        id: '456',
-                        key: 'testFloatField',
-                        type: 'float',
-                        value: '2.1',
-                    },
-                    testStringField: {
+                metadataFields: [
+                    {
                         description: 'Test description',
                         displayName: 'Test string field',
                         id: '123',
@@ -214,7 +206,16 @@ describe('api/Metadata', () => {
                         type: 'string',
                         value: 'This is string',
                     },
-                },
+                    {
+                        description: 'Test description',
+                        displayName: 'Test float field',
+                        id: '456',
+                        key: 'testFloatField',
+                        type: 'float',
+                        value: '2.1',
+                    },
+                ],
+                scope: undefined,
                 templateKey: 'instance_from_template',
             });
         });
@@ -238,13 +239,13 @@ describe('api/Metadata', () => {
                 displayName: 'Test template',
                 hidden: undefined,
                 id: '123456',
-                metadataFields: {
-                    testCustomField: {
+                metadataFields: [
+                    {
                         key: 'testCustomField',
                         type: 'string',
                         value: 'This is string',
                     },
-                },
+                ],
                 templateKey: 'properties',
             });
         });

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -858,7 +858,7 @@ describe('api/Metadata', () => {
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.getEditors).not.toHaveBeenCalled();
-            expect(metadata.getTemplateInstances).toHaveBeenCalled(
+            expect(metadata.getTemplateInstances).toHaveBeenCalledWith(
                 file.id,
                 'instances',
                 'custom',

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -849,7 +849,7 @@ describe('api/Metadata', () => {
                 .mockResolvedValueOnce('global')
                 .mockResolvedValueOnce('enterprise');
 
-            await metadata.getMetadata(file, jest.fn(), jest.fn(), true, true);
+            await metadata.getMetadata(file, jest.fn(), jest.fn(), true, {}, true);
 
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -813,11 +813,13 @@ describe('api/Metadata', () => {
             expect(metadata.getUserAddableTemplates).toHaveBeenCalledWith('custom', 'enterprise', true, true);
             expect(metadata.successHandler).toHaveBeenCalledWith({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
             expect(metadata.errorHandler).not.toHaveBeenCalled();
             expect(cache.get('cache_id_metadata')).toEqual({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
         });
@@ -865,12 +867,14 @@ describe('api/Metadata', () => {
             );
             expect(metadata.getUserAddableTemplates).toHaveBeenCalledWith('custom', 'enterprise', true, true);
             expect(metadata.successHandler).toHaveBeenCalledWith({
-                editors: 'editors',
+                editors: [],
+                templateInstances: 'templateInstances',
                 templates: 'templates',
             });
             expect(metadata.errorHandler).not.toHaveBeenCalled();
             expect(cache.get('cache_id_metadata')).toEqual({
-                editors: 'editors',
+                editors: [],
+                templateInstances: 'templateInstances',
                 templates: 'templates',
             });
         });
@@ -921,11 +925,13 @@ describe('api/Metadata', () => {
             expect(metadata.successHandler).toHaveBeenCalledWith('cached_metadata');
             expect(metadata.successHandler).toHaveBeenCalledWith({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
             expect(metadata.errorHandler).not.toHaveBeenCalled();
             expect(cache.get('cache_id_metadata')).toEqual({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
         });
@@ -975,11 +981,13 @@ describe('api/Metadata', () => {
             expect(metadata.successHandler).not.toHaveBeenCalledWith('cached_metadata');
             expect(metadata.successHandler).toHaveBeenCalledWith({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
             expect(metadata.errorHandler).not.toHaveBeenCalled();
             expect(cache.get('cache_id_metadata')).toEqual({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
         });
@@ -1020,11 +1028,13 @@ describe('api/Metadata', () => {
             expect(metadata.successHandler).toHaveBeenCalledTimes(1);
             expect(metadata.successHandler).toHaveBeenCalledWith({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
             expect(metadata.errorHandler).not.toHaveBeenCalled();
             expect(cache.get('cache_id_metadata')).toEqual({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
         });
@@ -1112,6 +1122,7 @@ describe('api/Metadata', () => {
             expect(metadata.errorHandler).not.toHaveBeenCalled();
             expect(cache.get('cache_id_metadata')).toEqual({
                 editors: 'editors',
+                templateInstances: [],
                 templates: 'templates',
             });
         });

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -575,7 +575,6 @@ describe('api/Metadata', () => {
                 },
             ];
 
-            metadata.extractClassification = jest.fn().mockReturnValueOnce(instances);
             metadata.createEditor = jest
                 .fn()
                 .mockReturnValueOnce('editor1')
@@ -592,7 +591,6 @@ describe('api/Metadata', () => {
 
             const editors = await metadata.getEditors('id', instances, {}, [], [], true);
             expect(editors).toEqual(['editor1', 'editor2', 'editor3', 'editor4']);
-            expect(metadata.extractClassification).toBeCalledWith('id', instances);
 
             expect(metadata.createEditor).toBeCalledTimes(4);
             expect(metadata.createEditor.mock.calls[0][0]).toBe(instances[0]);
@@ -657,7 +655,6 @@ describe('api/Metadata', () => {
                 },
             ];
 
-            metadata.extractClassification = jest.fn().mockReturnValueOnce(instances);
             metadata.createTemplateInstance = jest
                 .fn()
                 .mockReturnValueOnce('templateInstance1')
@@ -679,7 +676,6 @@ describe('api/Metadata', () => {
                 'templateInstance3',
                 'templateInstance4',
             ]);
-            expect(metadata.extractClassification).toBeCalledWith('id', instances);
 
             expect(metadata.createTemplateInstance).toBeCalledTimes(4);
             expect(metadata.createTemplateInstance.mock.calls[0][0]).toBe(instances[0]);
@@ -792,7 +788,11 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest
+                .fn()
+                .mockResolvedValueOnce('global')
+                .mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true);
 
@@ -802,9 +802,10 @@ describe('api/Metadata', () => {
             expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
+            expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
             expect(metadata.getEditors).toHaveBeenCalledWith(
                 file.id,
-                'instances',
+                'filteredInstances',
                 'custom',
                 'enterprise',
                 'global',
@@ -849,6 +850,7 @@ describe('api/Metadata', () => {
                 .fn()
                 .mockResolvedValueOnce('global')
                 .mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, {}, true);
 
@@ -858,10 +860,11 @@ describe('api/Metadata', () => {
             expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
+            expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
             expect(metadata.getEditors).not.toHaveBeenCalled();
             expect(metadata.getTemplateInstances).toHaveBeenCalledWith(
                 file.id,
-                'instances',
+                'filteredInstances',
                 'custom',
                 'enterprise',
                 'global',
@@ -902,7 +905,11 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest
+                .fn()
+                .mockResolvedValueOnce('global')
+                .mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, { refreshCache: true });
 
@@ -912,9 +919,10 @@ describe('api/Metadata', () => {
             expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
+            expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
             expect(metadata.getEditors).toHaveBeenCalledWith(
                 file.id,
-                'instances',
+                'filteredInstances',
                 'custom',
                 'enterprise',
                 'global',
@@ -958,7 +966,11 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest
+                .fn()
+                .mockResolvedValueOnce('global')
+                .mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, { forceFetch: true });
 
@@ -968,9 +980,10 @@ describe('api/Metadata', () => {
             expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
+            expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
             expect(metadata.getEditors).toHaveBeenCalledWith(
                 file.id,
-                'instances',
+                'filteredInstances',
                 'custom',
                 'enterprise',
                 'global',
@@ -1013,7 +1026,11 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest
+                .fn()
+                .mockResolvedValueOnce('global')
+                .mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), false);
 
@@ -1023,7 +1040,15 @@ describe('api/Metadata', () => {
             expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).not.toHaveBeenCalledWith(file.id, 'enterprise');
-            expect(metadata.getEditors).toHaveBeenCalledWith(file.id, 'instances', 'custom', [], 'global', true);
+            expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
+            expect(metadata.getEditors).toHaveBeenCalledWith(
+                file.id,
+                'filteredInstances',
+                'custom',
+                [],
+                'global',
+                true,
+            );
             expect(metadata.getTemplateInstances).not.toHaveBeenCalled();
             expect(metadata.getUserAddableTemplates).toHaveBeenCalledWith('custom', [], false, true);
             expect(metadata.successHandler).toHaveBeenCalledTimes(1);
@@ -1099,7 +1124,11 @@ describe('api/Metadata', () => {
             metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
             metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
             metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
-            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
+            metadata.getTemplates = jest
+                .fn()
+                .mockResolvedValueOnce('global')
+                .mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
 
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, { forceFetch: true });
 
@@ -1109,9 +1138,10 @@ describe('api/Metadata', () => {
             expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
+            expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
             expect(metadata.getEditors).toHaveBeenCalledWith(
                 file.id,
-                'instances',
+                'filteredInstances',
                 'custom',
                 'enterprise',
                 'global',

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -126,20 +126,17 @@ type MetadataInstanceTemplateField = {
     value: string,
 };
 
-type MetadataInstanceTemplateFields = { [string]: MetadataInstanceTemplateField };
-
 type MetadataTemplateInstance = {
     displayName?: string,
     hidden?: boolean,
     id: string,
-    metadataFields: MetadataInstanceTemplateFields,
+    metadataFields: MetadataInstanceTemplateField[],
     scope: string,
     templateKey: string,
 };
 
 export type {
     MetadataInstanceTemplateField,
-    MetadataInstanceTemplateFields,
     MetadataTemplateInstance,
     MetadataFieldType,
     MetadataTemplateFieldOption,

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -126,6 +126,7 @@ type MetadataTemplateInstanceField = {
 };
 
 type MetadataTemplateInstance = {
+    canEdit: boolean,
     displayName?: string,
     hidden?: boolean,
     id: string,

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -114,7 +114,33 @@ type MetadataSuggestion = {
     suggestions: { [key: string]: string | number | string[] },
 };
 
+type MetadataInstanceTemplateField = {
+    description?: string,
+    displayName: string,
+    hidden?: boolean,
+    id: string,
+    isHidden?: boolean,
+    key: string, // V2
+    options?: Array<MetadataTemplateFieldOption>, // V3
+    type: MetadataFieldType,
+    value: string,
+};
+
+type MetadataInstanceTemplateFields = { [string]: MetadataInstanceTemplateField };
+
+type MetadataTemplateInstance = {
+    displayName?: string,
+    hidden?: boolean,
+    id: string,
+    metadataFields: MetadataInstanceTemplateFields,
+    scope: string,
+    templateKey: string,
+};
+
 export type {
+    MetadataInstanceTemplateField,
+    MetadataInstanceTemplateFields,
+    MetadataTemplateInstance,
     MetadataFieldType,
     MetadataTemplateFieldOption,
     MetadataTemplateField,

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -122,7 +122,7 @@ type MetadataTemplateInstanceField = {
     key: string, // V2
     options?: Array<MetadataTemplateFieldOption>, // V3
     type: MetadataFieldType,
-    value: string,
+    value: MetadataFieldValue,
 };
 
 type MetadataTemplateInstance = {

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -114,11 +114,11 @@ type MetadataSuggestion = {
     suggestions: { [key: string]: string | number | string[] },
 };
 
-type MetadataInstanceTemplateField = {
+type MetadataTemplateInstanceField = {
     description?: string,
-    displayName: string,
+    displayName?: string,
     hidden?: boolean,
-    id: string,
+    id?: string,
     key: string, // V2
     options?: Array<MetadataTemplateFieldOption>, // V3
     type: MetadataFieldType,
@@ -129,13 +129,13 @@ type MetadataTemplateInstance = {
     displayName?: string,
     hidden?: boolean,
     id: string,
-    metadataFields: MetadataInstanceTemplateField[],
+    fields: MetadataTemplateInstanceField[],
     scope: string,
     templateKey: string,
 };
 
 export type {
-    MetadataInstanceTemplateField,
+    MetadataTemplateInstanceField,
     MetadataTemplateInstance,
     MetadataFieldType,
     MetadataTemplateFieldOption,

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -133,6 +133,7 @@ type MetadataTemplateInstance = {
     fields: MetadataTemplateInstanceField[],
     scope: string,
     templateKey: string,
+    type: string,
 };
 
 export type {

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -119,7 +119,6 @@ type MetadataInstanceTemplateField = {
     displayName: string,
     hidden?: boolean,
     id: string,
-    isHidden?: boolean,
     key: string, // V2
     options?: Array<MetadataTemplateFieldOption>, // V3
     type: MetadataFieldType,


### PR DESCRIPTION
This change extends `getMetadata` method in `Metadata API` in order to meet Metadata Sidebar Redesign needs as it will require less complex typing. 

Currently **MetadataSidebar** fetches `editors` which are objects containing:
* **`template` object** - it holds data on which template was used to create metadata instance for current file and current user and most importantly it holds `fields` array. This array consists of `field` objects which hold details on field displayName, field type etc. but do not hold field value for current file and current user - this is job for `instance` object.
* `instance` object - as explained above is simple object with instance details like id and key-value pairs which reflect template fields keys.
For now in order to get field details AND value for particular metadata instance, there's a lot of mapping needed which makes components implementation less straight forward. Additionally, more types are needed to handle that. 

On the top of that, most of the above explanation is not valid in custom metadata case as it does not use templates. This makes whole logic even more complex.

We want to improve this in new Metadata Sidebar to simplify logic inside components and reduce number of types. In this change we are unifying data provided for metadata instances from template and custom metadata, so that components do not have to introduce any additional logic, checks etc. In redesigned Metadata Sidebar we'll introduce the same component for viewing both metadata instances from template and custom metadata instead of dedicated component for each type of instance.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
