### PR TITLE
feat(metadata-editor): show empty state if there's no visible instances

### DIFF
--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -167,12 +167,13 @@ function MetadataSidebarRedesign({ api, elementId, fileId, onError, isFeatureEna
         </InlineError>
     );
 
-    const showTemplateInstances = file && templates && templateInstances;
+    const isFullyLoaded = file && templates && templateInstances;
+    const visibleTemplateInstances = templateInstances.filter(templateInstance => !templateInstance.hidden);
 
     const showLoading = status === STATUS.LOADING;
-    const showEmptyState = !showLoading && showTemplateInstances && templateInstances.length === 0 && !editingTemplate;
+    const showEmptyState = !showLoading && isFullyLoaded && visibleTemplateInstances.length === 0 && !editingTemplate;
     const showEditor = !showEmptyState && editingTemplate;
-    const showList = !showEditor && templateInstances.length > 0 && !editingTemplate;
+    const showList = !showEditor && visibleTemplateInstances.length > 0 && !editingTemplate;
     const areAiSuggestionsAvailable = isExtensionSupportedForMetadataSuggestions(file?.extension ?? '');
 
     const taxonomyOptionsFetcher = async (

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -49,6 +49,28 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         type: 'properties',
     } satisfies MetadataTemplateInstance;
 
+    const mockVisibleTemplateInstance = {
+        displayName: 'Visible Template',
+        canEdit: true,
+        hidden: false,
+        fields: [],
+        id: 'visible_template',
+        scope: 'global',
+        templateKey: 'visibleTemplate',
+        type: 'metadata_template',
+    } satisfies MetadataTemplateInstance;
+
+    const mockHiddenTemplateInstance = {
+        displayName: 'Hidden Template',
+        canEdit: true,
+        hidden: true,
+        fields: [],
+        id: 'hidden_template',
+        scope: 'global',
+        templateKey: 'hiddenTemplate',
+        type: 'metadata_template',
+    } satisfies MetadataTemplateInstance;
+
     const mockFile = {
         id: '123',
         permissions: { [FIELD_PERMISSIONS_CAN_UPLOAD]: true },
@@ -176,13 +198,35 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         ).toBeInTheDocument();
     });
 
+    test('should render empty state when no visible template instances are present', () => {
+        mockUseSidebarMetadataFetcher.mockReturnValue({
+            extractSuggestions: jest.fn(),
+            handleCreateMetadataInstance: jest.fn(),
+            handleDeleteMetadataInstance: jest.fn(),
+            handleUpdateMetadataInstance: jest.fn(),
+            templateInstances: [mockHiddenTemplateInstance],
+            templates: mockTemplates,
+            errorMessage: null,
+            status: STATUS.SUCCESS,
+            file: mockFile,
+        });
+
+        renderComponent();
+
+        expect(screen.getByRole('heading', { level: 2, name: 'Add Metadata Templates' })).toBeInTheDocument();
+        expect(
+            screen.getByText('Add Metadata to your file to support business operations, workflows, and more!'),
+        ).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { level: 4, name: 'Hidden Template' })).not.toBeInTheDocument();
+    });
+
     test('should render metadata instance list when templates are present', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
             handleUpdateMetadataInstance: jest.fn(),
-            templateInstances: [mockCustomTemplateInstance],
+            templateInstances: [mockCustomTemplateInstance, mockVisibleTemplateInstance],
             templates: mockTemplates,
             errorMessage: null,
             status: STATUS.SUCCESS,
@@ -195,5 +239,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         expect(screen.getByRole('heading', { level: 4, name: 'Custom Metadata' })).toBeInTheDocument();
         expect(screen.getByText(mockCustomTemplateInstance.fields[0].key)).toBeInTheDocument();
         expect(screen.getByText(mockCustomTemplateInstance.fields[1].key)).toBeInTheDocument();
+
+        expect(screen.getByRole('heading', { level: 4, name: 'Visible Template' })).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
### Description

Adjust logic to show empty state if only added metadata instance is hidden. 

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
