### PR TITLE
feat(metadata-sidebar): Metadata Instance Editor

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -144,6 +144,7 @@ class Metadata extends File {
             scope: METADATA_SCOPE_GLOBAL,
             templateKey: METADATA_TEMPLATE_PROPERTIES,
             hidden: false,
+            fields: [],
         };
     }
 

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -103,6 +103,7 @@ describe('api/Metadata', () => {
                 scope: METADATA_SCOPE_GLOBAL,
                 templateKey: METADATA_TEMPLATE_PROPERTIES,
                 hidden: false,
+                fields: [],
             });
         });
     });

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -1,15 +1,17 @@
-import { MetadataInstanceForm, MetadataTemplateInstance } from '@box/metadata-editor';
+import { MetadataInstanceForm, MetadataTemplateInstance, UnsavedChangesModal } from '@box/metadata-editor';
 import React from 'react';
 
-interface MetadataInstanceEditorProps {
+export interface MetadataInstanceEditorProps {
     isAiLoading: boolean;
     isBoxAiSuggestionsEnabled: boolean;
+    isDismissModalOpen: boolean;
     template: MetadataTemplateInstance;
 }
 
 const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     isAiLoading,
     isBoxAiSuggestionsEnabled,
+    isDismissModalOpen,
     template,
 }) => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -20,14 +22,17 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     const onDelete = () => {}; // ADOPT-4416
 
     return (
-        <MetadataInstanceForm
-            isAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled}
-            isLoading={isAiLoading}
-            selectedTemplateInstance={template}
-            onCancel={onCancel}
-            onDelete={onDelete}
-            onSubmit={handleSave}
-        />
+        <>
+            <MetadataInstanceForm
+                isAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled}
+                isLoading={isAiLoading}
+                selectedTemplateInstance={template}
+                onCancel={onCancel}
+                onDelete={onDelete}
+                onSubmit={handleSave}
+            />
+            {isDismissModalOpen && <UnsavedChangesModal onDismiss={onCancel} onSaveAndContinue={handleSave} />}
+        </>
     );
 };
 

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -17,12 +17,15 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     isUnsavedChangesModalOpen,
     template,
 }) => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const handleSubmit = () => {}; // TODO in a future PR
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const handleCancel = () => {}; // TODO in a future PR
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const handleDelete = () => {}; // TODO in a future PR
+    const handleSubmit = () => {
+        // TODO in a future PR
+    };
+    const handleCancel = () => {
+        // TODO in a future PR
+    };
+    const handleDelete = () => {
+        // TODO in a future PR
+    };
 
     return (
         <>

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -2,30 +2,28 @@ import { MetadataInstanceForm, MetadataTemplateInstance, UnsavedChangesModal } f
 import React from 'react';
 
 export interface MetadataInstanceEditorProps {
-    isAiLoading: boolean;
     isBoxAiSuggestionsEnabled: boolean;
     isDismissModalOpen: boolean;
     template: MetadataTemplateInstance;
 }
 
 const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
-    isAiLoading,
     isBoxAiSuggestionsEnabled,
     isDismissModalOpen,
     template,
 }) => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const handleSave = () => {}; // ADOPT-4412
+    const handleSave = () => {}; // TODO in a future PR
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const onCancel = () => {}; // ADOPT-4413
+    const onCancel = () => {}; // TODO in a future PR
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const onDelete = () => {}; // ADOPT-4416
+    const onDelete = () => {}; // TODO in a future PR
 
     return (
         <>
             <MetadataInstanceForm
                 isAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled}
-                isLoading={isAiLoading}
+                isLoading={false}
                 selectedTemplateInstance={template}
                 onCancel={onCancel}
                 onDelete={onDelete}

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -1,4 +1,4 @@
-import { MetadataInstanceForm, MetadataTemplateInstance, UnsavedChangesModal } from '@box/metadata-editor';
+import { MetadataInstanceForm, type MetadataTemplateInstance, UnsavedChangesModal } from '@box/metadata-editor';
 import React from 'react';
 
 export interface MetadataInstanceEditorProps {

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -1,0 +1,34 @@
+import { MetadataInstanceForm, MetadataTemplateInstance } from '@box/metadata-editor';
+import React from 'react';
+
+interface MetadataInstanceEditorProps {
+    isAiLoading: boolean;
+    isBoxAiSuggestionsEnabled: boolean;
+    template: MetadataTemplateInstance;
+}
+
+const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
+    isAiLoading,
+    isBoxAiSuggestionsEnabled,
+    template,
+}) => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const handleSave = () => {}; // ADOPT-4412
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const onCancel = () => {}; // ADOPT-4413
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const onDelete = () => {}; // ADOPT-4416
+
+    return (
+        <MetadataInstanceForm
+            isAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled}
+            isLoading={isAiLoading}
+            selectedTemplateInstance={template}
+            onCancel={onCancel}
+            onDelete={onDelete}
+            onSubmit={handleSave}
+        />
+    );
+};
+
+export default MetadataInstanceEditor;

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -34,9 +34,11 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
                 onDelete={handleDelete}
                 onSubmit={handleSubmit}
             />
-            {isUnsavedChangesModalOpen && (
-                <UnsavedChangesModal onDismiss={handleCancel} onSaveAndContinue={handleSubmit} />
-            )}
+            <UnsavedChangesModal
+                onDismiss={handleCancel}
+                onSaveAndContinue={handleSubmit}
+                open={isUnsavedChangesModalOpen}
+            />
         </>
     );
 };

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -1,23 +1,28 @@
-import { MetadataInstanceForm, type MetadataTemplateInstance, UnsavedChangesModal } from '@box/metadata-editor';
+import {
+    MetadataInstanceForm,
+    type MetadataTemplateInstance,
+    UnsavedChangesModal,
+    type MetadataTemplate,
+} from '@box/metadata-editor';
 import React from 'react';
 
 export interface MetadataInstanceEditorProps {
     isBoxAiSuggestionsEnabled: boolean;
-    isDismissModalOpen: boolean;
-    template: MetadataTemplateInstance;
+    isUnsavedChangesModalOpen: boolean;
+    template: MetadataTemplateInstance | MetadataTemplate;
 }
 
 const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     isBoxAiSuggestionsEnabled,
-    isDismissModalOpen,
+    isUnsavedChangesModalOpen,
     template,
 }) => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const handleSave = () => {}; // TODO in a future PR
+    const handleSubmit = () => {}; // TODO in a future PR
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const onCancel = () => {}; // TODO in a future PR
+    const handleCancel = () => {}; // TODO in a future PR
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const onDelete = () => {}; // TODO in a future PR
+    const handleDelete = () => {}; // TODO in a future PR
 
     return (
         <>
@@ -25,11 +30,13 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
                 isAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled}
                 isLoading={false}
                 selectedTemplateInstance={template}
-                onCancel={onCancel}
-                onDelete={onDelete}
-                onSubmit={handleSave}
+                onCancel={handleCancel}
+                onDelete={handleDelete}
+                onSubmit={handleSubmit}
             />
-            {isDismissModalOpen && <UnsavedChangesModal onDismiss={onCancel} onSaveAndContinue={handleSave} />}
+            {isUnsavedChangesModalOpen && (
+                <UnsavedChangesModal onDismiss={handleCancel} onSaveAndContinue={handleSubmit} />
+            )}
         </>
     );
 };

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -76,8 +76,6 @@ function MetadataSidebarRedesign({
         isFeatureEnabled,
     );
 
-    const isAiLoading = false; // TODO when ADOPT-4544 is merged
-
     const handleUnsavedChanges = () => {
         setIsDismissModalOpen(true);
     };
@@ -126,7 +124,6 @@ function MetadataSidebarRedesign({
                 ) : (
                     editingTemplate && (
                         <MetadataInstanceEditor
-                            isAiLoading={isAiLoading}
                             isBoxAiSuggestionsEnabled={isBoxAiSuggestionsEnabled}
                             isDismissModalOpen={isDismissModalOpen}
                             template={editingTemplate}

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -20,7 +20,7 @@ import useSidebarMetadataFetcher, { STATUS } from './hooks/useSidebarMetadataFet
 
 import { type ElementsXhrError } from '../../common/types/api';
 import { type ElementOrigin } from '../common/flowTypes';
-import { MetadataTemplate } from '../../common/types/metadata';
+import { MetadataTemplate, MetadataTemplateInstance } from '../../common/types/metadata';
 import { type WithLoggerProps } from '../../common/types/logging';
 
 import messages from '../common/messages';
@@ -66,7 +66,8 @@ function MetadataSidebarRedesign({
     const { formatMessage } = useIntl();
 
     const [selectedTemplates, setSelectedTemplates] = React.useState<Array<MetadataTemplate>>([]);
-    const [editingTemplate, setEditingTemplate] = React.useState<MetadataTemplate | null>(null);
+    const [editingTemplate, setEditingTemplate] = React.useState<MetadataTemplateInstance | null>(null);
+    const [isDismissModalOpen, setIsDismissModalOpen] = React.useState<boolean>(false);
 
     const { file, templates, errorMessage, status, templateInstances } = useSidebarMetadataFetcher(
         api,
@@ -77,12 +78,15 @@ function MetadataSidebarRedesign({
 
     const isAiLoading = false; // TODO when ADOPT-4544 is merged
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const handleUnsavedChanges = () => {}; // TODO when ADOPT-4667 is merged
+    const handleUnsavedChanges = () => {
+        setIsDismissModalOpen(true);
+    };
 
     const handleTemplateSelect = (selectedTemplate: MetadataTemplate) => {
         setSelectedTemplates([...selectedTemplates, selectedTemplate]);
-        setEditingTemplate(selectedTemplate);
+        selectedTemplate.fields
+            ? setEditingTemplate(selectedTemplate)
+            : setEditingTemplate({ ...selectedTemplate, fields: [] });
     };
 
     const metadataDropdown = status === STATUS.SUCCESS && templates && (
@@ -124,6 +128,7 @@ function MetadataSidebarRedesign({
                         <MetadataInstanceEditor
                             isAiLoading={isAiLoading}
                             isBoxAiSuggestionsEnabled={isBoxAiSuggestionsEnabled}
+                            isDismissModalOpen={isDismissModalOpen}
                             template={editingTemplate}
                         />
                     )

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import flow from 'lodash/flow';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { InlineError, LoadingIndicator } from '@box/blueprint-web';
-import { AddMetadataTemplateDropdown, MetadataEmptyState } from '@box/metadata-editor';
+import { AddMetadataTemplateDropdown, MetadataEmptyState, type MetadataTemplateInstance } from '@box/metadata-editor';
 
 import API from '../../api';
 import SidebarContent from './SidebarContent';
@@ -20,7 +20,7 @@ import useSidebarMetadataFetcher, { STATUS } from './hooks/useSidebarMetadataFet
 
 import { type ElementsXhrError } from '../../common/types/api';
 import { type ElementOrigin } from '../common/flowTypes';
-import { MetadataTemplate, MetadataTemplateInstance } from '../../common/types/metadata';
+import { MetadataTemplate } from '../../common/types/metadata';
 import { type WithLoggerProps } from '../../common/types/logging';
 
 import messages from '../common/messages';
@@ -82,9 +82,7 @@ function MetadataSidebarRedesign({
 
     const handleTemplateSelect = (selectedTemplate: MetadataTemplate) => {
         setSelectedTemplates([...selectedTemplates, selectedTemplate]);
-        selectedTemplate.fields
-            ? setEditingTemplate(selectedTemplate)
-            : setEditingTemplate({ ...selectedTemplate, fields: [] });
+        setEditingTemplate(selectedTemplate);
     };
 
     const metadataDropdown = status === STATUS.SUCCESS && templates && (

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -6,7 +6,12 @@ import * as React from 'react';
 import flow from 'lodash/flow';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { InlineError, LoadingIndicator } from '@box/blueprint-web';
-import { AddMetadataTemplateDropdown, MetadataEmptyState, type MetadataTemplateInstance } from '@box/metadata-editor';
+import {
+    AddMetadataTemplateDropdown,
+    MetadataEmptyState,
+    type MetadataTemplateInstance,
+    type MetadataTemplate,
+} from '@box/metadata-editor';
 
 import API from '../../api';
 import SidebarContent from './SidebarContent';
@@ -20,7 +25,6 @@ import useSidebarMetadataFetcher, { STATUS } from './hooks/useSidebarMetadataFet
 
 import { type ElementsXhrError } from '../../common/types/api';
 import { type ElementOrigin } from '../common/flowTypes';
-import { MetadataTemplate } from '../../common/types/metadata';
 import { type WithLoggerProps } from '../../common/types/logging';
 
 import messages from '../common/messages';
@@ -66,8 +70,10 @@ function MetadataSidebarRedesign({
     const { formatMessage } = useIntl();
 
     const [selectedTemplates, setSelectedTemplates] = React.useState<Array<MetadataTemplate>>([]);
-    const [editingTemplate, setEditingTemplate] = React.useState<MetadataTemplateInstance | null>(null);
-    const [isDismissModalOpen, setIsDismissModalOpen] = React.useState<boolean>(false);
+    const [editingTemplate, setEditingTemplate] = React.useState<MetadataTemplateInstance | MetadataTemplate | null>(
+        null,
+    );
+    const [isUnsavedChangesModalOpen, setIsUnsavedChangesModalOpen] = React.useState<boolean>(false);
 
     const { file, templates, errorMessage, status, templateInstances } = useSidebarMetadataFetcher(
         api,
@@ -77,7 +83,7 @@ function MetadataSidebarRedesign({
     );
 
     const handleUnsavedChanges = () => {
-        setIsDismissModalOpen(true);
+        setIsUnsavedChangesModalOpen(true);
     };
 
     const handleTemplateSelect = (selectedTemplate: MetadataTemplate) => {
@@ -123,7 +129,7 @@ function MetadataSidebarRedesign({
                     editingTemplate && (
                         <MetadataInstanceEditor
                             isBoxAiSuggestionsEnabled={isBoxAiSuggestionsEnabled}
-                            isDismissModalOpen={isDismissModalOpen}
+                            isUnsavedChangesModalOpen={isUnsavedChangesModalOpen}
                             template={editingTemplate}
                         />
                     )

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import flow from 'lodash/flow';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { InlineError, LoadingIndicator } from '@box/blueprint-web';
-import { AddMetadataTemplateDropdown , MetadataEmptyState } from '@box/metadata-editor';
+import { AddMetadataTemplateDropdown, MetadataEmptyState } from '@box/metadata-editor';
 
 import API from '../../api';
 import SidebarContent from './SidebarContent';
@@ -25,6 +25,7 @@ import { type WithLoggerProps } from '../../common/types/logging';
 
 import messages from '../common/messages';
 import './MetadataSidebarRedesign.scss';
+import MetadataInstanceEditor from './MetadataInstanceEditor';
 
 const MARK_NAME_JS_READY = `${ORIGIN_METADATA_SIDEBAR_REDESIGN}_${EVENT_JS_READY}`;
 
@@ -65,20 +66,31 @@ function MetadataSidebarRedesign({
     const { formatMessage } = useIntl();
 
     const [selectedTemplates, setSelectedTemplates] = React.useState<Array<MetadataTemplate>>([]);
+    const [editingTemplate, setEditingTemplate] = React.useState<MetadataTemplate | null>(null);
 
-    const { editors, file, templates, errorMessage, status } = useSidebarMetadataFetcher(
+    const { file, templates, errorMessage, status, templateInstances } = useSidebarMetadataFetcher(
         api,
         fileId,
         onError,
         isFeatureEnabled,
     );
 
+    const isAiLoading = false; // TODO when ADOPT-4544 is merged
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const handleUnsavedChanges = () => {}; // TODO when ADOPT-4667 is merged
+
+    const handleTemplateSelect = (selectedTemplate: MetadataTemplate) => {
+        setSelectedTemplates([...selectedTemplates, selectedTemplate]);
+        setEditingTemplate(selectedTemplate);
+    };
+
     const metadataDropdown = status === STATUS.SUCCESS && templates && (
         <AddMetadataTemplateDropdown
             availableTemplates={templates}
             selectedTemplates={selectedTemplates}
             onSelect={(selectedTemplate): void => {
-                setSelectedTemplates([...selectedTemplates, selectedTemplate]);
+                editingTemplate ? handleUnsavedChanges() : handleTemplateSelect(selectedTemplate);
             }}
         />
     );
@@ -89,8 +101,8 @@ function MetadataSidebarRedesign({
         </InlineError>
     );
 
-    const showEditor = file && templates && editors;
-    const showEmptyState = showEditor && editors.length === 0;
+    const showTemplateInstances = file && templates && templateInstances;
+    const showEmptyState = showTemplateInstances && templateInstances.length === 0 && !editingTemplate;
 
     return (
         <SidebarContent
@@ -105,8 +117,16 @@ function MetadataSidebarRedesign({
                 {status === STATUS.LOADING && (
                     <LoadingIndicator aria-label={formatMessage(messages.loading)} data-testid="loading" />
                 )}
-                {showEmptyState && (
+                {showEmptyState ? (
                     <MetadataEmptyState level={'file'} isBoxAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled} />
+                ) : (
+                    editingTemplate && (
+                        <MetadataInstanceEditor
+                            isAiLoading={isAiLoading}
+                            isBoxAiSuggestionsEnabled={isBoxAiSuggestionsEnabled}
+                            template={editingTemplate}
+                        />
+                    )
                 )}
             </div>
         </SidebarContent>

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -1,42 +1,42 @@
 import React from 'react';
-import { type MetadataTemplateInstance } from '@box/metadata-editor';
+import { type MetadataTemplate } from '@box/metadata-editor';
 import { screen, render } from '../../../test-utils/testing-library';
 import MetadataInstanceEditor, { MetadataInstanceEditorProps } from '../MetadataInstanceEditor';
 
 describe('MetadataInstanceEditor', () => {
-    const mockCustomMetadata: MetadataTemplateInstance = {
+    const mockCustomMetadataTemplate: MetadataTemplate = {
         id: 'template-id',
-        canEdit: true,
         fields: [],
         scope: 'global',
-        templateKey: 'template-id',
+        templateKey: 'properties',
         type: 'template-id',
+        hidden: false,
     };
 
-    const mockDefinedTemplate: MetadataTemplateInstance = { ...mockCustomMetadata, displayName: 'Template Name' };
+    const mockMetadataTemplate: MetadataTemplate = { ...mockCustomMetadataTemplate, displayName: 'Template Name' };
 
     const defaultProps: MetadataInstanceEditorProps = {
         isBoxAiSuggestionsEnabled: true,
-        isDismissModalOpen: false,
-        template: mockDefinedTemplate,
+        isUnsavedChangesModalOpen: false,
+        template: mockMetadataTemplate,
     };
 
     test('should render MetadataInstanceForm with correct props', () => {
         render(<MetadataInstanceEditor {...defaultProps} />);
 
-        const templateHeader = screen.getByText(mockDefinedTemplate.displayName);
+        const templateHeader = screen.getByText(mockMetadataTemplate.displayName);
         expect(templateHeader).toBeInTheDocument();
     });
 
     test('should render MetadataInstanceForm with Custom Template', () => {
-        const props = { ...defaultProps, template: mockCustomMetadata };
+        const props = { ...defaultProps, template: mockCustomMetadataTemplate };
         render(<MetadataInstanceEditor {...props} />);
 
         const templateHeader = screen.getByText('Custom Metadata');
         expect(templateHeader).toBeInTheDocument();
     });
 
-    test('should render UnsavedChangesModal if isDismissModalOpen is true', () => {
+    test('should render UnsavedChangesModal if isUnsavedChangesModalOpen is true', () => {
         // Mock window.matchMedia to simulate media query behavior for this test,
         // as the UnsavedChangesModal component relies on it.
         Object.defineProperty(window, 'matchMedia', {
@@ -51,11 +51,10 @@ describe('MetadataInstanceEditor', () => {
             })),
         });
 
-        const props = { ...defaultProps, isDismissModalOpen: true };
+        const props = { ...defaultProps, isUnsavedChangesModalOpen: true };
         render(<MetadataInstanceEditor {...props} />);
 
         const unsavedChangesModal = screen.getByText('Unsaved Changes');
-        screen.debug();
         expect(unsavedChangesModal).toBeInTheDocument();
     });
 });

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -26,7 +26,6 @@ describe('MetadataInstanceEditor', () => {
     const mockDefinedTemplate: MetadataTemplateInstance = { ...mockCustomMetadata, displayName: 'Template Name' };
 
     const defaultProps: MetadataInstanceEditorProps = {
-        isAiLoading: false,
         isBoxAiSuggestionsEnabled: true,
         isDismissModalOpen: false,
         template: mockDefinedTemplate,

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -1,34 +1,72 @@
 import React from 'react';
-import { MetadataInstanceForm, MetadataTemplateInstance } from '@box/metadata-editor';
+import { MetadataTemplateInstance } from '@box/metadata-editor';
 import { screen, render } from '../../../test-utils/testing-library';
-import MetadataInstanceEditor from '../MetadataInstanceEditor';
-
-jest.mock('@box/metadata-editor', () => ({
-    MetadataInstanceForm: jest.fn(() => <div data-testid="metadata-instance-form" />),
-}));
+import MetadataInstanceEditor, { MetadataInstanceEditorProps } from '../MetadataInstanceEditor';
 
 describe('MetadataInstanceEditor', () => {
-    const mockTemplate = {
+    // const mockTemplate: MetadataTemplateInstance = {
+    //     id: 'template-id',
+    //     displayName: 'Template Name',
+    //     canEdit: true,
+    //     fields: [],
+    //     scope: 'global',
+    //     templateKey: 'template-id',
+    //     type: 'template-id',
+    // };
+
+    const mockCustomMetadata: MetadataTemplateInstance = {
         id: 'template-id',
-        displayName: 'Template Name',
         canEdit: true,
         fields: [],
         scope: 'global',
         templateKey: 'template-id',
         type: 'template-id',
-    } as MetadataTemplateInstance;
+    };
+
+    const mockDefinedTemplate: MetadataTemplateInstance = { ...mockCustomMetadata, displayName: 'Template Name' };
+
+    const defaultProps: MetadataInstanceEditorProps = {
+        isAiLoading: false,
+        isBoxAiSuggestionsEnabled: true,
+        isDismissModalOpen: false,
+        template: mockDefinedTemplate,
+    };
 
     test('should render MetadataInstanceForm with correct props', () => {
-        render(<MetadataInstanceEditor isAiLoading={false} isBoxAiSuggestionsEnabled={true} template={mockTemplate} />);
+        render(<MetadataInstanceEditor {...defaultProps} />);
 
-        expect(screen.getByTestId('metadata-instance-form')).toBeInTheDocument();
-        expect(MetadataInstanceForm).toHaveBeenCalledWith(
-            expect.objectContaining({
-                isAiSuggestionsFeatureEnabled: true,
-                isLoading: false,
-                selectedTemplateInstance: mockTemplate,
-            }),
-            {},
-        );
+        const templateHeader = screen.getByText(mockDefinedTemplate.displayName);
+        expect(templateHeader).toBeInTheDocument();
+    });
+
+    test('should render MetadataInstanceForm with Custom Template', () => {
+        const props = { ...defaultProps, template: mockCustomMetadata };
+        render(<MetadataInstanceEditor {...props} />);
+
+        const templateHeader = screen.getByText('Custom Metadata');
+        expect(templateHeader).toBeInTheDocument();
+    });
+
+    test('should render UnsavedChangesModal if isDismissModalOpen is true', () => {
+        // Mock window.matchMedia to simulate media query behavior for this test,
+        // as the UnsavedChangesModal component relies on it.
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation(query => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+
+        const props = { ...defaultProps, isDismissModalOpen: true };
+        render(<MetadataInstanceEditor {...props} />);
+
+        const unsavedChangesModal = screen.getByText('Unsaved Changes');
+        screen.debug();
+        expect(unsavedChangesModal).toBeInTheDocument();
     });
 });

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { MetadataInstanceForm, MetadataTemplateInstance } from '@box/metadata-editor';
+import { screen, render } from '../../../test-utils/testing-library';
+import MetadataInstanceEditor from '../MetadataInstanceEditor';
+
+jest.mock('@box/metadata-editor', () => ({
+    MetadataInstanceForm: jest.fn(() => <div data-testid="metadata-instance-form" />),
+}));
+
+describe('MetadataInstanceEditor', () => {
+    const mockTemplate = {
+        id: 'template-id',
+        displayName: 'Template Name',
+        canEdit: true,
+        fields: [],
+        scope: 'global',
+        templateKey: 'template-id',
+        type: 'template-id',
+    } as MetadataTemplateInstance;
+
+    test('should render MetadataInstanceForm with correct props', () => {
+        render(<MetadataInstanceEditor isAiLoading={false} isBoxAiSuggestionsEnabled={true} template={mockTemplate} />);
+
+        expect(screen.getByTestId('metadata-instance-form')).toBeInTheDocument();
+        expect(MetadataInstanceForm).toHaveBeenCalledWith(
+            expect.objectContaining({
+                isAiSuggestionsFeatureEnabled: true,
+                isLoading: false,
+                selectedTemplateInstance: mockTemplate,
+            }),
+            {},
+        );
+    });
+});

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -1,19 +1,9 @@
 import React from 'react';
-import { MetadataTemplateInstance } from '@box/metadata-editor';
+import { type MetadataTemplateInstance } from '@box/metadata-editor';
 import { screen, render } from '../../../test-utils/testing-library';
 import MetadataInstanceEditor, { MetadataInstanceEditorProps } from '../MetadataInstanceEditor';
 
 describe('MetadataInstanceEditor', () => {
-    // const mockTemplate: MetadataTemplateInstance = {
-    //     id: 'template-id',
-    //     displayName: 'Template Name',
-    //     canEdit: true,
-    //     fields: [],
-    //     scope: 'global',
-    //     templateKey: 'template-id',
-    //     type: 'template-id',
-    // };
-
     const mockCustomMetadata: MetadataTemplateInstance = {
         id: 'template-id',
         canEdit: true,

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { userEvent } from '@testing-library/user-event';
+import { type MetadataTemplate } from '@box/metadata-editor';
 import { FIELD_PERMISSIONS_CAN_UPLOAD } from '../../../constants';
 import { screen, render } from '../../../test-utils/testing-library';
 import {
@@ -14,13 +15,14 @@ const mockUseSidebarMetadataFetcher = useSidebarMetadataFetcher as jest.MockedFu
 >;
 
 describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
-    const mockTemplates = [
+    const mockTemplates: MetadataTemplate[] = [
         {
             id: 'metadata_template_custom_1',
             scope: 'global',
             templateKey: 'properties',
             hidden: false,
             fields: [],
+            type: 'metadata_template',
         },
     ];
 

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -20,6 +20,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             scope: 'global',
             templateKey: 'properties',
             hidden: false,
+            fields: [],
         },
     ];
 

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -44,7 +44,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
     beforeEach(() => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
             templates: mockTemplates,
-            editors: [],
+            templateInstances: [],
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
@@ -85,7 +85,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render metadata sidebar with error', async () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
-            editors: [],
+            templateInstances: [],
             templates: [],
             errorMessage: {
                 id: 'error',
@@ -104,7 +104,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render metadata sidebar with loading indicator', async () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
-            editors: [],
+            templateInstances: [],
             templates: [],
             errorMessage: null,
             status: STATUS.LOADING,

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import getProp from 'lodash/get';
 import { type MessageDescriptor } from 'react-intl';
-import { MetadataTemplateInstance } from '@box/metadata-editor';
+import { MetadataTemplate, type MetadataTemplateInstance } from '@box/metadata-editor';
 import API from '../../../api';
 import { type ElementsXhrError } from '../../../common/types/api';
 import { isUserCorrectableError } from '../../../utils/error';
@@ -10,7 +10,6 @@ import { FIELD_IS_EXTERNALLY_OWNED, FIELD_PERMISSIONS, FIELD_PERMISSIONS_CAN_UPL
 import messages from '../../common/messages';
 
 import { type BoxItem } from '../../../common/types/core';
-import { MetadataTemplate } from '../../../common/types/metadata';
 import { type ErrorContextProps, type ExternalProps } from '../MetadataSidebarRedesign';
 
 export enum STATUS {

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import getProp from 'lodash/get';
 import { type MessageDescriptor } from 'react-intl';
+import { MetadataTemplateInstance } from '@box/metadata-editor';
 import API from '../../../api';
 import { type ElementsXhrError } from '../../../common/types/api';
 import { isUserCorrectableError } from '../../../utils/error';
-import { FIELD_IS_EXTERNALLY_OWNED, FIELD_PERMISSIONS, FIELD_PERMISSIONS_CAN_UPLOAD, IS_ERROR_DISPLAYED} from '../../../constants';
+import { FIELD_IS_EXTERNALLY_OWNED, FIELD_PERMISSIONS, FIELD_PERMISSIONS_CAN_UPLOAD } from '../../../constants';
 
 import messages from '../../common/messages';
 
 import { type BoxItem } from '../../../common/types/core';
-import { MetadataTemplate, type MetadataEditor } from '../../../common/types/metadata';
+import { MetadataTemplate } from '../../../common/types/metadata';
 import { type ErrorContextProps, type ExternalProps } from '../MetadataSidebarRedesign';
 
 export enum STATUS {
@@ -19,10 +20,10 @@ export enum STATUS {
     SUCCESS = 'success',
 }
 interface DataFetcher {
-    editors: Array<MetadataEditor>;
     file: BoxItem | null;
     errorMessage: MessageDescriptor | null;
     status: STATUS;
+    templateInstances: Array<MetadataTemplateInstance>;
     templates: Array<MetadataTemplate>;
 }
 
@@ -36,7 +37,7 @@ function useSidebarMetadataFetcher(
     const [file, setFile] = React.useState<BoxItem>(null);
     const [templates, setTemplates] = React.useState(null);
     const [errorMessage, setErrorMessage] = React.useState<MessageDescriptor | null>(null);
-    const [editors, setEditors] = React.useState<Array<MetadataEditor>>([]);
+    const [templateInstances, setTemplateInstances] = React.useState<Array<MetadataTemplateInstance>>([]);
 
     const onApiError = React.useCallback(
         (error: ElementsXhrError, code: string, message: MessageDescriptor) => {
@@ -53,10 +54,16 @@ function useSidebarMetadataFetcher(
     );
 
     const fetchMetadataSuccessCallback = React.useCallback(
-        ({ editors: fetchedEditors, templates: fetchedTemplates }: { editors: Array<MetadataEditor>; templates: Array<MetadataTemplate> }) => {
-            setEditors(fetchedEditors);
+        ({
+            templates: fetchedTemplates,
+            templateInstances: fetchedtemplateInstances,
+        }: {
+            templates: Array<MetadataTemplate>;
+            templateInstances: Array<MetadataTemplateInstance>;
+        }) => {
             setErrorMessage(null);
             setStatus(STATUS.SUCCESS);
+            setTemplateInstances(fetchedtemplateInstances);
             setTemplates(fetchedTemplates);
         },
         [],
@@ -64,8 +71,8 @@ function useSidebarMetadataFetcher(
 
     const fetchMetadataErrorCallback = React.useCallback(
         (e: ElementsXhrError, code: string) => {
-            setEditors(null);
             setTemplates(null);
+            setTemplateInstances(null);
             onApiError(e, code, messages.sidebarMetadataFetchingErrorContent);
         },
         [onApiError],
@@ -120,9 +127,9 @@ function useSidebarMetadataFetcher(
 
     return {
         file,
-        editors,
         errorMessage,
         status,
+        templateInstances,
         templates,
     };
 }

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import getProp from 'lodash/get';
 import { type MessageDescriptor } from 'react-intl';
-import { MetadataTemplate, type MetadataTemplateInstance } from '@box/metadata-editor';
+import { type MetadataTemplate, type MetadataTemplateInstance } from '@box/metadata-editor';
 import API from '../../../api';
 import { type ElementsXhrError } from '../../../common/types/api';
 import { isUserCorrectableError } from '../../../utils/error';
@@ -55,14 +55,14 @@ function useSidebarMetadataFetcher(
     const fetchMetadataSuccessCallback = React.useCallback(
         ({
             templates: fetchedTemplates,
-            templateInstances: fetchedtemplateInstances,
+            templateInstances: fetchedTemplateInstances,
         }: {
             templates: Array<MetadataTemplate>;
             templateInstances: Array<MetadataTemplateInstance>;
         }) => {
             setErrorMessage(null);
             setStatus(STATUS.SUCCESS);
-            setTemplateInstances(fetchedtemplateInstances);
+            setTemplateInstances(fetchedTemplateInstances);
             setTemplates(fetchedTemplates);
         },
         [],

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -86,6 +86,7 @@ function useSidebarMetadataFetcher(
                 fetchMetadataErrorCallback,
                 isFeatureEnabled,
                 { refreshCache: true },
+                true,
             );
         },
         [api, fetchMetadataErrorCallback, fetchMetadataSuccessCallback, isFeatureEnabled],

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -56,7 +56,6 @@ const renderWithEditor = template => (
         >
             <div className="bcs-MetadataSidebarRedesign-content">
                 <MetadataInstanceEditor
-                    isAiLoading={false}
                     isBoxAiSuggestionsEnabled={true}
                     isDismissModalOpen={false}
                     template={template}

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -45,11 +45,22 @@ export const EmptyStateWithBoxAiEnabled: StoryObj<typeof MetadataSidebarRedesign
         metadataSidebarProps: {
             ...defaultMetadataSidebarProps,
         },
-    },};
+    },
+};
 
 export const EmptyStateWithBoxAiDisabled: StoryObj<typeof MetadataSidebarRedesign> = {
     args: {
         fileId: fileIdWithNoMetadata,
+        metadataSidebarProps: {
+            ...defaultMetadataSidebarProps,
+            isBoxAiSuggestionsEnabled: false,
+        },
+    },
+};
+
+export const MetadataInstanceEditor: StoryObj<typeof MetadataSidebarRedesign> = {
+    args: {
+        fileId: fileIdWithMetadata,
         metadataSidebarProps: {
             ...defaultMetadataSidebarProps,
             isBoxAiSuggestionsEnabled: false,

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -1,8 +1,12 @@
 import { type StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React, { type ComponentProps } from 'react';
+import { AddMetadataTemplateDropdown, MetadataTemplateFieldType } from '@box/metadata-editor';
 import MetadataSidebarRedesign from '../MetadataSidebarRedesign';
 import ContentSidebar from '../ContentSidebar';
+import SidebarContent from '../SidebarContent';
+import { SIDEBAR_VIEW_METADATA } from '../../../constants';
+import MetadataInstanceEditor from '../MetadataInstanceEditor';
 
 const fileIdWithMetadata = global.FILE_ID;
 const fileIdWithNoMetadata = '416047501580';
@@ -20,6 +24,47 @@ const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign
     isFeatureEnabled: true,
     onError: fn,
 };
+
+const mockTemplateFields = [
+    {
+        description: 'My Value',
+        displayName: 'My Attribute',
+        hidden: false,
+        id: '4fc86fb1-43cd-4aa2-a585-5e94ec445d90',
+        key: 'myAttribute',
+        type: 'string' as MetadataTemplateFieldType,
+    },
+];
+
+const mockCustomMetadata = {
+    id: 'template-id',
+    canEdit: true,
+    fields: [],
+    scope: 'global',
+    templateKey: 'template-id',
+    type: 'template-id',
+};
+
+const renderWithEditor = template => (
+    <div style={{ display: 'flex', height: '500px' }}>
+        <SidebarContent
+            actions={<AddMetadataTemplateDropdown availableTemplates={[]} selectedTemplates={[]} onSelect={fn()} />}
+            className="bcs-MetadataSidebarRedesign"
+            elementId="bcs_120"
+            sidebarView={SIDEBAR_VIEW_METADATA}
+            title="Metadata"
+        >
+            <div className="bcs-MetadataSidebarRedesign-content">
+                <MetadataInstanceEditor
+                    isAiLoading={false}
+                    isBoxAiSuggestionsEnabled={true}
+                    isDismissModalOpen={false}
+                    template={template}
+                />
+            </div>
+        </SidebarContent>
+    </div>
+);
 
 export default {
     title: 'Elements/ContentSidebar/MetadataSidebarRedesign',
@@ -58,12 +103,16 @@ export const EmptyStateWithBoxAiDisabled: StoryObj<typeof MetadataSidebarRedesig
     },
 };
 
-export const MetadataInstanceEditor: StoryObj<typeof MetadataSidebarRedesign> = {
-    args: {
-        fileId: fileIdWithMetadata,
-        metadataSidebarProps: {
-            ...defaultMetadataSidebarProps,
-            isBoxAiSuggestionsEnabled: false,
-        },
+export const MetadataInstanceEditorWithDefinedTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
+    render: () => {
+        const mockDefinedTemplate = { ...mockCustomMetadata, displayName: 'Template Name', fields: mockTemplateFields };
+
+        return renderWithEditor(mockDefinedTemplate);
+    },
+};
+
+export const MetadataInstanceEditorWithCustomTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
+    render: () => {
+        return renderWithEditor(mockCustomMetadata);
     },
 };

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -1,11 +1,7 @@
 import { type StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React, { type ComponentProps } from 'react';
-import {
-    AddMetadataTemplateDropdown,
-    type MetadataTemplateInstance,
-    type MetadataTemplateFieldType,
-} from '@box/metadata-editor';
+import { AddMetadataTemplateDropdown, type MetadataTemplate, type MetadataTemplateField } from '@box/metadata-editor';
 import MetadataSidebarRedesign from '../MetadataSidebarRedesign';
 import ContentSidebar from '../ContentSidebar';
 import SidebarContent from '../SidebarContent';
@@ -29,27 +25,27 @@ const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign
     onError: fn,
 };
 
-const mockTemplateFields = [
+const mockTemplateFields: MetadataTemplateField[] = [
     {
         description: 'My Value',
         displayName: 'My Attribute',
         hidden: false,
         id: '4fc86fb1-43cd-4aa2-a585-5e94ec445d90',
         key: 'myAttribute',
-        type: 'string' as MetadataTemplateFieldType,
+        type: 'string',
     },
 ];
 
-const mockCustomMetadata: MetadataTemplateInstance = {
+const mockCustomMetadataTemplate: MetadataTemplate = {
     id: 'template-id',
-    canEdit: true,
     fields: [],
     scope: 'global',
-    templateKey: 'template-id',
+    templateKey: 'properties',
     type: 'template-id',
+    hidden: false,
 };
 
-const renderWithEditor = template => (
+const renderWithEditor = (template: MetadataTemplate) => (
     <div style={{ display: 'flex', height: '500px' }}>
         <SidebarContent
             actions={<AddMetadataTemplateDropdown availableTemplates={[]} selectedTemplates={[]} onSelect={fn()} />}
@@ -61,7 +57,7 @@ const renderWithEditor = template => (
             <div className="bcs-MetadataSidebarRedesign-content">
                 <MetadataInstanceEditor
                     isBoxAiSuggestionsEnabled={true}
-                    isDismissModalOpen={false}
+                    isUnsavedChangesModalOpen={false}
                     template={template}
                 />
             </div>
@@ -108,14 +104,18 @@ export const EmptyStateWithBoxAiDisabled: StoryObj<typeof MetadataSidebarRedesig
 
 export const MetadataInstanceEditorWithDefinedTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
     render: () => {
-        const mockDefinedTemplate = { ...mockCustomMetadata, displayName: 'Template Name', fields: mockTemplateFields };
+        const mockMetadataTemplate = {
+            ...mockCustomMetadataTemplate,
+            displayName: 'Template Name',
+            fields: mockTemplateFields,
+        };
 
-        return renderWithEditor(mockDefinedTemplate);
+        return renderWithEditor(mockMetadataTemplate);
     },
 };
 
 export const MetadataInstanceEditorWithCustomTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
     render: () => {
-        return renderWithEditor(mockCustomMetadata);
+        return renderWithEditor(mockCustomMetadataTemplate);
     },
 };

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -1,12 +1,8 @@
 import { type StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
+import { fn, userEvent, within } from '@storybook/test';
 import React, { type ComponentProps } from 'react';
-import { AddMetadataTemplateDropdown, type MetadataTemplate, type MetadataTemplateField } from '@box/metadata-editor';
 import MetadataSidebarRedesign from '../MetadataSidebarRedesign';
 import ContentSidebar from '../ContentSidebar';
-import SidebarContent from '../SidebarContent';
-import { SIDEBAR_VIEW_METADATA } from '../../../constants';
-import MetadataInstanceEditor from '../MetadataInstanceEditor';
 
 const fileIdWithMetadata = global.FILE_ID;
 const fileIdWithNoMetadata = '416047501580';
@@ -24,46 +20,6 @@ const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign
     isFeatureEnabled: true,
     onError: fn,
 };
-
-const mockTemplateFields: MetadataTemplateField[] = [
-    {
-        description: 'My Value',
-        displayName: 'My Attribute',
-        hidden: false,
-        id: '4fc86fb1-43cd-4aa2-a585-5e94ec445d90',
-        key: 'myAttribute',
-        type: 'string',
-    },
-];
-
-const mockCustomMetadataTemplate: MetadataTemplate = {
-    id: 'template-id',
-    fields: [],
-    scope: 'global',
-    templateKey: 'properties',
-    type: 'template-id',
-    hidden: false,
-};
-
-const renderWithEditor = (template: MetadataTemplate) => (
-    <div style={{ display: 'flex', height: '500px' }}>
-        <SidebarContent
-            actions={<AddMetadataTemplateDropdown availableTemplates={[]} selectedTemplates={[]} onSelect={fn()} />}
-            className="bcs-MetadataSidebarRedesign"
-            elementId="bcs_120"
-            sidebarView={SIDEBAR_VIEW_METADATA}
-            title="Metadata"
-        >
-            <div className="bcs-MetadataSidebarRedesign-content">
-                <MetadataInstanceEditor
-                    isBoxAiSuggestionsEnabled={true}
-                    isUnsavedChangesModalOpen={false}
-                    template={template}
-                />
-            </div>
-        </SidebarContent>
-    </div>
-);
 
 export default {
     title: 'Elements/ContentSidebar/MetadataSidebarRedesign',
@@ -103,19 +59,27 @@ export const EmptyStateWithBoxAiDisabled: StoryObj<typeof MetadataSidebarRedesig
 };
 
 export const MetadataInstanceEditorWithDefinedTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
-    render: () => {
-        const mockMetadataTemplate = {
-            ...mockCustomMetadataTemplate,
-            displayName: 'Template Name',
-            fields: mockTemplateFields,
-        };
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await canvas.findByRole('heading', { name: 'Metadata' });
 
-        return renderWithEditor(mockMetadataTemplate);
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        await userEvent.click(addTemplateButton);
+
+        const customMetadataOption = canvas.getByRole('option', { name: 'Select Dropdowns' });
+        await userEvent.click(customMetadataOption);
     },
 };
 
 export const MetadataInstanceEditorWithCustomTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
-    render: () => {
-        return renderWithEditor(mockCustomMetadataTemplate);
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await canvas.findByRole('heading', { name: 'Metadata' });
+
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        await userEvent.click(addTemplateButton);
+
+        const customMetadataOption = canvas.getByRole('option', { name: 'Custom Metadata' });
+        await userEvent.click(customMetadataOption);
     },
 };

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -1,7 +1,11 @@
 import { type StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React, { type ComponentProps } from 'react';
-import { AddMetadataTemplateDropdown, MetadataTemplateFieldType } from '@box/metadata-editor';
+import {
+    AddMetadataTemplateDropdown,
+    type MetadataTemplateInstance,
+    type MetadataTemplateFieldType,
+} from '@box/metadata-editor';
 import MetadataSidebarRedesign from '../MetadataSidebarRedesign';
 import ContentSidebar from '../ContentSidebar';
 import SidebarContent from '../SidebarContent';
@@ -36,7 +40,7 @@ const mockTemplateFields = [
     },
 ];
 
-const mockCustomMetadata = {
+const mockCustomMetadata: MetadataTemplateInstance = {
     id: 'template-id',
     canEdit: true,
     fields: [],

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -61,9 +61,8 @@ export const EmptyStateWithBoxAiDisabled: StoryObj<typeof MetadataSidebarRedesig
 export const MetadataInstanceEditorWithDefinedTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        await canvas.findByRole('heading', { name: 'Metadata' });
 
-        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' }, { timeout: 5000 });
         await userEvent.click(addTemplateButton);
 
         const customMetadataOption = canvas.getByRole('option', { name: 'Select Dropdowns' });
@@ -74,9 +73,8 @@ export const MetadataInstanceEditorWithDefinedTemplate: StoryObj<typeof Metadata
 export const MetadataInstanceEditorWithCustomTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        await canvas.findByRole('heading', { name: 'Metadata' });
 
-        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' }, { timeout: 5000 });
         await userEvent.click(addTemplateButton);
 
         const customMetadataOption = canvas.getByRole('option', { name: 'Custom Metadata' });

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -56,7 +56,8 @@ export default {
 export const MetadataInstanceEditorWithCustomMetadata: StoryObj<typeof MetadataSidebarRedesign> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        await canvas.findByRole('heading', { name: 'Metadata' });
+        const heading = await canvas.findByRole('heading', { name: 'Metadata' });
+        expect(heading).toBeInTheDocument();
 
         const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
         expect(addTemplateButton).toBeInTheDocument();
@@ -74,7 +75,8 @@ export const MetadataInstanceEditorWithCustomMetadata: StoryObj<typeof MetadataS
 export const MetadataInstanceEditorWithTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        await canvas.findByRole('heading', { name: 'Metadata' });
+        const heading = await canvas.findByRole('heading', { name: 'Metadata' });
+        expect(heading).toBeInTheDocument();
 
         const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
         expect(addTemplateButton).toBeInTheDocument();
@@ -92,7 +94,8 @@ export const MetadataInstanceEditorWithTemplate: StoryObj<typeof MetadataSidebar
 export const UnsavedChangesModalWhenChoosingDifferentTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        await canvas.findByRole('heading', { name: 'Metadata' });
+        const heading = await canvas.findByRole('heading', { name: 'Metadata' });
+        expect(heading).toBeInTheDocument();
 
         const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
         expect(addTemplateButton).toBeInTheDocument();

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -1,6 +1,8 @@
 import { expect, userEvent, within, fn } from '@storybook/test';
+import { type StoryObj } from '@storybook/react';
 import { defaultVisualConfig } from '../../../../utils/storybook';
 import ContentSidebar from '../../ContentSidebar';
+import MetadataSidebarRedesign from '../../MetadataSidebarRedesign';
 
 export const Basic = {
     play: async ({ canvasElement }) => {
@@ -48,5 +50,55 @@ export default {
     },
     parameters: {
         ...defaultVisualConfig.parameters,
+    },
+};
+
+export const MetadataInstanceEditorWithCustomMetadata: StoryObj<typeof MetadataSidebarRedesign> = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await canvas.findByRole('heading', { name: 'Metadata' });
+
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        expect(addTemplateButton).toBeInTheDocument();
+        await userEvent.click(addTemplateButton);
+
+        const customMetadataOption = canvas.getByRole('option', { name: 'Custom Metadata' });
+        expect(customMetadataOption).toBeInTheDocument();
+        await userEvent.click(customMetadataOption);
+    },
+};
+
+export const MetadataInstanceEditorWithTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await canvas.findByRole('heading', { name: 'Metadata' });
+
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        expect(addTemplateButton).toBeInTheDocument();
+        await userEvent.click(addTemplateButton);
+
+        const customMetadataOption = canvas.getByRole('option', { name: 'My Template' });
+        expect(customMetadataOption).toBeInTheDocument();
+        await userEvent.click(customMetadataOption);
+    },
+};
+
+export const UnsavedChangesModalWhenChoosingDifferentTemplate: StoryObj<typeof MetadataSidebarRedesign> = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await canvas.findByRole('heading', { name: 'Metadata' });
+
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        expect(addTemplateButton).toBeInTheDocument();
+        await userEvent.click(addTemplateButton);
+
+        const customMetadataOption = canvas.getByRole('option', { name: 'Custom Metadata' });
+        expect(customMetadataOption).toBeInTheDocument();
+        await userEvent.click(customMetadataOption);
+
+        await userEvent.click(addTemplateButton);
+        const myTemplateOption = canvas.getByRole('option', { name: 'My Template' });
+        expect(myTemplateOption).toBeInTheDocument();
+        await userEvent.click(myTemplateOption);
     },
 };

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, userEvent, within, fn } from '@storybook/test';
+import { expect, userEvent, within, fn, screen } from '@storybook/test';
 import { type StoryObj } from '@storybook/react';
 import { defaultVisualConfig } from '../../../../utils/storybook';
 import ContentSidebar from '../../ContentSidebar';
@@ -106,5 +106,8 @@ export const UnsavedChangesModalWhenChoosingDifferentTemplate: StoryObj<typeof M
         const myTemplateOption = canvas.getByRole('option', { name: 'My Template' });
         expect(myTemplateOption).toBeInTheDocument();
         await userEvent.click(myTemplateOption);
+
+        const unsavedChangesModal = screen.getByText('Unsaved Changes');
+        expect(unsavedChangesModal).toBeInTheDocument();
     },
 };

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -65,6 +65,9 @@ export const MetadataInstanceEditorWithCustomMetadata: StoryObj<typeof MetadataS
         const customMetadataOption = canvas.getByRole('option', { name: 'Custom Metadata' });
         expect(customMetadataOption).toBeInTheDocument();
         await userEvent.click(customMetadataOption);
+
+        const templateHeader = await canvas.findByRole('heading', { name: 'Custom Metadata' });
+        expect(templateHeader).toBeInTheDocument();
     },
 };
 
@@ -80,6 +83,9 @@ export const MetadataInstanceEditorWithTemplate: StoryObj<typeof MetadataSidebar
         const customMetadataOption = canvas.getByRole('option', { name: 'My Template' });
         expect(customMetadataOption).toBeInTheDocument();
         await userEvent.click(customMetadataOption);
+
+        const templateHeader = await canvas.findByRole('heading', { name: 'My Template' });
+        expect(templateHeader).toBeInTheDocument();
     },
 };
 


### PR DESCRIPTION
**Description**

The `MetadataInstanceEditor` lets users edit metadata templates for a file. It uses the `MetadataInstanceForm` from `@box/metadata-editor` to handle the form. Only one template can be edited at a time, selected via the `AddMetadataTemplateDropdown`. If users try to switch templates while editing, a modal will pop up to save or discard any unsaved changes.

**Screenshots**

<img width="454" alt="Screenshot 2024-09-04 at 11 22 43" src="https://github.com/user-attachments/assets/23b2b2ce-f8c5-4737-a445-480629bd4084">
<img width="438" alt="Screenshot 2024-09-04 at 11 22 57" src="https://github.com/user-attachments/assets/d8fd56e8-cefb-4f4b-abf8-138cc8283b16">
<img width="955" alt="Screenshot 2024-09-04 at 11 23 07" src="https://github.com/user-attachments/assets/265bc668-85d4-488f-af8a-8e2ad57fc6c1">

