### PR TITLE
feat(boxai-sidebar): Additional UI fixes

### DIFF
--- a/src/elements/content-sidebar/BoxAISidebar.scss
+++ b/src/elements/content-sidebar/BoxAISidebar.scss
@@ -14,7 +14,7 @@ $agentSelectorSidebarWidth: 211px;
         }
 
         .bcs-content-header {
-            margin: 0 tokens.$space-4;
+            padding: 0 tokens.$space-4;
         }
 
         .bcs-scroll-content {

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -109,20 +109,6 @@ const BoxAISidebar = (props: BoxAISidebarProps) => {
         questionsWithoutInProgress = questionsWithoutInProgress.slice(0, -1);
     }
 
-    const handleKeyPress = React.useCallback((event: KeyboardEvent) => {
-        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-            event.preventDefault();
-            event.stopPropagation();
-        }
-    }, []);
-
-    React.useEffect(() => {
-        document.addEventListener('keydown', handleKeyPress, { capture: true });
-        return () => {
-            document.removeEventListener('keydown', handleKeyPress, { capture: true });
-        };
-    }, [handleKeyPress]);
-
     const localizedQuestions = DOCUMENT_SUGGESTED_QUESTIONS.map(question => ({
         id: question.id,
         label: formatMessage(messages[question.labelId]),

--- a/src/elements/content-sidebar/BoxAISidebarContent.tsx
+++ b/src/elements/content-sidebar/BoxAISidebarContent.tsx
@@ -8,7 +8,7 @@ import { useIntl } from 'react-intl';
 import classNames from 'classnames';
 import { AgentsProvider, BoxAiAgentSelectorWithApi } from '@box/box-ai-agent-selector';
 import { IconButton, Tooltip } from '@box/blueprint-web';
-import { ArrowsExpand } from '@box/blueprint-web-assets/icons/Line';
+import { ArrowsExpand } from '@box/blueprint-web-assets/icons/Fill';
 import {
     BoxAiContentAnswers,
     ClearConversationButton,

--- a/src/elements/content-sidebar/SidebarContent.scss
+++ b/src/elements/content-sidebar/SidebarContent.scss
@@ -16,8 +16,8 @@ $sidebarScrollContentIncreasedWidth: $sidebarScrollContentWidth + 40px;
         align-items: center;
         justify-content: space-between;
         height: $sidebarHeaderHeight;
-        margin: 0 $sidebarActivityFeedSpacingHorizontal;
-        padding: 0;
+        margin: 0;
+        padding: 0 $sidebarActivityFeedSpacingHorizontal;
         border-bottom: 1px solid $bdl-gray-10;
 
         .bcs-title {

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -9,13 +9,11 @@ import { injectIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 import noop from 'lodash/noop';
 import { BoxAiLogo } from '@box/blueprint-web-assets/icons/Logo';
-import { Size5 } from '@box/blueprint-web-assets/tokens/tokens';
+import { EllipsisBubble, InfoDoc, MetadataBadge } from '@box/blueprint-web-assets/icons/Line';
+import { Size6 } from '@box/blueprint-web-assets/tokens/tokens';
 import AdditionalTabs from './additional-tabs';
 import DocGenIcon from '../../icon/fill/DocGenIcon';
-import IconChatRound from '../../icons/general/IconChatRound';
-import IconDocInfo from '../../icons/general/IconDocInfo';
 import IconMagicWand from '../../icons/general/IconMagicWand';
-import IconMetadataThick from '../../icons/general/IconMetadataThick';
 import SidebarNavButton from './SidebarNavButton';
 import SidebarNavSign from './SidebarNavSign';
 import SidebarNavTablist from './SidebarNavTablist';
@@ -93,7 +91,7 @@ const SidebarNav = ({
                                     : intl.formatMessage(messages.sidebarBoxAITitle)
                             }
                         >
-                            <BoxAiLogo height={Size5} width={Size5} />
+                            <BoxAiLogo height={Size6} width={Size6} />
                         </SidebarNavButton>
                     )}
                     {hasActivity && (
@@ -105,7 +103,7 @@ const SidebarNav = ({
                             sidebarView={SIDEBAR_VIEW_ACTIVITY}
                             tooltip={intl.formatMessage(messages.sidebarActivityTitle)}
                         >
-                            <IconChatRound />
+                            <EllipsisBubble className="bcs-SidebarNav-icon" />
                         </SidebarNavButton>
                     )}
                     {hasDetails && (
@@ -117,7 +115,7 @@ const SidebarNav = ({
                             sidebarView={SIDEBAR_VIEW_DETAILS}
                             tooltip={intl.formatMessage(messages.sidebarDetailsTitle)}
                         >
-                            <IconDocInfo />
+                            <InfoDoc className="bcs-SidebarNav-icon" />
                         </SidebarNavButton>
                     )}
                     {hasSkills && (
@@ -129,7 +127,7 @@ const SidebarNav = ({
                             sidebarView={SIDEBAR_VIEW_SKILLS}
                             tooltip={intl.formatMessage(messages.sidebarSkillsTitle)}
                         >
-                            <IconMagicWand />
+                            <IconMagicWand className="bcs-SidebarNav-icon" />
                         </SidebarNavButton>
                     )}
                     {hasMetadata && (
@@ -141,7 +139,7 @@ const SidebarNav = ({
                             sidebarView={SIDEBAR_VIEW_METADATA}
                             tooltip={intl.formatMessage(messages.sidebarMetadataTitle)}
                         >
-                            <IconMetadataThick />
+                            <MetadataBadge className="bcs-SidebarNav-icon" />
                         </SidebarNavButton>
                     )}
                     {hasDocGen && (

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -9,11 +9,13 @@ import { injectIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 import noop from 'lodash/noop';
 import { BoxAiLogo } from '@box/blueprint-web-assets/icons/Logo';
-import { EllipsisBubble, InfoDoc, MetadataBadge } from '@box/blueprint-web-assets/icons/Line';
 import { Size6 } from '@box/blueprint-web-assets/tokens/tokens';
 import AdditionalTabs from './additional-tabs';
 import DocGenIcon from '../../icon/fill/DocGenIcon';
+import IconChatRound from '../../icons/general/IconChatRound';
+import IconDocInfo from '../../icons/general/IconDocInfo';
 import IconMagicWand from '../../icons/general/IconMagicWand';
+import IconMetadataThick from '../../icons/general/IconMetadataThick';
 import SidebarNavButton from './SidebarNavButton';
 import SidebarNavSign from './SidebarNavSign';
 import SidebarNavTablist from './SidebarNavTablist';
@@ -103,7 +105,7 @@ const SidebarNav = ({
                             sidebarView={SIDEBAR_VIEW_ACTIVITY}
                             tooltip={intl.formatMessage(messages.sidebarActivityTitle)}
                         >
-                            <EllipsisBubble className="bcs-SidebarNav-icon" />
+                            <IconChatRound className="bcs-SidebarNav-icon" />
                         </SidebarNavButton>
                     )}
                     {hasDetails && (
@@ -115,7 +117,7 @@ const SidebarNav = ({
                             sidebarView={SIDEBAR_VIEW_DETAILS}
                             tooltip={intl.formatMessage(messages.sidebarDetailsTitle)}
                         >
-                            <InfoDoc className="bcs-SidebarNav-icon" />
+                            <IconDocInfo className="bcs-SidebarNav-icon" />
                         </SidebarNavButton>
                     )}
                     {hasSkills && (
@@ -139,7 +141,7 @@ const SidebarNav = ({
                             sidebarView={SIDEBAR_VIEW_METADATA}
                             tooltip={intl.formatMessage(messages.sidebarMetadataTitle)}
                         >
-                            <MetadataBadge className="bcs-SidebarNav-icon" />
+                            <IconMetadataThick className="bcs-SidebarNav-icon" />
                         </SidebarNavButton>
                     )}
                     {hasDocGen && (

--- a/src/elements/content-sidebar/SidebarNav.scss
+++ b/src/elements/content-sidebar/SidebarNav.scss
@@ -21,7 +21,12 @@
     }
 
     .bcs-SidebarNav-icon {
-        @include bdl-SidebarNavIcon;
+        width: 20px;
+        height: 20px;
+
+        path {
+            fill: $bdl-gray-65;
+        }
     }
 
     .bcs-SidebarNav-overflow {

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -247,28 +247,4 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
 
         expect(screen.queryByTestId('content-answers-modal')).not.toBeInTheDocument();
     });
-
-    describe('BoxAISidebar handleKeyPress', () => {
-        test('should prevent default behavior and stop propagation for ArrowLeft and ArrowRight keys', async () => {
-            await renderComponent();
-
-            const eventLeft = new KeyboardEvent('keydown', { key: 'ArrowLeft' });
-            const preventDefaultSpy = jest.spyOn(eventLeft, 'preventDefault');
-            const stopPropagationSpy = jest.spyOn(eventLeft, 'stopPropagation');
-
-            document.dispatchEvent(eventLeft);
-
-            expect(preventDefaultSpy).toHaveBeenCalled();
-            expect(stopPropagationSpy).toHaveBeenCalled();
-
-            const eventRight = new KeyboardEvent('keydown', { key: 'ArrowRight' });
-            const preventDefaultSpyRight = jest.spyOn(eventRight, 'preventDefault');
-            const stopPropagationSpyRight = jest.spyOn(eventRight, 'stopPropagation');
-
-            document.dispatchEvent(eventRight);
-
-            expect(preventDefaultSpyRight).toHaveBeenCalled();
-            expect(stopPropagationSpyRight).toHaveBeenCalled();
-        });
-    });
 });


### PR DESCRIPTION
### Description
Provided additional UI fixes to the sidebar:

- Header horizontal line should go all the way across - apply to all sidebar tabs

- Update sidebar icons to fill icons

- Change icon for expand button

- Change SidebarNav icon sizes

### Screenshots
<img width="447" alt="image" src="https://github.com/user-attachments/assets/f8aee20f-066e-4cc3-82e3-d1cf3f9f9883" />


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
