### PR TITLE
fix(content-uploader): fix bug in assigning new item ids

### DIFF
--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -295,7 +295,12 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     getNewFiles = (files: Array<UploadFileWithAPIOptions | File>): Array<UploadFileWithAPIOptions | File> => {
         const { rootFolderId } = this.props;
 
-        return Array.from(files).filter(file => !this.itemIdsRef.current[getFileId(file, rootFolderId)]);
+        return Array.from(files).filter(file => {
+            console.log('getFileId(item, rootFolderId)', getFileId(file, rootFolderId));
+            console.log('this.itemIdsRef.current', this.itemIdsRef.current);
+            console.log('filterOutcome', !this.itemIdsRef.current[getFileId(file, rootFolderId)]);
+            return !this.itemIdsRef.current[getFileId(file, rootFolderId)];
+        });
     };
 
     /**
@@ -308,7 +313,12 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     ): Array<DataTransferItem | UploadDataTransferItemWithAPIOptions> => {
         const { rootFolderId } = this.props;
 
-        return Array.from(items).filter(item => !this.itemIdsRef.current[getDataTransferItemId(item, rootFolderId)]);
+        return Array.from(items).filter(item => {
+            console.log('getDataTransferItemId(item, rootFolderId)', getDataTransferItemId(item, rootFolderId));
+            console.log('this.itemIdsRef.current', this.itemIdsRef.current);
+            console.log('filterOutcome', !this.itemIdsRef.current[getDataTransferItemId(item, rootFolderId)]);
+            return !this.itemIdsRef.current[getDataTransferItemId(item, rootFolderId)];
+        });
     };
 
     /**
@@ -345,7 +355,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
 
         const firstFile = getFile(newFiles[0]);
 
-        const newItemIdsState = { ...this.itemsRef.current, ...newItemIds };
+        const newItemIdsState = { ...this.itemIdsRef.current, ...newItemIds };
 
         this.itemIdsRef.current = newItemIdsState;
 

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -295,12 +295,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     getNewFiles = (files: Array<UploadFileWithAPIOptions | File>): Array<UploadFileWithAPIOptions | File> => {
         const { rootFolderId } = this.props;
 
-        return Array.from(files).filter(file => {
-            console.log('getFileId(item, rootFolderId)', getFileId(file, rootFolderId));
-            console.log('this.itemIdsRef.current', this.itemIdsRef.current);
-            console.log('filterOutcome', !this.itemIdsRef.current[getFileId(file, rootFolderId)]);
-            return !this.itemIdsRef.current[getFileId(file, rootFolderId)];
-        });
+        return Array.from(files).filter(file => !this.itemIdsRef.current[getFileId(file, rootFolderId)]);
     };
 
     /**
@@ -313,12 +308,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     ): Array<DataTransferItem | UploadDataTransferItemWithAPIOptions> => {
         const { rootFolderId } = this.props;
 
-        return Array.from(items).filter(item => {
-            console.log('getDataTransferItemId(item, rootFolderId)', getDataTransferItemId(item, rootFolderId));
-            console.log('this.itemIdsRef.current', this.itemIdsRef.current);
-            console.log('filterOutcome', !this.itemIdsRef.current[getDataTransferItemId(item, rootFolderId)]);
-            return !this.itemIdsRef.current[getDataTransferItemId(item, rootFolderId)];
-        });
+        return Array.from(items).filter(item => !this.itemIdsRef.current[getDataTransferItemId(item, rootFolderId)]);
     };
 
     /**

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -143,12 +143,13 @@ describe('elements/content-uploader/ContentUploader', () => {
         test('should add generated itemId', () => {
             const wrapper = getWrapper({ rootFolderId: 0 });
             const instance = wrapper.instance();
+            instance.itemIdsRef.current = { abcd: true };
 
             global.Date.now = jest.fn(() => 10000);
 
             instance.addFilesToUploadQueue([{ name: 'yoyo', size: 1000 }], jest.fn(), false);
 
-            const expected = { yoyo: true, yoyo_0_10000: true };
+            const expected = { abcd: true, yoyo: true, yoyo_0_10000: true };
             expect(wrapper.state().itemIds).toEqual(expected);
             expect(instance.itemIdsRef.current).toEqual(expected);
         });


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
