### PR TITLE
feat(content-sidebar): Added recordAction call on Box AI Sidebar load

### DIFF
--- a/src/elements/content-sidebar/BoxAISidebarContent.tsx
+++ b/src/elements/content-sidebar/BoxAISidebarContent.tsx
@@ -93,6 +93,20 @@ function BoxAISidebarContent(props: ApiWrapperProps) {
             sendQuestion({ prompt: cacheQuestions[cacheQuestions.length - 1].prompt });
         }
 
+        if (recordAction) {
+            recordAction({
+                action: 'programmatic',
+                component: 'sidebar',
+                feature: 'answers',
+                target: 'loaded',
+                data: {
+                    items: items.map(item => {
+                        return { status: item.status, fileType: item.fileType };
+                    }),
+                },
+            });
+        }
+
         return () => {
             // stop API request on unmount (e.g. during switching to another tab)
             stopQuestion();

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -75,6 +75,15 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         getAnswerStreaming: jest.fn(),
         getSuggestedQuestions: jest.fn(),
         hostAppName: 'appName',
+        items: [
+            {
+                id: '1',
+                type: 'type',
+                fileType: 'pdf',
+                name: 'test.pdf',
+                status: 'supported',
+            },
+        ],
         itemSize: '1234',
         isAgentSelectorEnabled: false,
         isAIStudioAgentSelectorEnabled: true,
@@ -138,6 +147,21 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         await renderComponent({ isResetChatEnabled: false });
 
         expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
+    });
+
+    test('should call recordAction on load if provided', async () => {
+        const mockRecordAction = jest.fn();
+        await renderComponent({ recordAction: mockRecordAction });
+
+        expect(mockRecordAction).toHaveBeenCalledWith({
+            action: 'programmatic',
+            component: 'sidebar',
+            feature: 'answers',
+            target: 'loaded',
+            data: {
+                items: [{ fileType: 'pdf', status: 'supported' }],
+            },
+        });
     });
 
     test('should call onClearClick when click "Clear" button', async () => {

--- a/src/elements/content-sidebar/context/BoxAISidebarContext.ts
+++ b/src/elements/content-sidebar/context/BoxAISidebarContext.ts
@@ -1,7 +1,17 @@
 import * as React from 'react';
 import noop from 'lodash/noop';
-import { RecordActionType } from '@box/box-ai-agent-selector';
+import { RecordActionType as AgentSelectorRecordActionType } from '@box/box-ai-agent-selector';
+import { RecordActionType as ContentAnswersRecordActionType } from '@box/box-ai-content-answers';
 import type { ItemType, QuestionType } from '@box/box-ai-content-answers';
+
+type BoxAISidebarRecordActionType =
+    | AgentSelectorRecordActionType
+    | ContentAnswersRecordActionType
+    | (Omit<ContentAnswersRecordActionType, 'data'> & {
+          data: {
+              items: Array<Pick<ItemType, 'fileType' | 'status'>>;
+          };
+      });
 
 export interface BoxAISidebarContextValues {
     cache: { encodedSession?: string | null; questions?: QuestionType[] };
@@ -12,7 +22,7 @@ export interface BoxAISidebarContextValues {
     isStopResponseEnabled: boolean;
     items: Array<ItemType>;
     itemSize?: string;
-    recordAction: (params: RecordActionType) => void;
+    recordAction: (params: BoxAISidebarRecordActionType) => void;
     setCacheValue: (key: 'encodedSession' | 'questions', value: string | null | QuestionType[]) => void;
     userInfo: { name: string; avatarURL: string };
 }


### PR DESCRIPTION
### Description

Added `recordAction` call to track Box AI Sidebar load event.

### Screenshots
![image](https://github.com/user-attachments/assets/8b8b76f8-21c8-45c0-823e-e7f76aa9c7ff)

![image](https://github.com/user-attachments/assets/9e1151e6-13aa-4115-88d9-25221a21d998)


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
