### PR TITLE
feat(taxonomy): added view/create/updated taxonomy field support

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -904,7 +904,7 @@ class Metadata extends File {
                 }
 
                 // API expects values as an array of strings
-                if (obj.type === 'taxonomy' && value) {
+                if (obj.type === 'taxonomy' && value && Array.isArray(value)) {
                     value = value.map(option => option.value);
                 }
 

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -9,7 +9,7 @@ import uniqueId from 'lodash/uniqueId';
 import isEmpty from 'lodash/isEmpty';
 import { getBadItemError, getBadPermissionsError, isUserCorrectableError } from '../utils/error';
 import { getTypedFileId } from '../utils/file';
-import { handleOnAbort } from './utils';
+import { handleOnAbort, formatMetadataFieldValue } from './utils';
 import File from './File';
 import {
     HEADER_CONTENT_TYPE,
@@ -226,14 +226,17 @@ class Metadata extends File {
      * Gets metadata instances for a Box file
      *
      * @param {string} id - file id
+     * @param {boolean} isMetadataRedesign - feature flag
      * @return {Object} array of metadata instances
      */
-    async getInstances(id: string): Promise<Array<MetadataInstanceV2>> {
+    async getInstances(id: string, isMetadataRedesign: boolean = false): Promise<Array<MetadataInstanceV2>> {
         this.errorCode = ERROR_CODE_FETCH_METADATA;
+        const baseUrl = this.getMetadataUrl(id);
+        const url = isMetadataRedesign ? `${baseUrl}?view=hydrated` : baseUrl;
         let instances = {};
         try {
             instances = await this.xhr.get({
-                url: this.getMetadataUrl(id),
+                url,
                 id: getTypedFileId(id),
             });
         } catch (e) {
@@ -377,9 +380,11 @@ class Metadata extends File {
             // Get Metadata Fields for Instances created from predefined template
             const templateFields = template.fields || [];
             templateFields.forEach(field => {
+                const value = formatMetadataFieldValue(field, instance[field.key]);
+
                 fields.push({
                     ...field,
-                    value: instance[field.key],
+                    value,
                 });
             });
         } else {
@@ -501,7 +506,7 @@ class Metadata extends File {
         try {
             const customPropertiesTemplate: MetadataTemplate = this.getCustomPropertiesTemplate();
             const [instances, globalTemplates, enterpriseTemplates] = await Promise.all([
-                this.getInstances(id),
+                this.getInstances(id, isMetadataRedesign),
                 this.getTemplates(id, METADATA_SCOPE_GLOBAL),
                 hasMetadataFeature ? this.getTemplates(id, METADATA_SCOPE_ENTERPRISE) : Promise.resolve([]),
             ]);
@@ -887,11 +892,24 @@ class Metadata extends File {
         try {
             const fieldsValues = template.fields.reduce((acc, obj) => {
                 let { value } = obj;
+
                 // API does not accept string for float type
-                if (obj.type === 'float' && value) value = parseFloat(obj.value);
+                if (obj.type === 'float' && value) {
+                    value = parseFloat(obj.value);
+                }
+
                 // API does not accept empty string for enum type
-                if (obj.type === 'enum' && value && value.length === 0) value = undefined;
+                if (obj.type === 'enum' && value && value.length === 0) {
+                    value = undefined;
+                }
+
+                // API expects values as an array of strings
+                if (obj.type === 'taxonomy' && value) {
+                    value = value.map(option => option.value);
+                }
+
                 acc[obj.key] = value;
+
                 return acc;
             }, {});
 

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -25,6 +25,7 @@ import { handleOnAbort } from '../utils';
 let metadata: Metadata;
 
 jest.mock('../utils', () => ({
+    ...jest.requireActual('../utils'),
     handleOnAbort: jest.fn(),
 }));
 
@@ -823,7 +824,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -878,7 +879,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -935,7 +936,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -993,7 +994,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -1050,7 +1051,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).not.toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -1105,7 +1106,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).not.toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.getEditors).not.toHaveBeenCalled();
@@ -1145,7 +1146,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -443,6 +443,19 @@ describe('api/Metadata', () => {
                 id: 'file_id',
             });
         });
+        test('should apply hydrated query string param for isMetadataRedesign', async () => {
+            metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
+            metadata.xhr.get = jest.fn().mockReturnValueOnce({
+                data: {
+                    entries: [],
+                },
+            });
+            await metadata.getInstances('id', true);
+            expect(metadata.xhr.get).toHaveBeenCalledWith({
+                url: 'metadata_url?view=hydrated',
+                id: 'file_id',
+            });
+        });
     });
 
     describe('getUserAddableTemplates()', () => {

--- a/src/api/__tests__/utils.test.js
+++ b/src/api/__tests__/utils.test.js
@@ -1,7 +1,8 @@
 import Xhr from '../../utils/Xhr';
 import { getAbortError } from '../../utils/error';
-import { formatComment, handleOnAbort } from '../utils';
+import { formatComment, formatMetadataFieldValue, handleOnAbort } from '../utils';
 import { threadedComments, threadedCommentsFormatted } from '../fixtures';
+import { FIELD_TYPE_STRING, FIELD_TYPE_TAXONOMY } from '../../features/metadata-instance-fields/constants';
 
 jest.mock('../../utils/Xhr', () => {
     return jest.fn().mockImplementation(() => ({
@@ -24,6 +25,34 @@ describe('api/utils', () => {
             await expect(() => handleOnAbort(xhr)).toThrow(getAbortError());
 
             expect(xhr.abort).toHaveBeenCalled();
+        });
+    });
+
+    describe('formatMetadataFieldValue()', () => {
+        test('should format string field value', async () => {
+            const stringField = {
+                displayName: 'State',
+                id: '1',
+                key: 'stateField',
+                type: FIELD_TYPE_STRING,
+            };
+            const value = 'California';
+
+            expect(formatMetadataFieldValue(stringField, value)).toEqual(value);
+        });
+
+        test('should format taxonomy field value', async () => {
+            const taxonomyField = {
+                displayName: 'State',
+                id: '1',
+                key: 'stateField',
+                type: FIELD_TYPE_TAXONOMY,
+            };
+            const id = '123-456';
+            const displayName = 'California';
+            const expectedValue = [{ value: id, displayValue: displayName }];
+
+            expect(formatMetadataFieldValue(taxonomyField, [{ id, displayName }])).toEqual(expectedValue);
         });
     });
 });

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -7,6 +7,8 @@
 import type Xhr from '../utils/Xhr';
 import type { Comment } from '../common/types/feed';
 import { getAbortError } from '../utils/error';
+import type { MetadataTemplateField, MetadataFieldValue } from '../common/types/metadata';
+import { FIELD_TYPE_TAXONOMY } from '../features/metadata-instance-fields/constants';
 
 /**
  * Formats comment data (including replies) for use in components.
@@ -25,6 +27,20 @@ export const formatComment = (comment: Comment): Comment => {
     }
 
     return formattedComment;
+};
+
+export const formatMetadataFieldValue = (
+    field: MetadataTemplateField,
+    value: MetadataFieldValue,
+): MetadataFieldValue => {
+    if (field.type === FIELD_TYPE_TAXONOMY) {
+        return value.map((option: { id: string, displayName: string }) => ({
+            value: option.id,
+            displayValue: option.displayName,
+        }));
+    }
+
+    return value;
 };
 
 export const handleOnAbort = (xhr: Xhr) => {

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -16,7 +16,7 @@ import { FIELD_TYPE_TAXONOMY } from '../features/metadata-instance-fields/consta
  * @param {Comment} comment - An individual comment entry from the API
  * @return {Comment} Updated comment
  */
-export const formatComment = (comment: Comment): Comment => {
+const formatComment = (comment: Comment): Comment => {
     const formattedComment = {
         ...comment,
         tagged_message: comment.message,
@@ -29,11 +29,8 @@ export const formatComment = (comment: Comment): Comment => {
     return formattedComment;
 };
 
-export const formatMetadataFieldValue = (
-    field: MetadataTemplateField,
-    value: MetadataFieldValue,
-): MetadataFieldValue => {
-    if (field.type === FIELD_TYPE_TAXONOMY) {
+const formatMetadataFieldValue = (field: MetadataTemplateField, value: MetadataFieldValue): MetadataFieldValue => {
+    if (field.type === FIELD_TYPE_TAXONOMY && Array.isArray(value)) {
         return value.map((option: { id: string, displayName: string }) => ({
             value: option.id,
             displayValue: option.displayName,
@@ -43,12 +40,10 @@ export const formatMetadataFieldValue = (
     return value;
 };
 
-export const handleOnAbort = (xhr: Xhr) => {
+const handleOnAbort = (xhr: Xhr) => {
     xhr.abort();
 
     throw getAbortError();
 };
 
-export default {
-    formatComment,
-};
+export { formatComment, formatMetadataFieldValue, handleOnAbort };


### PR DESCRIPTION
* Added support for creating metadata instances with taxonomy field values
* Added support for updating taxonomy field values on existing instances
* Added support for showing taxonomy field values on page load

Demos:

![2024-10-17 12 09 55 1](https://github.com/user-attachments/assets/a7e0a605-1e41-4c56-bc9e-e3ffb2e6a63b)
![2024-10-17 12 09 55 2](https://github.com/user-attachments/assets/df48ca1b-c939-4a05-b6ed-a8c497fab379)


