### PR TITLE
fix: resolve missing exports for esbuild

### DIFF
--- a/src/api/Intelligence.js
+++ b/src/api/Intelligence.js
@@ -5,13 +5,13 @@
  */
 
 import getProp from 'lodash/get';
-import { QuestionType } from '@box/box-ai-content-answers';
-import type { BoxItem } from '../common/types/core';
-import { ERROR_CODE_EXTRACT_STRUCTURED } from '../constants';
-import { isUserCorrectableError } from '../utils/error';
+import type { QuestionType } from '@box/box-ai-content-answers';
 import Base from './Base';
+import { isUserCorrectableError } from '../utils/error';
 import { AiExtractResponse } from './schemas/AiExtractResponse';
 import { AiExtractStructured } from './schemas/AiExtractStructured';
+import { ERROR_CODE_EXTRACT_STRUCTURED } from '../constants';
+import type { BoxItem } from '../common/types/core';
 
 class Intelligence extends Base {
     /**

--- a/src/elements/common/annotator-context/index.ts
+++ b/src/elements/common/annotator-context/index.ts
@@ -2,4 +2,6 @@ export { default as AnnotatorContext } from './AnnotatorContext';
 export { default as useAnnotatorEvents } from './useAnnotatorEvents';
 export { default as withAnnotations } from './withAnnotations';
 export { default as withAnnotatorContext } from './withAnnotatorContext';
+export type { WithAnnotationsProps } from './withAnnotations';
+export type { WithAnnotatorContextProps } from './withAnnotatorContext';
 export * from './types';

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -27,6 +27,7 @@ import AsyncLoad from '../common/async-load';
 import TokenService from '../../utils/TokenService';
 import { isInputElement, focus } from '../../utils/dom';
 import { getTypedFileId } from '../../utils/file';
+import { withAnnotations, withAnnotatorContext } from '../common/annotator-context';
 import { withErrorBoundary } from '../common/error-boundary';
 import { withLogger } from '../common/logger';
 import { PREVIEW_FIELDS_TO_FETCH } from '../../utils/fields';
@@ -40,12 +41,6 @@ import PreviewHeader from './preview-header';
 import PreviewMask from './PreviewMask';
 import PreviewNavigation from './PreviewNavigation';
 import Providers from '../common/Providers';
-import {
-    withAnnotations,
-    WithAnnotationsProps,
-    withAnnotatorContext,
-    WithAnnotatorContextProps,
-} from '../common/annotator-context';
 import {
     DEFAULT_HOSTNAME_API,
     DEFAULT_HOSTNAME_APP,
@@ -66,6 +61,7 @@ import type { RequestOptions, ErrorContextProps, ElementsXhrError } from '../../
 import type { StringMap, Token, BoxItem, BoxItemVersion } from '../../common/types/core';
 import type { VersionChangeCallback } from '../content-sidebar/versions';
 import type { FeatureConfig } from '../common/feature-checking';
+import type { WithAnnotationsProps, WithAnnotatorContextProps } from '../common/annotator-context';
 import type APICache from '../../utils/Cache';
 
 import '../common/fonts.scss';

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -18,10 +18,10 @@ import AddTaskButton from './AddTaskButton';
 import API from '../../api';
 import messages from '../common/messages';
 import SidebarContent from './SidebarContent';
-import { WithAnnotatorContextProps, withAnnotatorContext } from '../common/annotator-context';
 import { EVENT_DATA_READY, EVENT_JS_READY } from '../common/logger/constants';
 import { getBadUserError } from '../../utils/error';
 import { mark } from '../../utils/performance';
+import { withAnnotatorContext } from '../common/annotator-context';
 import { withAPIContext } from '../common/api-context';
 import { withErrorBoundary } from '../common/error-boundary';
 import { withFeatureConsumer, isFeatureEnabled } from '../common/feature-checking';
@@ -72,6 +72,7 @@ import type { SelectorItems, User, UserMini, GroupMini, BoxItem } from '../../co
 import type { Errors, GetProfileUrlCallback } from '../common/flowTypes';
 import type { Translations } from './flowTypes';
 import type { FeatureConfig } from '../common/feature-checking';
+import type { WithAnnotatorContextProps } from '../common/annotator-context';
 import './ActivitySidebar.scss';
 
 import type { OnAnnotationEdit, OnAnnotationStatusChange } from './activity-feed/comment/types';


### PR DESCRIPTION
Vite apps that install box-ui-elements hit the following errors:
```
No matching export in "node_modules/@box/box-ai-content-answers/esm/index.js" for import "QuestionType"

No matching export in "node_modules/box-ui-elements/es/elements/common/annotator-context/index.js" for import "WithAnnotatorContextProps"

No matching export in "node_modules/box-ui-elements/es/elements/common/annotator-context/index.js" for import "WithAnnotationsProps"
```

two issues:
- `type` is needed in the import statement so that during the `es` build step, these lines are properly removed
- `WithAnnotationsProps` and `WithAnnotatorContextProps` were not exported in the `index.ts` when ContentPreview is trying to import from that file