### PR TITLE
fix(classification): Apps to Integrations name change

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1394,6 +1394,8 @@ boxui.securityCloudGame.targetInRange = Target in range, you can drop the cloud 
 boxui.securityCloudGame.targetPosition = Target position: Row {row}, Column {column}.
 # Name list of all applications download restriction applied to classification
 boxui.securityControls.allAppNames = All applications: {appsList}
+# Name list of all integrations download restriction applied to classification
+boxui.securityControls.allIntegrationNames = All integrations: {appsList}
 # Bullet point that summarizes application download restriction applied to classification
 boxui.securityControls.appDownloadBlacklist = Download restricted for some applications: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
@@ -1420,6 +1422,16 @@ boxui.securityControls.downloadExternal = Download restricted on Box Drive for e
 boxui.securityControls.externalCollabBlock = External collaboration restricted.
 # Bullet point that summarizes external collaboration restriction applied to classification
 boxui.securityControls.externalCollabDomainList = External collaboration limited to approved domains.
+# Bullet point that summarizes integration download restriction applied to classification
+boxui.securityControls.integrationDownloadAllowlist = Only select integrations are allowed: {appNames}
+# Bullet point that summarizes integration download restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold
+boxui.securityControls.integrationDownloadAllowlistOverflow = Only select integrations are allowed: {appNames} +{remainingAppCount} more
+# Bullet point that summarizes integration download restriction applied to classification
+boxui.securityControls.integrationDownloadDenylist = Download restricted for some integrations: {appNames}
+# Bullet point that summarizes integration download restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold
+boxui.securityControls.integrationDownloadDenylistOverflow = Download restricted for some integrations: {appNames} +{remainingAppCount} more
+# Bullet point that summarizes integration download restriction applied to classification
+boxui.securityControls.integrationDownloadRestricted = Download restricted for some integrations.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users
 boxui.securityControls.mobileDownloadExternal = Download restricted on mobile for external users.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners
@@ -1450,8 +1462,16 @@ boxui.securityControls.shortDownload = Download restrictions apply
 boxui.securityControls.shortDownloadApp = Download and app restrictions apply
 # Short summary displayed for items when download, app download and Sign restrictions are applied to them. Box Sign is a product name
 boxui.securityControls.shortDownloadAppSign = Download, app and Sign restrictions apply
+# Short summary displayed for classification when both download and integration download restrictions are applied to it
+boxui.securityControls.shortDownloadIntegration = Download and integration restrictions apply
+# Short summary displayed for items when download, integration download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortDownloadIntegrationSign = Download, integration and Sign restrictions apply
 # Short summary displayed for items when both download and Sign restrictions are applied to them. Box Sign is a product name
 boxui.securityControls.shortDownloadSign = Download and Sign restrictions apply
+# Short summary displayed for classification when an integration download restriction is applied to it
+boxui.securityControls.shortIntegration = Integration restrictions apply
+# Short summary displayed for items when both integration download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortIntegrationSign = Integration and Sign restrictions apply
 # Short summary displayed for classification when a sharing restriction is applied to it
 boxui.securityControls.shortSharing = Sharing restriction applies
 # Short summary displayed for classification when both sharing and app download restrictions are applied to it
@@ -1464,8 +1484,16 @@ boxui.securityControls.shortSharingDownload = Sharing and download restrictions 
 boxui.securityControls.shortSharingDownloadApp = Sharing, download and app restrictions apply
 # Short summary displayed for items when sharing, download, app download and Sign restrictions are applied to them. Box Sign is a product name
 boxui.securityControls.shortSharingDownloadAppSign = Sharing, download, app and Sign restrictions apply
+# Short summary displayed for items when sharing, download and integration download restrictions are applied to them.
+boxui.securityControls.shortSharingDownloadIntegration = Sharing, download and integration restrictions apply
+# Short summary displayed for items when sharing, download, integration download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortSharingDownloadIntegrationSign = Sharing, download, integration and Sign restrictions apply
 # Short summary displayed for items when sharing, download and Sign restrictions are applied to them. Box Sign is a product name
 boxui.securityControls.shortSharingDownloadSign = Sharing, download and Sign restrictions apply
+# Short summary displayed for classification when both sharing and integration download restrictions are applied to it
+boxui.securityControls.shortSharingIntegration = Sharing and integration restrictions apply
+# Short summary displayed for items when sharing, integration download and Sign restrictions are applied to them. Box Sign is a product name
+boxui.securityControls.shortSharingIntegrationSign = Sharing, integration and Sign restrictions apply
 # Short summary displayed for items when both sharing and Sign restrictions are applied to them. Box Sign is a product name
 boxui.securityControls.shortSharingSign = Sharing and Sign restrictions apply
 # Short summary displayed for items when Sign restriction is applied to them. Box Sign is a product name

--- a/src/features/classification/Classification.js
+++ b/src/features/classification/Classification.js
@@ -29,6 +29,7 @@ type Props = {
     modifiedBy?: string,
     name?: string,
     onClick?: (event: SyntheticEvent<HTMLButtonElement>) => void,
+    shouldDisplayAppsAsIntegrations?: boolean,
 };
 
 const Classification = ({
@@ -46,6 +47,7 @@ const Classification = ({
     modifiedBy,
     name,
     onClick,
+    shouldDisplayAppsAsIntegrations = false,
 }: Props) => {
     const isClassified = !!name;
     const hasDefinition = !!definition;
@@ -109,6 +111,7 @@ const Classification = ({
                     itemName={itemName}
                     maxAppCount={maxAppCount}
                     shouldRenderLabel
+                    shouldDisplayAppsAsIntegrations={shouldDisplayAppsAsIntegrations}
                 />
             )}
             {isControlsIndicatorEnabled && <LoadingIndicator />}

--- a/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
+++ b/src/features/classification/__tests__/__snapshots__/Classification.test.js.snap
@@ -96,6 +96,7 @@ exports[`features/classification/Classification should render a classified badge
     definition="fubar"
     itemName=""
     maxAppCount={3}
+    shouldDisplayAppsAsIntegrations={false}
     shouldRenderLabel={true}
   />
 </article>

--- a/src/features/classification/security-controls/SecurityControls.js
+++ b/src/features/classification/security-controls/SecurityControls.js
@@ -24,6 +24,7 @@ type Props = {
     itemName?: string,
     maxAppCount?: number,
     shouldRenderLabel?: boolean,
+    shouldDisplayAppsAsIntegrations?: boolean,
 };
 
 type State = {
@@ -39,6 +40,7 @@ class SecurityControls extends React.Component<Props, State> {
         controlsFormat: SHORT,
         maxAppCount: DEFAULT_MAX_APP_COUNT,
         shouldRenderLabel: false,
+        shouldDisplayAppsAsIntegrations: false,
     };
 
     state = {
@@ -59,18 +61,19 @@ class SecurityControls extends React.Component<Props, State> {
             itemName,
             maxAppCount,
             shouldRenderLabel,
+            shouldDisplayAppsAsIntegrations,
         } = this.props;
 
         let items = [];
         let modalItems;
 
         if (controlsFormat === FULL) {
-            items = getFullSecurityControlsMessages(controls, maxAppCount);
+            items = getFullSecurityControlsMessages(controls, maxAppCount, shouldDisplayAppsAsIntegrations);
         } else {
-            items = getShortSecurityControlsMessage(controls);
+            items = getShortSecurityControlsMessage(controls, shouldDisplayAppsAsIntegrations);
 
             if (items.length && controlsFormat === SHORT_WITH_BTN) {
-                modalItems = getFullSecurityControlsMessages(controls, maxAppCount);
+                modalItems = getFullSecurityControlsMessages(controls, maxAppCount, shouldDisplayAppsAsIntegrations);
             }
         }
 

--- a/src/features/classification/security-controls/__tests__/SecurityControls.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControls.test.js
@@ -45,6 +45,13 @@ describe('features/classification/security-controls/SecurityControls', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should render SecurityControls with Integration label when using SHORT controlsFormat and shouldDisplayAppsAsIntegrations is true', () => {
+        wrapper.setProps({ controlsFormat: SHORT, shouldDisplayAppsAsIntegrations: true });
+        expect(wrapper.find('SecurityControlsItem').prop('message').id).toBe(
+            messages.shortSharingDownloadIntegration.id,
+        );
+    });
+
     test('should render SecurityControls with single SecurityControlsItem and modal items when using SHORT_WITH_BTN controlsFormat and item, classification data is provided', () => {
         wrapper.setProps({
             controlsFormat: SHORT_WITH_BTN,
@@ -55,9 +62,36 @@ describe('features/classification/security-controls/SecurityControls', () => {
         expect(wrapper).toMatchSnapshot();
     });
 
+    test('should render SecurityControls with Integration label when SHORT_WITH_BTN controlsFormat and shouldDisplayAppsAsIntegrations is true', () => {
+        wrapper.setProps({
+            controlsFormat: SHORT_WITH_BTN,
+            classificationName: 'internal only',
+            definition: 'classification definition',
+            itemName: 'welcome.pdf',
+            shouldDisplayAppsAsIntegrations: true,
+        });
+        expect(
+            wrapper
+                .find('SecurityControlsModal')
+                .prop('modalItems')
+                .find(item => item.message.id === messages.integrationDownloadAllowlist.id),
+        ).toBeDefined();
+    });
+
     test('should render SecurityControls multiple SecurityControlsItem when using FULL controlsFormat', () => {
         wrapper.setProps({ controlsFormat: FULL });
         expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should render SecurityControls with Integration label when FULL controlsFormat and shouldDisplayAppsAsIntegrations is true', () => {
+        wrapper.setProps({ controlsFormat: FULL, shouldDisplayAppsAsIntegrations: true });
+        expect(
+            wrapper.findWhere(
+                node =>
+                    node.type() === 'SecurityControlsItem' &&
+                    node.prop('message').id === messages.integrationDownloadAllowlist.id,
+            ),
+        ).toBeDefined();
     });
 
     test('should render label for security controls when shouldRenderLabel prop is set', () => {

--- a/src/features/classification/security-controls/__tests__/SecurityControls.test.js
+++ b/src/features/classification/security-controls/__tests__/SecurityControls.test.js
@@ -47,8 +47,8 @@ describe('features/classification/security-controls/SecurityControls', () => {
 
     test('should render SecurityControls with Integration label when using SHORT controlsFormat and shouldDisplayAppsAsIntegrations is true', () => {
         wrapper.setProps({ controlsFormat: SHORT, shouldDisplayAppsAsIntegrations: true });
-        expect(wrapper.find('SecurityControlsItem').prop('message').id).toBe(
-            messages.shortSharingDownloadIntegration.id,
+        expect(wrapper.find('SecurityControlsItem').prop('message').defaultMessage).toBe(
+            'Sharing, download and integration restrictions apply',
         );
     });
 
@@ -74,7 +74,7 @@ describe('features/classification/security-controls/SecurityControls', () => {
             wrapper
                 .find('SecurityControlsModal')
                 .prop('modalItems')
-                .find(item => item.message.id === messages.integrationDownloadAllowlist.id),
+                .find(item => item.message.defaultMessage === 'Only select integrations are allowed: {appNames}'),
         ).toBeDefined();
     });
 
@@ -89,7 +89,7 @@ describe('features/classification/security-controls/SecurityControls', () => {
             wrapper.findWhere(
                 node =>
                     node.type() === 'SecurityControlsItem' &&
-                    node.prop('message').id === messages.integrationDownloadAllowlist.id,
+                    node.prop('message').defaultMessage === 'Only select integrations are allowed: {appNames}',
             ),
         ).toBeDefined();
     });

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -202,7 +202,7 @@ describe('features/classification/security-controls/utils', () => {
         );
 
         test.each([WHITELIST, BLACKLIST])(
-            'should include correct message when integration download is restricted by %s and integrations list is not provided and shouldDisplayAppsAsIntegrations is true',
+            'should include correct variable when integration download is restricted by %s and integrations list is not provided and shouldDisplayAppsAsIntegrations is true',
             listType => {
                 accessPolicy = {
                     app: {
@@ -248,7 +248,7 @@ describe('features/classification/security-controls/utils', () => {
         );
 
         test.each([WHITELIST, BLACKLIST])(
-            'should include correct message when integration download is restricted by %s and integrations are less than maxAppCount and shouldDisplayAppsAsIntegrations is true',
+            'should include correct variable when integration download is restricted by %s and integrations are less than maxAppCount and shouldDisplayAppsAsIntegrations is true',
             listType => {
                 accessPolicy = {
                     app: {

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -1,5 +1,6 @@
 import messages from '../messages';
 import appRestrictionsMessageMap from '../appRestrictionsMessageMap';
+import integrationRestrictionsMessageMap from '../integrationRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from '../downloadRestrictionsMessageMap';
 import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from '../utils';
 import {
@@ -67,6 +68,45 @@ describe('features/classification/security-controls/utils', () => {
 
             expect(result).toEqual(expectedResult);
         });
+
+        test.each`
+            securityControls                                            | expectedMessages                                                              | description
+            ${{}}                                                       | ${[]}                                                                         | ${'there are no restrictions'}
+            ${allSecurityControls}                                      | ${[messages.shortSharingDownloadIntegrationSign, messages.shortWatermarking]} | ${'all restrictions are present'}
+            ${{ sharedLink: { accessLevel: PUBLIC } }}                  | ${[]}                                                                         | ${'shared link restriction has a "public" access level'}
+            ${{ sharedLink: {}, download: {}, app: {} }}                | ${[messages.shortSharingDownloadIntegration]}                                 | ${'download, integration and shared link restrictions are present'}
+            ${{ externalCollab: {}, download: {}, app: {} }}            | ${[messages.shortSharingDownloadIntegration]}                                 | ${'download, integration and external collab restrictions are present'}
+            ${{ download: {}, app: {}, boxSignRequest: {} }}            | ${[messages.shortDownloadIntegrationSign]}                                    | ${'download, integration and sign restrictions are present'}
+            ${{ app: {}, boxSignRequest: {}, sharedLink: {} }}          | ${[messages.shortSharingIntegrationSign]}                                     | ${'integration, sign and shared link restrictions are present'}
+            ${{ app: {}, boxSignRequest: {}, externalCollab: {} }}      | ${[messages.shortSharingIntegrationSign]}                                     | ${'integration, sign and external collab restrictions are present'}
+            ${{ download: {}, boxSignRequest: {}, sharedLink: {} }}     | ${[messages.shortSharingDownloadSign]}                                        | ${'download, sign and shared link restrictions are present'}
+            ${{ download: {}, boxSignRequest: {}, externalCollab: {} }} | ${[messages.shortSharingDownloadSign]}                                        | ${'download, sign and external collab restrictions are present'}
+            ${{ sharedLink: {}, boxSignRequest: {} }}                   | ${[messages.shortSharingSign]}                                                | ${'sign and shared link restrictions are present'}
+            ${{ externalCollab: {}, boxSignRequest: {} }}               | ${[messages.shortSharingSign]}                                                | ${'sign and external collab restrictions are present'}
+            ${{ download: {}, boxSignRequest: {} }}                     | ${[messages.shortDownloadSign]}                                               | ${'download and sign restrictions are present'}
+            ${{ app: {}, boxSignRequest: {} }}                          | ${[messages.shortIntegrationSign]}                                            | ${'integration and sign restrictions are present'}
+            ${{ sharedLink: {}, download: {} }}                         | ${[messages.shortSharingDownload]}                                            | ${'download and shared link restrictions are present'}
+            ${{ externalCollab: {}, download: {} }}                     | ${[messages.shortSharingDownload]}                                            | ${'download and external collab restrictions are present'}
+            ${{ sharedLink: {}, app: {} }}                              | ${[messages.shortSharingIntegration]}                                         | ${'integration and shared link restrictions are present'}
+            ${{ externalCollab: {}, app: {} }}                          | ${[messages.shortSharingIntegration]}                                         | ${'integration and external collab restrictions are present'}
+            ${{ download: {}, app: {} }}                                | ${[messages.shortDownloadIntegration]}                                        | ${'integration and download restrictions are present'}
+            ${{ sharedLink: {}, externalCollab: {} }}                   | ${[messages.shortSharing]}                                                    | ${'shared link and external collab restrictions are present'}
+            ${{ sharedLink: {} }}                                       | ${[messages.shortSharing]}                                                    | ${'shared link restrictions are present'}
+            ${{ externalCollab: {} }}                                   | ${[messages.shortSharing]}                                                    | ${'external collab restrictions are present'}
+            ${{ download: {} }}                                         | ${[messages.shortDownload]}                                                   | ${'download restrictions are present'}
+            ${{ app: {} }}                                              | ${[messages.shortIntegration]}                                                | ${'integration restrictions are present'}
+            ${{ watermark: {} }}                                        | ${[messages.shortWatermarking]}                                               | ${'watermark restrictions are present'}
+            ${{ boxSignRequest: {} }}                                   | ${[messages.shortSign]}                                                       | ${'sign restrictions are present'}
+        `(
+            'should return correct messages when $description and shouldDisplayAppsAsIntegrations is true',
+            ({ securityControls, expectedMessages }) => {
+                const expectedResult = expectedMessages.map(message => ({ message }));
+
+                const result = getShortSecurityControlsMessage(securityControls, true);
+
+                expect(result).toEqual(expectedResult);
+            },
+        );
 
         test('should not return tooltipMessage', () => {
             accessPolicy = { sharedLink: {}, download: {}, externalCollab: {}, app: {} };
@@ -162,6 +202,29 @@ describe('features/classification/security-controls/utils', () => {
         );
 
         test.each([WHITELIST, BLACKLIST])(
+            'should include correct message when integration download is restricted by %s and integrations list is not provided and shouldDisplayAppsAsIntegrations is true',
+            listType => {
+                accessPolicy = {
+                    app: {
+                        accessLevel: listType,
+                        apps: [],
+                    },
+                };
+                const expectedMessage = integrationRestrictionsMessageMap[listType][DEFAULT];
+
+                expect(expectedMessage).toBeTruthy();
+                expect(getFullSecurityControlsMessages(accessPolicy, 3, true)).toEqual([
+                    {
+                        message: {
+                            ...expectedMessage,
+                            values: { appNames: '' },
+                        },
+                    },
+                ]);
+            },
+        );
+
+        test.each([WHITELIST, BLACKLIST])(
             'should include correct message when app download is restricted by %s and apps are less than maxAppCount',
             listType => {
                 accessPolicy = {
@@ -174,6 +237,29 @@ describe('features/classification/security-controls/utils', () => {
 
                 expect(expectedMessage).toBeTruthy();
                 expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
+                    {
+                        message: {
+                            ...expectedMessage,
+                            values: { appNames: 'a, b, c' },
+                        },
+                    },
+                ]);
+            },
+        );
+
+        test.each([WHITELIST, BLACKLIST])(
+            'should include correct message when integration download is restricted by %s and integrations are less than maxAppCount and shouldDisplayAppsAsIntegrations is true',
+            listType => {
+                accessPolicy = {
+                    app: {
+                        accessLevel: listType,
+                        apps: [{ displayText: 'a' }, { displayText: 'b' }, { displayText: 'c' }],
+                    },
+                };
+                const expectedMessage = integrationRestrictionsMessageMap[listType][WITH_APP_LIST];
+
+                expect(expectedMessage).toBeTruthy();
+                expect(getFullSecurityControlsMessages(accessPolicy, 3, true)).toEqual([
                     {
                         message: {
                             ...expectedMessage,
@@ -210,6 +296,39 @@ describe('features/classification/security-controls/utils', () => {
                         },
                         tooltipMessage: {
                             ...messages.allAppNames,
+                            values: { appsList: 'a, b, c, d, e' },
+                        },
+                    },
+                ]);
+            },
+        );
+
+        test.each([WHITELIST, BLACKLIST])(
+            'should include correct message and tooltipMessage when integration download is restricted by %s and integrations are maxAppCount or more and shouldDisplayAppsAsIntegrations is true',
+            listType => {
+                accessPolicy = {
+                    app: {
+                        accessLevel: listType,
+                        apps: [
+                            { displayText: 'a' },
+                            { displayText: 'b' },
+                            { displayText: 'c' },
+                            { displayText: 'd' },
+                            { displayText: 'e' },
+                        ],
+                    },
+                };
+                const expectedMessage = integrationRestrictionsMessageMap[listType][WITH_OVERFLOWN_APP_LIST];
+
+                expect(expectedMessage).toBeTruthy();
+                expect(getFullSecurityControlsMessages(accessPolicy, 3, true)).toEqual([
+                    {
+                        message: {
+                            ...expectedMessage,
+                            values: { appNames: 'a, b, c', remainingAppCount: 2 },
+                        },
+                        tooltipMessage: {
+                            ...messages.allIntegrationNames,
                             values: { appsList: 'a, b, c, d, e' },
                         },
                     },

--- a/src/features/classification/security-controls/integrationRestrictionsMessageMap.js
+++ b/src/features/classification/security-controls/integrationRestrictionsMessageMap.js
@@ -1,0 +1,21 @@
+// @flow
+import messages from './messages';
+import { APP_RESTRICTION_MESSAGE_TYPE, LIST_ACCESS_LEVEL } from '../constants';
+
+const { BLACKLIST, WHITELIST } = LIST_ACCESS_LEVEL;
+const { DEFAULT, WITH_APP_LIST, WITH_OVERFLOWN_APP_LIST } = APP_RESTRICTION_MESSAGE_TYPE;
+
+const integrationRestrictionsMessageMap = {
+    [BLACKLIST]: {
+        [DEFAULT]: messages.integrationDownloadRestricted,
+        [WITH_APP_LIST]: messages.integrationDownloadDenylist,
+        [WITH_OVERFLOWN_APP_LIST]: messages.integrationDownloadDenylistOverflow,
+    },
+    [WHITELIST]: {
+        [DEFAULT]: messages.integrationDownloadRestricted,
+        [WITH_APP_LIST]: messages.integrationDownloadAllowlist,
+        [WITH_OVERFLOWN_APP_LIST]: messages.integrationDownloadAllowlistOverflow,
+    },
+};
+
+export default integrationRestrictionsMessageMap;

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -25,6 +25,12 @@ const messages = defineMessages({
             'Short summary displayed for classification when an application download restriction is applied to it',
         id: 'boxui.securityControls.shortApp',
     },
+    shortIntegration: {
+        defaultMessage: 'Integration restrictions apply',
+        description:
+            'Short summary displayed for classification when an integration download restriction is applied to it',
+        id: 'boxui.securityControls.shortIntegration',
+    },
     shortWatermarking: {
         defaultMessage: 'Watermarking applies',
         description: 'Short summary displayed for classification when watermarking is applied to it',
@@ -49,11 +55,23 @@ const messages = defineMessages({
             'Short summary displayed for classification when both sharing and app download restrictions are applied to it',
         id: 'boxui.securityControls.shortSharingApp',
     },
+    shortSharingIntegration: {
+        defaultMessage: 'Sharing and integration restrictions apply',
+        description:
+            'Short summary displayed for classification when both sharing and integration download restrictions are applied to it',
+        id: 'boxui.securityControls.shortSharingIntegration',
+    },
     shortDownloadApp: {
         defaultMessage: 'Download and app restrictions apply',
         description:
             'Short summary displayed for classification when both download and app download restrictions are applied to it',
         id: 'boxui.securityControls.shortDownloadApp',
+    },
+    shortDownloadIntegration: {
+        defaultMessage: 'Download and integration restrictions apply',
+        description:
+            'Short summary displayed for classification when both download and integration download restrictions are applied to it',
+        id: 'boxui.securityControls.shortDownloadIntegration',
     },
     shortSharingSign: {
         defaultMessage: 'Sharing and Sign restrictions apply',
@@ -73,6 +91,12 @@ const messages = defineMessages({
             'Short summary displayed for items when both app download and Sign restrictions are applied to them. Box Sign is a product name',
         id: 'boxui.securityControls.shortAppSign',
     },
+    shortIntegrationSign: {
+        defaultMessage: 'Integration and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when both integration download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortIntegrationSign',
+    },
     // Short summary messages - 3 restrictions
     shortDownloadAppSign: {
         defaultMessage: 'Download, app and Sign restrictions apply',
@@ -80,11 +104,23 @@ const messages = defineMessages({
             'Short summary displayed for items when download, app download and Sign restrictions are applied to them. Box Sign is a product name',
         id: 'boxui.securityControls.shortDownloadAppSign',
     },
+    shortDownloadIntegrationSign: {
+        defaultMessage: 'Download, integration and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when download, integration download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortDownloadIntegrationSign',
+    },
     shortSharingAppSign: {
         defaultMessage: 'Sharing, app and Sign restrictions apply',
         description:
             'Short summary displayed for items when sharing, app download and Sign restrictions are applied to them. Box Sign is a product name',
         id: 'boxui.securityControls.shortSharingAppSign',
+    },
+    shortSharingIntegrationSign: {
+        defaultMessage: 'Sharing, integration and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when sharing, integration download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortSharingIntegrationSign',
     },
     shortSharingDownloadSign: {
         defaultMessage: 'Sharing, download and Sign restrictions apply',
@@ -98,12 +134,24 @@ const messages = defineMessages({
             'Short summary displayed for items when sharing, download and app download restrictions are applied to them.',
         id: 'boxui.securityControls.shortSharingDownloadApp',
     },
+    shortSharingDownloadIntegration: {
+        defaultMessage: 'Sharing, download and integration restrictions apply',
+        description:
+            'Short summary displayed for items when sharing, download and integration download restrictions are applied to them.',
+        id: 'boxui.securityControls.shortSharingDownloadIntegration',
+    },
     // Short summary messages - 4 restrictions
     shortSharingDownloadAppSign: {
         defaultMessage: 'Sharing, download, app and Sign restrictions apply',
         description:
             'Short summary displayed for items when sharing, download, app download and Sign restrictions are applied to them. Box Sign is a product name',
         id: 'boxui.securityControls.shortSharingDownloadAppSign',
+    },
+    shortSharingDownloadIntegrationSign: {
+        defaultMessage: 'Sharing, download, integration and Sign restrictions apply',
+        description:
+            'Short summary displayed for items when sharing, download, integration download and Sign restrictions are applied to them. Box Sign is a product name',
+        id: 'boxui.securityControls.shortSharingDownloadIntegrationSign',
     },
     // Full list individual restriction bullets
     sharingCollabOnly: {
@@ -137,10 +185,20 @@ const messages = defineMessages({
         description: 'Bullet point that summarizes application download restriction applied to classification',
         id: 'boxui.securityControls.appDownloadRestricted',
     },
+    integrationDownloadRestricted: {
+        defaultMessage: 'Download restricted for some integrations.',
+        description: 'Bullet point that summarizes integration download restriction applied to classification',
+        id: 'boxui.securityControls.integrationDownloadRestricted',
+    },
     appDownloadBlacklist: {
         defaultMessage: 'Download restricted for some applications: {appNames}',
         description: 'Bullet point that summarizes application download restriction applied to classification',
         id: 'boxui.securityControls.appDownloadBlacklist',
+    },
+    integrationDownloadDenylist: {
+        defaultMessage: 'Download restricted for some integrations: {appNames}',
+        description: 'Bullet point that summarizes integration download restriction applied to classification',
+        id: 'boxui.securityControls.integrationDownloadDenylist',
     },
     appDownloadBlacklistOverflow: {
         defaultMessage: 'Download restricted for some applications: {appNames} +{remainingAppCount} more',
@@ -148,10 +206,21 @@ const messages = defineMessages({
             'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
         id: 'boxui.securityControls.appDownloadBlacklistOverflow',
     },
+    integrationDownloadDenylistOverflow: {
+        defaultMessage: 'Download restricted for some integrations: {appNames} +{remainingAppCount} more',
+        description:
+            'Bullet point that summarizes integration download restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold',
+        id: 'boxui.securityControls.integrationDownloadDenylistOverflow',
+    },
     appDownloadWhitelist: {
         defaultMessage: 'Only select applications are allowed: {appNames}',
         description: 'Bullet point that summarizes application download restriction applied to classification',
         id: 'boxui.securityControls.appDownloadWhitelist',
+    },
+    integrationDownloadAllowlist: {
+        defaultMessage: 'Only select integrations are allowed: {appNames}',
+        description: 'Bullet point that summarizes integration download restriction applied to classification',
+        id: 'boxui.securityControls.integrationDownloadAllowlist',
     },
     appDownloadWhitelistOverflow: {
         defaultMessage: 'Only select applications are allowed: {appNames} +{remainingAppCount} more',
@@ -159,10 +228,21 @@ const messages = defineMessages({
             'Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
         id: 'boxui.securityControls.appDownloadWhitelistOverflow',
     },
+    integrationDownloadAllowlistOverflow: {
+        defaultMessage: 'Only select integrations are allowed: {appNames} +{remainingAppCount} more',
+        description:
+            'Bullet point that summarizes integration download restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold',
+        id: 'boxui.securityControls.integrationDownloadAllowlistOverflow',
+    },
     allAppNames: {
         defaultMessage: 'All applications: {appsList}',
         description: 'Name list of all applications download restriction applied to classification',
         id: 'boxui.securityControls.allAppNames',
+    },
+    allIntegrationNames: {
+        defaultMessage: 'All integrations: {appsList}',
+        description: 'Name list of all integrations download restriction applied to classification',
+        id: 'boxui.securityControls.allIntegrationNames',
     },
     // Web Download Restrictions
     webDownloadOwners: {

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -5,6 +5,7 @@ import isNil from 'lodash/isNil';
 import type { Controls, MessageItem } from '../flowTypes';
 
 import appRestrictionsMessageMap from './appRestrictionsMessageMap';
+import integrationRestrictionsMessageMap from './integrationRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from './downloadRestrictionsMessageMap';
 import messages from './messages';
 import {
@@ -21,7 +22,10 @@ const { DESKTOP, MOBILE, WEB } = DOWNLOAD_CONTROL;
 const { BLOCK, WHITELIST, BLACKLIST } = LIST_ACCESS_LEVEL;
 const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVEL;
 
-const getShortSecurityControlsMessage = (controls: Controls): Array<MessageItem> => {
+const getShortSecurityControlsMessage = (
+    controls: Controls,
+    shouldDisplayAppsAsIntegrations?: boolean,
+): Array<MessageItem> => {
     const items = [];
     const { app, boxSignRequest, download, externalCollab, sharedLink, watermark } = controls;
 
@@ -31,15 +35,31 @@ const getShortSecurityControlsMessage = (controls: Controls): Array<MessageItem>
 
     // 4 restriction combinations
     if (sharing && download && app && boxSignRequest) {
-        items.push({ message: messages.shortSharingDownloadAppSign });
+        items.push({
+            message: shouldDisplayAppsAsIntegrations
+                ? messages.shortSharingDownloadIntegrationSign
+                : messages.shortSharingDownloadAppSign,
+        });
     }
     // 3 restriction combinations
     else if (sharing && download && app) {
-        items.push({ message: messages.shortSharingDownloadApp });
+        items.push({
+            message: shouldDisplayAppsAsIntegrations
+                ? messages.shortSharingDownloadIntegration
+                : messages.shortSharingDownloadApp,
+        });
     } else if (download && app && boxSignRequest) {
-        items.push({ message: messages.shortDownloadAppSign });
+        items.push({
+            message: shouldDisplayAppsAsIntegrations
+                ? messages.shortDownloadIntegrationSign
+                : messages.shortDownloadAppSign,
+        });
     } else if (sharing && app && boxSignRequest) {
-        items.push({ message: messages.shortSharingAppSign });
+        items.push({
+            message: shouldDisplayAppsAsIntegrations
+                ? messages.shortSharingIntegrationSign
+                : messages.shortSharingAppSign,
+        });
     } else if (sharing && download && boxSignRequest) {
         items.push({ message: messages.shortSharingDownloadSign });
     }
@@ -49,13 +69,19 @@ const getShortSecurityControlsMessage = (controls: Controls): Array<MessageItem>
     } else if (download && boxSignRequest) {
         items.push({ message: messages.shortDownloadSign });
     } else if (app && boxSignRequest) {
-        items.push({ message: messages.shortAppSign });
+        items.push({
+            message: shouldDisplayAppsAsIntegrations ? messages.shortIntegrationSign : messages.shortAppSign,
+        });
     } else if (sharing && download) {
         items.push({ message: messages.shortSharingDownload });
     } else if (sharing && app) {
-        items.push({ message: messages.shortSharingApp });
+        items.push({
+            message: shouldDisplayAppsAsIntegrations ? messages.shortSharingIntegration : messages.shortSharingApp,
+        });
     } else if (download && app) {
-        items.push({ message: messages.shortDownloadApp });
+        items.push({
+            message: shouldDisplayAppsAsIntegrations ? messages.shortDownloadIntegration : messages.shortDownloadApp,
+        });
     }
     // 1 restriction combinations
     else if (boxSignRequest) {
@@ -65,7 +91,7 @@ const getShortSecurityControlsMessage = (controls: Controls): Array<MessageItem>
     } else if (download) {
         items.push({ message: messages.shortDownload });
     } else if (app) {
-        items.push({ message: messages.shortApp });
+        items.push({ message: shouldDisplayAppsAsIntegrations ? messages.shortIntegration : messages.shortApp });
     }
 
     if (watermark) {
@@ -123,13 +149,21 @@ const getExternalCollabMessages = (controls: Controls): Array<MessageItem> => {
     return items;
 };
 
-const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array<MessageItem> => {
+const getAppDownloadMessages = (
+    controls: Controls,
+    maxAppCount?: number,
+    shouldDisplayAppsAsIntegrations?: boolean,
+): Array<MessageItem> => {
     const items = [];
     const accessLevel = getProp(controls, `${APP}.accessLevel`);
 
     switch (accessLevel) {
         case BLOCK:
-            items.push({ message: messages.appDownloadRestricted });
+            items.push({
+                message: shouldDisplayAppsAsIntegrations
+                    ? messages.integrationDownloadRestricted
+                    : messages.appDownloadRestricted,
+            });
             break;
         case WHITELIST:
         case BLACKLIST: {
@@ -145,11 +179,13 @@ const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array
 
                 items.push({
                     message: {
-                        ...appRestrictionsMessageMap[accessLevel][WITH_OVERFLOWN_APP_LIST],
+                        ...(shouldDisplayAppsAsIntegrations
+                            ? integrationRestrictionsMessageMap[accessLevel][WITH_OVERFLOWN_APP_LIST]
+                            : appRestrictionsMessageMap[accessLevel][WITH_OVERFLOWN_APP_LIST]),
                         values: { appNames, remainingAppCount },
                     },
                     tooltipMessage: {
-                        ...messages.allAppNames,
+                        ...(shouldDisplayAppsAsIntegrations ? messages.allIntegrationNames : messages.allAppNames),
                         values: { appsList },
                     },
                 });
@@ -160,7 +196,9 @@ const getAppDownloadMessages = (controls: Controls, maxAppCount?: number): Array
 
                 items.push({
                     message: {
-                        ...appRestrictionsMessageMap[accessLevel][messageType],
+                        ...(shouldDisplayAppsAsIntegrations
+                            ? integrationRestrictionsMessageMap[accessLevel][messageType]
+                            : appRestrictionsMessageMap[accessLevel][messageType]),
                         values: { appNames },
                     },
                 });
@@ -220,12 +258,16 @@ const getBoxSignRequestMessages = (controls: Controls): Array<MessageItem> => {
     return items;
 };
 
-const getFullSecurityControlsMessages = (controls: Controls, maxAppCount?: number): Array<MessageItem> => {
+const getFullSecurityControlsMessages = (
+    controls: Controls,
+    maxAppCount?: number,
+    shouldDisplayAppsAsIntegrations?: boolean,
+): Array<MessageItem> => {
     const items = [
         ...getSharedLinkMessages(controls),
         ...getExternalCollabMessages(controls),
         ...getDownloadMessages(controls),
-        ...getAppDownloadMessages(controls, maxAppCount),
+        ...getAppDownloadMessages(controls, maxAppCount, shouldDisplayAppsAsIntegrations),
         ...getWatermarkingMessages(controls),
         ...getBoxSignRequestMessages(controls),
     ];


### PR DESCRIPTION
Replaced 'application' references in Classification modal with 'integration', based on optional flag variable (by default set to false, so I won't break existing code and will display 'application' as usual). When flag is passed as 'True' then 'Integrations' will be displayed, otherwise 'Applications'. Also, unit tests are added for related changes.