### PR TITLE
fix: remove negative timestamps from uploads

### DIFF
--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -55,11 +55,13 @@ describe('util/uploads', () => {
             ${{ lastModified: 'not a number' }}                           | ${null}
             ${{ lastModified: new Date('2017-01-02T03:04:05.678Z') }}     | ${'2017-01-02T03:04:05Z'}
             ${{ lastModified: new Date('not valid') }}                    | ${null}
+            ${{ lastModified: -11644473600 }}                             | ${null}
             ${{}}                                                         | ${null}
             ${{ lastModifiedDate: 1483326245678 }}                        | ${'2017-01-02T03:04:05Z'}
             ${{ lastModifiedDate: 'not a number' }}                       | ${null}
             ${{ lastModifiedDate: new Date('2017-01-02T03:04:05.678Z') }} | ${'2017-01-02T03:04:05Z'}
             ${{ lastModifiedDate: new Date('not valid') }}                | ${null}
+            ${{ lastModifiedDate: -11644473600 }}                         | ${null}
             ${{}}                                                         | ${null}
         `(
             'should return the properly formatted date when possible and return null otherwise',

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -133,13 +133,23 @@ function getFileLastModifiedAsISONoMSIfPossible(file: UploadFile): ?string {
     // The compatibility chart at https://developer.mozilla.org/en-US/docs/Web/API/File/lastModified#Browser_compatibility
     // is not up to date as of 12-13-2018. Edge & ie11 do not support lastModified, but support lastModifiedDate.
     const lastModified = file.lastModified || file.lastModifiedDate;
-    if (
-        lastModified &&
-        (typeof lastModified === 'string' || typeof lastModified === 'number' || lastModified instanceof Date)
-    ) {
-        const lastModifiedDate = new Date(lastModified);
-        if (isValidDateObject(lastModifiedDate)) {
-            return toISOStringNoMS(lastModifiedDate);
+    if (lastModified) {
+        let lastModifiedDate: Date | null = null;
+
+        if (typeof lastModified === 'number') {
+            // Only non-negative timestamps are valid. In rare cases, the timestamp may be erroneously set to a negative value
+            // https://issues.chromium.org/issues/393149335
+            if (lastModified < 0) {
+                return null;
+            }
+            lastModifiedDate = new Date(lastModified); // Try number first
+        } else if (typeof lastModified === 'string' || lastModified instanceof Date) {
+            lastModifiedDate = new Date(lastModified);
+        }
+
+        if (lastModifiedDate && isValidDateObject(lastModifiedDate)) {
+            const isoString = toISOStringNoMS(lastModifiedDate);
+            return isoString;
         }
     }
 


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
### Description
I've updated `getFileLastModifiedAsISONoMSIfPossible()` to not accept negative timestamp values. Due to an [issue](https://issues.chromium.org/issues/393149335) in Chromium for Android, the `file.lastModified` and `file.lastModifiedAt` values are not being read properly from the file's metadata. `lastModified` is instead being read as `-11644473600`.

The existing logic does not handle this, and will attempt to create a date for any non-zero timestamp value. The downstream affect is that the [PlainUpload](https://github.com/box/box-ui-elements/blob/master/src/api/uploads/PlainUpload.js#L81) API will send `content_modified_at` as a negative timestamp. This is not allowed by the API, and results in a 400 response

```
{
    "type": "error",
    "status": 400,
    "code": "bad_request",
    "context_info": {
        "errors": [
            {
                "reason": "invalid_parameter",
                "name": "content_updated_at",
                "message": "Invalid value '-11644473600'. Value must be greater than or equal to 0"
            }
        ]
    },
    "help_url": "http:\/\/developers.box.com\/docs\/#errors",
    "message": "Bad Request",
    "request_id": "g5312ghy9vy8mkla"
} 
```

The change is to return null for negative timestamps.
