### PR TITLE
feat: noop for BREAKING CHANGE blueprint peer dependency

### DIFF
--- a/src/test-utils/testing-library.tsx
+++ b/src/test-utils/testing-library.tsx
@@ -4,7 +4,6 @@ import { render, type RenderOptions } from '@testing-library/react';
 // Data Providers
 import { TooltipProvider } from '@box/blueprint-web';
 import { IntlProvider } from 'react-intl';
-
 import { FeatureProvider } from '../elements/common/feature-checking';
 
 jest.unmock('react-intl');


### PR DESCRIPTION
BREAKING CHANGE: blueprint-web and blueprint-web-assets peer dependencies

this PR should be labeled as a breaking change: https://github.com/box/box-ui-elements/pull/3585