### PR TITLE
feat(content-sidebar): Added open state change handler prop

### DIFF
--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -76,6 +76,7 @@ type Props = {
     metadataSidebarProps: MetadataSidebarProps,
     onAnnotationSelect?: Function,
     onFetchFileSuccess?: () => void,
+    onOpenChange?: (isOpen: boolean) => void,
     onPanelChange?: (name: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
@@ -358,6 +359,7 @@ class ContentSidebar extends React.Component<Props, State> {
             messages,
             metadataSidebarProps,
             onAnnotationSelect,
+            onOpenChange,
             onPanelChange,
             onVersionChange,
             onVersionHistoryClick,
@@ -398,6 +400,7 @@ class ContentSidebar extends React.Component<Props, State> {
                                 metadataEditors={metadataEditors}
                                 metadataSidebarProps={metadataSidebarProps}
                                 onAnnotationSelect={onAnnotationSelect}
+                                onOpenChange={onOpenChange}
                                 onPanelChange={onPanelChange}
                                 onVersionChange={onVersionChange}
                                 onVersionHistoryClick={onVersionHistoryClick}

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -61,6 +61,7 @@ type Props = {
     metadataEditors?: Array<MetadataEditor>,
     metadataSidebarProps: MetadataSidebarProps,
     onAnnotationSelect?: Function,
+    onOpenChange?: (isOpen: boolean) => void,
     onPanelChange?: (name: string) => void,
     onVersionChange?: Function,
     onVersionHistoryClick?: Function,
@@ -82,6 +83,7 @@ class Sidebar extends React.Component<Props, State> {
         isLoading: false,
         getAnnotationsMatchPath: noop,
         getAnnotationsPath: noop,
+        onOpenChange: noop,
     };
 
     id: string = uniqueid('bcs_');
@@ -113,7 +115,7 @@ class Sidebar extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props): void {
-        const { fileId, history, location }: Props = this.props;
+        const { fileId, history, location, onOpenChange }: Props = this.props;
         const { fileId: prevFileId, location: prevLocation }: Props = prevProps;
         const { isDirty }: State = this.state;
 
@@ -126,6 +128,11 @@ class Sidebar extends React.Component<Props, State> {
         if (location !== prevLocation && !this.getLocationState('silent')) {
             this.setForcedByLocation();
             this.setState({ isDirty: true });
+            const openState = this.getLocationState('open');
+            // Check if the sidebar was expanded / collapsed
+            if (prevLocation.state?.open !== openState) {
+                onOpenChange(openState);
+            }
         }
 
         this.handleDocgenTemplateOnUpdate(prevProps);

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -83,7 +83,6 @@ class Sidebar extends React.Component<Props, State> {
         isLoading: false,
         getAnnotationsMatchPath: noop,
         getAnnotationsPath: noop,
-        onOpenChange: noop,
     };
 
     id: string = uniqueid('bcs_');
@@ -115,7 +114,7 @@ class Sidebar extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props): void {
-        const { fileId, history, location, onOpenChange }: Props = this.props;
+        const { fileId, history, location, onOpenChange = noop }: Props = this.props;
         const { fileId: prevFileId, location: prevLocation }: Props = prevProps;
         const { isDirty }: State = this.state;
 

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -195,9 +195,11 @@ describe('elements/content-sidebar/Sidebar', () => {
             });
 
             test.each`
-                prevOpen | open
-                ${false} | ${true}
-                ${true}  | ${false}
+                prevOpen     | open
+                ${false}     | ${true}
+                ${true}      | ${false}
+                ${undefined} | ${true}
+                ${undefined} | ${false}
             `(
                 'given previous open state = $prevOpen and new open state = $open should call onOpenChange with $open',
                 ({ prevOpen, open }) => {
@@ -206,6 +208,20 @@ describe('elements/content-sidebar/Sidebar', () => {
                     rerender(getSidebar(open));
 
                     expect(mockOnOpenChange).toBeCalledWith(open);
+                },
+            );
+            test.each`
+                prevOpen | open
+                ${false} | ${false}
+                ${true}  | ${true}
+            `(
+                'given previous open state = $prevOpen and new open state = $open should not call onOpenChange',
+                ({ prevOpen, open }) => {
+                    const { rerender } = render(getSidebar(prevOpen));
+
+                    rerender(getSidebar(open));
+
+                    expect(mockOnOpenChange).not.toBeCalled();
                 },
             );
         });

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
 import {
     SIDEBAR_FORCE_KEY,
     SIDEBAR_FORCE_VALUE_CLOSED,
@@ -171,6 +173,41 @@ describe('elements/content-sidebar/Sidebar', () => {
                 docGenSidebarProps: withDocgenFeature,
             });
             expect(historyMock.push).toHaveBeenCalledWith('/');
+        });
+        describe('open state change', () => {
+            const mockOnOpenChange = jest.fn();
+            const getSidebar = open => (
+                <MemoryRouter initialEntries={['/']}>
+                    <Sidebar
+                        {...defaultProps}
+                        file={file}
+                        location={{
+                            pathname: '/',
+                            state: { open },
+                        }}
+                        onOpenChange={mockOnOpenChange}
+                    />
+                </MemoryRouter>
+            );
+
+            afterEach(() => {
+                mockOnOpenChange.mockClear();
+            });
+
+            test.each`
+                prevOpen | open
+                ${false} | ${true}
+                ${true}  | ${false}
+            `(
+                'given previous open state = $prevOpen and new open state = $open should call onOpenChange with $open',
+                ({ prevOpen, open }) => {
+                    const { rerender } = render(getSidebar(prevOpen));
+
+                    rerender(getSidebar(open));
+
+                    expect(mockOnOpenChange).toBeCalledWith(open);
+                },
+            );
         });
     });
 


### PR DESCRIPTION
### Description
Added `onOpenChange` prop to ContentSidebar. The reason for that is that we need to handle sidebar being collapsed or expanded.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
