### PR TITLE
fix(preview): remove dependency on isSignRemoveInterstitialEnabled feature flag

### DIFF
--- a/src/elements/content-sidebar/SidebarNavSign.tsx
+++ b/src/elements/content-sidebar/SidebarNavSign.tsx
@@ -25,40 +25,27 @@ export function SidebarNavSign() {
         onClickSignMyself: onBoxClickSignMyself,
         status: boxSignStatus,
         targetingApi: boxSignTargetingApi,
-        isSignRemoveInterstitialEnabled,
     } = useFeatureConfig('boxSign');
 
     return (
-        <>
-            {isSignRemoveInterstitialEnabled ? (
-                <DropdownMenu isResponsive constrainToWindow isRightAligned>
-                    <SidebarNavSignButton
-                        blockedReason={boxSignBlockedReason}
-                        status={boxSignStatus}
-                        targetingApi={boxSignTargetingApi}
-                        data-resin-target={SIDEBAR_NAV_TARGETS.SIGN}
-                    />
-                    <Menu>
-                        <MenuItem data-testid="sign-request-signature-button" onClick={onBoxClickRequestSignature}>
-                            <SignMeOthers32 width={16} height={16} className="bcs-SidebarNavSign-icon" />
-                            <FormattedMessage {...messages.boxSignRequestSignature} />
-                        </MenuItem>
-                        <MenuItem data-testid="sign-sign-myself-button" onClick={onBoxClickSignMyself}>
-                            <SignMe32 width={16} height={16} className="bcs-SidebarNavSign-icon" />
-                            <FormattedMessage {...messages.boxSignSignMyself} />
-                        </MenuItem>
-                    </Menu>
-                </DropdownMenu>
-            ) : (
-                <SidebarNavSignButton
-                    blockedReason={boxSignBlockedReason}
-                    data-resin-target={SIDEBAR_NAV_TARGETS.SIGN}
-                    onClick={onBoxClickRequestSignature}
-                    status={boxSignStatus}
-                    targetingApi={boxSignTargetingApi}
-                />
-            )}
-        </>
+        <DropdownMenu isResponsive constrainToWindow isRightAligned>
+            <SidebarNavSignButton
+                blockedReason={boxSignBlockedReason}
+                status={boxSignStatus}
+                targetingApi={boxSignTargetingApi}
+                data-resin-target={SIDEBAR_NAV_TARGETS.SIGN}
+            />
+            <Menu>
+                <MenuItem data-testid="sign-request-signature-button" onClick={onBoxClickRequestSignature}>
+                    <SignMeOthers32 width={16} height={16} className="bcs-SidebarNavSign-icon" />
+                    <FormattedMessage {...messages.boxSignRequestSignature} />
+                </MenuItem>
+                <MenuItem data-testid="sign-sign-myself-button" onClick={onBoxClickSignMyself}>
+                    <SignMe32 width={16} height={16} className="bcs-SidebarNavSign-icon" />
+                    <FormattedMessage {...messages.boxSignSignMyself} />
+                </MenuItem>
+            </Menu>
+        </DropdownMenu>
     );
 }
 

--- a/src/elements/content-sidebar/__tests__/SidebarNavSign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/SidebarNavSign.test.tsx
@@ -1,80 +1,75 @@
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
 import SidebarNavSign from '../SidebarNavSign';
 // @ts-ignore Module is written in Flow
 import FeatureProvider from '../../common/feature-checking/FeatureProvider';
+// @ts-ignore Module is written in Flow
+import messages from '../messages';
+// @ts-ignore Module is written in Flow
+import localize from '../../../../test/support/i18n.js';
+
+jest.unmock('react-intl');
 
 describe('elements/content-sidebar/SidebarNavSign', () => {
     const onClickRequestSignature = jest.fn();
     const onClickSignMyself = jest.fn();
+    const signLabel = localize(messages.boxSignRequestSignature.id);
+    const requestSignatureButtonText = localize(messages.boxSignRequestSignature.id);
+    const signMyselfButtonText = localize(messages.boxSignSignMyself.id);
 
     const renderComponent = (props = {}, features = {}) =>
         render(
             <FeatureProvider features={features}>
                 <SidebarNavSign {...props} />
             </FeatureProvider>,
+            {
+                wrapper: ({ children }: { children?: React.ReactNode }) => (
+                    <IntlProvider locale="en-US">{children}</IntlProvider>
+                ),
+            },
         );
 
-    test.each([true, false])('should render sign button', isRemoveInterstitialEnabled => {
-        const features = {
-            boxSign: {
-                isSignRemoveInterstitialEnabled: isRemoveInterstitialEnabled,
-            },
-        };
+    test('should render sign button', () => {
+        const wrapper = renderComponent();
 
-        const wrapper = renderComponent({}, features);
-        expect(wrapper.getByTestId('sign-button')).toBeVisible();
-    });
-
-    test('should call correct handler when sign button is clicked', () => {
-        const features = {
-            boxSign: {
-                isSignRemoveInterstitialEnabled: false,
-                onClick: onClickRequestSignature,
-            },
-        };
-        const { getByTestId } = renderComponent({}, features);
-
-        fireEvent.click(getByTestId('sign-button'));
-
-        expect(onClickRequestSignature).toBeCalled();
+        expect(wrapper.getByLabelText(signLabel)).toBeVisible();
     });
 
     test('should open dropdown with 2 menu items when sign button is clicked', () => {
-        const features = {
-            boxSign: {
-                isSignRemoveInterstitialEnabled: true,
-            },
-        };
-        const { getByTestId } = renderComponent({}, features);
-        fireEvent.click(getByTestId('sign-button'));
-        expect(getByTestId('sign-request-signature-button')).toBeVisible();
-        expect(getByTestId('sign-sign-myself-button')).toBeVisible();
+        const wrapper = renderComponent();
+
+        fireEvent.click(wrapper.getByLabelText(signLabel));
+
+        expect(wrapper.getByText(requestSignatureButtonText)).toBeVisible();
+        expect(wrapper.getByText(signMyselfButtonText)).toBeVisible();
     });
 
     test('should call correct handler when request signature option is clicked', () => {
         const features = {
             boxSign: {
-                isSignRemoveInterstitialEnabled: true,
                 onClick: onClickRequestSignature,
             },
         };
-        const { getByTestId } = renderComponent({}, features);
-        fireEvent.click(getByTestId('sign-button'));
-        fireEvent.click(getByTestId('sign-request-signature-button'));
+        const wrapper = renderComponent({}, features);
+
+        fireEvent.click(wrapper.getByLabelText(signLabel));
+        fireEvent.click(wrapper.getByText(requestSignatureButtonText));
+
         expect(onClickRequestSignature).toBeCalled();
     });
 
     test('should call correct handler when sign myself option is clicked', () => {
         const features = {
             boxSign: {
-                isSignRemoveInterstitialEnabled: true,
                 onClickSignMyself,
             },
         };
-        const { getByTestId } = renderComponent({}, features);
-        fireEvent.click(getByTestId('sign-button'));
-        fireEvent.click(getByTestId('sign-sign-myself-button'));
+        const wrapper = renderComponent({}, features);
+
+        fireEvent.click(wrapper.getByLabelText(signLabel));
+        fireEvent.click(wrapper.getByText(signMyselfButtonText));
+
         expect(onClickSignMyself).toBeCalled();
     });
 });


### PR DESCRIPTION
The isSignRemoveInterstitialEnabled feature flag was recently cleaned up in EUA, causing a production defect due to a dependency in this components. This commit removes the dependency in BUIE components to align with EUA

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
