### PR TITLE
feat(content-sidebar): Added panel selection preservation

### DIFF
--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -67,6 +67,7 @@ type Props = {
     hasAdditionalTabs: boolean,
     hasMetadata: boolean,
     hasNav: boolean,
+    hasPanelSelectionPreservation: boolean,
     hasSkills: boolean,
     hasVersions: boolean,
     history?: RouterHistory,
@@ -351,6 +352,7 @@ class ContentSidebar extends React.Component<Props, State> {
             hasActivityFeed,
             hasMetadata,
             hasNav,
+            hasPanelSelectionPreservation,
             hasSkills,
             hasVersions,
             history,
@@ -393,6 +395,7 @@ class ContentSidebar extends React.Component<Props, State> {
                                 hasAdditionalTabs={hasAdditionalTabs}
                                 hasNav={hasNav}
                                 hasMetadata={hasMetadata}
+                                hasPanelSelectionPreservation={hasPanelSelectionPreservation}
                                 hasSkills={hasSkills}
                                 hasVersions={hasVersions}
                                 isDefaultOpen={isDefaultOpen}

--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -67,7 +67,6 @@ type Props = {
     hasAdditionalTabs: boolean,
     hasMetadata: boolean,
     hasNav: boolean,
-    hasPanelSelectionPreservation: boolean,
     hasSkills: boolean,
     hasVersions: boolean,
     history?: RouterHistory,
@@ -352,7 +351,6 @@ class ContentSidebar extends React.Component<Props, State> {
             hasActivityFeed,
             hasMetadata,
             hasNav,
-            hasPanelSelectionPreservation,
             hasSkills,
             hasVersions,
             history,
@@ -395,7 +393,6 @@ class ContentSidebar extends React.Component<Props, State> {
                                 hasAdditionalTabs={hasAdditionalTabs}
                                 hasNav={hasNav}
                                 hasMetadata={hasMetadata}
-                                hasPanelSelectionPreservation={hasPanelSelectionPreservation}
                                 hasSkills={hasSkills}
                                 hasVersions={hasVersions}
                                 isDefaultOpen={isDefaultOpen}

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -18,7 +18,7 @@ import SidebarNav from './SidebarNav';
 import SidebarPanels from './SidebarPanels';
 import SidebarUtils from './SidebarUtils';
 import { withCurrentUser } from '../common/current-user';
-import { withFeatureConsumer } from '../common/feature-checking';
+import { isFeatureEnabled, withFeatureConsumer } from '../common/feature-checking';
 import type { FeatureConfig } from '../common/feature-checking';
 import type { ActivitySidebarProps } from './ActivitySidebar';
 import type { DetailsSidebarProps } from './DetailsSidebar';
@@ -52,7 +52,6 @@ type Props = {
     hasAdditionalTabs: boolean,
     hasMetadata: boolean,
     hasNav: boolean,
-    hasPanelSelectionPreservation: boolean,
     hasSkills: boolean,
     hasVersions: boolean,
     history: RouterHistory,
@@ -255,9 +254,9 @@ class Sidebar extends React.Component<Props, State> {
     }
 
     getDefaultPanel(): string | typeof undefined {
-        const { hasPanelSelectionPreservation } = this.props;
+        const { features } = this.props;
 
-        if (!hasPanelSelectionPreservation) {
+        if (!isFeatureEnabled(features, 'panelSelectionPreservation')) {
             return undefined;
         }
 
@@ -265,8 +264,8 @@ class Sidebar extends React.Component<Props, State> {
     }
 
     handlePanelChange = (name: string) => {
-        const { hasPanelSelectionPreservation, onPanelChange = noop } = this.props;
-        if (hasPanelSelectionPreservation) {
+        const { features, onPanelChange = noop } = this.props;
+        if (isFeatureEnabled(features, 'panelSelectionPreservation')) {
             this.store.setItem(SIDEBAR_SELECTED_PANEL_KEY, name);
         }
         onPanelChange(name);

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -254,7 +254,7 @@ class Sidebar extends React.Component<Props, State> {
         }
     }
 
-    getDefaultPanel(): string | undefined {
+    getDefaultPanel(): string | typeof undefined {
         const { hasPanelSelectionPreservation } = this.props;
 
         if (!hasPanelSelectionPreservation) {

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -52,6 +52,7 @@ type Props = {
     hasAdditionalTabs: boolean,
     hasMetadata: boolean,
     hasNav: boolean,
+    hasPanelSelectionPreservation: boolean,
     hasSkills: boolean,
     hasVersions: boolean,
     history: RouterHistory,
@@ -75,6 +76,7 @@ type State = {
 export const SIDEBAR_FORCE_KEY: 'bcs.force' = 'bcs.force';
 export const SIDEBAR_FORCE_VALUE_CLOSED: 'closed' = 'closed';
 export const SIDEBAR_FORCE_VALUE_OPEN: 'open' = 'open';
+export const SIDEBAR_SELECTED_PANEL_KEY: 'sidebar-selected-panel' = 'sidebar-selected-panel';
 
 class Sidebar extends React.Component<Props, State> {
     static defaultProps = {
@@ -252,6 +254,24 @@ class Sidebar extends React.Component<Props, State> {
         }
     }
 
+    getDefaultPanel(): string | undefined {
+        const { hasPanelSelectionPreservation } = this.props;
+
+        if (!hasPanelSelectionPreservation) {
+            return undefined;
+        }
+
+        return this.store.getItem(SIDEBAR_SELECTED_PANEL_KEY) || undefined;
+    }
+
+    handlePanelChange = (name: string) => {
+        const { hasPanelSelectionPreservation, onPanelChange = noop } = this.props;
+        if (hasPanelSelectionPreservation) {
+            this.store.setItem(SIDEBAR_SELECTED_PANEL_KEY, name);
+        }
+        onPanelChange(name);
+    };
+
     render() {
         const {
             activitySidebarProps,
@@ -274,7 +294,6 @@ class Sidebar extends React.Component<Props, State> {
             metadataEditors,
             metadataSidebarProps,
             onAnnotationSelect,
-            onPanelChange,
             onVersionChange,
             versionsSidebarProps,
         }: Props = this.props;
@@ -288,6 +307,7 @@ class Sidebar extends React.Component<Props, State> {
         const styleClassName = classNames('be bcs', className, {
             'bcs-is-open': isOpen,
         });
+        const defaultPanel = this.getDefaultPanel();
 
         return (
             <aside id={this.id} className={styleClassName} data-testid="preview-sidebar">
@@ -310,7 +330,7 @@ class Sidebar extends React.Component<Props, State> {
                                 hasSkills={hasSkills}
                                 hasDocGen={docGenSidebarProps.isDocGenTemplate}
                                 isOpen={isOpen}
-                                onPanelChange={onPanelChange}
+                                onPanelChange={this.handlePanelChange}
                             />
                         )}
                         <SidebarPanels
@@ -319,6 +339,7 @@ class Sidebar extends React.Component<Props, State> {
                             currentUser={currentUser}
                             currentUserError={currentUserError}
                             elementId={this.id}
+                            defaultPanel={defaultPanel}
                             detailsSidebarProps={detailsSidebarProps}
                             docGenSidebarProps={docGenSidebarProps}
                             file={file}

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -185,7 +185,7 @@ class SidebarPanels extends React.Component<Props, State> {
             boxAISidebarProps,
             currentUser,
             currentUserError,
-            defaultPanel,
+            defaultPanel = '',
             detailsSidebarProps,
             docGenSidebarProps,
             elementId,

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -46,6 +46,7 @@ type Props = {
     boxAISidebarProps: BoxAISidebarProps,
     currentUser?: User,
     currentUserError?: Errors,
+    defaultPanel?: string,
     detailsSidebarProps: DetailsSidebarProps,
     docGenSidebarProps: DocGenSidebarProps,
     elementId: string,
@@ -184,6 +185,7 @@ class SidebarPanels extends React.Component<Props, State> {
             boxAISidebarProps,
             currentUser,
             currentUserError,
+            defaultPanel,
             detailsSidebarProps,
             docGenSidebarProps,
             elementId,
@@ -211,6 +213,16 @@ class SidebarPanels extends React.Component<Props, State> {
 
         const isMetadataSidebarRedesignEnabled = isFeatureEnabled(features, 'metadata.redesign.enabled');
         const isMetadataAiSuggestionsEnabled = isFeatureEnabled(features, 'metadata.aiSuggestions.enabled');
+
+        const availablePanels = [
+            SIDEBAR_VIEW_BOXAI,
+            SIDEBAR_VIEW_DOCGEN,
+            SIDEBAR_VIEW_SKILLS,
+            SIDEBAR_VIEW_ACTIVITY,
+            SIDEBAR_VIEW_DETAILS,
+            SIDEBAR_VIEW_METADATA,
+        ];
+        const canShowDefaultPanel = !!(defaultPanel && availablePanels.includes(defaultPanel));
 
         if (!isOpen || (!hasBoxAI && !hasActivity && !hasDetails && !hasMetadata && !hasSkills && !hasVersions)) {
             return null;
@@ -369,7 +381,9 @@ class SidebarPanels extends React.Component<Props, State> {
                     render={() => {
                         let redirect = '';
 
-                        if (hasBoxAI) {
+                        if (canShowDefaultPanel) {
+                            redirect = defaultPanel;
+                        } else if (hasBoxAI) {
                             redirect = SIDEBAR_VIEW_BOXAI;
                         } else if (hasDocGen) {
                             redirect = SIDEBAR_VIEW_DOCGEN;

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -214,15 +214,16 @@ class SidebarPanels extends React.Component<Props, State> {
         const isMetadataSidebarRedesignEnabled = isFeatureEnabled(features, 'metadata.redesign.enabled');
         const isMetadataAiSuggestionsEnabled = isFeatureEnabled(features, 'metadata.aiSuggestions.enabled');
 
-        const availablePanels = [
-            SIDEBAR_VIEW_BOXAI,
-            SIDEBAR_VIEW_DOCGEN,
-            SIDEBAR_VIEW_SKILLS,
-            SIDEBAR_VIEW_ACTIVITY,
-            SIDEBAR_VIEW_DETAILS,
-            SIDEBAR_VIEW_METADATA,
-        ];
-        const canShowDefaultPanel = !!(defaultPanel && availablePanels.includes(defaultPanel));
+        const panelsEligibility = {
+            [SIDEBAR_VIEW_BOXAI]: hasBoxAI,
+            [SIDEBAR_VIEW_DOCGEN]: hasDocGen,
+            [SIDEBAR_VIEW_SKILLS]: hasSkills,
+            [SIDEBAR_VIEW_ACTIVITY]: hasActivity,
+            [SIDEBAR_VIEW_DETAILS]: hasDetails,
+            [SIDEBAR_VIEW_METADATA]: hasMetadata,
+        };
+
+        const canShowDefaultPanel: boolean = !!(defaultPanel && panelsEligibility[defaultPanel]);
 
         if (!isOpen || (!hasBoxAI && !hasActivity && !hasDetails && !hasMetadata && !hasSkills && !hasVersions)) {
             return null;

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -223,7 +223,7 @@ class SidebarPanels extends React.Component<Props, State> {
             [SIDEBAR_VIEW_METADATA]: hasMetadata,
         };
 
-        const canShowDefaultPanel: boolean = !!(defaultPanel && panelsEligibility[defaultPanel]);
+        const showDefaultPanel: boolean = !!(defaultPanel && panelsEligibility[defaultPanel]);
 
         if (!isOpen || (!hasBoxAI && !hasActivity && !hasDetails && !hasMetadata && !hasSkills && !hasVersions)) {
             return null;
@@ -382,7 +382,7 @@ class SidebarPanels extends React.Component<Props, State> {
                     render={() => {
                         let redirect = '';
 
-                        if (canShowDefaultPanel) {
+                        if (showDefaultPanel) {
                             redirect = defaultPanel;
                         } else if (hasBoxAI) {
                             redirect = SIDEBAR_VIEW_BOXAI;

--- a/src/elements/content-sidebar/__mocks__/SidebarUtils.js
+++ b/src/elements/content-sidebar/__mocks__/SidebarUtils.js
@@ -42,6 +42,11 @@ export default {
                     return <div data-testid="versions-sidebar" />;
                 }
             },
+            docgen: class DocGenSidebar extends React.Component {
+                render() {
+                    return <div data-testid="docgen-sidebar" />;
+                }
+            },
         }[panelName];
     }),
 };

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -416,19 +416,19 @@ describe('elements/content-sidebar/Sidebar', () => {
                 MockSidebarPanels.mockClear();
             });
             test.each`
-                hasPanelSelectionPreservation | savedDefaultPanel | expected
-                ${true}                       | ${'activity'}     | ${'activity'}
-                ${true}                       | ${'details'}      | ${'details'}
-                ${true}                       | ${null}           | ${undefined}
-                ${false}                      | ${'activity'}     | ${undefined}
-                ${undefined}                  | ${'activity'}     | ${undefined}
+                panelSelectionPreservation | savedDefaultPanel | expected
+                ${true}                    | ${'activity'}     | ${'activity'}
+                ${true}                    | ${'details'}      | ${'details'}
+                ${true}                    | ${null}           | ${undefined}
+                ${false}                   | ${'activity'}     | ${undefined}
+                ${undefined}               | ${'activity'}     | ${undefined}
             `(
-                'should render SidebarPanels with defaultPanel prop = $defaultPanel, given sidebar selected panel saved in LocalStore is $defaultPanel and hasPanelSelectionPreservation = $hasPanelSelectionPreservation',
-                ({ hasPanelSelectionPreservation, savedDefaultPanel, expected }) => {
+                'should render SidebarPanels with defaultPanel prop = $defaultPanel, given sidebar selected panel saved in LocalStore is $defaultPanel and panelSelectionPreservation feature = $panelSelectionPreservation',
+                ({ panelSelectionPreservation, savedDefaultPanel, expected }) => {
                     mockGetItem.mockReturnValue(savedDefaultPanel);
                     render(
                         getSidebar({
-                            hasPanelSelectionPreservation,
+                            features: { panelSelectionPreservation },
                         }),
                     );
                     expect(MockSidebarPanels).toHaveBeenCalledWith(
@@ -484,11 +484,11 @@ describe('elements/content-sidebar/Sidebar', () => {
             expect(mockOnPanelChange).toHaveBeenCalledWith(mockPanelName);
         });
 
-        test('given hasPanelSelectionPreservation = true should save panel name in LocalStore', () => {
+        test('given panelSelectionPreservation feature = true should save panel name in LocalStore', () => {
             render(
                 getSidebar({
+                    features: { panelSelectionPreservation: true },
                     hasNav: true,
-                    hasPanelSelectionPreservation: true,
                 }),
             );
 
@@ -496,16 +496,16 @@ describe('elements/content-sidebar/Sidebar', () => {
         });
 
         test.each`
-            hasPanelSelectionPreservation
+            panelSelectionPreservation
             ${undefined}
             ${false}
         `(
-            'given hasPanelSelectionPreservation = $hasPanelSelectionPreservation should not save panel name in LocalStore',
-            ({ hasPanelSelectionPreservation }) => {
+            'given panelSelectionPreservation feature = $panelSelectionPreservation should not save panel name in LocalStore',
+            ({ panelSelectionPreservation }) => {
                 render(
                     getSidebar({
+                        features: { panelSelectionPreservation },
                         hasNav: true,
-                        hasPanelSelectionPreservation,
                     }),
                 );
 

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -6,10 +6,21 @@ import {
     SIDEBAR_FORCE_KEY,
     SIDEBAR_FORCE_VALUE_CLOSED,
     SIDEBAR_FORCE_VALUE_OPEN,
+    SIDEBAR_SELECTED_PANEL_KEY,
     SidebarComponent as Sidebar,
 } from '../Sidebar';
+import SidebarNav from '../SidebarNav';
+import SidebarPanels from '../SidebarPanels';
 import LocalStore from '../../../utils/LocalStore';
 
+jest.mock('../SidebarNav', () => ({
+    __esModule: true,
+    default: jest.fn(() => 'SidebarNav'),
+}));
+jest.mock('../SidebarPanels', () => ({
+    __esModule: true,
+    default: jest.fn(() => 'SidebarPanels'),
+}));
 jest.mock('../../common/async-load', () => () => 'LoadableComponent');
 jest.mock('../../../utils/LocalStore');
 
@@ -40,6 +51,12 @@ describe('elements/content-sidebar/Sidebar', () => {
     };
 
     const getWrapper = props => shallow(<Sidebar {...defaultProps} {...props} />);
+
+    const getSidebar = props => (
+        <MemoryRouter initialEntries={['/']}>
+            <Sidebar {...defaultProps} {...props} />
+        </MemoryRouter>
+    );
 
     beforeEach(() => {
         LocalStore.mockClear();
@@ -176,19 +193,6 @@ describe('elements/content-sidebar/Sidebar', () => {
         });
         describe('open state change', () => {
             const mockOnOpenChange = jest.fn();
-            const getSidebar = open => (
-                <MemoryRouter initialEntries={['/']}>
-                    <Sidebar
-                        {...defaultProps}
-                        file={file}
-                        location={{
-                            pathname: '/',
-                            state: { open },
-                        }}
-                        onOpenChange={mockOnOpenChange}
-                    />
-                </MemoryRouter>
-            );
 
             afterEach(() => {
                 mockOnOpenChange.mockClear();
@@ -203,9 +207,25 @@ describe('elements/content-sidebar/Sidebar', () => {
             `(
                 'given previous open state = $prevOpen and new open state = $open should call onOpenChange with $open',
                 ({ prevOpen, open }) => {
-                    const { rerender } = render(getSidebar(prevOpen));
+                    const { rerender } = render(
+                        getSidebar({
+                            location: {
+                                pathname: '/',
+                                state: { open: prevOpen },
+                            },
+                            onOpenChange: mockOnOpenChange,
+                        }),
+                    );
 
-                    rerender(getSidebar(open));
+                    rerender(
+                        getSidebar({
+                            location: {
+                                pathname: '/',
+                                state: { open },
+                            },
+                            onOpenChange: mockOnOpenChange,
+                        }),
+                    );
 
                     expect(mockOnOpenChange).toBeCalledWith(open);
                 },
@@ -217,9 +237,25 @@ describe('elements/content-sidebar/Sidebar', () => {
             `(
                 'given previous open state = $prevOpen and new open state = $open should not call onOpenChange',
                 ({ prevOpen, open }) => {
-                    const { rerender } = render(getSidebar(prevOpen));
+                    const { rerender } = render(
+                        getSidebar({
+                            location: {
+                                pathname: '/',
+                                state: { open: prevOpen },
+                            },
+                            onOpenChange: mockOnOpenChange,
+                        }),
+                    );
 
-                    rerender(getSidebar(open));
+                    rerender(
+                        getSidebar({
+                            location: {
+                                pathname: '/',
+                                state: { open },
+                            },
+                            onOpenChange: mockOnOpenChange,
+                        }),
+                    );
 
                     expect(mockOnOpenChange).not.toBeCalled();
                 },
@@ -362,6 +398,46 @@ describe('elements/content-sidebar/Sidebar', () => {
 
             expect(wrapper.exists('SidebarNav')).toBe(false);
         });
+
+        describe('SidebarPanels', () => {
+            const mockGetItem = jest.fn();
+            const MockSidebarPanels = jest.fn(() => 'SidebarPanels');
+
+            beforeEach(() => {
+                LocalStore.mockImplementationOnce(() => ({
+                    getItem: mockGetItem,
+                    setItem: jest.fn(),
+                }));
+                SidebarPanels.mockImplementationOnce(MockSidebarPanels);
+            });
+
+            afterEach(() => {
+                mockGetItem.mockClear();
+                MockSidebarPanels.mockClear();
+            });
+            test.each`
+                hasPanelSelectionPreservation | savedDefaultPanel | expected
+                ${true}                       | ${'activity'}     | ${'activity'}
+                ${true}                       | ${'details'}      | ${'details'}
+                ${true}                       | ${null}           | ${undefined}
+                ${false}                      | ${'activity'}     | ${undefined}
+                ${undefined}                  | ${'activity'}     | ${undefined}
+            `(
+                'should render SidebarPanels with defaultPanel prop = $defaultPanel, given sidebar selected panel saved in LocalStore is $defaultPanel and hasPanelSelectionPreservation = $hasPanelSelectionPreservation',
+                ({ hasPanelSelectionPreservation, savedDefaultPanel, expected }) => {
+                    mockGetItem.mockReturnValue(savedDefaultPanel);
+                    render(
+                        getSidebar({
+                            hasPanelSelectionPreservation,
+                        }),
+                    );
+                    expect(MockSidebarPanels).toHaveBeenCalledWith(
+                        expect.objectContaining({ defaultPanel: expected }),
+                        {},
+                    );
+                },
+            );
+        });
     });
 
     describe('refresh()', () => {
@@ -374,5 +450,67 @@ describe('elements/content-sidebar/Sidebar', () => {
 
             expect(refresh).toHaveBeenCalledWith(shouldRefreshCache);
         });
+    });
+
+    describe('on panel change', () => {
+        const mockSetItem = jest.fn();
+        const mockPanelName = 'activity';
+
+        beforeEach(() => {
+            LocalStore.mockImplementationOnce(() => ({
+                getItem: jest.fn(),
+                setItem: mockSetItem,
+            }));
+
+            SidebarNav.mockImplementationOnce(({ onPanelChange }) => {
+                onPanelChange(mockPanelName);
+                return 'SidebarNav';
+            });
+        });
+
+        afterEach(() => {
+            mockSetItem.mockClear();
+        });
+
+        test('should call onPanelChange prop', () => {
+            const mockOnPanelChange = jest.fn();
+            render(
+                getSidebar({
+                    hasNav: true,
+                    onPanelChange: mockOnPanelChange,
+                }),
+            );
+
+            expect(mockOnPanelChange).toHaveBeenCalledWith(mockPanelName);
+        });
+
+        test('given hasPanelSelectionPreservation = true should save panel name in LocalStore', () => {
+            render(
+                getSidebar({
+                    hasNav: true,
+                    hasPanelSelectionPreservation: true,
+                }),
+            );
+
+            expect(mockSetItem).toHaveBeenCalledWith(SIDEBAR_SELECTED_PANEL_KEY, mockPanelName);
+        });
+
+        test.each`
+            hasPanelSelectionPreservation
+            ${undefined}
+            ${false}
+        `(
+            'given hasPanelSelectionPreservation = $hasPanelSelectionPreservation should not save panel name in LocalStore',
+            ({ hasPanelSelectionPreservation }) => {
+                render(
+                    getSidebar({
+                        hasNav: true,
+                        hasPanelSelectionPreservation,
+                    }),
+                );
+
+                expect(mockSetItem).not.toHaveBeenCalled();
+            },
+        );
     });
 });

--- a/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
@@ -15,6 +15,7 @@ describe('elements/content-sidebar/SidebarPanels', () => {
             <SidebarPanels
                 file={{ id: '1234' }}
                 hasBoxAI
+                hasDocGen
                 hasActivity
                 hasDetails
                 hasMetadata
@@ -37,6 +38,7 @@ describe('elements/content-sidebar/SidebarPanels', () => {
             <SidebarPanels
                 file={{ id: '1234' }}
                 hasBoxAI
+                hasDocGen
                 hasActivity
                 hasDetails
                 hasMetadata
@@ -67,6 +69,7 @@ describe('elements/content-sidebar/SidebarPanels', () => {
             ${'/metadata'}                       | ${'MetadataSidebar'}
             ${'/skills'}                         | ${'SkillsSidebar'}
             ${'/boxai'}                          | ${'BoxAISidebar'}
+            ${'/docgen'}                         | ${'DocGenSidebar'}
             ${'/nonsense'}                       | ${'BoxAISidebar'}
             ${'/'}                               | ${'BoxAISidebar'}
         `('should render $sidebar given the path $path', ({ path, sidebar }) => {
@@ -77,6 +80,7 @@ describe('elements/content-sidebar/SidebarPanels', () => {
         test.each`
             defaultPanel  | sidebar
             ${'activity'} | ${'activity-sidebar'}
+            ${'docgen'}   | ${'docgen-sidebar'}
             ${'details'}  | ${'details-sidebar'}
             ${'metadata'} | ${'metadata-sidebar'}
             ${'skills'}   | ${'skills-sidebar'}
@@ -94,6 +98,74 @@ describe('elements/content-sidebar/SidebarPanels', () => {
                 expect(screen.getByTestId(sidebar)).toBeInTheDocument();
             },
         );
+
+        test.each`
+            defaultPanel  | expectedSidebar     | hasActivity | hasDetails | hasMetadata | hasSkills | hasDocGen | hasBoxAI
+            ${'activity'} | ${'boxai-sidebar'}  | ${false}    | ${true}    | ${true}     | ${true}   | ${true}   | ${true}
+            ${'details'}  | ${'boxai-sidebar'}  | ${true}     | ${false}   | ${true}     | ${true}   | ${true}   | ${true}
+            ${'metadata'} | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${false}    | ${true}   | ${true}   | ${true}
+            ${'skills'}   | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${true}     | ${false}  | ${true}   | ${true}
+            ${'docgen'}   | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${true}     | ${false}  | ${false}  | ${true}
+            ${'boxai'}    | ${'docgen-sidebar'} | ${true}     | ${true}    | ${true}     | ${true}   | ${true}   | ${false}
+        `(
+            'should render first available panel for users without rights to render default panel, given the path = "/" and defaultPanel = $defaultPanel',
+            ({
+                defaultPanel,
+                expectedSidebar,
+                hasActivity,
+                hasDetails,
+                hasMetadata,
+                hasSkills,
+                hasDocGen,
+                hasBoxAI,
+            }) => {
+                render(
+                    getSidebarPanels({
+                        defaultPanel,
+                        hasActivity,
+                        hasDetails,
+                        hasMetadata,
+                        hasSkills,
+                        hasDocGen,
+                        hasBoxAI,
+                    }),
+                );
+                expect(screen.getByTestId(expectedSidebar)).toBeInTheDocument();
+            },
+        );
+
+        describe('sidebar selected with path should take precedence over default panel', () => {
+            test.each`
+                path                                 | sidebar               | defaultPanel
+                ${'/activity'}                       | ${'activity-sidebar'} | ${'details'}
+                ${'/activity/comments'}              | ${'activity-sidebar'} | ${'details'}
+                ${'/activity/comments/1234'}         | ${'activity-sidebar'} | ${'details'}
+                ${'/activity/tasks'}                 | ${'activity-sidebar'} | ${'details'}
+                ${'/activity/tasks/1234'}            | ${'activity-sidebar'} | ${'details'}
+                ${'/activity/annotations/1234/5678'} | ${'activity-sidebar'} | ${'details'}
+                ${'/activity/annotations/1234'}      | ${'activity-sidebar'} | ${'details'}
+                ${'/activity/versions'}              | ${'versions-sidebar'} | ${'details'}
+                ${'/activity/versions/1234'}         | ${'versions-sidebar'} | ${'details'}
+                ${'/details'}                        | ${'details-sidebar'}  | ${'activity'}
+                ${'/details/versions'}               | ${'versions-sidebar'} | ${'activity'}
+                ${'/details/versions/1234'}          | ${'versions-sidebar'} | ${'activity'}
+                ${'/metadata'}                       | ${'metadata-sidebar'} | ${'details'}
+                ${'/skills'}                         | ${'skills-sidebar'}   | ${'details'}
+                ${'/boxai'}                          | ${'boxai-sidebar'}    | ${'details'}
+                ${'/docgen'}                         | ${'docgen-sidebar'}   | ${'details'}
+            `(
+                'should render $sidebar given the path = $path and defaultPanel = $defaultPanel',
+                ({ path, sidebar, defaultPanel }) => {
+                    render(
+                        getSidebarPanels({
+                            defaultPanel,
+                            path,
+                        }),
+                    );
+                    expect(screen.getByTestId(sidebar)).toBeInTheDocument();
+                },
+            );
+        });
 
         test('should render redesigned metadata sidebar if it is enabled', () => {
             const wrapper = getWrapper({ path: '/metadata', features: { metadata: { redesign: { enabled: true } } } });

--- a/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme/build';
 import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
 
 import { FEED_ITEM_TYPE_ANNOTATION, FEED_ITEM_TYPE_COMMENT, FEED_ITEM_TYPE_TASK } from '../../../constants';
 import { SidebarPanelsComponent as SidebarPanels } from '../SidebarPanels';
@@ -31,6 +32,23 @@ describe('elements/content-sidebar/SidebarPanels', () => {
             },
         );
 
+    const getSidebarPanels = ({ path = '/', ...props }) => (
+        <MemoryRouter initialEntries={[path]}>
+            <SidebarPanels
+                file={{ id: '1234' }}
+                hasBoxAI
+                hasActivity
+                hasDetails
+                hasMetadata
+                hasSkills
+                hasVersions
+                isOpen
+                {...props}
+            />
+            ,
+        </MemoryRouter>
+    );
+
     describe('render', () => {
         test.each`
             path                                 | sidebar
@@ -55,6 +73,27 @@ describe('elements/content-sidebar/SidebarPanels', () => {
             const wrapper = getWrapper({ path });
             expect(wrapper.exists(sidebar)).toBe(true);
         });
+
+        test.each`
+            defaultPanel  | sidebar
+            ${'activity'} | ${'activity-sidebar'}
+            ${'details'}  | ${'details-sidebar'}
+            ${'metadata'} | ${'metadata-sidebar'}
+            ${'skills'}   | ${'skills-sidebar'}
+            ${'boxai'}    | ${'boxai-sidebar'}
+            ${'nonsense'} | ${'boxai-sidebar'}
+            ${undefined}  | ${'boxai-sidebar'}
+        `(
+            'should render $sidebar given the path = "/" and defaultPanel = $defaultPanel',
+            ({ defaultPanel, sidebar }) => {
+                render(
+                    getSidebarPanels({
+                        defaultPanel,
+                    }),
+                );
+                expect(screen.getByTestId(sidebar)).toBeInTheDocument();
+            },
+        );
 
         test('should render redesigned metadata sidebar if it is enabled', () => {
             const wrapper = getWrapper({ path: '/metadata', features: { metadata: { redesign: { enabled: true } } } });

--- a/src/elements/content-sidebar/stories/ContentSidebar.stories.js
+++ b/src/elements/content-sidebar/stories/ContentSidebar.stories.js
@@ -1,25 +1,45 @@
 // @flow
+import * as React from 'react';
+import { http, HttpResponse } from 'msw';
 import ContentSidebar from '../ContentSidebar';
+import { mockFileRequest } from './__mocks__/ContentSidebarMocks';
+
+const defaultArgs = {
+    detailsSidebarProps: {
+        hasProperties: true,
+        hasNotices: true,
+        hasAccessStats: true,
+        hasClassification: true,
+        hasRetentionPolicy: true,
+    },
+    features: global.FEATURES,
+    fileId: global.FILE_ID,
+    hasActivityFeed: true,
+    hasMetadata: true,
+    hasSkills: true,
+    hasVersions: true,
+    token: global.TOKEN,
+};
 
 export const basic = {};
+
+export const withPanelPreservation = () => {
+    const features = { ...defaultArgs.features, panelSelectionPreservation: true };
+
+    return <ContentSidebar {...defaultArgs} features={features} />;
+};
 
 export default {
     title: 'Elements/ContentSidebar',
     component: ContentSidebar,
-    args: {
-        detailsSidebarProps: {
-            hasProperties: true,
-            hasNotices: true,
-            hasAccessStats: true,
-            hasClassification: true,
-            hasRetentionPolicy: true,
+    args: defaultArgs,
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(mockFileRequest.url, () => {
+                    return HttpResponse.json(mockFileRequest.response);
+                }),
+            ],
         },
-        features: global.FEATURES,
-        fileId: global.FILE_ID,
-        hasActivityFeed: true,
-        hasMetadata: true,
-        hasSkills: true,
-        hasVersions: true,
-        token: global.TOKEN,
     },
 };

--- a/src/elements/content-sidebar/stories/ContentSidebar.stories.js
+++ b/src/elements/content-sidebar/stories/ContentSidebar.stories.js
@@ -1,5 +1,4 @@
 // @flow
-import * as React from 'react';
 import { http, HttpResponse } from 'msw';
 import ContentSidebar from '../ContentSidebar';
 import { mockFileRequest } from './__mocks__/ContentSidebarMocks';
@@ -23,10 +22,11 @@ const defaultArgs = {
 
 export const basic = {};
 
-export const withPanelPreservation = () => {
-    const features = { ...defaultArgs.features, panelSelectionPreservation: true };
-
-    return <ContentSidebar {...defaultArgs} features={features} />;
+export const withPanelPreservation = {
+    args: {
+        ...defaultArgs,
+        features: { ...defaultArgs.features, panelSelectionPreservation: true },
+    },
 };
 
 export default {

--- a/src/elements/content-sidebar/stories/ContentSidebar.stories.js
+++ b/src/elements/content-sidebar/stories/ContentSidebar.stories.js
@@ -24,7 +24,6 @@ export const basic = {};
 
 export const withPanelPreservation = {
     args: {
-        ...defaultArgs,
         features: { ...defaultArgs.features, panelSelectionPreservation: true },
     },
 };

--- a/src/elements/content-sidebar/stories/__mocks__/ContentSidebarMocks.ts
+++ b/src/elements/content-sidebar/stories/__mocks__/ContentSidebarMocks.ts
@@ -1,0 +1,30 @@
+import { DEFAULT_HOSTNAME_API } from '../../../../constants';
+
+const apiV2Path = `${DEFAULT_HOSTNAME_API}/2.0`;
+
+export const mockFileRequest = {
+    url: `${apiV2Path}/files/${global.FILE_ID}?fields=is_externally_owned,permissions`,
+    response: {
+        type: 'file',
+        id: global.FILE_ID,
+        etag: '3',
+        is_externally_owned: false,
+        extension: 'pdf',
+        permissions: {
+            can_download: true,
+            can_preview: true,
+            can_upload: true,
+            can_comment: true,
+            can_rename: false,
+            can_delete: false,
+            can_share: false,
+            can_set_share_access: false,
+            can_invite_collaborator: false,
+            can_annotate: false,
+            can_view_annotations_all: true,
+            can_view_annotations_self: true,
+            can_create_annotations: true,
+            can_view_annotations: true,
+        },
+    },
+};


### PR DESCRIPTION
### Description

Added functionality to `content-sidebar` to preserve (using `LocalStore`) the selected panel, so that it's active next time Sidebar is open. This is controlled with new `panelSelectionPreservation` feature.

### Demo

![panel-preservation-demo](https://github.com/user-attachments/assets/c2feee7d-9d3e-41b7-adba-0ed4d1303ca2)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
