### PR TITLE
feat(metadata-sidebar): Use error code prop in MetadataInstanceEditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         "@box/frontend": "^10.0.0",
         "@box/item-icon": "^0.9.58",
         "@box/languages": "^1.0.0",
-        "@box/metadata-editor": "^0.88.1",
+        "@box/metadata-editor": "0.91.0",
         "@box/react-virtualized": "9.22.3-rc-box.9",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@chromatic-com/storybook": "^1.6.1",

--- a/src/constants.js
+++ b/src/constants.js
@@ -324,6 +324,8 @@ export const ERROR_CODE_UNEXPECTED_EXCEPTION = 'unexpected_exception_error';
 export const ERROR_CODE_SEARCH = 'search_error';
 export const ERROR_CODE_METADATA_QUERY = 'metadata_query_error';
 export const ERROR_CODE_METADATA_STRUCTURED_TEXT_REP = 'metadata_structured_text_rep_error';
+export const ERROR_CODE_METADATA_AUTOFILL_TIMEOUT = 'metadata_autofill_timeout_error';
+export const ERROR_CODE_METADATA_PRECONDITION_FAILED = 'metadata_precondition_failed_error';
 export const ERROR_CODE_UNKNOWN = 'unknown_error';
 
 /* ------------------ Origins ---------------------- */

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -54,6 +54,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     return (
         <MetadataInstanceForm
             areAiSuggestionsAvailable={areAiSuggestionsAvailable}
+            errorCode={errorCode}
             isAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled}
             isBetaLanguageEnabled={isBetaLanguageEnabled}
             isDeleteButtonDisabled={isDeleteButtonDisabled}
@@ -65,7 +66,6 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
             selectedTemplateInstance={template}
             setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
             taxonomyOptionsFetcher={taxonomyOptionsFetcher}
-            errorCode={errorCode}
         />
     );
 };

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -8,9 +8,15 @@ import {
     type PaginationQueryInput,
 } from '@box/metadata-editor';
 import React from 'react';
+import {
+    ERROR_CODE_METADATA_AUTOFILL_TIMEOUT,
+    ERROR_CODE_UNKNOWN,
+    ERROR_CODE_METADATA_PRECONDITION_FAILED,
+} from '../../constants';
 
 export interface MetadataInstanceEditorProps {
     areAiSuggestionsAvailable: boolean;
+    errorCode?: ERROR_CODE_METADATA_AUTOFILL_TIMEOUT | ERROR_CODE_METADATA_PRECONDITION_FAILED | ERROR_CODE_UNKNOWN;
     isBetaLanguageEnabled: boolean;
     isBoxAiSuggestionsEnabled: boolean;
     isDeleteButtonDisabled: boolean;
@@ -32,6 +38,7 @@ export interface MetadataInstanceEditorProps {
 
 const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     areAiSuggestionsAvailable,
+    errorCode,
     isBetaLanguageEnabled,
     isBoxAiSuggestionsEnabled,
     isDeleteButtonDisabled,
@@ -58,6 +65,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
             selectedTemplateInstance={template}
             setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
             taxonomyOptionsFetcher={taxonomyOptionsFetcher}
+            errorCode={errorCode}
         />
     );
 };

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -92,6 +92,7 @@ function MetadataSidebarRedesign({
     getStructuredTextRep,
 }: MetadataSidebarRedesignProps) {
     const {
+        clearExtractError,
         extractSuggestions,
         file,
         handleCreateMetadataInstance,
@@ -157,6 +158,8 @@ function MetadataSidebarRedesign({
     }, [editingTemplate, templateInstances, templateInstances.length]);
 
     const handleTemplateSelect = (selectedTemplate: MetadataTemplate) => {
+        clearExtractError();
+
         if (editingTemplate) {
             setPendingTemplateToEdit(convertTemplateToTemplateInstance(file, selectedTemplate));
             setIsUnsavedChangesModalOpen(true);
@@ -167,6 +170,7 @@ function MetadataSidebarRedesign({
     };
 
     const handleCancel = () => {
+        clearExtractError();
         setEditingTemplate(null);
     };
 
@@ -190,6 +194,7 @@ function MetadataSidebarRedesign({
         } catch {
             // ignore error, handled in useSidebarMetadataFetcher
         }
+        clearExtractError();
         setEditingTemplate(null);
     };
 
@@ -280,6 +285,7 @@ function MetadataSidebarRedesign({
                     {editingTemplate && (
                         <MetadataInstanceEditor
                             areAiSuggestionsAvailable={areAiSuggestionsAvailable}
+                            errorCode={extractErrorCode}
                             isBetaLanguageEnabled={isBetaLanguageEnabled}
                             isBoxAiSuggestionsEnabled={isBoxAiSuggestionsEnabled}
                             isDeleteButtonDisabled={isDeleteButtonDisabled}
@@ -291,7 +297,6 @@ function MetadataSidebarRedesign({
                             setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
                             taxonomyOptionsFetcher={taxonomyOptionsFetcher}
                             template={editingTemplate}
-                            errorCode={extractErrorCode}
                         />
                     )}
                     {showList && (

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -98,6 +98,7 @@ function MetadataSidebarRedesign({
         handleDeleteMetadataInstance,
         handleUpdateMetadataInstance,
         templates,
+        extractErrorCode,
         errorMessage,
         status,
         templateInstances,
@@ -290,6 +291,7 @@ function MetadataSidebarRedesign({
                             setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
                             taxonomyOptionsFetcher={taxonomyOptionsFetcher}
                             template={editingTemplate}
+                            errorCode={extractErrorCode}
                         />
                     )}
                     {showList && (

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -127,6 +127,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
     });
 
@@ -151,6 +152,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         renderComponent();
@@ -193,6 +195,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         renderComponent();
@@ -216,6 +219,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             },
             status: STATUS.ERROR,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         const errorMessage = { id: 'error', defaultMessage: 'error message' };
@@ -236,6 +240,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.LOADING,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         renderComponent();
@@ -275,6 +280,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         renderComponent();
@@ -297,6 +303,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         renderComponent();
@@ -320,6 +327,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         renderComponent();
@@ -346,6 +354,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
                 errorMessage: null,
                 status: STATUS.SUCCESS,
                 file: mockFile,
+                extractErrorCode: null,
             });
 
             renderComponent();
@@ -365,6 +374,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         const filteredTemplateIds = [mockVisibleTemplateInstance.id];
@@ -387,6 +397,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             errorMessage: null,
             status: STATUS.SUCCESS,
             file: mockFile,
+            extractErrorCode: null,
         });
 
         const filteredTemplateIds = ['non-existing-template-id'];

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -118,6 +118,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     beforeEach(() => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -143,6 +144,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should have accessible "All templates" combobox trigger button', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -186,6 +188,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should have accessible "All templates" combobox trigger button', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -207,6 +210,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render metadata sidebar with error', async () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -231,6 +235,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render metadata sidebar with loading indicator', async () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -271,6 +276,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render empty state when no visible template instances are present', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -294,6 +300,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render metadata instance list when templates are present', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -318,6 +325,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render filter dropdown when more than one templates are present', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -345,6 +353,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         'should not render filter dropdown when only one or none visible template is present',
         (templateInstances: MetadataTemplateInstance[]) => {
             mockUseSidebarMetadataFetcher.mockReturnValue({
+                clearExtractError: jest.fn(),
                 extractSuggestions: jest.fn(),
                 handleCreateMetadataInstance: jest.fn(),
                 handleDeleteMetadataInstance: jest.fn(),
@@ -365,6 +374,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render metadata filterd instance list when fileterd templates are present and matching', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),
@@ -388,6 +398,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
     test('should render metadata unfiltered instance list when fileterd templates are present and do not match existing templates', () => {
         mockUseSidebarMetadataFetcher.mockReturnValue({
+            clearExtractError: jest.fn(),
             extractSuggestions: jest.fn(),
             handleCreateMetadataInstance: jest.fn(),
             handleDeleteMetadataInstance: jest.fn(),

--- a/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
+++ b/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
@@ -4,15 +4,33 @@ import messages from '../../common/messages';
 import {
     ERROR_CODE_EMPTY_METADATA_SUGGESTIONS,
     ERROR_CODE_FETCH_METADATA_SUGGESTIONS,
+    ERROR_CODE_METADATA_AUTOFILL_TIMEOUT,
+    ERROR_CODE_METADATA_PRECONDITION_FAILED,
+    ERROR_CODE_UNKNOWN,
     FIELD_PERMISSIONS_CAN_UPLOAD,
     SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE,
     SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE,
 } from '../../../constants';
 import useSidebarMetadataFetcher, { STATUS } from '../hooks/useSidebarMetadataFetcher';
 
-const mockError = {
+const mockRateLimitError = {
+    status: 429,
+    message: 'Rate Limit Exceeded',
+};
+
+const mockInternalServerError = {
     status: 500,
     message: 'Internal Server Error',
+};
+
+const mockTimeoutError = {
+    status: 408,
+    message: 'Request Timeout',
+};
+
+const mockPreconditionFailedError = {
+    status: 412,
+    message: 'Precondition Failed',
 };
 
 const mockFile = {
@@ -147,7 +165,7 @@ describe('useSidebarMetadataFetcher', () => {
 
     test('should handle file fetching error', async () => {
         mockAPI.getFile.mockImplementation((id, successCallback, errorCallback) =>
-            errorCallback(mockError, 'file_fetch_error'),
+            errorCallback(mockInternalServerError, 'file_fetch_error'),
         );
 
         const { result } = setupHook();
@@ -158,10 +176,10 @@ describe('useSidebarMetadataFetcher', () => {
         expect(result.current.errorMessage).toBe(messages.sidebarMetadataEditingErrorContent);
         expect(onSuccessMock).not.toHaveBeenCalled();
         expect(onErrorMock).toHaveBeenCalledWith(
-            mockError,
+            mockInternalServerError,
             'file_fetch_error',
             expect.objectContaining({
-                error: mockError,
+                error: mockInternalServerError,
                 isErrorDisplayed: true,
             }),
         );
@@ -172,7 +190,7 @@ describe('useSidebarMetadataFetcher', () => {
             successCallback(mockFile);
         });
         mockAPI.getMetadata.mockImplementation((file, successCallback, errorCallback) => {
-            errorCallback(mockError, 'metadata_fetch_error');
+            errorCallback(mockInternalServerError, 'metadata_fetch_error');
         });
         const { result } = setupHook();
 
@@ -182,10 +200,10 @@ describe('useSidebarMetadataFetcher', () => {
         expect(result.current.errorMessage).toBe(messages.sidebarMetadataFetchingErrorContent);
         expect(onSuccessMock).not.toHaveBeenCalled();
         expect(onErrorMock).toHaveBeenCalledWith(
-            mockError,
+            mockInternalServerError,
             'metadata_fetch_error',
             expect.objectContaining({
-                error: mockError,
+                error: mockInternalServerError,
                 isErrorDisplayed: true,
             }),
         );
@@ -215,7 +233,7 @@ describe('useSidebarMetadataFetcher', () => {
             successCallback({ templateInstances: mockTemplateInstances, templates: mockTemplates });
         });
         mockAPI.deleteMetadata.mockImplementation((file, template, successCallback, errorCallback) => {
-            errorCallback(mockError, 'metadata_remove_error');
+            errorCallback(mockInternalServerError, 'metadata_remove_error');
         });
 
         const { result } = setupHook();
@@ -226,10 +244,10 @@ describe('useSidebarMetadataFetcher', () => {
         expect(result.current.status).toEqual(STATUS.ERROR);
         expect(onSuccessMock).not.toHaveBeenCalled();
         expect(onErrorMock).toHaveBeenCalledWith(
-            mockError,
+            mockInternalServerError,
             'metadata_remove_error',
             expect.objectContaining({
-                error: mockError,
+                error: mockInternalServerError,
                 isErrorDisplayed: true,
             }),
         );
@@ -259,7 +277,7 @@ describe('useSidebarMetadataFetcher', () => {
             successCallback({ templateInstances: mockTemplateInstances, templates: mockTemplates });
         });
         mockAPI.createMetadataRedesign.mockImplementation((file, template, successCallback, errorCallback) => {
-            errorCallback(mockError, 'metadata_creation_error');
+            errorCallback(mockInternalServerError, 'metadata_creation_error');
         });
 
         const { result } = setupHook();
@@ -270,10 +288,10 @@ describe('useSidebarMetadataFetcher', () => {
         expect(result.current.status).toBe(STATUS.ERROR);
         expect(onSuccessMock).not.toHaveBeenCalled();
         expect(onErrorMock).toHaveBeenCalledWith(
-            mockError,
+            mockInternalServerError,
             'metadata_creation_error',
             expect.objectContaining({
-                error: mockError,
+                error: mockInternalServerError,
                 isErrorDisplayed: true,
             }),
         );
@@ -302,7 +320,7 @@ describe('useSidebarMetadataFetcher', () => {
     test('should handle metadata update error', async () => {
         mockAPI.updateMetadataRedesign.mockImplementation(
             (_file, _metadataInstance, _JSONPatch, successCallback, errorCallback) => {
-                errorCallback(mockError, 'metadata_update_error');
+                errorCallback(mockInternalServerError, 'metadata_update_error');
             },
         );
         const ops = [{ op: 'add', path: '/foo', value: 'bar' }];
@@ -322,10 +340,10 @@ describe('useSidebarMetadataFetcher', () => {
         expect(result.current.templates).toEqual(mockTemplates);
         expect(result.current.errorMessage).toEqual(messages.sidebarMetadataEditingErrorContent);
         expect(onErrorMock).toHaveBeenCalledWith(
-            mockError,
+            mockInternalServerError,
             'metadata_update_error',
             expect.objectContaining({
-                error: mockError,
+                error: mockInternalServerError,
                 isErrorDisplayed: true,
             }),
         );
@@ -351,8 +369,8 @@ describe('useSidebarMetadataFetcher', () => {
             ]);
         });
 
-        test('should handle error during suggestions extraction', async () => {
-            mockAPI.extractStructured.mockRejectedValue(mockError);
+        test('should handle user correctable error during suggestions extraction', async () => {
+            mockAPI.extractStructured.mockRejectedValue(mockRateLimitError);
 
             const { result } = setupHook();
             const suggestions = await result.current.extractSuggestions('templateKey', 'global');
@@ -360,12 +378,30 @@ describe('useSidebarMetadataFetcher', () => {
             expect(suggestions).toEqual([]);
             expect(onSuccessMock).not.toHaveBeenCalled();
             expect(onErrorMock).toHaveBeenCalledWith(
-                mockError,
+                mockRateLimitError,
                 ERROR_CODE_FETCH_METADATA_SUGGESTIONS,
                 expect.objectContaining({
                     showNotification: true,
                 }),
             );
+            await waitFor(() => expect(result.current.extractErrorCode).toBeNull());
+        });
+
+        test.each`
+            description                               | error                          | expectedErrorCode
+            ${'metadata autofill timeout error'}      | ${mockTimeoutError}            | ${ERROR_CODE_METADATA_AUTOFILL_TIMEOUT}
+            ${'metadata pre-condition failure error'} | ${mockPreconditionFailedError} | ${ERROR_CODE_METADATA_PRECONDITION_FAILED}
+            ${'internal server error'}                | ${mockInternalServerError}     | ${ERROR_CODE_UNKNOWN}
+        `('should set extract error code for $description', async ({ error, expectedErrorCode }) => {
+            mockAPI.extractStructured.mockRejectedValue(error);
+
+            const { result } = setupHook();
+            const suggestions = await result.current.extractSuggestions('templateKey', 'global');
+
+            expect(suggestions).toEqual([]);
+            expect(onSuccessMock).not.toHaveBeenCalled();
+            expect(onErrorMock).toHaveBeenCalledWith(error, expectedErrorCode);
+            await waitFor(() => expect(result.current.extractErrorCode).toEqual(expectedErrorCode));
         });
 
         test('should handle empty suggestions', async () => {

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -226,16 +226,16 @@ function useSidebarMetadataFetcher(
                 })) as Record<string, MetadataFieldValue>;
             } catch (error) {
                 // Axios makes the status code nested under the response object
-                if (error.response.status === 408) {
+                if (error.response?.status === 408) {
                     onError(error, ERROR_CODE_METADATA_AUTOFILL_TIMEOUT);
                     setExtractErrorCode(ERROR_CODE_METADATA_AUTOFILL_TIMEOUT);
-                } else if (error.response.status === 412) {
+                } else if (error.response?.status === 412) {
                     onError(error, ERROR_CODE_METADATA_PRECONDITION_FAILED);
                     setExtractErrorCode(ERROR_CODE_METADATA_PRECONDITION_FAILED);
-                } else if (error.response.status === 500) {
+                } else if (error.response?.status === 500) {
                     onError(error, ERROR_CODE_UNKNOWN);
                     setExtractErrorCode(ERROR_CODE_UNKNOWN);
-                } else if (isUserCorrectableError(error.response.status)) {
+                } else if (isUserCorrectableError(error.response?.status)) {
                     onError(error, ERROR_CODE_FETCH_METADATA_SUGGESTIONS, { showNotification: true });
                 } else {
                     onError(error, ERROR_CODE_UNKNOWN, { showNotification: true });

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -211,6 +211,7 @@ function useSidebarMetadataFetcher(
         [api, file, onApiError, onSuccess],
     );
 
+    const [, setError] = React.useState();
     const extractSuggestions = React.useCallback(
         async (templateKey: string, scope: string): Promise<MetadataTemplateField[]> => {
             const aiAPI = api.getIntelligenceAPI();
@@ -236,6 +237,10 @@ function useSidebarMetadataFetcher(
                     onError(error, ERROR_CODE_FETCH_METADATA_SUGGESTIONS, { showNotification: true });
                 } else {
                     onError(error, ERROR_CODE_UNKNOWN);
+                    // react way of throwing errors from async callbacks - https://github.com/facebook/react/issues/14981#issuecomment-468460187
+                    setError(() => {
+                        throw error;
+                    });
                 }
                 return [];
             }

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -432,7 +432,7 @@ export const ShowErrorWhenAIAPIIsUnavailable: StoryObj<typeof MetadataSidebarRed
             handlers: [
                 ...defaultMockHandlers,
                 http.post(aiSuggestionsForMyAttribute.url, () => {
-                    return new HttpResponse('Internal Server Error', { status: 500 });
+                    return new HttpResponse('Internal Server Error', { status: 503 });
                 }),
             ],
         },

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -432,7 +432,7 @@ export const ShowErrorWhenAIAPIIsUnavailable: StoryObj<typeof MetadataSidebarRed
             handlers: [
                 ...defaultMockHandlers,
                 http.post(aiSuggestionsForMyAttribute.url, () => {
-                    return new HttpResponse('Internal Server Error', { status: 503 });
+                    return new HttpResponse('Not Found', { status: 404 });
                 }),
             ],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,10 +1528,10 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.1.2.tgz#cd4266b3da62da18560d881e10b429653186be29"
   integrity sha512-d64TGosx+KRmrLZj4CIyLp42LUiEbgBJ8n8cviMQwTJmfU0g+UwZqLjmQZR1j+Q9D64yV4xHzY9K1t5nInWWeQ==
 
-"@box/metadata-editor@^0.88.1":
-  version "0.88.1"
-  resolved "https://registry.yarnpkg.com/@box/metadata-editor/-/metadata-editor-0.88.1.tgz#6beedb9e7c73cdd8824f9f52e641ac1ff1899967"
-  integrity sha512-Q6GXv9B0wSbDh9Uy7tLOg9lMeBiNx3d2WYoEZsf8Jm9kC2w8dWIGbHRqiD3E6GpvomhSrWfHzt2Zy/Bn7BRXDg==
+"@box/metadata-editor@0.91.0":
+  version "0.91.0"
+  resolved "https://registry.yarnpkg.com/@box/metadata-editor/-/metadata-editor-0.91.0.tgz#f7562f4cefd224aad491e955adefce2147c2a803"
+  integrity sha512-TyJD6n8jS5MW9rericaLlG7h203+xWpjt9deqkrYiQ9K6Vu79FqAmrW3sbBRHJFREy6Os34SruvSqL71qCPclw==
 
 "@box/react-virtualized@9.22.3-rc-box.9":
   version "9.22.3-rc-box.9"


### PR DESCRIPTION
Passes down the error code into MetadataInstanceEditor if there's an error extracting suggestions.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
