### PR TITLE
feat(metadata-sidebar): tab content styles change

### DIFF
--- a/src/elements/content-sidebar/MetadataSidebarRedesign.scss
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.scss
@@ -7,9 +7,7 @@
         position: absolute;
         top: 0;
         right: 0;
-        bottom: 0;
         left: 0;
-        padding: $space-2;
-        background-color: $gray-02;
+        padding: $space-4;
     }
 }


### PR DESCRIPTION
**Description**

Changes in styles for `MetadataSidebarRedsign` to align with the design:
- bottom property removed
- padding changed to 16px
- background-color removed 

**Screenshots**

<img width="410" alt="Screenshot 2024-10-09 at 12 27 27" src="https://github.com/user-attachments/assets/d74a9a86-e7b2-4eb3-ba91-1fc35aa62b91">
<img width="417" alt="Screenshot 2024-10-09 at 12 27 37" src="https://github.com/user-attachments/assets/3b906b83-d585-4a4d-9323-5184dc3aea96">
