### PR TITLE
feat(activity-sidebar): Initial idea for activity indicator

### DIFF
--- a/src/elements/content-sidebar/ActivityIndicator.scss
+++ b/src/elements/content-sidebar/ActivityIndicator.scss
@@ -1,0 +1,12 @@
+.bcs-activity-indicator {
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+    width: 15px;
+    height: 15px;
+    color: white;
+    font-size: 10px;
+    line-height: 15px;
+    background-color: black;
+    border-radius: 50%;
+}

--- a/src/elements/content-sidebar/ActivityIndicator.tsx
+++ b/src/elements/content-sidebar/ActivityIndicator.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import flow from 'lodash/flow';
+import noop from 'lodash/noop';
+
+import { withAPIContext } from '../common/api-context';
+
+import './ActivityIndicator.scss';
+
+export function ActivityIndicator({ api, features, file }) {
+    const [count, setCount] = useState(0);
+    const [shouldShowIndicator, setShouldShowIndicator] = useState(false);
+    const [canLoadActivities, setCanLoadActivities] = useState(true);
+
+    useEffect(() => {
+        // early return to not refetch on every re-render
+        if (!canLoadActivities) {
+            return;
+        }
+        setCanLoadActivities(false);
+        api.getFeedAPI().feedItems(
+            file,
+            false,
+            (data: Array<unknown>) => {
+                if (data.length > 0) {
+                    // has comments, replies, annotations or tasks
+                    setCount(data.length);
+                    setShouldShowIndicator(true);
+                }
+            },
+            noop,
+            noop,
+            {
+                shouldShowAnnotations: true,
+                shouldShowAppActivity: true,
+                shouldShowReplies: true,
+                shouldShowTasks: true,
+                shouldShowVersions: false, // do we need to inform about versions?
+                shouldUseUAA: false, // don't know what this is
+            },
+        );
+    }, [api, features, file, canLoadActivities]);
+
+    return shouldShowIndicator ? <div className="bcs-activity-indicator">{count}</div> : null;
+}
+
+export default flow([withAPIContext])(ActivityIndicator);

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -331,6 +331,7 @@ class Sidebar extends React.Component<Props, State> {
                             <SidebarNav
                                 additionalTabs={additionalTabs}
                                 elementId={this.id}
+                                file={file}
                                 fileId={fileId}
                                 hasActivity={hasActivity}
                                 hasAdditionalTabs={hasAdditionalTabs}

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -10,6 +10,7 @@ import type { IntlShape } from 'react-intl';
 import noop from 'lodash/noop';
 import { BoxAiLogo } from '@box/blueprint-web-assets/icons/Logo';
 import { Size5 } from '@box/blueprint-web-assets/tokens/tokens';
+import ActivityIndicator from './ActivityIndicator';
 import AdditionalTabs from './additional-tabs';
 import DocGenIcon from '../../icon/fill/DocGenIcon';
 import IconChatRound from '../../icons/general/IconChatRound';
@@ -37,6 +38,7 @@ import './SidebarNav.scss';
 type Props = {
     additionalTabs?: Array<AdditionalSidebarTab>,
     elementId: string,
+    file: BoxItem,
     fileId: string,
     hasActivity: boolean,
     hasAdditionalTabs: boolean,
@@ -54,6 +56,7 @@ type Props = {
 const SidebarNav = ({
     additionalTabs,
     elementId,
+    file,
     fileId,
     hasActivity,
     hasAdditionalTabs,
@@ -106,6 +109,7 @@ const SidebarNav = ({
                             tooltip={intl.formatMessage(messages.sidebarActivityTitle)}
                         >
                             <IconChatRound />
+                            <ActivityIndicator file={file} />
                         </SidebarNavButton>
                     )}
                     {hasDetails && (


### PR DESCRIPTION
Raw idea how we could indicate that there are some activities to see in the Activity tab in Sidebar.

Visuals are to be specified.


![Screenshot 2025-01-15 at 22 06 27](https://github.com/user-attachments/assets/baf3df44-07b8-4ed2-818d-2aa40fdf654a)

![Screenshot 2025-01-15 at 22 06 55](https://github.com/user-attachments/assets/7cda361c-8ae0-4108-9147-0e0d57f83071)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
