### PR TITLE
feat(metadata-sidebar): handle update metadata instance

### DIFF
--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -11,6 +11,7 @@ import {
     MetadataEmptyState,
     MetadataInstanceList,
     type FormValues,
+    type JSONPatchOperations,
     type MetadataTemplateInstance,
     type MetadataTemplate,
 } from '@box/metadata-editor';
@@ -72,9 +73,10 @@ function MetadataSidebarRedesign({
     isFeatureEnabled,
 }: MetadataSidebarRedesignProps) {
     const {
+        file,
         handleCreateMetadataInstance,
         handleDeleteMetadataInstance,
-        file,
+        handleUpdateMetadataInstance,
         templates,
         errorMessage,
         status,
@@ -113,9 +115,12 @@ function MetadataSidebarRedesign({
         );
     };
 
-    const handleSubmit = async (values: FormValues) => {
-        !isExistingMetadataInstance() &&
-            handleCreateMetadataInstance(values.metadata as MetadataTemplateInstance, () => setEditingTemplate(null));
+    const handleSubmit = async (values: FormValues, operations: JSONPatchOperations) => {
+        isExistingMetadataInstance()
+            ? handleUpdateMetadataInstance(values.metadata as MetadataTemplateInstance, operations, () =>
+                  setEditingTemplate(null),
+              )
+            : handleCreateMetadataInstance(values.metadata as MetadataTemplateInstance, () => setEditingTemplate(null));
     };
 
     const metadataDropdown = status === STATUS.SUCCESS && templates && (

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -71,6 +71,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
             handleDeleteMetadataInstance: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
+            handleUpdateMetadataInstance: jest.fn(),
             templates: mockTemplates,
             templateInstances: [],
             errorMessage: null,
@@ -115,6 +116,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
             handleDeleteMetadataInstance: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
+            handleUpdateMetadataInstance: jest.fn(),
             templateInstances: [],
             templates: [],
             errorMessage: {
@@ -136,6 +138,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
+            handleUpdateMetadataInstance: jest.fn(),
             templateInstances: [],
             templates: [],
             errorMessage: null,
@@ -171,12 +174,13 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
     test('should render metadata instance list when templates are present', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
             handleDeleteMetadataInstance: jest.fn(),
+            handleCreateMetadataInstance: jest.fn(),
+            handleUpdateMetadataInstance: jest.fn(),
             templateInstances: [mockCustomTemplateInstance],
             templates: mockTemplates,
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
-            handleCreateMetadataInstance: jest.fn(),
         });
 
         renderComponent();


### PR DESCRIPTION
Add Metadata Instance update handler for Metadata Sidebar Redesigned

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
