### PR TITLE
fix(notification): unblock UI beneath Notification

### DIFF
--- a/src/components/notification/Notification.scss
+++ b/src/components/notification/Notification.scss
@@ -13,6 +13,10 @@
     height: 0; /* allows elements around notifications to be clickable */
 }
 
+.notification-container {
+    height: 0;
+}
+
 .notification {
     display: flex;
     align-items: center;

--- a/src/components/notification/NotificationsWrapper.js
+++ b/src/components/notification/NotificationsWrapper.js
@@ -10,7 +10,7 @@ type Props = {
 
 const NotificationsWrapper = ({ children }: Props) => (
     <Portal className="notifications-wrapper" aria-live="polite">
-        {children ? <FocusTrap>{children}</FocusTrap> : null}
+        {children ? <FocusTrap className="notification-container">{children}</FocusTrap> : null}
     </Portal>
 );
 


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

**Issue:**
When `Notification` component rendered inside the `NotificationsWrapper`, it blocks the UI on the entire width of the page under the toast. The issue is reproducible on [live demo](https://opensource.box.com/box-ui-elements/#/Components/NotificationsWrapper): when a notification toast appears, button 'Open isolated' on the right becomes unclickable, and text on the left - unselectable. 

**Reason:**
After [this commit](https://github.com/box/box-ui-elements/commit/21af3552ca25231fe0bfbc47d9db1f6f2ec6c440), `NotificationsWrapper` wraps all children element in `FocusTrap`, which basically wraps children in a `<div>` element. This `<div>` doesn't have any style, so it defaults to `height: auto`, ignoring `height: 0` set on `NotificationsWrapper` [here](https://github.com/box/box-ui-elements/blob/v21.1.0-beta.18/src/components/notification/Notification.scss), thus blocking UI on the same level as Notification is rendered.

**Solution:**
New CSS class 'notification-container' is passed to `FocusTrap` element's `className` attribute inside `NotificationsWrapper`, making `<div>` wrapper from `FocusTrap` kind of 'transparent'.

**Testing details:**
Tested locally using `yarn start` and local demo: `Notification` and `NotificationsWrapper` elements rendered in the same fashion as on live demo, but UI elements on both sides of a toast message are not blocked.