### PR TITLE
fix(hubs): fix shared link text

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1838,8 +1838,6 @@ boxui.unifiedShare.peopleInThisFolder = Invited people only
 boxui.unifiedShare.peopleInYourCompany = People in your company
 # Description of an open shared link
 boxui.unifiedShare.peopleWithLinkDescription = Publicly accessible and no sign-in required
-# Description of an open shared link with signed required
-boxui.unifiedShare.peopleWithLinkSignedInRequiredDescription = Publicly accessible, sign-in required
 # Text to show that those having the link will have access
 boxui.unifiedShare.peopleWithTheLinkText = People with the link
 # Text used in button label to describe permission level - previewer

--- a/src/features/unified-share-modal/SharedLinkAccessDescription.js
+++ b/src/features/unified-share-modal/SharedLinkAccessDescription.js
@@ -17,14 +17,6 @@ type Props = {
 };
 
 const SharedLinkAccessDescription = ({ accessLevel, enterpriseName, itemType }: Props) => {
-    const getDescriptionForAnyoneWithLink = (type: ItemType) => {
-        switch (type) {
-            case ITEM_TYPE_HUBS:
-                return messages.peopleWithLinkSignedInRequiredDescription;
-            default:
-                return messages.peopleWithLinkDescription;
-        }
-    };
     const getDescriptionForAnyoneInCompany = (type: ItemType) => {
         switch (type) {
             case ITEM_TYPE_FOLDER:
@@ -57,7 +49,7 @@ const SharedLinkAccessDescription = ({ accessLevel, enterpriseName, itemType }: 
 
     switch (accessLevel) {
         case ANYONE_WITH_LINK:
-            description = getDescriptionForAnyoneWithLink(itemType);
+            description = messages.peopleWithLinkDescription;
             break;
         case ANYONE_IN_COMPANY:
             description = getDescriptionForAnyoneInCompany(itemType);

--- a/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessDescription.test.js.snap
+++ b/src/features/unified-share-modal/__tests__/__snapshots__/SharedLinkAccessDescription.test.js.snap
@@ -181,8 +181,8 @@ exports[`features/unified-share-modal/SharedLinkAccessDescription people with li
   className="usm-menu-description"
 >
   <FormattedMessage
-    defaultMessage="Publicly accessible, sign-in required"
-    id="boxui.unifiedShare.peopleWithLinkSignedInRequiredDescription"
+    defaultMessage="Publicly accessible and no sign-in required"
+    id="boxui.unifiedShare.peopleWithLinkDescription"
     values={
       {
         "company": "Box",

--- a/src/features/unified-share-modal/messages.js
+++ b/src/features/unified-share-modal/messages.js
@@ -291,11 +291,6 @@ const messages = defineMessages({
         description: 'Description of an open shared link',
         id: 'boxui.unifiedShare.peopleWithLinkDescription',
     },
-    peopleWithLinkSignedInRequiredDescription: {
-        defaultMessage: 'Publicly accessible, sign-in required',
-        description: 'Description of an open shared link with signed required',
-        id: 'boxui.unifiedShare.peopleWithLinkSignedInRequiredDescription',
-    },
     peopleInSpecifiedCompanyCanAccessFolder: {
         defaultMessage: 'Anyone at {company} with the link or people invited to this folder can access',
         description: 'Description of a specific company shared link for a folder. {company} is the company name',


### PR DESCRIPTION
fix public shared link text for hubs

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
