### PR TITLE
feat(metadata-sidebar): handle success events

### DIFF
--- a/src/common/types/api.js
+++ b/src/common/types/api.js
@@ -68,6 +68,11 @@ type ErrorContextProps = {
 
 type ElementsErrorCallback = (e: ElementsXhrError, code: string, contextInfo?: Object) => void;
 
+type ElementsSuccess = {
+    code: string,
+    showNotification: boolean,
+};
+
 type APIOptions = {
     apiHost?: string,
     cache?: APICache,
@@ -92,6 +97,7 @@ export type {
     ElementOrigin,
     ElementsError,
     ElementsErrorCallback,
+    ElementsSuccess,
     ElementsXhrError,
     ErrorContextProps,
     ErrorResponseData,

--- a/src/constants.js
+++ b/src/constants.js
@@ -91,7 +91,6 @@ export const METADATA_SCOPE_GLOBAL = 'global';
 export const METADATA_SCOPE_ENTERPRISE = 'enterprise';
 export const METADATA_TEMPLATE_FETCH_LIMIT = API_PAGE_LIMIT;
 export const METADATA_SUGGESTIONS_CONFIDENCE_EXPERIMENTAL = 'experimental';
-export const SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS = 'extract_metadata_suggestions_success';
 export const SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE = 'update_metadata_template_instance_success';
 export const SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE = 'delete_metadata_template_instance_success';
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -91,7 +91,7 @@ export const METADATA_SCOPE_GLOBAL = 'global';
 export const METADATA_SCOPE_ENTERPRISE = 'enterprise';
 export const METADATA_TEMPLATE_FETCH_LIMIT = API_PAGE_LIMIT;
 export const METADATA_SUGGESTIONS_CONFIDENCE_EXPERIMENTAL = 'experimental';
-export const SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS = 'EXTRACT_metadata_suggestions_success';
+export const SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS = 'extract_metadata_suggestions_success';
 export const SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE = 'update_metadata_template_instance_success';
 export const SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE = 'delete_metadata_template_instance_success';
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -91,6 +91,9 @@ export const METADATA_SCOPE_GLOBAL = 'global';
 export const METADATA_SCOPE_ENTERPRISE = 'enterprise';
 export const METADATA_TEMPLATE_FETCH_LIMIT = API_PAGE_LIMIT;
 export const METADATA_SUGGESTIONS_CONFIDENCE_EXPERIMENTAL = 'experimental';
+export const SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS = 'EXTRACT_metadata_suggestions_success';
+export const SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE = 'update_metadata_template_instance_success';
+export const SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE = 'delete_metadata_template_instance_success';
 
 /* ----------------------- Fields --------------------------- */
 export const FIELD_ID = 'id';

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -60,9 +60,14 @@ export interface ErrorContextProps {
     onError: (error: Error, code: string, contextInfo?: Record<string, unknown>) => void;
 }
 
+export interface SuccessContextProps {
+    onSuccess: (code: string, showNotification: boolean) => void;
+}
+
 export interface MetadataSidebarRedesignProps
     extends PropsWithoutContext,
         ErrorContextProps,
+        SuccessContextProps,
         WithLoggerProps,
         RouteComponentProps {
     api: API;
@@ -75,6 +80,7 @@ function MetadataSidebarRedesign({
     filteredTemplateIds = [],
     history,
     onError,
+    onSuccess,
     isFeatureEnabled,
 }: MetadataSidebarRedesignProps) {
     const {
@@ -87,7 +93,7 @@ function MetadataSidebarRedesign({
         errorMessage,
         status,
         templateInstances,
-    } = useSidebarMetadataFetcher(api, fileId, onError, isFeatureEnabled);
+    } = useSidebarMetadataFetcher(api, fileId, onError, onSuccess, isFeatureEnabled);
 
     const { formatMessage } = useIntl();
     const isBoxAiSuggestionsEnabled: boolean = useFeatureEnabled('metadata.aiSuggestions.enabled');

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -97,6 +97,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             filteredTemplateIds: emptyFilteredTemplateIds,
             isFeatureEnabled: true,
             onError: jest.fn(),
+            onSuccess: jest.fn(),
             ...routeComponentProps,
         } satisfies MetadataSidebarRedesignProps;
 

--- a/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
+++ b/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
@@ -7,7 +7,6 @@ import {
     FIELD_PERMISSIONS_CAN_UPLOAD,
     SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE,
     SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE,
-    SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS,
 } from '../../../constants';
 import useSidebarMetadataFetcher, { STATUS } from '../hooks/useSidebarMetadataFetcher';
 
@@ -350,7 +349,6 @@ describe('useSidebarMetadataFetcher', () => {
                 { ...mockTemplates[0].fields[0], aiSuggestion: 'value1' },
                 { ...mockTemplates[0].fields[1], aiSuggestion: 'value2' },
             ]);
-            expect(onSuccessMock).toHaveBeenCalledWith(SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS, true);
         });
 
         test('should handle error during suggestions extraction', async () => {

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -65,7 +65,6 @@ function useSidebarMetadataFetcher(
     const [file, setFile] = React.useState<BoxItem>(null);
     const [templates, setTemplates] = React.useState(null);
     const [errorMessage, setErrorMessage] = React.useState<MessageDescriptor | null>(null);
-    // const [successMessage, setSuccessMessage] = React.useState<MessageDescriptor | null>(null);
     const [templateInstances, setTemplateInstances] = React.useState<Array<MetadataTemplateInstance>>([]);
 
     const onApiError = React.useCallback(
@@ -100,7 +99,6 @@ function useSidebarMetadataFetcher(
 
     const fetchMetadataErrorCallback = React.useCallback(
         (e: ElementsXhrError, code: string) => {
-            // setSuccessMessage(null);
             setTemplates(null);
             setTemplateInstances(null);
             onApiError(e, code, messages.sidebarMetadataFetchingErrorContent);

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -18,7 +18,6 @@ import {
     FIELD_IS_EXTERNALLY_OWNED,
     FIELD_PERMISSIONS_CAN_UPLOAD,
     FIELD_PERMISSIONS,
-    SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS,
     SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE,
     SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE,
 } from '../../../constants';
@@ -236,8 +235,6 @@ function useSidebarMetadataFetcher(
             const templateInstance = templates.find(template => template.templateKey === templateKey && template.scope);
             const fields = templateInstance?.fields || [];
 
-            onSuccess(SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS, true);
-
             return fields.map(field => {
                 const value = answer[field.key];
                 // TODO: @box/metadadata-editor does not support AI suggestions, enable once supported
@@ -250,7 +247,7 @@ function useSidebarMetadataFetcher(
                 };
             });
         },
-        [api, file, onError, onSuccess, templates],
+        [api, file, onError, templates],
     );
 
     React.useEffect(() => {

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -18,12 +18,15 @@ import {
     FIELD_IS_EXTERNALLY_OWNED,
     FIELD_PERMISSIONS_CAN_UPLOAD,
     FIELD_PERMISSIONS,
+    SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS,
+    SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE,
+    SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE,
 } from '../../../constants';
 
 import messages from '../../common/messages';
 
 import { type BoxItem } from '../../../common/types/core';
-import { type ErrorContextProps, type ExternalProps } from '../MetadataSidebarRedesign';
+import { type ErrorContextProps, type ExternalProps, type SuccessContextProps } from '../MetadataSidebarRedesign';
 
 export enum STATUS {
     IDLE = 'idle',
@@ -55,12 +58,14 @@ function useSidebarMetadataFetcher(
     api: API,
     fileId: string,
     onError: ErrorContextProps['onError'],
+    onSuccess: SuccessContextProps['onSuccess'],
     isFeatureEnabled: ExternalProps['isFeatureEnabled'],
 ): DataFetcher {
     const [status, setStatus] = React.useState<STATUS>(STATUS.IDLE);
     const [file, setFile] = React.useState<BoxItem>(null);
     const [templates, setTemplates] = React.useState(null);
     const [errorMessage, setErrorMessage] = React.useState<MessageDescriptor | null>(null);
+    // const [successMessage, setSuccessMessage] = React.useState<MessageDescriptor | null>(null);
     const [templateInstances, setTemplateInstances] = React.useState<Array<MetadataTemplateInstance>>([]);
 
     const onApiError = React.useCallback(
@@ -95,6 +100,7 @@ function useSidebarMetadataFetcher(
 
     const fetchMetadataErrorCallback = React.useCallback(
         (e: ElementsXhrError, code: string) => {
+            // setSuccessMessage(null);
             setTemplates(null);
             setTemplateInstances(null);
             onApiError(e, code, messages.sidebarMetadataFetchingErrorContent);
@@ -149,14 +155,17 @@ function useSidebarMetadataFetcher(
             await api.getMetadataAPI(false).deleteMetadata(
                 file,
                 metadataInstance,
-                () => setStatus(STATUS.SUCCESS),
+                () => {
+                    setStatus(STATUS.SUCCESS);
+                    onSuccess(SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE, true);
+                },
                 (error: ElementsXhrError, code: string) => {
                     onApiError(error, code, messages.sidebarMetadataEditingErrorContent);
                 },
                 true,
             );
         },
-        [api, onApiError, file],
+        [api, onApiError, onSuccess, file],
     );
 
     const handleCreateMetadataInstance = React.useCallback(
@@ -180,19 +189,20 @@ function useSidebarMetadataFetcher(
             JSONPatch: JSONPatchOperations,
             successCallback: () => void,
         ) => {
-            await api
-                .getMetadataAPI(false)
-                .updateMetadataRedesign(
-                    file,
-                    metadataInstance,
-                    JSONPatch,
-                    successCallback,
-                    (error: ElementsXhrError, code: string) => {
-                        onApiError(error, code, messages.sidebarMetadataEditingErrorContent);
-                    },
-                );
+            await api.getMetadataAPI(false).updateMetadataRedesign(
+                file,
+                metadataInstance,
+                JSONPatch,
+                () => {
+                    successCallback();
+                    onSuccess(SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE, true);
+                },
+                (error: ElementsXhrError, code: string) => {
+                    onApiError(error, code, messages.sidebarMetadataEditingErrorContent);
+                },
+            );
         },
-        [api, file, onApiError],
+        [api, file, onApiError, onSuccess],
     );
 
     const [, setError] = React.useState();
@@ -227,6 +237,9 @@ function useSidebarMetadataFetcher(
 
             const templateInstance = templates.find(template => template.templateKey === templateKey && template.scope);
             const fields = templateInstance?.fields || [];
+
+            onSuccess(SUCCESS_CODE_EXTRACT_METADATA_SUGGESTIONS, true);
+
             return fields.map(field => {
                 const value = answer[field.key];
                 // TODO: @box/metadadata-editor does not support AI suggestions, enable once supported
@@ -239,7 +252,7 @@ function useSidebarMetadataFetcher(
                 };
             });
         },
-        [api, file, onError, templates],
+        [api, file, onError, onSuccess, templates],
     );
 
     React.useEffect(() => {

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -26,6 +26,9 @@ const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign
     isBoxAiSuggestionsEnabled: true,
     isFeatureEnabled: true,
     onError: fn,
+    onSuccess: () => {
+        console.log('success');
+    },
 };
 
 export default {

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -25,10 +25,8 @@ const mockLogger = {
 const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign> = {
     isBoxAiSuggestionsEnabled: true,
     isFeatureEnabled: true,
-    onError: fn,
-    onSuccess: () => {
-        console.log('success');
-    },
+    onError: fn(),
+    onSuccess: fn(),
 };
 
 export default {

--- a/src/elements/content-sidebar/stories/__mocks__/MetadataSidebarRedesignedMocks.ts
+++ b/src/elements/content-sidebar/stories/__mocks__/MetadataSidebarRedesignedMocks.ts
@@ -84,6 +84,7 @@ export const mockMetadataInstances = {
                 $typeVersion: 1,
                 $template: 'myTemplate',
                 $scope: 'enterprise_173733877',
+                $templateKey: 'myTemplate',
                 myAttribute: 'My Value',
                 $canEdit: true,
             },

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -24,17 +24,13 @@ const token = global.TOKEN;
 const defaultMetadataArgs = {
     fileId: fileIdWithMetadata,
     isFeatureEnabled: true,
-    onError: fn,
-    onSuccess: () => {
-        console.log('success');
-    },
+    onError: fn(),
+    onSuccess: fn(),
 };
 const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign> = {
     isFeatureEnabled: true,
-    onError: fn,
-    onSuccess: () => {
-        console.log('success');
-    },
+    onError: fn(),
+    onSuccess: fn(),
 };
 const mockFeatures = {
     'metadata.redesign.enabled': true,
@@ -67,10 +63,8 @@ export const AddTemplateDropdownMenuOnEmpty = {
         metadataSidebarProps: {
             isBoxAiSuggestionsEnabled: true,
             isFeatureEnabled: true,
-            onError: fn,
-            onSuccess: () => {
-                console.log('success');
-            },
+            onError: fn(),
+            onSuccess: fn(),
         },
     },
     play: async ({ canvasElement }) => {

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -25,10 +25,16 @@ const defaultMetadataArgs = {
     fileId: fileIdWithMetadata,
     isFeatureEnabled: true,
     onError: fn,
+    onSuccess: () => {
+        console.log('success');
+    },
 };
 const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign> = {
     isFeatureEnabled: true,
     onError: fn,
+    onSuccess: () => {
+        console.log('success');
+    },
 };
 const mockFeatures = {
     'metadata.redesign.enabled': true,
@@ -62,6 +68,9 @@ export const AddTemplateDropdownMenuOnEmpty = {
             isBoxAiSuggestionsEnabled: true,
             isFeatureEnabled: true,
             onError: fn,
+            onSuccess: () => {
+                console.log('success');
+            },
         },
     },
     play: async ({ canvasElement }) => {

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -278,16 +278,21 @@ export const DeleteButtonIsDisabledWhenAddingNewMetadataTemplate: StoryObj<typeo
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
-        expect(addTemplateButton).toBeInTheDocument();
-        await userEvent.click(addTemplateButton);
+        await waitFor(
+            async () => {
+                const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+                expect(addTemplateButton).toBeInTheDocument();
+                await userEvent.click(addTemplateButton);
 
-        const customMetadataOption = canvas.getByRole('option', { name: 'Virus Scan' });
-        expect(customMetadataOption).toBeInTheDocument();
-        await userEvent.click(customMetadataOption);
+                const customMetadataOption = canvas.getByRole('option', { name: 'Virus Scan' });
+                expect(customMetadataOption).toBeInTheDocument();
+                await userEvent.click(customMetadataOption);
 
-        const deleteButton = await canvas.findByRole('button', { name: 'Delete' });
-        expect(deleteButton).toBeDisabled();
+                const deleteButton = await canvas.findByRole('button', { name: 'Delete' });
+                expect(deleteButton).toBeDisabled();
+            },
+            { timeout: 2000 },
+        );
     },
 };
 

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -278,21 +278,20 @@ export const DeleteButtonIsDisabledWhenAddingNewMetadataTemplate: StoryObj<typeo
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
 
-        await waitFor(
-            async () => {
-                const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
-                expect(addTemplateButton).toBeInTheDocument();
-                await userEvent.click(addTemplateButton);
+        const addTemplateButton = await canvas.findByRole('button', { name: 'Add template' });
+        expect(addTemplateButton).toBeInTheDocument();
+        await act(async () => {
+            await userEvent.click(addTemplateButton);
+        });
 
-                const customMetadataOption = canvas.getByRole('option', { name: 'Virus Scan' });
-                expect(customMetadataOption).toBeInTheDocument();
-                await userEvent.click(customMetadataOption);
+        const customMetadataOption = canvas.getByRole('option', { name: 'Virus Scan' });
+        expect(customMetadataOption).toBeInTheDocument();
+        await act(async () => {
+            await userEvent.click(customMetadataOption);
+        });
 
-                const deleteButton = await canvas.findByRole('button', { name: 'Delete' });
-                expect(deleteButton).toBeDisabled();
-            },
-            { timeout: 2000 },
-        );
+        const deleteButton = await canvas.findByRole('button', { name: 'Delete' });
+        expect(deleteButton).toBeDisabled();
     },
 };
 


### PR DESCRIPTION
We want to call `onSuccess` when following events are performed successfully:
- template instance is updated
- template instance is deleted

* add `onSuccess` prop to `useSidebarMetadataFetcher`
* call `onSuccess` in `useSidebarMetadataFetcher` as success callback in:
   * `handleDeleteMetadataInstance`
   * `handleUpdateMetadataInstance`
* add adequate success code to constants
* define `ElementsSuccess` type to be later used in consumer app
* add `onSuccess` prop to `MetadataSidebarRedesign` and pass it to `useSidebarMetadataFetcher`
* update `MetadataSidebarRedesignProps` to extend `SuccessContextProps` (needs to be defined and reused in `useSidebarMetadataFetcher` for `onSuccess` prop type)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
