### PR TITLE
feat(boxai-sidebar): Add Agent selector and clear button to sidebar

### DIFF
--- a/i18n.config.js
+++ b/i18n.config.js
@@ -1,4 +1,4 @@
 module.exports = {
     // packages to bundle into translation files
-    translationDependencies: ['@box/box-ai-content-answers', '@box/metadata-editor'],
+    translationDependencies: ['@box/box-ai-agent-selector', '@box/box-ai-content-answers', '@box/metadata-editor'],
 };

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -346,8 +346,6 @@ be.contentSidebar.addTask.general.description = Assignees will be responsible fo
 be.contentSidebar.addTask.general.title = Create General Task
 # Default message for Box AI clear button in sidebar header
 be.contentSidebar.boxAI.clear = Clear
-# Default message for Box AI expand button in sidebar header
-be.contentSidebar.boxAI.expand = Expand
 # body for first-time user experience tooltip shown to new users of Box Sign
 be.contentSidebar.boxSignFtuxBody = Sign documents or send signature requests, right from where your content lives
 # title for first-time user experience tooltip shown to new users of Box Sign

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -344,6 +344,8 @@ be.contentSidebar.addTask.general = General Task
 be.contentSidebar.addTask.general.description = Assignees will be responsible for marking tasks as complete
 # title for general task popup
 be.contentSidebar.addTask.general.title = Create General Task
+# Default message for Box AI clear button in sidebar header
+be.contentSidebar.boxAI.clear = Clear
 # Default message for Box AI expand button in sidebar header
 be.contentSidebar.boxAI.expand = Expand
 # body for first-time user experience tooltip shown to new users of Box Sign

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "@babel/types": "^7.24.7",
         "@box/blueprint-web": "^7.36.3",
         "@box/blueprint-web-assets": "^4.28.0",
+        "@box/box-ai-agent-selector": "^0.15.8",
         "@box/box-ai-content-answers": "^0.57.1",
         "@box/cldr-data": "^34.2.0",
         "@box/frontend": "^10.0.0",
@@ -304,6 +305,7 @@
     "peerDependencies": {
         "@box/blueprint-web": "^7.36.3",
         "@box/blueprint-web-assets": "^4.28.0",
+        "@box/box-ai-agent-selector": "^0.15.8",
         "@box/box-ai-content-answers": "^0.57.1",
         "@box/cldr-data": ">=34.2.0",
         "@box/metadata-editor": "^0.79.1",
@@ -367,8 +369,5 @@
     },
     "msw": {
         "workerDirectory": [".storybook/public"]
-    },
-    "dependencies": {
-        "@box/box-ai-agent-selector": "^0.15.8"
     }
 }

--- a/package.json
+++ b/package.json
@@ -367,5 +367,8 @@
     },
     "msw": {
         "workerDirectory": [".storybook/public"]
+    },
+    "dependencies": {
+        "@box/box-ai-agent-selector": "^0.15.8"
     }
 }

--- a/scripts/jest/jest.config.js
+++ b/scripts/jest/jest.config.js
@@ -26,6 +26,6 @@ module.exports = {
     testMatch: ['**/__tests__/**/*.test.+(js|jsx|ts|tsx)'],
     testPathIgnorePatterns: ['stories.test.js$', 'stories.test.tsx$', 'stories.test.d.ts'],
     transformIgnorePatterns: [
-        'node_modules/(?!(@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers)/)',
+        'node_modules/(?!(@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers|@box/box-ai-agent-selector)/)',
     ],
 };

--- a/src/elements/content-sidebar/BoxAISidebar.scss
+++ b/src/elements/content-sidebar/BoxAISidebar.scss
@@ -1,4 +1,8 @@
+@use '@box/blueprint-web-assets/tokens/tokens.scss';
+
 @import '../common/variables';
+
+$agentSelectorSidebarWidth: 211px;
 
 .bcs-BoxAISidebar {
     .bcs-BoxAISidebar-title-part {
@@ -8,10 +12,10 @@
         margin: 0;
         padding: 0;
         font-weight: normal;
-        font-size: 16px;
+        font-size: tokens.$title-medium-font-size;
 
         .bcs-title {
-            margin-right: 8px;
+            margin-right: tokens.$space-2;
         }
     }
 
@@ -20,12 +24,12 @@
         justify-content: right;
 
         .bcs-BoxAISidebar-expand {
-            margin-left: 8px;
+            margin-left: tokens.$space-2;
         }
     }
 
     .sidebar-chip {
-        max-width: 211px;
+        max-width: $agentSelectorSidebarWidth;
         margin-inline-start: 0;
 
         button {

--- a/src/elements/content-sidebar/BoxAISidebar.scss
+++ b/src/elements/content-sidebar/BoxAISidebar.scss
@@ -1,0 +1,35 @@
+@import '../common/variables';
+
+.bcs-BoxAISidebar {
+    .bcs-BoxAISidebar-title-part {
+        display: flex;
+        align-items: center;
+        justify-content: left;
+        margin: 0;
+        padding: 0;
+        font-weight: normal;
+        font-size: 16px;
+
+        .bcs-title {
+            margin-right: 8px;
+        }
+    }
+
+    .bcs-BoxAISidebar-chat-actions {
+        display: flex;
+        justify-content: right;
+
+        .bcs-BoxAISidebar-expand {
+            margin-left: 8px;
+        }
+    }
+
+    .sidebar-chip {
+        max-width: 211px;
+        margin-inline-start: 0;
+
+        button {
+            width: 100%;
+        }
+    }
+}

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -8,7 +8,7 @@ import { useIntl } from 'react-intl';
 
 import { ArrowsExpand } from '@box/blueprint-web-assets/icons/Fill';
 import { BoxAiAgentSelector, REQUEST_STATE } from '@box/box-ai-agent-selector';
-import {IconButton, Text} from '@box/blueprint-web';
+import { IconButton, Text } from '@box/blueprint-web';
 import { Trash } from '@box/blueprint-web-assets/icons/Line';
 import SidebarContent from './SidebarContent';
 import { withAPIContext } from '../common/api-context';
@@ -27,11 +27,11 @@ const MARK_NAME_JS_READY: string = `${ORIGIN_BOXAI_SIDEBAR}_${EVENT_JS_READY}`;
 mark(MARK_NAME_JS_READY);
 
 export interface BoxAISidebarProps {
-    onClearCLick: () => void;
+    onClearClick: () => void;
     onExpandClick: () => void;
 }
 
-function BoxAISidebar({ onClearCLick, onExpandClick }: BoxAISidebarProps) {
+function BoxAISidebar({ onClearClick, onExpandClick }: BoxAISidebarProps) {
     const { formatMessage } = useIntl();
 
     const renderBoxAISidebarTitle = () => {
@@ -57,7 +57,7 @@ function BoxAISidebar({ onClearCLick, onExpandClick }: BoxAISidebarProps) {
                 <IconButton
                     aria-label={formatMessage(sidebarMessages.boxAISidebarClear)}
                     icon={Trash}
-                    onClick={onClearCLick}
+                    onClick={onClearClick}
                     size="x-small"
                 />
                 <IconButton

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -8,7 +8,7 @@ import { useIntl } from 'react-intl';
 
 import { ArrowsExpand } from '@box/blueprint-web-assets/icons/Fill';
 import { BoxAiAgentSelector, REQUEST_STATE } from '@box/box-ai-agent-selector';
-import { IconButton } from '@box/blueprint-web';
+import {IconButton, Text} from '@box/blueprint-web';
 import { Trash } from '@box/blueprint-web-assets/icons/Line';
 import SidebarContent from './SidebarContent';
 import { withAPIContext } from '../common/api-context';
@@ -37,7 +37,9 @@ function BoxAISidebar({ onClearCLick, onExpandClick }: BoxAISidebarProps) {
     const renderBoxAISidebarTitle = () => {
         return (
             <div className="bcs-BoxAISidebar-title-part">
-                <h3 className="bcs-title">{formatMessage(messages.sidebarBoxAITitle)}</h3>
+                <Text as="h3" className="bcs-title">
+                    {formatMessage(messages.sidebarBoxAITitle)}
+                </Text>
                 <BoxAiAgentSelector
                     agents={[]}
                     onErrorAction={() => null}

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import flow from 'lodash/flow';
 import { useIntl } from 'react-intl';
 
-import { ArrowsExpand } from '@box/blueprint-web-assets/icons/Fill';
 import { BoxAiAgentSelector, REQUEST_STATE } from '@box/box-ai-agent-selector';
 import { IconButton, Text } from '@box/blueprint-web';
 import { Trash } from '@box/blueprint-web-assets/icons/Line';
@@ -17,6 +16,7 @@ import { withLogger } from '../common/logger';
 import { ORIGIN_BOXAI_SIDEBAR, SIDEBAR_VIEW_BOXAI } from '../../constants';
 import { EVENT_JS_READY } from '../common/logger/constants';
 import { mark } from '../../utils/performance';
+import { useFeatureEnabled } from '../common/feature-checking';
 
 import messages from '../common/messages';
 import sidebarMessages from './messages';
@@ -28,11 +28,11 @@ mark(MARK_NAME_JS_READY);
 
 export interface BoxAISidebarProps {
     onClearClick: () => void;
-    onExpandClick: () => void;
 }
 
-function BoxAISidebar({ onClearClick, onExpandClick }: BoxAISidebarProps) {
+function BoxAISidebar({ onClearClick }: BoxAISidebarProps) {
     const { formatMessage } = useIntl();
+    const isAgentSelectorEnabled = useFeatureEnabled('boxai.agentSelector.enabled');
 
     const renderBoxAISidebarTitle = () => {
         return (
@@ -40,33 +40,16 @@ function BoxAISidebar({ onClearClick, onExpandClick }: BoxAISidebarProps) {
                 <Text as="h3" className="bcs-title">
                     {formatMessage(messages.sidebarBoxAITitle)}
                 </Text>
-                <BoxAiAgentSelector
-                    agents={[]}
-                    onErrorAction={() => null}
-                    requestState={REQUEST_STATE.SUCCESS}
-                    selectedAgent={null}
-                    triggerChipClassName="sidebar-chip"
-                />
-            </div>
-        );
-    };
-
-    const renderChatActionButtons = () => {
-        return (
-            <div className="bcs-BoxAISidebar-chat-actions">
-                <IconButton
-                    aria-label={formatMessage(sidebarMessages.boxAISidebarClear)}
-                    icon={Trash}
-                    onClick={onClearClick}
-                    size="x-small"
-                />
-                <IconButton
-                    aria-label={formatMessage(sidebarMessages.boxAISidebarExpand)}
-                    className="bcs-BoxAISidebar-expand"
-                    icon={ArrowsExpand}
-                    onClick={onExpandClick}
-                    size="x-small"
-                />
+                {isAgentSelectorEnabled &&
+                        <div data-testid="sidebar-agent-selector">
+                            <BoxAiAgentSelector
+                                    agents={[]}
+                                    onErrorAction={() => null}
+                                    requestState={REQUEST_STATE.SUCCESS}
+                                    selectedAgent={null}
+                                    triggerChipClassName="sidebar-chip" />
+                        </div>
+                }
             </div>
         );
     };
@@ -74,7 +57,12 @@ function BoxAISidebar({ onClearClick, onExpandClick }: BoxAISidebarProps) {
     const renderActions = () => (
         <>
             {renderBoxAISidebarTitle()}
-            {renderChatActionButtons()}
+            <IconButton
+                aria-label={formatMessage(sidebarMessages.boxAISidebarClear)}
+                icon={Trash}
+                onClick={onClearClick}
+                size="x-small"
+            />
         </>
     );
 

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -46,7 +46,6 @@ function BoxAISidebar({ onClearCLick, onExpandClick }: BoxAISidebarProps) {
                     requestState={REQUEST_STATE.SUCCESS}
                     selectedAgent={null}
                     triggerChipClassName="sidebar-chip"
-                    data-testid="agent-selector"
                 />
             </div>
         );

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -7,7 +7,9 @@ import flow from 'lodash/flow';
 import { useIntl } from 'react-intl';
 
 import { ArrowsExpand } from '@box/blueprint-web-assets/icons/Fill';
+import { BoxAiAgentSelector, REQUEST_STATE } from '@box/box-ai-agent-selector';
 import { IconButton } from '@box/blueprint-web';
+import { Trash } from '@box/blueprint-web-assets/icons/Line';
 import SidebarContent from './SidebarContent';
 import { withAPIContext } from '../common/api-context';
 import { withErrorBoundary } from '../common/error-boundary';
@@ -18,32 +20,65 @@ import { mark } from '../../utils/performance';
 
 import messages from '../common/messages';
 import sidebarMessages from './messages';
+import './BoxAISidebar.scss';
 
 const MARK_NAME_JS_READY: string = `${ORIGIN_BOXAI_SIDEBAR}_${EVENT_JS_READY}`;
 
 mark(MARK_NAME_JS_READY);
 
 export interface BoxAISidebarProps {
+    onClearCLick: () => void;
     onExpandClick: () => void;
 }
 
-function BoxAISidebar({ onExpandClick }: BoxAISidebarProps) {
+function BoxAISidebar({ onClearCLick, onExpandClick }: BoxAISidebarProps) {
     const { formatMessage } = useIntl();
 
-    return (
-        <SidebarContent
-            actions={
+    const renderBoxAISidebarTitle = () => {
+        return (
+            <div className="bcs-BoxAISidebar-title-part">
+                <h3 className="bcs-title">{formatMessage(messages.sidebarBoxAITitle)}</h3>
+                <BoxAiAgentSelector
+                    agents={[]}
+                    onErrorAction={() => null}
+                    requestState={REQUEST_STATE.SUCCESS}
+                    selectedAgent={null}
+                    triggerChipClassName="sidebar-chip"
+                    data-testid="agent-selector"
+                />
+            </div>
+        );
+    };
+
+    const renderChatActionButtons = () => {
+        return (
+            <div className="bcs-BoxAISidebar-chat-actions">
+                <IconButton
+                    aria-label={formatMessage(sidebarMessages.boxAISidebarClear)}
+                    icon={Trash}
+                    onClick={onClearCLick}
+                    size="x-small"
+                />
                 <IconButton
                     aria-label={formatMessage(sidebarMessages.boxAISidebarExpand)}
+                    className="bcs-BoxAISidebar-expand"
                     icon={ArrowsExpand}
                     onClick={onExpandClick}
                     size="x-small"
                 />
-            }
-            className="bcs-BoxAISidebar"
-            sidebarView={SIDEBAR_VIEW_BOXAI}
-            title={formatMessage(messages.sidebarBoxAITitle)}
-        >
+            </div>
+        );
+    };
+
+    const renderActions = () => (
+        <>
+            {renderBoxAISidebarTitle()}
+            {renderChatActionButtons()}
+        </>
+    );
+
+    return (
+        <SidebarContent actions={renderActions()} className="bcs-BoxAISidebar" sidebarView={SIDEBAR_VIEW_BOXAI}>
             <div className="bcs-BoxAISidebar-content" />
         </SidebarContent>
     );

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import flow from 'lodash/flow';
 import { useIntl } from 'react-intl';
 
-import { BoxAiAgentSelector, REQUEST_STATE } from '@box/box-ai-agent-selector';
+import {AgentType, BoxAiAgentSelector, REQUEST_STATE} from '@box/box-ai-agent-selector';
 import { IconButton, Text } from '@box/blueprint-web';
 import { Trash } from '@box/blueprint-web-assets/icons/Line';
 import SidebarContent from './SidebarContent';
@@ -28,9 +28,11 @@ mark(MARK_NAME_JS_READY);
 
 export interface BoxAISidebarProps {
     onClearClick: () => void;
+    agents: AgentType[];
+    selectedAgent: AgentType | null;
 }
 
-function BoxAISidebar({ onClearClick }: BoxAISidebarProps) {
+function BoxAISidebar({ agents = [], onClearClick, selectedAgent}: BoxAISidebarProps) {
     const { formatMessage } = useIntl();
     const isAgentSelectorEnabled = useFeatureEnabled('boxai.agentSelector.enabled');
 
@@ -41,14 +43,12 @@ function BoxAISidebar({ onClearClick }: BoxAISidebarProps) {
                     {formatMessage(messages.sidebarBoxAITitle)}
                 </Text>
                 {isAgentSelectorEnabled &&
-                        <div data-testid="sidebar-agent-selector">
-                            <BoxAiAgentSelector
-                                    agents={[]}
-                                    onErrorAction={() => null}
-                                    requestState={REQUEST_STATE.SUCCESS}
-                                    selectedAgent={null}
-                                    triggerChipClassName="sidebar-chip" />
-                        </div>
+                        <BoxAiAgentSelector
+                            agents={agents}
+                            onErrorAction={() => null}
+                            requestState={REQUEST_STATE.SUCCESS}
+                            selectedAgent={selectedAgent}
+                            triggerChipClassName="sidebar-chip" />
                 }
             </div>
         );

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -10,7 +10,7 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
     const renderComponent = (props = {}) => {
         const defaultProps = {
             onExpandClick: mockOnExpandClick,
-            onClearCLick: mockOnClearClick,
+            onClearClick: mockOnClearClick,
         } satisfies BoxAISidebarProps;
 
         render(<BoxAISidebarComponent {...defaultProps} {...props} />);

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -9,6 +9,8 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
     const renderComponent = (props = {}, features = {}) => {
         const defaultProps = {
             onClearClick: mockOnClearClick,
+            agents: [],
+            selectedAgent: null,
         } satisfies BoxAISidebarProps;
 
         render(<BoxAISidebarComponent {...defaultProps} {...props} />, { wrapperProps: { features } });
@@ -27,7 +29,7 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
     test('should have accessible Agent selector if boxai.agentSelector.enabled is true', () => {
         renderComponent({}, { 'boxai.agentSelector.enabled': true });
 
-        expect(screen.getByTestId('sidebar-agent-selector')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Agent Select an Agent'})).toBeInTheDocument();
     });
 
     test('should not have accessible Agent selector if boxai.agentSelector.enabled is false', () => {

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -1,18 +1,31 @@
 import React from 'react';
 import { userEvent } from '@testing-library/user-event';
+import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
 import { screen, render } from '../../../test-utils/testing-library';
 import BoxAISidebarComponent, { BoxAISidebarProps } from '../BoxAISidebar';
 
 const mockOnExpandClick = jest.fn();
+const mockOnClearClick = jest.fn();
+
+jest.mock('@box/box-ai-agent-selector', () => ({
+    BoxAiAgentSelector: jest.fn(),
+}));
 
 describe('elements/content-sidebar/BoxAISidebar', () => {
     const renderComponent = (props = {}) => {
         const defaultProps = {
             onExpandClick: mockOnExpandClick,
+            onClearCLick: mockOnClearClick,
         } satisfies BoxAISidebarProps;
 
         render(<BoxAISidebarComponent {...defaultProps} {...props} />);
     };
+
+    beforeEach(() => {
+        (BoxAiAgentSelector as jest.MockedFunction<typeof BoxAiAgentSelector>).mockImplementation(() => (
+            <div>BoxAiAgentSelector</div>
+        ));
+    });
 
     afterEach(() => {
         jest.clearAllMocks();
@@ -22,6 +35,21 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         renderComponent();
 
         expect(screen.getByRole('heading', { level: 3, name: 'Box AI' })).toBeInTheDocument();
+    });
+
+    test('should have accessible "Clear" button', () => {
+        renderComponent();
+
+        expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+    });
+
+    test('should call onExpandClick when click "Clear" button', async () => {
+        renderComponent();
+
+        const expandButton = screen.getByRole('button', { name: 'Clear' });
+        await userEvent.click(expandButton);
+
+        expect(mockOnClearClick).toHaveBeenCalled();
     });
 
     test('should have accessible "Expand" button', () => {

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -33,7 +33,7 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
     test('should not have accessible Agent selector if boxai.agentSelector.enabled is false', () => {
         renderComponent({}, { 'boxai.agentSelector.enabled': false });
 
-        expect(screen.getByTestId('sidebar-agent-selector')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('sidebar-agent-selector')).not.toBeInTheDocument();
     });
 
     test('should have accessible "Clear" button', () => {

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import { userEvent } from '@testing-library/user-event';
-import { screen, render } from '../../../test-utils/testing-library';
-import BoxAISidebarComponent, { BoxAISidebarProps } from '../BoxAISidebar';
+import {userEvent} from '@testing-library/user-event';
+import {render, screen} from '../../../test-utils/testing-library';
+import BoxAISidebarComponent, {BoxAISidebarProps} from '../BoxAISidebar';
 
-const mockOnExpandClick = jest.fn();
 const mockOnClearClick = jest.fn();
 
 describe('elements/content-sidebar/BoxAISidebar', () => {
-    const renderComponent = (props = {}) => {
+    const renderComponent = (props = {}, features = {}) => {
         const defaultProps = {
-            onExpandClick: mockOnExpandClick,
             onClearClick: mockOnClearClick,
         } satisfies BoxAISidebarProps;
 
-        render(<BoxAISidebarComponent {...defaultProps} {...props} />);
+        render(<BoxAISidebarComponent {...defaultProps} {...props} />, { wrapperProps: { features } });
     };
 
     afterEach(() => {
@@ -26,33 +24,30 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         expect(screen.getByRole('heading', { level: 3, name: 'Box AI' })).toBeInTheDocument();
     });
 
+    test('should have accessible Agent selector if boxai.agentSelector.enabled is true', () => {
+        renderComponent({}, { 'boxai.agentSelector.enabled': true });
+
+        expect(screen.getByTestId('sidebar-agent-selector')).toBeInTheDocument();
+    });
+
+    test('should not have accessible Agent selector if boxai.agentSelector.enabled is false', () => {
+        renderComponent({}, { 'boxai.agentSelector.enabled': false });
+
+        expect(screen.getByTestId('sidebar-agent-selector')).not.toBeInTheDocument();
+    });
+
     test('should have accessible "Clear" button', () => {
         renderComponent();
 
         expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
     });
 
-    test('should call onExpandClick when click "Clear" button', async () => {
+    test('should call onClearClick when click "Clear" button', async () => {
         renderComponent();
 
         const expandButton = screen.getByRole('button', { name: 'Clear' });
         await userEvent.click(expandButton);
 
         expect(mockOnClearClick).toHaveBeenCalled();
-    });
-
-    test('should have accessible "Expand" button', () => {
-        renderComponent();
-
-        expect(screen.getByRole('button', { name: 'Expand' })).toBeInTheDocument();
-    });
-
-    test('should call onExpandClick when click "Expand" button', async () => {
-        renderComponent();
-
-        const expandButton = screen.getByRole('button', { name: 'Expand' });
-        await userEvent.click(expandButton);
-
-        expect(mockOnExpandClick).toHaveBeenCalled();
     });
 });

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { userEvent } from '@testing-library/user-event';
-import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
 import { screen, render } from '../../../test-utils/testing-library';
 import BoxAISidebarComponent, { BoxAISidebarProps } from '../BoxAISidebar';
 
 const mockOnExpandClick = jest.fn();
 const mockOnClearClick = jest.fn();
-
-jest.mock('@box/box-ai-agent-selector');
 
 describe('elements/content-sidebar/BoxAISidebar', () => {
     const renderComponent = (props = {}) => {
@@ -18,12 +15,6 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
 
         render(<BoxAISidebarComponent {...defaultProps} {...props} />);
     };
-
-    beforeEach(() => {
-        (BoxAiAgentSelector as jest.MockedFunction<typeof BoxAiAgentSelector>).mockImplementation(() => (
-            <div>BoxAiAgentSelector</div>
-        ));
-    });
 
     afterEach(() => {
         jest.clearAllMocks();

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -7,9 +7,7 @@ import BoxAISidebarComponent, { BoxAISidebarProps } from '../BoxAISidebar';
 const mockOnExpandClick = jest.fn();
 const mockOnClearClick = jest.fn();
 
-jest.mock('@box/box-ai-agent-selector', () => ({
-    BoxAiAgentSelector: jest.fn(),
-}));
+jest.mock('@box/box-ai-agent-selector');
 
 describe('elements/content-sidebar/BoxAISidebar', () => {
     const renderComponent = (props = {}) => {

--- a/src/elements/content-sidebar/messages.js
+++ b/src/elements/content-sidebar/messages.js
@@ -37,11 +37,6 @@ const messages = defineMessages({
         description: 'Default message for Box AI clear button in sidebar header',
         defaultMessage: 'Clear',
     },
-    boxAISidebarExpand: {
-        id: 'be.contentSidebar.boxAI.expand',
-        description: 'Default message for Box AI expand button in sidebar header',
-        defaultMessage: 'Expand',
-    },
     boxSignFtuxBody: {
         id: 'be.contentSidebar.boxSignFtuxBody',
         defaultMessage: 'Sign documents or send signature requests, right from where your content lives',

--- a/src/elements/content-sidebar/messages.js
+++ b/src/elements/content-sidebar/messages.js
@@ -32,6 +32,11 @@ const messages = defineMessages({
         defaultMessage: 'Tasks',
         description: 'Dropdown option for filtering tasks from activity list',
     },
+    boxAISidebarClear: {
+        id: 'be.contentSidebar.boxAI.clear',
+        description: 'Default message for Box AI clear button in sidebar header',
+        defaultMessage: 'Clear',
+    },
     boxAISidebarExpand: {
         id: 'be.contentSidebar.boxAI.expand',
         description: 'Default message for Box AI expand button in sidebar header',

--- a/src/elements/content-sidebar/stories/__mocks__/BoxAISidebarMocks.ts
+++ b/src/elements/content-sidebar/stories/__mocks__/BoxAISidebarMocks.ts
@@ -1,0 +1,29 @@
+import {AgentType} from "@box/box-ai-agent-selector";
+
+export const mockAgents: AgentType[] = [
+    {
+        id: '1',
+        name: 'Agent 1',
+        description: 'This is the default agent',
+        isEnterpriseDefault: true,
+        imageURL: 'https://cdn01.boxcdn.net/_assets/img/favicons/favicon-32x32.png',
+    },
+    {
+        id: '2',
+        name: 'Agent 2',
+        description: 'This agent has a different description',
+        isEnterpriseDefault: false,
+    },
+    {
+        id: '3',
+        name: 'Agent 3',
+        isEnterpriseDefault: false,
+        ask: { foo: 'foobar' },
+    },
+    {
+        id: '4',
+        name: 'Agent 4',
+        description: 'This is agent 4',
+        imageURL: 'https://cdn01.boxcdn.net/_assets/img/favicons/favicon-32x32.png',
+    },
+];

--- a/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
@@ -25,11 +25,25 @@ export const BoxAIInSidebar: StoryObj<typeof BoxAISidebar> = {
     },
 };
 
-export const BoxAIWithExpandedView: StoryObj<typeof BoxAISidebar> = {
+export const BoxAIWithAgentSelector: StoryObj<typeof BoxAISidebar> = {
+    args: {
+        features: {
+            ...mockFeatures,
+            'boxai.agentSelector.enabled': true,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const agentSelector = await canvas.findByTestId('sidebar-agent-selector');
+        expect(agentSelector).toBeInTheDocument();
+    },
+};
+
+export const BoxAIWithClearButton: StoryObj<typeof BoxAISidebar> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        const expandButton = await canvas.findByRole('button', { name: 'Expand' }, { timeout: 5000 });
-        await userEvent.click(expandButton);
+        const clearButton = await canvas.findByRole('button', { name: 'Clear' }, { timeout: 5000 });
+        await userEvent.click(clearButton);
     },
 };

--- a/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
@@ -1,11 +1,40 @@
-import { expect, userEvent, within } from '@storybook/test';
+import {expect, fn, screen, userEvent, waitFor, within} from '@storybook/test';
 import { type StoryObj } from '@storybook/react';
+import {AgentType} from '@box/box-ai-agent-selector';
 import ContentSidebar from '../../ContentSidebar';
 import BoxAISidebar from '../../BoxAISidebar';
 
 const mockFeatures = {
     'boxai.sidebar.enabled': true,
 };
+
+export const mockAgents: AgentType[] = [
+    {
+        id: '1',
+        name: 'Agent 1',
+        description: 'This is the default agent',
+        isEnterpriseDefault: true,
+        imageURL: 'https://cdn01.boxcdn.net/_assets/img/favicons/favicon-32x32.png',
+    },
+    {
+        id: '2',
+        name: 'Agent 2',
+        description: 'This agent has a different description',
+        isEnterpriseDefault: false,
+    },
+    {
+        id: '3',
+        name: 'Agent 3',
+        isEnterpriseDefault: false,
+        ask: { foo: 'foobar' },
+    },
+    {
+        id: '4',
+        name: 'Agent 4',
+        description: 'This is agent 4',
+        imageURL: 'https://cdn01.boxcdn.net/_assets/img/favicons/favicon-32x32.png',
+    },
+];
 
 export default {
     title: 'Elements/ContentSidebar/BoxAISidebar/tests/visual-regression-tests',
@@ -14,6 +43,7 @@ export default {
         features: mockFeatures,
         fileId: global.FILE_ID,
         token: global.TOKEN,
+        selectedAgent: mockAgents[0],
     },
 };
 
@@ -25,17 +55,26 @@ export const BoxAIInSidebar: StoryObj<typeof BoxAISidebar> = {
     },
 };
 
-export const BoxAIWithAgentSelector: StoryObj<typeof BoxAISidebar> = {
+export const BoxAIWithAgentSelectorOpened: StoryObj<typeof BoxAISidebar> = {
     args: {
         features: {
             ...mockFeatures,
             'boxai.agentSelector.enabled': true,
         },
+        boxAISidebarProps: {
+            onClearClick: fn,
+            agents: mockAgents,
+            selectedAgent: mockAgents[0],
+        },
+
     },
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-        const agentSelector = await canvas.findByTestId('sidebar-agent-selector');
-        expect(agentSelector).toBeInTheDocument();
+    play: async () => {
+        await waitFor(async () => {
+            const agentSelector = await screen.findByRole('button', {name: 'Agent Agent 1'}, { timeout: 5000 });
+            expect(agentSelector).toBeInTheDocument();
+
+            await userEvent.click(agentSelector);
+        });
     },
 };
 

--- a/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
@@ -1,40 +1,12 @@
 import {expect, fn, screen, userEvent, waitFor, within} from '@storybook/test';
 import { type StoryObj } from '@storybook/react';
-import {AgentType} from '@box/box-ai-agent-selector';
 import ContentSidebar from '../../ContentSidebar';
 import BoxAISidebar from '../../BoxAISidebar';
+import {mockAgents} from "../__mocks__/BoxAISidebarMocks";
 
 const mockFeatures = {
     'boxai.sidebar.enabled': true,
 };
-
-export const mockAgents: AgentType[] = [
-    {
-        id: '1',
-        name: 'Agent 1',
-        description: 'This is the default agent',
-        isEnterpriseDefault: true,
-        imageURL: 'https://cdn01.boxcdn.net/_assets/img/favicons/favicon-32x32.png',
-    },
-    {
-        id: '2',
-        name: 'Agent 2',
-        description: 'This agent has a different description',
-        isEnterpriseDefault: false,
-    },
-    {
-        id: '3',
-        name: 'Agent 3',
-        isEnterpriseDefault: false,
-        ask: { foo: 'foobar' },
-    },
-    {
-        id: '4',
-        name: 'Agent 4',
-        description: 'This is agent 4',
-        imageURL: 'https://cdn01.boxcdn.net/_assets/img/favicons/favicon-32x32.png',
-    },
-];
 
 export default {
     title: 'Elements/ContentSidebar/BoxAISidebar/tests/visual-regression-tests',
@@ -70,7 +42,7 @@ export const BoxAIWithAgentSelectorOpened: StoryObj<typeof BoxAISidebar> = {
     },
     play: async () => {
         await waitFor(async () => {
-            const agentSelector = await screen.findByRole('button', {name: 'Agent Agent 1'}, { timeout: 5000 });
+            const agentSelector = await screen.findByRole('button', {name: 'Agent Agent 1'}, { timeout: 2000 });
             expect(agentSelector).toBeInTheDocument();
 
             await userEvent.click(agentSelector);

--- a/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
@@ -22,7 +22,7 @@ export default {
 export const BoxAIInSidebar: StoryObj<typeof BoxAISidebar> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
-        const sidebar = await canvas.findByRole('heading', { name: 'Box AI' }, { timeout: 5000 });
+        const sidebar = await canvas.findByRole('heading', { name: 'Box AI' }, { timeout: 2000 });
         expect(sidebar).toBeInTheDocument();
     },
 };
@@ -54,7 +54,7 @@ export const BoxAIWithClearButton: StoryObj<typeof BoxAISidebar> = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        const clearButton = await canvas.findByRole('button', { name: 'Clear' }, { timeout: 5000 });
+        const clearButton = await canvas.findByRole('button', { name: 'Clear' }, { timeout: 2000 });
         await userEvent.click(clearButton);
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,11 @@
     tabbable "^4.0.0"
     type-fest "^3.2.0"
 
+"@box/box-ai-agent-selector@^0.15.8":
+  version "0.15.8"
+  resolved "https://registry.yarnpkg.com/@box/box-ai-agent-selector/-/box-ai-agent-selector-0.15.8.tgz#30484b819f2c57da7a5e461f7d66a8c9fdbcfd18"
+  integrity sha512-bFwrE82P7ePxKQ/x5H4Q77gdGYkFhNn7ejOi7IfEKU8ekbJd8cVI5d/T/luxsrG74bEG0sLDswFzMGYbI8H5lg==
+
 "@box/box-ai-content-answers@^0.57.1":
   version "0.57.1"
   resolved "https://registry.yarnpkg.com/@box/box-ai-content-answers/-/box-ai-content-answers-0.57.1.tgz#a2a8d75c5319be2b6636acdcfdcfb4f439f45997"


### PR DESCRIPTION
### Description
Added `box-ai-agent-selector` shared component to Box AI sidebar header.
Important thing to mention - since [this](https://github.com/box/box-ui-elements/pull/3758) PR is in review at the moment, the width for the sidebar was adjusted locally.

One remark to make - the styles of this shared component will need to be changed in order to 

1. Place more text in `SELECTED_AGENT` area. Styles of the inner element need to be changed, specifically some margin needs to be adjusted.
2. In order to show AI models in a dropdown list, we need to adjust list `max-width`, so it can fit in sidebar and not cover too much content. Here you can see how wide this dropdown is with some agents in it:

<img width="442" alt="image" src="https://github.com/user-attachments/assets/c2e22a32-93db-4bf1-b287-d2bd5fa30de8">


### Screenshots
<img width="445" alt="image" src="https://github.com/user-attachments/assets/10571588-c2bf-4924-a1b9-8302817da785">


Showcasing dropdown list width, that needs to be adjusted in a shared component:
<img width="445" alt="image" src="https://github.com/user-attachments/assets/80d35d4b-0926-4115-8777-e69ba116c7f6">


