### PR TITLE
feat(content-sidebar): Option to render Box AI nav button disabled

### DIFF
--- a/src/elements/common/nav-button/NavButton.js
+++ b/src/elements/common/nav-button/NavButton.js
@@ -18,6 +18,7 @@ type Props = {
     component?: React.ComponentType<any>,
     exact?: boolean,
     isActive?: (match: Match, location: Location) => ?boolean,
+    isDisabled?: boolean,
     onClick?: (event: SyntheticEvent<>) => void,
     replace?: boolean,
     strict?: boolean,
@@ -32,6 +33,7 @@ const NavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, ref: Re
         component: Component = PlainButton,
         exact,
         isActive,
+        isDisabled,
         onClick,
         replace,
         strict,
@@ -40,6 +42,8 @@ const NavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, ref: Re
     } = props;
     const path = typeof to === 'object' ? to.pathname : to;
 
+    const disabledClassName = 'bdl-is-disabled';
+
     return (
         <Route exact={exact} path={path} strict={strict}>
             {({ history, location, match }) => {
@@ -47,7 +51,11 @@ const NavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, ref: Re
 
                 return (
                     <Component
-                        className={classNames(className, { [activeClassName]: isActiveValue })}
+                        className={classNames(className, {
+                            [activeClassName]: isActiveValue,
+                            [disabledClassName]: isDisabled,
+                        })}
+                        isDisabled={isDisabled}
                         onClick={event => {
                             if (onClick) {
                                 onClick(event);

--- a/src/elements/common/nav-button/__tests__/NavButton.test.js
+++ b/src/elements/common/nav-button/__tests__/NavButton.test.js
@@ -1,9 +1,18 @@
 import * as React from 'react';
 import { mount, render } from 'enzyme';
 import { MemoryRouter, Router } from 'react-router-dom';
+import { render as rtlRender, screen } from '@testing-library/react';
 import NavButton from '..';
 
 describe('elements/common/nav-button/NavButton', () => {
+    const getNavButton = (content, { path = '/activity', ...props }) => (
+        <MemoryRouter initialEntries={[path]}>
+            <NavButton to={path} {...props}>
+                {content}
+            </NavButton>
+        </MemoryRouter>
+    );
+
     describe('when active', () => {
         test('applies its default activeClassName', () => {
             const button = render(
@@ -51,6 +60,15 @@ describe('elements/common/nav-button/NavButton', () => {
 
             expect(button.hasClass('bdl-is-active')).toBe(false);
             expect(button.hasClass('bdl-is-selected')).toBe(false);
+        });
+    });
+
+    describe('when disabled', () => {
+        test('applies bdl-is-disabled class name', () => {
+            const content = 'Activity';
+            rtlRender(getNavButton(content, { isDisabled: true }));
+
+            expect(screen.getByText(content, { selector: '.bdl-is-disabled' })).toBeInTheDocument();
         });
     });
 

--- a/src/elements/common/nav-button/__tests__/NavButton.test.js
+++ b/src/elements/common/nav-button/__tests__/NavButton.test.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { mount, render } from 'enzyme';
 import { MemoryRouter, Router } from 'react-router-dom';
-import { render as rtlRender, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '../../../../test-utils/testing-library';
 import NavButton from '..';
 
 describe('elements/common/nav-button/NavButton', () => {

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -68,6 +68,8 @@ const SidebarNav = ({
     onPanelChange = noop,
 }: Props) => {
     const { enabled: hasBoxSign } = useFeatureConfig('boxSign');
+    const { disabledTooltip: boxAIDisabledTooltip, showOnlyNavButton: showOnlyBoxAINavButton } =
+        useFeatureConfig('boxai.sidebar');
 
     const handleSidebarNavButtonClick = (sidebarview: string) => {
         onPanelChange(sidebarview, false);
@@ -82,9 +84,13 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.BOXAI}
                             data-target-id="SidebarNavButton-boxAI"
                             data-testid="sidebarboxai"
+                            isDisabled={showOnlyBoxAINavButton}
                             onClick={handleSidebarNavButtonClick}
                             sidebarView={SIDEBAR_VIEW_BOXAI}
-                            tooltip={intl.formatMessage(messages.sidebarBoxAITitle)}
+                            tooltip={
+                                (showOnlyBoxAINavButton && boxAIDisabledTooltip) ||
+                                intl.formatMessage(messages.sidebarBoxAITitle)
+                            }
                         >
                             <BoxAiLogo height={Size5} width={Size5} />
                         </SidebarNavButton>

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -88,8 +88,9 @@ const SidebarNav = ({
                             onClick={handleSidebarNavButtonClick}
                             sidebarView={SIDEBAR_VIEW_BOXAI}
                             tooltip={
-                                (showOnlyBoxAINavButton && boxAIDisabledTooltip) ||
-                                intl.formatMessage(messages.sidebarBoxAITitle)
+                                showOnlyBoxAINavButton
+                                    ? boxAIDisabledTooltip
+                                    : intl.formatMessage(messages.sidebarBoxAITitle)
                             }
                         >
                             <BoxAiLogo height={Size5} width={Size5} />

--- a/src/elements/content-sidebar/SidebarNavButton.js
+++ b/src/elements/content-sidebar/SidebarNavButton.js
@@ -16,6 +16,7 @@ type Props = {
     'data-testid'?: string,
     children: React.Node,
     elementId?: string,
+    isDisabled?: boolean,
     isOpen?: boolean,
     onClick?: (sidebarView: string) => void,
     sidebarView: string,
@@ -28,6 +29,7 @@ const SidebarNavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, 
         'data-testid': dataTestId,
         children,
         elementId = '',
+        isDisabled,
         isOpen,
         onClick = noop,
         sidebarView,
@@ -61,6 +63,7 @@ const SidebarNavButton = React.forwardRef<Props, React.Ref<any>>((props: Props, 
                             getDOMRef={ref}
                             id={id}
                             isActive={isActive}
+                            isDisabled={isDisabled}
                             onClick={handleNavButtonClick}
                             replace={isExactMatch}
                             role="tab"

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -239,8 +239,10 @@ class SidebarPanels extends React.Component<Props, State> {
 
         const { showOnlyNavButton: showOnlyBoxAINavButton } = getFeatureConfig(features, 'boxai.sidebar');
 
+        const canShowBoxAISidebarPanel = hasBoxAI && !showOnlyBoxAINavButton;
+
         const panelsEligibility = {
-            [SIDEBAR_VIEW_BOXAI]: hasBoxAI,
+            [SIDEBAR_VIEW_BOXAI]: canShowBoxAISidebarPanel,
             [SIDEBAR_VIEW_DOCGEN]: hasDocGen,
             [SIDEBAR_VIEW_SKILLS]: hasSkills,
             [SIDEBAR_VIEW_ACTIVITY]: hasActivity,
@@ -249,8 +251,6 @@ class SidebarPanels extends React.Component<Props, State> {
         };
 
         const showDefaultPanel: boolean = !!(defaultPanel && panelsEligibility[defaultPanel]);
-
-        const canShowBoxAISidebarPanel = hasBoxAI && !showOnlyBoxAINavButton;
 
         if (!isOpen || (!hasBoxAI && !hasActivity && !hasDetails && !hasMetadata && !hasSkills && !hasVersions)) {
             return null;
@@ -441,7 +441,7 @@ class SidebarPanels extends React.Component<Props, State> {
 
                         if (showDefaultPanel) {
                             redirect = defaultPanel;
-                        } else if (hasBoxAI) {
+                        } else if (canShowBoxAISidebarPanel) {
                             redirect = SIDEBAR_VIEW_BOXAI;
                         } else if (hasDocGen) {
                             redirect = SIDEBAR_VIEW_DOCGEN;

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -13,7 +13,7 @@ import SidebarUtils from './SidebarUtils';
 import withSidebarAnnotations from './withSidebarAnnotations';
 import { withAnnotatorContext } from '../common/annotator-context';
 import { withAPIContext } from '../common/api-context';
-import { withFeatureConsumer, isFeatureEnabled } from '../common/feature-checking';
+import { getFeatureConfig, withFeatureConsumer, isFeatureEnabled } from '../common/feature-checking';
 import { withRouterAndRef } from '../common/routing';
 import {
     ORIGIN_ACTIVITY_SIDEBAR,
@@ -237,6 +237,8 @@ class SidebarPanels extends React.Component<Props, State> {
         const isMetadataSidebarRedesignEnabled = isFeatureEnabled(features, 'metadata.redesign.enabled');
         const isMetadataAiSuggestionsEnabled = isFeatureEnabled(features, 'metadata.aiSuggestions.enabled');
 
+        const { showOnlyNavButton: showOnlyBoxAINavButton } = getFeatureConfig(features, 'boxai.sidebar');
+
         const panelsEligibility = {
             [SIDEBAR_VIEW_BOXAI]: hasBoxAI,
             [SIDEBAR_VIEW_DOCGEN]: hasDocGen,
@@ -248,13 +250,15 @@ class SidebarPanels extends React.Component<Props, State> {
 
         const showDefaultPanel: boolean = !!(defaultPanel && panelsEligibility[defaultPanel]);
 
+        const canShowBoxAISidebarPanel = hasBoxAI && !showOnlyBoxAINavButton;
+
         if (!isOpen || (!hasBoxAI && !hasActivity && !hasDetails && !hasMetadata && !hasSkills && !hasVersions)) {
             return null;
         }
 
         return (
             <Switch>
-                {hasBoxAI && (
+                {canShowBoxAISidebarPanel && (
                     <Route
                         exact
                         path={`/${SIDEBAR_VIEW_BOXAI}`}

--- a/src/elements/content-sidebar/__tests__/SidebarNav.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNav.test.js
@@ -16,7 +16,6 @@ import SidebarNav from '../SidebarNav';
 import SidebarNavButton from '../SidebarNavButton';
 import SidebarNavSignButton from '../SidebarNavSignButton';
 import { render, screen } from '../../../test-utils/testing-library';
-import messages from '../../common/messages';
 
 describe('elements/content-sidebar/SidebarNav', () => {
     const getWrapper = (props = {}, active = '', features = {}) =>
@@ -99,13 +98,10 @@ describe('elements/content-sidebar/SidebarNav', () => {
     });
 
     describe('should render box ai tab with correct disabled state and tooltip', () => {
-        const defaultTooltip = messages.sidebarBoxAITitle.defaultMessage;
-
         test.each`
             disabledTooltip          | expectedTooltip
             ${'tooltip msg'}         | ${'tooltip msg'}
             ${'another tooltip msg'} | ${'another tooltip msg'}
-            ${undefined}             | ${defaultTooltip}
         `(
             'given feature boxai.sidebar.showOnlyNavButton = true and boxai.sidebar.disabledTooltip = $disabledTooltip, should render box ai tab with disabled state and tooltip = $expectedTooltip',
             async ({ disabledTooltip, expectedTooltip }) => {
@@ -125,28 +121,21 @@ describe('elements/content-sidebar/SidebarNav', () => {
             },
         );
 
-        test.each`
-            disabledTooltip
-            ${'tooltip msg'}
-            ${undefined}
-        `(
-            'given feature boxai.sidebar.showOnlyNavButton = false and boxai.sidebar.disabledTooltip = $disabledTooltip, should render box ai tab with default tooltip',
-            async ({ disabledTooltip }) => {
-                render(
-                    getSidebarNav({
-                        features: { boxai: { sidebar: { disabledTooltip, showOnlyNavButton: false } } },
-                        props: { hasBoxAI: true },
-                    }),
-                );
+        test('given feature boxai.sidebar.showOnlyNavButton = false, should render box ai tab with default tooltip', async () => {
+            render(
+                getSidebarNav({
+                    features: { boxai: { sidebar: { showOnlyNavButton: false } } },
+                    props: { hasBoxAI: true },
+                }),
+            );
 
-                const button = screen.getByTestId('sidebarboxai');
+            const button = screen.getByTestId('sidebarboxai');
 
-                await userEvent.hover(button);
+            await userEvent.hover(button);
 
-                expect(button).not.toHaveAttribute('aria-disabled');
-                expect(screen.getByText(defaultTooltip)).toBeInTheDocument();
-            },
-        );
+            expect(button).not.toHaveAttribute('aria-disabled');
+            expect(screen.getByText('Box AI')).toBeInTheDocument();
+        });
     });
 
     test('should have multiple tabs', () => {

--- a/src/elements/content-sidebar/__tests__/SidebarNav.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNav.test.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mount } from 'enzyme';
 import { BoxAiLogo } from '@box/blueprint-web-assets/icons/Logo';
@@ -16,6 +15,7 @@ import IconMetadataThick from '../../../icons/general/IconMetadataThick';
 import SidebarNav from '../SidebarNav';
 import SidebarNavButton from '../SidebarNavButton';
 import SidebarNavSignButton from '../SidebarNavSignButton';
+import { render, screen } from '../../../test-utils/testing-library';
 import messages from '../../common/messages';
 
 describe('elements/content-sidebar/SidebarNav', () => {

--- a/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
@@ -365,6 +365,36 @@ describe('elements/content-sidebar/SidebarPanels', () => {
             });
         });
 
+        describe('boxai sidebar', () => {
+            test('should render, given hasBoxAI = true and feature boxai.sidebar.showOnlyNavButton = false', () => {
+                render(
+                    getSidebarPanels({
+                        features: { boxai: { sidebar: { showOnlyNavButton: false } } },
+                        hasBoxAI: true,
+                    }),
+                );
+                expect(screen.getByTestId('boxai-sidebar')).toBeInTheDocument();
+            });
+
+            test.each`
+                hasBoxAI | showOnlyNavButton
+                ${true}  | ${true}
+                ${false} | ${true}
+                ${false} | ${false}
+            `(
+                'should not render, given hasBoxAI = $hasBoxAI and feature boxai.sidebar.showOnlyNavButton = $showOnlyNavButton',
+                ({ hasBoxAI, showOnlyNavButton }) => {
+                    render(
+                        getSidebarPanels({
+                            features: { boxai: { sidebar: { showOnlyNavButton } } },
+                            hasBoxAI,
+                        }),
+                    );
+                    expect(screen.queryByTestId('boxai-sidebar')).not.toBeInTheDocument();
+                },
+            );
+        });
+
         describe('first loaded behavior', () => {
             test('should update isInitialized state on mount', () => {
                 const wrapper = getWrapper({ path: '/activity' });

--- a/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarPanels.test.js
@@ -104,13 +104,14 @@ describe('elements/content-sidebar/SidebarPanels', () => {
         );
 
         test.each`
-            defaultPanel  | expectedSidebar     | hasActivity | hasDetails | hasMetadata | hasSkills | hasDocGen | hasBoxAI | expectedPanelName
-            ${'activity'} | ${'boxai-sidebar'}  | ${false}    | ${true}    | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'details'}  | ${'boxai-sidebar'}  | ${true}     | ${false}   | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'metadata'} | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${false}    | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'skills'}   | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${true}     | ${false}  | ${true}   | ${true}  | ${'boxai'}
-            ${'docgen'}   | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${true}     | ${false}  | ${false}  | ${true}  | ${'boxai'}
-            ${'boxai'}    | ${'docgen-sidebar'} | ${true}     | ${true}    | ${true}     | ${true}   | ${true}   | ${false} | ${'docgen'}
+            defaultPanel  | expectedSidebar     | hasActivity | hasDetails | hasMetadata | hasSkills | hasDocGen | hasBoxAI | showOnlyBoxAINavButton | expectedPanelName
+            ${'activity'} | ${'boxai-sidebar'}  | ${false}    | ${true}    | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'details'}  | ${'boxai-sidebar'}  | ${true}     | ${false}   | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'metadata'} | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${false}    | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'skills'}   | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${true}     | ${false}  | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'docgen'}   | ${'boxai-sidebar'}  | ${true}     | ${true}    | ${true}     | ${false}  | ${false}  | ${true}  | ${false}               | ${'boxai'}
+            ${'boxai'}    | ${'docgen-sidebar'} | ${true}     | ${true}    | ${true}     | ${true}   | ${true}   | ${false} | ${false}               | ${'docgen'}
+            ${'boxai'}    | ${'docgen-sidebar'} | ${true}     | ${true}    | ${true}     | ${true}   | ${true}   | ${true}  | ${true}                | ${'docgen'}
         `(
             'should render first available panel and call onPanelChange with $expectedPanelName for users without rights to render default panel, given the path = "/" and defaultPanel = $defaultPanel',
             ({
@@ -122,11 +123,13 @@ describe('elements/content-sidebar/SidebarPanels', () => {
                 hasSkills,
                 hasDocGen,
                 hasBoxAI,
+                showOnlyBoxAINavButton,
                 expectedPanelName,
             }) => {
                 const onPanelChange = jest.fn();
                 render(
                     getSidebarPanels({
+                        features: { boxai: { sidebar: { showOnlyNavButton: showOnlyBoxAINavButton } } },
                         defaultPanel,
                         hasActivity,
                         hasDetails,
@@ -212,24 +215,25 @@ describe('elements/content-sidebar/SidebarPanels', () => {
         });
 
         test.each`
-            path                                 | hasActivity | hasDetails | hasVersions | hasMetadata | hasSkills | hasDocGen | hasBoxAI | expectedPanelName
-            ${'/activity'}                       | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/comments'}              | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/comments/1234'}         | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/tasks'}                 | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/tasks/1234'}            | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/annotations/1234/5678'} | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/annotations/1234'}      | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/versions'}              | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/activity/versions/1234'}         | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/details'}                        | ${true}     | ${false}   | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/details/versions'}               | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/details/versions/1234'}          | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/metadata'}                       | ${true}     | ${true}    | ${true}     | ${false}    | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/metadata/filteredTemplates/1,3'} | ${true}     | ${true}    | ${true}     | ${false}    | ${true}   | ${true}   | ${true}  | ${'boxai'}
-            ${'/skills'}                         | ${true}     | ${true}    | ${true}     | ${true}     | ${false}  | ${true}   | ${true}  | ${'boxai'}
-            ${'/docgen'}                         | ${true}     | ${true}    | ${true}     | ${true}     | ${true}   | ${false}  | ${true}  | ${'boxai'}
-            ${'/boxai'}                          | ${true}     | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${false} | ${'docgen'}
+            path                                 | hasActivity | hasDetails | hasVersions | hasMetadata | hasSkills | hasDocGen | hasBoxAI | showOnlyBoxAINavButton | expectedPanelName
+            ${'/activity'}                       | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/comments'}              | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/comments/1234'}         | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/tasks'}                 | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/tasks/1234'}            | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/annotations/1234/5678'} | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/annotations/1234'}      | ${false}    | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/versions'}              | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/activity/versions/1234'}         | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/details'}                        | ${true}     | ${false}   | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/details/versions'}               | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/details/versions/1234'}          | ${true}     | ${true}    | ${false}    | ${true}     | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/metadata'}                       | ${true}     | ${true}    | ${true}     | ${false}    | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/metadata/filteredTemplates/1,3'} | ${true}     | ${true}    | ${true}     | ${false}    | ${true}   | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/skills'}                         | ${true}     | ${true}    | ${true}     | ${true}     | ${false}  | ${true}   | ${true}  | ${false}               | ${'boxai'}
+            ${'/docgen'}                         | ${true}     | ${true}    | ${true}     | ${true}     | ${true}   | ${false}  | ${true}  | ${false}               | ${'boxai'}
+            ${'/boxai'}                          | ${true}     | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${false} | ${false}               | ${'docgen'}
+            ${'/boxai'}                          | ${true}     | ${true}    | ${true}     | ${true}     | ${true}   | ${true}   | ${true}  | ${true}                | ${'docgen'}
         `(
             'should call onPanelChange with $expectedPanelName given the path = $path for users without rights to render the panel for given path',
             ({
@@ -241,11 +245,13 @@ describe('elements/content-sidebar/SidebarPanels', () => {
                 hasSkills,
                 hasDocGen,
                 hasBoxAI,
+                showOnlyBoxAINavButton,
                 expectedPanelName,
             }) => {
                 const onPanelChange = jest.fn();
                 render(
                     getSidebarPanels({
+                        features: { boxai: { sidebar: { showOnlyNavButton: showOnlyBoxAINavButton } } },
                         hasActivity,
                         hasBoxAI,
                         hasDetails,

--- a/src/elements/content-sidebar/stories/BoxAISidebar.stories.tsx
+++ b/src/elements/content-sidebar/stories/BoxAISidebar.stories.tsx
@@ -6,6 +6,20 @@ const mockFeatures = {
 
 export const basic = {};
 
+export const withFileTypeNotSupported = {
+    args: {
+        features: {
+            boxai: {
+                sidebar: {
+                    disabledTooltip: 'Box AI is not currently supported for this file type',
+                    enabled: true,
+                    showOnlyNavButton: true,
+                },
+            },
+        },
+    },
+};
+
 export default {
     title: 'Elements/ContentSidebar/BoxAISidebar',
     component: ContentSidebar,
@@ -14,7 +28,7 @@ export default {
         fileId: global.FILE_ID,
         token: global.TOKEN,
         boxAISidebarProps: {
-            createSessionRequest: () => ({ encodedSession: '1234'}),
+            createSessionRequest: () => ({ encodedSession: '1234' }),
             fetchTimeout: { initial: 20000 },
             getAgentConfig: () => ({}),
             getAIStudioAgents: () => ({}),
@@ -32,6 +46,6 @@ export default {
             isStopResponseEnabled: true,
             isStreamingEnabled: false,
             recordAction: () => ({}),
-        }
+        },
     },
 };


### PR DESCRIPTION
### Description

Added option to display disabled tab nav item (button) without the corresponding sidebar.

This is used for Box AI Sidebar when the file is not compatible with AI features or there are permissions issues. In that case we want to not render Box AI Sidebar, however we still want to display the tab nav button with a proper tooltip.

This is controlled with `boxai.sidebar` feature.

### Screenshots

![image](https://github.com/user-attachments/assets/f862fab6-3edb-4ad9-8620-99bf70aefeb1)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
