### PR TITLE
feat(taxonomy): integrate taxonomy options fetcher

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -1055,6 +1055,14 @@ class Metadata extends File {
         return getProp(suggestionsResponse, 'data.suggestions', []);
     }
 
+    /**
+     * Build URL for metadata options associated to a taxonomy field.
+     *
+     * @param scope
+     * @param templateKey
+     * @param fieldKey
+     * @returns {`${string}/metadata_templates/${string}/${string}/fields/${string}/options`}
+     */
     getMetadataOptionsUrl(scope: string, templateKey: string, fieldKey: string): string {
         return `${this.getBaseApiUrl()}/metadata_templates/${scope}/${templateKey}/fields/${fieldKey}/options`;
     }

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -1104,8 +1104,8 @@ class Metadata extends File {
         const url = this.getMetadataOptionsUrl(scope, templateKey, fieldKey);
         const { marker, searchInput, signal } = options;
         const params = {
-            ...(marker && { marker }),
-            ...(searchInput && { searchInput }),
+            ...(marker ? { marker } : {}),
+            ...(searchInput ? { searchInput } : {}),
         };
 
         if (signal?.aborted) {

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -7,7 +7,7 @@
 import getProp from 'lodash/get';
 import uniqueId from 'lodash/uniqueId';
 import isEmpty from 'lodash/isEmpty';
-import { getBadItemError, getBadPermissionsError, isUserCorrectableError } from '../utils/error';
+import { getAbortError, getBadItemError, getBadPermissionsError, isUserCorrectableError } from '../utils/error';
 import { getTypedFileId } from '../utils/file';
 import File from './File';
 import {
@@ -1119,7 +1119,7 @@ class Metadata extends File {
         if (signal?.aborted) {
             this.xhr.abort();
 
-            return {};
+            throw getAbortError();
         }
 
         const metadataOptions = this.xhr.get({

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -7,8 +7,9 @@
 import getProp from 'lodash/get';
 import uniqueId from 'lodash/uniqueId';
 import isEmpty from 'lodash/isEmpty';
-import { getAbortError, getBadItemError, getBadPermissionsError, isUserCorrectableError } from '../utils/error';
+import { getBadItemError, getBadPermissionsError, isUserCorrectableError } from '../utils/error';
 import { getTypedFileId } from '../utils/file';
+import { handleOnAbort } from './utils';
 import File from './File';
 import {
     HEADER_CONTENT_TYPE,
@@ -1116,13 +1117,13 @@ class Metadata extends File {
             ...(searchInput ? { searchInput } : {}),
         };
 
-        if (signal?.aborted) {
-            this.xhr.abort();
-
-            throw getAbortError();
+        if (signal) {
+            signal.onabort = () => {
+                handleOnAbort(this.xhr);
+            };
         }
 
-        const metadataOptions = this.xhr.get({
+        const metadataOptions = await this.xhr.get({
             url,
             id: getTypedFileId(id),
             params,

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -2941,6 +2941,14 @@ describe('api/Metadata', () => {
             expect(metadata.xhr.abort).toHaveBeenCalled();
         });
 
+        test('should build getMetadataOptionsUrl correctly', async () => {
+            const url = metadata.getMetadataOptionsUrl('enterprise', 'templateKey', 'fieldKey');
+
+            expect(url).toBe(
+                'https://api.box.com/2.0/metadata_templates/enterprise/templateKey/fields/fieldKey/options',
+            );
+        });
+
         test('should throw an error if id is missing', async () => {
             await expect(() =>
                 metadata.getMetadataOptions('', 'enterprise', 'templateKey', 'fieldKey', 'level', {}),

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -2937,7 +2937,9 @@ describe('api/Metadata', () => {
 
             metadata.xhr.abort = jest.fn();
 
-            await metadata.getMetadataOptions('id', 'enterprise', 'templateKey', 'fieldKey', 0, options);
+            await expect(() =>
+                metadata.getMetadataOptions('id', 'enterprise', 'templateKey', 'fieldKey', 0, options),
+            ).rejects.toThrow(ErrorUtil.getAbortError());
 
             expect(metadata.xhr.abort).toHaveBeenCalled();
         });

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -25,7 +25,7 @@ import { handleOnAbort } from '../utils';
 let metadata: Metadata;
 
 jest.mock('../utils', () => ({
-    handleOnAbort: jest.fn(), // Mock the specific function
+    handleOnAbort: jest.fn(),
 }));
 
 describe('api/Metadata', () => {
@@ -2901,13 +2901,14 @@ describe('api/Metadata', () => {
                 next_marker: 'next_marker',
                 result_count: 1,
             };
+            const abortController = new AbortController();
 
             metadata.getMetadataOptionsUrl = jest.fn().mockReturnValueOnce('options_url');
             metadata.xhr.get = jest.fn().mockReturnValueOnce({ data: response });
 
             const options = {
                 marker: 'current_marker',
-                signal: AbortController,
+                signal: abortController.signal,
                 searchInput: 'search_term',
             };
 

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -2901,7 +2901,7 @@ describe('api/Metadata', () => {
             metadata.xhr.get = jest.fn().mockReturnValueOnce({ data: response });
 
             const options = {
-                marker: null,
+                marker: 'current_marker',
                 signal: AbortController,
                 searchInput: 'search_term',
             };
@@ -2922,6 +2922,7 @@ describe('api/Metadata', () => {
                 url: 'options_url',
                 id: 'file_id',
                 params: {
+                    marker: 'current_marker',
                     searchInput: 'search_term',
                 },
             });

--- a/src/api/__tests__/utils.test.js
+++ b/src/api/__tests__/utils.test.js
@@ -1,11 +1,29 @@
-import { formatComment } from '../utils';
+import Xhr from '../../utils/Xhr';
+import { getAbortError } from '../../utils/error';
+import { formatComment, handleOnAbort } from '../utils';
 import { threadedComments, threadedCommentsFormatted } from '../fixtures';
+
+jest.mock('../../utils/Xhr', () => {
+    return jest.fn().mockImplementation(() => ({
+        abort: jest.fn(),
+    }));
+});
 
 describe('api/utils', () => {
     describe('formatComment()', () => {
         test('should return a comment and its replies with tagged_message property equal to message', () => {
             expect(formatComment(threadedComments[0])).toMatchObject(threadedCommentsFormatted[0]);
             expect(formatComment(threadedComments[1])).toMatchObject(threadedCommentsFormatted[1]);
+        });
+    });
+
+    describe('handleOnAbort()', () => {
+        test('should abort and throw when called', async () => {
+            const xhr = new Xhr();
+
+            await expect(() => handleOnAbort(xhr)).toThrow(getAbortError());
+
+            expect(xhr.abort).toHaveBeenCalled();
         });
     });
 });

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -4,7 +4,9 @@
  * @author Box
  */
 
+import type Xhr from '../utils/Xhr';
 import type { Comment } from '../common/types/feed';
+import { getAbortError } from '../utils/error';
 
 /**
  * Formats comment data (including replies) for use in components.
@@ -23,6 +25,12 @@ export const formatComment = (comment: Comment): Comment => {
     }
 
     return formattedComment;
+};
+
+export const handleOnAbort = (xhr: Xhr) => {
+    xhr.abort();
+
+    throw getAbortError();
 };
 
 export default {

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -5,6 +5,7 @@ import {
     FIELD_TYPE_FLOAT,
     FIELD_TYPE_MULTISELECT,
     FIELD_TYPE_STRING,
+    FIELD_TYPE_TAXONOMY,
 } from '../../features/metadata-instance-fields/constants';
 import type { SkillCards } from './skills';
 
@@ -13,7 +14,8 @@ type MetadataFieldType =
     | typeof FIELD_TYPE_ENUM
     | typeof FIELD_TYPE_FLOAT
     | typeof FIELD_TYPE_MULTISELECT
-    | typeof FIELD_TYPE_STRING;
+    | typeof FIELD_TYPE_STRING
+    | typeof FIELD_TYPE_TAXONOMY;
 
 type MetadataTemplateFieldOption = {
     id?: string,

--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -117,6 +117,27 @@ type MetadataSuggestion = {
     suggestions: { [key: string]: string | number | string[] },
 };
 
+type MetadataOptionEntryAncestor = {
+    id: string,
+    display_name: string,
+    level: string,
+};
+
+type MetadataOptionEntry = {
+    id: string,
+    display_name: string,
+    level: string,
+    ancestors: MetadataOptionEntryAncestor[],
+    deprecated: boolean,
+    selectable: boolean,
+};
+
+type MetadataOptions = {
+    entries: MetadataOptionEntry[],
+    next_marker: string | null,
+    result_count: number,
+};
+
 type MetadataTemplateInstanceField = {
     description?: string,
     displayName?: string,
@@ -156,4 +177,5 @@ export type {
     MetadataInstanceV2,
     MetadataEditor,
     MetadataSuggestion,
+    MetadataOptions,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,7 @@ export const CACHE_PREFIX_SEARCH = 'search_';
 export const CACHE_PREFIX_RECENTS = 'recents_';
 export const CACHE_PREFIX_METADATA = 'metadata_';
 export const CACHE_PREFIX_METADATA_QUERY = 'metadata_query_';
+export const CACHE_PREFIX_METADATA_OPTIONS = 'metadata_options_';
 
 /* ----------------------- Sorts ---------------------------- */
 export const SORT_ASC: 'ASC' = 'ASC';
@@ -273,6 +274,7 @@ export const ERROR_CODE_FETCH_ACCESS_STATS = 'fetch_access_stats_error';
 export const ERROR_CODE_FETCH_SKILLS = 'fetch_skills_error';
 export const ERROR_CODE_FETCH_RECENTS = 'fetch_recents_error';
 export const ERROR_CODE_FETCH_METADATA_SUGGESTIONS = 'fetch_metadata_suggestions_error';
+export const ERROR_CODE_FETCH_METADATA_OPTIONS = 'fetch_metadata_options_error';
 export const ERROR_CODE_EMPTY_METADATA_SUGGESTIONS = 'empty_metadata_suggestions_error';
 export const ERROR_CODE_EXECUTE_INTEGRATION = 'execute_integrations_error';
 export const ERROR_CODE_EXTRACT_STRUCTURED = 'extract_structured_error';

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,7 +56,6 @@ export const CACHE_PREFIX_SEARCH = 'search_';
 export const CACHE_PREFIX_RECENTS = 'recents_';
 export const CACHE_PREFIX_METADATA = 'metadata_';
 export const CACHE_PREFIX_METADATA_QUERY = 'metadata_query_';
-export const CACHE_PREFIX_METADATA_OPTIONS = 'metadata_options_';
 
 /* ----------------------- Sorts ---------------------------- */
 export const SORT_ASC: 'ASC' = 'ASC';

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -4,6 +4,9 @@ import {
     type FormValues,
     type JSONPatchOperations,
     type MetadataTemplateInstance,
+    type BaseOptionType,
+    type FetcherResponse,
+    type PaginationQueryInput,
 } from '@box/metadata-editor';
 import React from 'react';
 
@@ -17,6 +20,13 @@ export interface MetadataInstanceEditorProps {
     onSubmit: (values: FormValues, operations: JSONPatchOperations) => Promise<void>;
     setIsUnsavedChangesModalOpen: (isUnsavedChangesModalOpen: boolean) => void;
     onUnsavedChangesModalCancel: () => void;
+    taxonomyOptionsFetcher: (
+        scope: string,
+        templateKey: string,
+        fieldKey: string,
+        level: number,
+        options: PaginationQueryInput,
+    ) => Promise<FetcherResponse<BaseOptionType>>;
 }
 
 const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
@@ -29,6 +39,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     template,
     onCancel,
     onUnsavedChangesModalCancel,
+    taxonomyOptionsFetcher,
 }) => {
     const handleCancel = () => {
         onCancel();
@@ -46,6 +57,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
                 setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
                 onDelete={onDelete}
                 onUnsavedChangesModalCancel={onUnsavedChangesModalCancel}
+                taxonomyOptionsFetcher={taxonomyOptionsFetcher}
             />
         </AutofillContextProvider>
     );

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -14,6 +14,7 @@ import {
     type JSONPatchOperations,
     type MetadataTemplateInstance,
     type MetadataTemplate,
+    type PaginationQueryInput,
 } from '@box/metadata-editor';
 import noop from 'lodash/noop';
 
@@ -35,6 +36,7 @@ import messages from '../common/messages';
 import './MetadataSidebarRedesign.scss';
 import MetadataInstanceEditor from './MetadataInstanceEditor';
 import { convertTemplateToTemplateInstance } from './utils/convertTemplateToTemplateInstance';
+import { metadataTaxonomyFetcher } from './fetchers/metadataTaxonomyFetcher';
 
 const MARK_NAME_JS_READY = `${ORIGIN_METADATA_SIDEBAR_REDESIGN}_${EVENT_JS_READY}`;
 
@@ -166,6 +168,14 @@ function MetadataSidebarRedesign({
     const showEditor = !showEmptyState && editingTemplate;
     const showList = !showEditor && templateInstances.length > 0 && !editingTemplate;
 
+    const taxonomyOptionsFetcher = async (
+        scope: string,
+        templateKey: string,
+        fieldKey: string,
+        level: number,
+        options: PaginationQueryInput,
+    ) => metadataTaxonomyFetcher(api, fileId, scope, templateKey, fieldKey, level, options);
+
     return (
         <SidebarContent
             actions={metadataDropdown}
@@ -191,6 +201,7 @@ function MetadataSidebarRedesign({
                         onDelete={handleDeleteInstance}
                         template={editingTemplate}
                         setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
+                        taxonomyOptionsFetcher={taxonomyOptionsFetcher}
                     />
                 )}
                 {showList && (

--- a/src/elements/content-sidebar/__tests__/metadataTaxonomyFetcher.test.ts
+++ b/src/elements/content-sidebar/__tests__/metadataTaxonomyFetcher.test.ts
@@ -1,0 +1,122 @@
+import type { PaginationQueryInput } from '@box/metadata-editor';
+import { metadataTaxonomyFetcher } from '../fetchers/metadataTaxonomyFetcher';
+import type API from '../../../api';
+
+describe('metadataTaxonomyFetcher', () => {
+    let apiMock: jest.Mocked<API>;
+    const fileId = '12345';
+    const scope = 'global';
+    const templateKey = 'template_123';
+    const fieldKey = 'field_abc';
+    const level = 1;
+    const options: PaginationQueryInput = { marker: 'marker_1' };
+
+    beforeEach(() => {
+        // Create a mocked API instance
+        apiMock = {
+            getMetadataAPI: jest.fn().mockReturnValue({
+                getMetadataOptions: jest.fn(),
+            }),
+        };
+    });
+
+    test('should fetch metadata options and return formatted data', async () => {
+        // Mock data returned by getMetadataOptions
+        const mockMetadataOptions = {
+            entries: [
+                { id: 'opt1', display_name: 'Option 1' },
+                { id: 'opt2', display_name: 'Option 2' },
+            ],
+        };
+
+        // Mock the getMetadataOptions method to return mock data
+        apiMock.getMetadataAPI(false).getMetadataOptions.mockResolvedValue(mockMetadataOptions);
+
+        // Call the function under test
+        const result = await metadataTaxonomyFetcher(apiMock, fileId, scope, templateKey, fieldKey, level, options);
+
+        // Expected output
+        const expectedResult = {
+            options: [
+                { value: 'opt1', displayValue: 'Option 1' },
+                { value: 'opt2', displayValue: 'Option 2' },
+            ],
+            marker: 'marker_1',
+        };
+
+        // Assertions
+        expect(apiMock.getMetadataAPI).toHaveBeenCalledWith(false);
+        expect(apiMock.getMetadataAPI(false).getMetadataOptions).toHaveBeenCalledWith(
+            fileId,
+            scope,
+            templateKey,
+            fieldKey,
+            level,
+            options,
+        );
+        expect(result).toEqual(expectedResult);
+    });
+
+    test('should handle empty entries array', async () => {
+        // Mock data with empty entries
+        const mockMetadataOptions = {
+            entries: [],
+        };
+
+        // Mock the getMetadataOptions method to return mock data
+        apiMock.getMetadataAPI(false).getMetadataOptions.mockResolvedValue(mockMetadataOptions);
+
+        // Call the function under test
+        const result = await metadataTaxonomyFetcher(apiMock, fileId, scope, templateKey, fieldKey, level, options);
+
+        // Expected output
+        const expectedResult = {
+            options: [],
+            marker: 'marker_1',
+        };
+
+        // Assertions
+        expect(result).toEqual(expectedResult);
+    });
+
+    test('should set marker to null if not provided in options', async () => {
+        // Mock data returned by getMetadataOptions
+        const mockMetadataOptions = {
+            entries: [{ id: 'opt1', display_name: 'Option 1' }],
+        };
+
+        // Mock the getMetadataOptions method to return mock data
+        apiMock.getMetadataAPI(false).getMetadataOptions.mockResolvedValue(mockMetadataOptions);
+
+        // Call the function under test with options without marker
+        const result = await metadataTaxonomyFetcher(
+            apiMock,
+            fileId,
+            scope,
+            templateKey,
+            fieldKey,
+            level,
+            {}, // options without marker
+        );
+
+        // Expected output
+        const expectedResult = {
+            options: [{ value: 'opt1', displayValue: 'Option 1' }],
+            marker: null,
+        };
+
+        // Assertions
+        expect(result).toEqual(expectedResult);
+    });
+
+    test('should throw an error if getMetadataOptions fails', async () => {
+        // Mock the getMetadataOptions method to throw an error
+        const error = new Error('API Error');
+        apiMock.getMetadataAPI(false).getMetadataOptions.mockRejectedValue(error);
+
+        // Assertions
+        await expect(
+            metadataTaxonomyFetcher(apiMock, fileId, scope, templateKey, fieldKey, level, options),
+        ).rejects.toThrow('API Error');
+    });
+});

--- a/src/elements/content-sidebar/fetchers/metadataTaxonomyFetcher.ts
+++ b/src/elements/content-sidebar/fetchers/metadataTaxonomyFetcher.ts
@@ -1,0 +1,26 @@
+import type { PaginationQueryInput } from '@box/metadata-editor';
+import type API from '../../../api';
+import type { MetadataOptionEntry } from '../../../common/types/metadata';
+
+export const metadataTaxonomyFetcher = async (
+    api: API,
+    fileId: string,
+    scope: string,
+    templateKey: string,
+    fieldKey: string,
+    level: number,
+    options: PaginationQueryInput,
+) => {
+    const metadataOptions = await api
+        .getMetadataAPI(false)
+        .getMetadataOptions(fileId, scope, templateKey, fieldKey, level, options);
+    const { marker = null } = options;
+
+    return {
+        options: metadataOptions.entries.map((metadataOption: MetadataOptionEntry) => ({
+            value: metadataOption.id,
+            displayValue: metadataOption.display_name,
+        })),
+        marker,
+    };
+};

--- a/src/features/metadata-instance-fields/constants.js
+++ b/src/features/metadata-instance-fields/constants.js
@@ -6,3 +6,4 @@ export const FIELD_TYPE_INTEGER: 'integer' = 'integer';
 export const FIELD_TYPE_FLOAT: 'float' = 'float';
 export const FIELD_TYPE_MULTISELECT: 'multiSelect' = 'multiSelect';
 export const FIELD_TYPE_STRING: 'string' = 'string';
+export const FIELD_TYPE_TAXONOMY: 'taxonomy' = 'taxonomy';

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -35,4 +35,15 @@ function isUserCorrectableError(status: number) {
     );
 }
 
-export { getBadItemError, getBadPermissionsError, getBadUserError, getMissingItemTextOrStatus, isUserCorrectableError };
+function getAbortError() {
+    return new DOMException('Aborted', 'AbortError');
+}
+
+export {
+    getAbortError,
+    getBadItemError,
+    getBadPermissionsError,
+    getBadUserError,
+    getMissingItemTextOrStatus,
+    isUserCorrectableError,
+};

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -36,7 +36,14 @@ function isUserCorrectableError(status: number) {
 }
 
 function getAbortError() {
-    return new DOMException('Aborted', 'AbortError');
+    class AbortError extends Error {
+        constructor(message: string) {
+            super(message);
+            this.name = 'AbortError';
+        }
+    }
+
+    return new AbortError('Aborted');
 }
 
 export {


### PR DESCRIPTION
* Integrating new fetcher from metadata options endpoint into metadata editor

NOTE:
* This cannot be merged until https://github.com/box/box-ui-elements/pull/3678, metadata editor contributions complete and `metadata-editor` package upgraded