### PR TITLE
fix(boxai-sidebar): header width and white-space adjustment

### DIFF
--- a/src/elements/content-sidebar/BoxAISidebar.scss
+++ b/src/elements/content-sidebar/BoxAISidebar.scss
@@ -9,6 +9,7 @@ $agentSelectorSidebarWidth: 211px;
         display: flex;
         align-items: center;
         justify-content: left;
+        width: 100%;
         margin: 0;
         padding: 0;
         font-weight: normal;
@@ -16,6 +17,7 @@ $agentSelectorSidebarWidth: 211px;
 
         .bcs-title {
             margin-right: tokens.$space-2;
+            white-space: nowrap;
         }
     }
 


### PR DESCRIPTION
**Description**

This PR implements two updates to the header of the "Box AI" tab to improve its display.

<img width="401" alt="Screenshot 2024-12-13 at 15 36 42" src="https://github.com/user-attachments/assets/29d3711c-d6a4-4a1b-aa44-5e7ea9531f2b" />

Medium screen

<img width="753" alt="Screenshot 2024-12-16 at 15 47 17" src="https://github.com/user-attachments/assets/b07cb25c-eda9-4b56-b515-f5ad4531aa76" />



<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
