### PR TITLE
fix(content-uploader): use refs for items and itemIds

### DIFF
--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -72,9 +72,12 @@ describe('elements/content-uploader/ContentUploader', () => {
                 isResumableUploadsEnabled,
             });
 
-            wrapper.instance().updateViewAndCollection([], null);
+            const instance = wrapper.instance();
+
+            instance.updateViewAndCollection([], null);
 
             expect(wrapper.state().itemIds).toEqual({});
+            expect(instance.itemIdsRef.current).toEqual({});
         });
 
         test.each([
@@ -124,23 +127,30 @@ describe('elements/content-uploader/ContentUploader', () => {
     describe('addFilesToUploadQueue()', () => {
         test('should overwrite itemIds if they already exist', () => {
             const wrapper = getWrapper();
-            wrapper.setState({ itemIds: { yoyo: false } });
+            const instance = wrapper.instance();
+
+            const itemIds = { yoyo: false };
+            wrapper.setState({ itemIds });
+            instance.itemIdsRef.current = itemIds;
 
             wrapper.instance().addFilesToUploadQueue([{ name: 'yoyo', size: 1000 }], jest.fn(), false);
 
             const expected = { yoyo: true };
             expect(wrapper.state().itemIds).toMatchObject(expected);
+            expect(instance.itemIdsRef.current).toMatchObject(expected);
         });
 
         test('should add generated itemId', () => {
             const wrapper = getWrapper({ rootFolderId: 0 });
+            const instance = wrapper.instance();
 
             global.Date.now = jest.fn(() => 10000);
 
-            wrapper.instance().addFilesToUploadQueue([{ name: 'yoyo', size: 1000 }], jest.fn(), false);
+            instance.addFilesToUploadQueue([{ name: 'yoyo', size: 1000 }], jest.fn(), false);
 
             const expected = { yoyo: true, yoyo_0_10000: true };
             expect(wrapper.state().itemIds).toEqual(expected);
+            expect(instance.itemIdsRef.current).toEqual(expected);
         });
 
         test('should handle accepting package "files" separate from folders', () => {
@@ -176,6 +186,7 @@ describe('elements/content-uploader/ContentUploader', () => {
             });
             const expected = { hi: true, hi_0_10000: true };
             expect(wrapper.state().itemIds).toEqual(expected);
+            expect(wrapper.instance().itemIdsRef.current).toEqual(expected);
         });
     });
 
@@ -194,6 +205,7 @@ describe('elements/content-uploader/ContentUploader', () => {
                 items: [item],
             });
             instance = wrapper.instance();
+            instance.itemsRef.current = [item];
         });
 
         test('should cancel and remove item from uploading queue', () => {
@@ -201,6 +213,7 @@ describe('elements/content-uploader/ContentUploader', () => {
 
             expect(item.api.cancel).toBeCalled();
             expect(wrapper.state().items.length).toBe(0);
+            expect(instance.itemsRef.current.length).toBe(0);
         });
 
         test.each`

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -386,6 +386,7 @@ describe('elements/content-uploader/ContentUploader', () => {
             const instance = wrapper.instance();
             const items = [{ status: STATUS_COMPLETE }, { status: STATUS_IN_PROGRESS }, { status: STATUS_ERROR }];
             instance.state.items = items;
+            instance.itemsRef.current = items;
 
             instance.onClick = jest.fn();
             instance.clickAllWithStatus();
@@ -404,6 +405,7 @@ describe('elements/content-uploader/ContentUploader', () => {
                 { status: STATUS_ERROR },
             ];
             instance.state.items = items;
+            instance.itemsRef.current = items;
 
             instance.onClick = jest.fn();
             instance.clickAllWithStatus(STATUS_ERROR);
@@ -585,6 +587,8 @@ describe('elements/content-uploader/ContentUploader', () => {
                 items,
                 isUploadsManagerExpanded: true,
             });
+
+            instance.itemsRef.current = items;
 
             instance.isAutoExpanded = true;
 


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
