### PR TITLE
chore(circleci): update caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ aliases:
 
   - &clean
     name: Cleaning
-    command: yarn clean
+    command: yarn cache clean
 
   - &i18n
     name: Building locales
@@ -17,13 +17,20 @@ aliases:
 
   - &restore-yarn-cache
     keys:
-        - yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-        - yarn-packages-v1-{{ .Branch }}-
+        - yarn-cache-{{ .Branch }}-{{ checksum "yarn.lock" }}
+        - yarn-cache-{{ .Branch }}-
 
   - &save-yarn-cache
     paths:
       - ~/.cache/yarn
-    key: yarn-packages-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - node_modules
+    key: yarn-cache-{{ .Branch }}-{{ checksum "yarn.lock" }}
+
+  - &prepare-cache
+    name: Prepare Yarn Cache
+    command: |
+        mkdir -p ~/.cache/yarn
+        chown -R $(whoami) ~/.cache/yarn
 
 defaults: &defaults
   resource_class: large
@@ -38,6 +45,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run: *prepare-cache
       - restore-cache: *restore-yarn-cache
       - run: *yarn
       - save-cache: *save-yarn-cache
@@ -54,6 +62,7 @@ jobs:
       <<: *defaults
       steps:
         - checkout
+        - run: *prepare-cache
         - restore-cache: *restore-yarn-cache
         - run: *yarn
         - save-cache: *save-yarn-cache
@@ -66,6 +75,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - run: *prepare-cache
       - restore-cache: *restore-yarn-cache
       - run: *yarn
       - save-cache: *save-yarn-cache
@@ -91,6 +101,7 @@ jobs:
       - image: cypress/included:13.13.0
     steps:
       - checkout
+      - run: *prepare-cache
       - restore-cache: *restore-yarn-cache
       - run: *yarn
       - save-cache: *save-yarn-cache
@@ -102,6 +113,7 @@ jobs:
     <<: *defaults
     steps:
         - checkout
+        - run: *prepare-cache
         - restore-cache: *restore-yarn-cache
         - run: *yarn
         - save-cache: *save-yarn-cache


### PR DESCRIPTION
Reduce build times by 35% by fixing the caching issue in circleci
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
