### PR TITLE
feat(metadata-sidebar): adjust extractSuggestions to use metadata_template

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
         "@box/blueprint-web-assets": "^4.28.0",
         "@box/box-ai-content-answers": "^0.57.1",
         "@box/cldr-data": ">=34.2.0",
-        "@box/metadata-editor": "^0.73.0",
+        "@box/metadata-editor": "^0.78.3",
         "@box/react-virtualized": "9.22.3-rc-box.9",
         "@hapi/address": "^2.1.4",
         "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
         "@box/cldr-data": "^34.2.0",
         "@box/frontend": "^10.0.0",
         "@box/languages": "^1.0.0",
-        "@box/metadata-editor": "^0.73.0",
+        "@box/metadata-editor": "0.78.3",
         "@box/react-virtualized": "9.22.3-rc-box.9",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@chromatic-com/storybook": "^1.6.1",

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -225,9 +225,10 @@ function useSidebarMetadataFetcher(
                 return [];
             }
 
-            const fields =
-                templateInstances.find(template => template.templateKey === templateKey && template.scope === scope)
-                    ?.fields || [];
+            const templateInstance = templateInstances.find(
+                template => template.templateKey === templateKey && template.scope,
+            );
+            const fields = templateInstance?.fields || [];
             return fields.map(field => {
                 const value = answer[field.key];
                 // TODO: @box/metadadata-editor does not support AI suggestions, enable once supported

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -34,7 +34,7 @@ export enum STATUS {
 
 interface DataFetcher {
     errorMessage: MessageDescriptor | null;
-    extractSuggestions: (templateKey: string, fields: MetadataTemplateField[]) => Promise<MetadataTemplateField[]>;
+    extractSuggestions: (templateKey: string, scope: string) => Promise<MetadataTemplateField[]>;
     file: BoxItem | null;
     handleCreateMetadataInstance: (
         templateInstance: MetadataTemplateInstance,
@@ -197,14 +197,14 @@ function useSidebarMetadataFetcher(
 
     const [, setError] = React.useState();
     const extractSuggestions = React.useCallback(
-        async (templateKey: string, fields: MetadataTemplateField[]): Promise<MetadataTemplateField[]> => {
+        async (templateKey: string, scope: string): Promise<MetadataTemplateField[]> => {
             const aiAPI = api.getIntelligenceAPI();
 
             let answer = null;
             try {
                 answer = (await aiAPI.extractStructured({
                     items: [{ id: file.id, type: file.type }],
-                    fields,
+                    metadata_template: { template_key: templateKey, scope, type: 'metadata_template' },
                 })) as Record<string, MetadataFieldValue>;
             } catch (error) {
                 if (isUserCorrectableError(error.status)) {
@@ -222,8 +222,12 @@ function useSidebarMetadataFetcher(
             if (isEmpty(answer)) {
                 const error = new Error('No suggestions found.');
                 onError(error, ERROR_CODE_EMPTY_METADATA_SUGGESTIONS, { showNotification: true });
+                return [];
             }
 
+            const fields =
+                templateInstances.find(template => template.templateKey === templateKey && template.scope === scope)
+                    ?.fields || [];
             return fields.map(field => {
                 const value = answer[field.key];
                 // TODO: @box/metadadata-editor does not support AI suggestions, enable once supported
@@ -236,7 +240,7 @@ function useSidebarMetadataFetcher(
                 };
             });
         },
-        [api, file, onError],
+        [api, file, onError, templateInstances],
     );
 
     React.useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,10 +1564,10 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.1.2.tgz#cd4266b3da62da18560d881e10b429653186be29"
   integrity sha512-d64TGosx+KRmrLZj4CIyLp42LUiEbgBJ8n8cviMQwTJmfU0g+UwZqLjmQZR1j+Q9D64yV4xHzY9K1t5nInWWeQ==
 
-"@box/metadata-editor@^0.73.0":
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/@box/metadata-editor/-/metadata-editor-0.73.0.tgz#8f89ac3c8f908b812b9b45a64a40eac39e1ecb65"
-  integrity sha512-IJIzMg4sF4Vx8J1LtusXOhm1dYRuoUVgzsRq7QABeaadgCJ+DrLnQ68vFBgQkOE7URWw4zOGCPa0R3Gc1pRiiQ==
+"@box/metadata-editor@0.78.3":
+  version "0.78.3"
+  resolved "https://registry.yarnpkg.com/@box/metadata-editor/-/metadata-editor-0.78.3.tgz#a766413279f8e75917d3bc998dd673237dd8065b"
+  integrity sha512-WVhQORUZoty+y1/a8fucqJcrqZKDYB7NumkQaIWccspn78lOr/ZeHPWkTJOUoRHOVR2DZbxk/z/fMEbDGFmh1A==
 
 "@box/react-virtualized@9.22.3-rc-box.9":
   version "9.22.3-rc-box.9"


### PR DESCRIPTION
Adjust extractSuggestions function to use metadata_template instead of fields

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
