### PR TITLE
fix(metadata-sidebar): handle onCancel action for editing templates

### DIFF
--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -16,6 +16,7 @@ export interface MetadataInstanceEditorProps {
     template: MetadataTemplateInstance;
     onSubmit: (values: FormValues, operations: JSONPatchOperations) => Promise<void>;
     setIsUnsavedChangesModalOpen: (isUnsavedChangesModalOpen: boolean) => void;
+    onUnsavedChangesModalCancel: () => void;
 }
 
 const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
@@ -27,6 +28,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     setIsUnsavedChangesModalOpen,
     template,
     onCancel,
+    onUnsavedChangesModalCancel,
 }) => {
     const handleCancel = () => {
         onCancel();
@@ -43,6 +45,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
                 onSubmit={onSubmit}
                 setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
                 onDelete={onDelete}
+                onUnsavedChangesModalCancel={onUnsavedChangesModalCancel}
             />
         </AutofillContextProvider>
     );

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -90,19 +90,40 @@ function MetadataSidebarRedesign({
     const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] = React.useState<boolean>(false);
     const [selectedTemplates, setSelectedTemplates] =
         React.useState<Array<MetadataTemplateInstance | MetadataTemplate>>(templateInstances);
+    const [pendingTemplateToEdit, setPendingTemplateToEdit] = React.useState<MetadataTemplateInstance | null>(null);
 
     React.useEffect(() => {
         setSelectedTemplates(templateInstances);
     }, [templateInstances]);
 
-    const handleUnsavedChanges = () => {
-        setIsUnsavedChangesModalOpen(true);
+    const handleTemplateSelect = (selectedTemplate: MetadataTemplate) => {
+        if (editingTemplate) {
+            setPendingTemplateToEdit(convertTemplateToTemplateInstance(file, selectedTemplate));
+            setIsUnsavedChangesModalOpen(true);
+        } else {
+            setSelectedTemplates([...selectedTemplates, selectedTemplate]);
+            setEditingTemplate(convertTemplateToTemplateInstance(file, selectedTemplate));
+            setIsDeleteButtonDisabled(true);
+        }
     };
 
-    const handleTemplateSelect = (selectedTemplate: MetadataTemplate) => {
-        setSelectedTemplates([...selectedTemplates, selectedTemplate]);
-        setEditingTemplate(convertTemplateToTemplateInstance(file, selectedTemplate));
-        setIsDeleteButtonDisabled(true);
+    const handleCancel = () => {
+        setEditingTemplate(null);
+        setSelectedTemplates(templateInstances);
+    };
+
+    const handleCancelUnsavedChanges = () => {
+        // check if user tried to edit another template before unsaved changes modal
+        if (pendingTemplateToEdit) {
+            setEditingTemplate(pendingTemplateToEdit);
+            setSelectedTemplates([...templateInstances, pendingTemplateToEdit]);
+            setIsDeleteButtonDisabled(true);
+
+            setPendingTemplateToEdit(null);
+            setIsUnsavedChangesModalOpen(false);
+        } else {
+            handleCancel();
+        }
     };
 
     const handleDeleteInstance = (metadataInstance: MetadataTemplateInstance) => {
@@ -128,9 +149,7 @@ function MetadataSidebarRedesign({
         <AddMetadataTemplateDropdown
             availableTemplates={templates}
             selectedTemplates={selectedTemplates as MetadataTemplate[]}
-            onSelect={(selectedTemplate): void => {
-                editingTemplate ? handleUnsavedChanges() : handleTemplateSelect(selectedTemplate);
-            }}
+            onSelect={handleTemplateSelect}
         />
     );
 
@@ -166,7 +185,8 @@ function MetadataSidebarRedesign({
                         isBoxAiSuggestionsEnabled={isBoxAiSuggestionsEnabled}
                         isDeleteButtonDisabled={isDeleteButtonDisabled}
                         isUnsavedChangesModalOpen={isUnsavedChangesModalOpen}
-                        onCancel={() => setEditingTemplate(null)}
+                        onCancel={handleCancel}
+                        onUnsavedChangesModalCancel={handleCancelUnsavedChanges}
                         onSubmit={handleSubmit}
                         onDelete={handleDeleteInstance}
                         template={editingTemplate}

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -33,6 +33,7 @@ describe('MetadataInstanceEditor', () => {
         onDelete: jest.fn(),
         onSubmit: jest.fn(),
         setIsUnsavedChangesModalOpen: jest.fn(),
+        onUnsavedChangesModalCancel: jest.fn(),
     };
 
     test('should render MetadataInstanceForm with correct props', () => {

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -60,21 +60,6 @@ describe('MetadataInstanceEditor', () => {
         onUnsavedChangesModalCancel: mockOnUnsavedChangesModalCancel,
     };
 
-    // Mock window.matchMedia to simulate media query behavior for tests
-    // in which UnsavedChangesModal component relies on it.
-    const mockMatchMedia = () =>
-        Object.defineProperty(window, 'matchMedia', {
-            writable: true,
-            value: jest.fn().mockImplementation(query => ({
-                matches: false,
-                media: query,
-                onchange: null,
-                addEventListener: jest.fn(),
-                removeEventListener: jest.fn(),
-                dispatchEvent: jest.fn(),
-            })),
-        });
-
     test('should render MetadataInstanceForm with correct props', () => {
         render(<MetadataInstanceEditor {...defaultProps} />);
 
@@ -91,8 +76,6 @@ describe('MetadataInstanceEditor', () => {
     });
 
     test('should render UnsavedChangesModal if isUnsavedChangesModalOpen is true', async () => {
-        mockMatchMedia();
-
         const props = { ...defaultProps, isUnsavedChangesModalOpen: true };
         const { findByText } = render(<MetadataInstanceEditor {...props} />);
 
@@ -126,8 +109,6 @@ describe('MetadataInstanceEditor', () => {
     });
 
     test('Should call onUnsavedChangesModalCancel instead onCancel when canceling through UnsavedChangesModal', async () => {
-        mockMatchMedia();
-
         const props: MetadataInstanceEditorProps = {
             ...defaultProps,
             template: mockCustomMetadataTemplateWithField,

--- a/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataInstanceEditor.test.tsx
@@ -137,6 +137,7 @@ describe('MetadataInstanceEditor', () => {
 
         rerender(<MetadataInstanceEditor {...props} isUnsavedChangesModalOpen={true} />);
         const unsavedChangesModal = screen.getByText('Unsaved Changes');
+
         expect(unsavedChangesModal).toBeInTheDocument();
 
         act(() => {

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -248,3 +248,31 @@ export const DeleteButtonIsEnabledWhenEditingMetadataTemplateInstance: StoryObj<
         expect(deleteButton).toBeEnabled();
     },
 };
+
+export const MetadataInstanceEditorAddTemplateAgainAfterCancel: StoryObj<typeof MetadataSidebarRedesign> = {
+    args: {
+        fileId: '416047501580',
+        metadataSidebarProps: defaultMetadataSidebarProps,
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' }, { timeout: 5000 });
+
+        await userEvent.click(addTemplateButton);
+
+        const templateMetadataOption = canvas.getByRole('option', { name: 'My Template' });
+        expect(templateMetadataOption).not.toHaveStyle('pointer-events: none;');
+        await userEvent.click(templateMetadataOption);
+
+        // Check if currently open template is disabled in dropdown
+        await userEvent.click(addTemplateButton);
+        expect(templateMetadataOption).toHaveStyle('pointer-events: none;');
+
+        // Check if template available again after cancelling
+        const cancelButton = await canvas.findByRole('button', { name: 'Cancel' });
+        await userEvent.click(cancelButton);
+        await userEvent.click(addTemplateButton);
+        expect(templateMetadataOption).not.toHaveStyle('pointer-events: none;');
+    },
+};

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -267,12 +267,14 @@ export const MetadataInstanceEditorAddTemplateAgainAfterCancel: StoryObj<typeof 
 
         // Check if currently open template is disabled in dropdown
         await userEvent.click(addTemplateButton);
-        expect(templateMetadataOption).toHaveStyle('pointer-events: none;');
+        const templateMetadataOptionDisabled = canvas.getByRole('option', { name: 'My Template' });
+        expect(templateMetadataOptionDisabled).toHaveStyle('pointer-events: none;');
 
         // Check if template available again after cancelling
         const cancelButton = await canvas.findByRole('button', { name: 'Cancel' });
         await userEvent.click(cancelButton);
         await userEvent.click(addTemplateButton);
-        expect(templateMetadataOption).not.toHaveStyle('pointer-events: none;');
+        const templateMetadataOptionEnabled = canvas.getByRole('option', { name: 'My Template' });
+        expect(templateMetadataOptionEnabled).not.toHaveStyle('pointer-events: none;');
     },
 };

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -262,19 +262,19 @@ export const MetadataInstanceEditorAddTemplateAgainAfterCancel: StoryObj<typeof 
         await userEvent.click(addTemplateButton);
 
         const templateMetadataOption = canvas.getByRole('option', { name: 'My Template' });
-        expect(templateMetadataOption).not.toHaveStyle('pointer-events: none;');
+        expect(templateMetadataOption).not.toHaveAttribute('aria-disabled');
         await userEvent.click(templateMetadataOption);
 
         // Check if currently open template is disabled in dropdown
         await userEvent.click(addTemplateButton);
         const templateMetadataOptionDisabled = canvas.getByRole('option', { name: 'My Template' });
-        expect(templateMetadataOptionDisabled).toHaveStyle('pointer-events: none;');
+        expect(templateMetadataOptionDisabled).toHaveAttribute('aria-disabled');
 
         // Check if template available again after cancelling
         const cancelButton = await canvas.findByRole('button', { name: 'Cancel' });
         await userEvent.click(cancelButton);
         await userEvent.click(addTemplateButton);
         const templateMetadataOptionEnabled = canvas.getByRole('option', { name: 'My Template' });
-        expect(templateMetadataOptionEnabled).not.toHaveStyle('pointer-events: none;');
+        expect(templateMetadataOptionEnabled).not.toHaveAttribute('aria-disabled');
     },
 };


### PR DESCRIPTION
# Description 
- fix and refactor cancelling logic for `MetadataInstanceEditor`
- add new additional props for `MetadataInstanceEditor`: `setIsUnsavedChangesModalOpen` and `onUnsavedChangesModalCancel` for handling the `UnsavedChangesModal` directly from BUIE
- fix issues with templates in `AddMetadataTemplateDropdown` still being disabled after cancelling editing a new template
- handle adding a new template when another one is still in edit mode with `UnsavedChangesModal`, add `handleCancelUnsavedChanges` in `MetadataSidebarRedesign` ('Cancel' action in `UnsavedChangesModal`) for checking if there are pending editors to switch to immediately after cancelling the previous one

## Additional Notes:
Temporary conversion between `MetadataTemplateInstance` and `MetadataTemplate` was added, which will be handled properly in the future [PR](https://github.com/box/box-ui-elements/pull/3663/files#diff-eba8562abef4626a4e079dd7ce4779484fc05c0ae63b242451ef3882dc272fa3R93)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
