### PR TITLE
fix(content-sidebar): fix archive date formatting

### DIFF
--- a/src/elements/content-sidebar/SidebarFileProperties.js
+++ b/src/elements/content-sidebar/SidebarFileProperties.js
@@ -43,7 +43,7 @@ const SidebarFileProperties = ({
     return (
         <LoadingIndicatorWrapper isLoading={isLoading}>
             <ItemProperties
-                archivedAt={archiveDate && archiveDate * 1}
+                archivedAt={archiveDate && Number(archiveDate)}
                 createdAt={file.content_created_at}
                 description={file.description}
                 descriptionTextareaProps={{

--- a/src/elements/content-sidebar/SidebarFileProperties.js
+++ b/src/elements/content-sidebar/SidebarFileProperties.js
@@ -43,7 +43,7 @@ const SidebarFileProperties = ({
     return (
         <LoadingIndicatorWrapper isLoading={isLoading}>
             <ItemProperties
-                archivedAt={archiveDate && archiveDate * 1000}
+                archivedAt={archiveDate && archiveDate * 1}
                 createdAt={file.content_created_at}
                 description={file.description}
                 descriptionTextareaProps={{

--- a/src/elements/content-sidebar/__tests__/SidebarFileProperties.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarFileProperties.test.js
@@ -23,7 +23,7 @@ describe('elements/content-sidebar/SidebarFileProperties', () => {
             metadata: {
                 global: {
                     archivedItemTemplate: {
-                        archiveDate: '1726832355',
+                        archiveDate: '1726832355000',
                     },
                 },
             },


### PR DESCRIPTION
It has turned out that we store archive date in milliseconds, so multiplication by 1000 was not necessary.
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
