### PR TITLE
fix(content-explorer): fix infinite scroll setup

### DIFF
--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -164,6 +164,8 @@ const ItemList = ({
         return result;
     };
 
+    const isRowLoaded = ({ index }) => !items[index]?.isLoading;
+
     const renderRow = rendererParams => {
         const { index, key, style, className: rowClassName, columns } = rendererParams;
         const item = items[index];
@@ -203,7 +205,7 @@ const ItemList = ({
     if (onLoadMoreItems) {
         TableComponent = InfiniteLoaderTable;
         tableProps.infiniteLoaderProps = {
-            isRowLoaded: getRow,
+            isRowLoaded,
             loadMoreRows: onLoadMoreItems,
             minimumBatchSize: numItemsPerPage,
             rowCount: numTotalItems,

--- a/src/features/content-explorer/item-list/ItemList.js
+++ b/src/features/content-explorer/item-list/ItemList.js
@@ -164,7 +164,7 @@ const ItemList = ({
         return result;
     };
 
-    const isRowLoaded = ({ index }) => !items[index]?.isLoading;
+    const isRowLoaded = ({ index }) => index >= 0 && index < items.length && !items[index].isLoading;
 
     const renderRow = rendererParams => {
         const { index, key, style, className: rowClassName, columns } = rendererParams;

--- a/src/features/content-explorer/item-list/__tests__/ItemList.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemList.test.js
@@ -98,7 +98,7 @@ describe('features/content-explorer/item-list/ItemList', () => {
                 { id: '2', name: 'item2' },
                 { id: '3', name: 'item3' },
             ];
-            const selectedItems = { '1': items[0] };
+            const selectedItems = { 1: items[0] };
             const wrapper = renderComponent({
                 items,
                 selectedItems,
@@ -187,10 +187,7 @@ describe('features/content-explorer/item-list/ItemList', () => {
                 onItemNameClick: onItemNameClickSpy,
             });
 
-            wrapper
-                .find('.item-list-name')
-                .hostNodes()
-                .simulate('click');
+            wrapper.find('.item-list-name').hostNodes().simulate('click');
 
             expect(onItemNameClickSpy.calledOnce).toBe(true);
         });
@@ -337,6 +334,49 @@ describe('features/content-explorer/item-list/ItemList', () => {
             });
             const headerRow = wrapper.find("[data-testid='customHeader']");
             expect(headerRow.length).not.toBe(1);
+        });
+    });
+
+    describe('infinite scroll', () => {
+        test.each([
+            // threshold item is (nLoadedItems - numItemsPerPage)th item
+            {
+                description:
+                    'should call onLoadMoreItems initially when threshold item is visible and there are loading items',
+                nLoadedItems: 100,
+                nLoadingItems: 10,
+                numItemsPerPage: 100,
+                expectedCallCount: 1,
+            },
+            {
+                description: 'should not call onLoadMoreItems initially when threshold item is not visible',
+                nLoadedItems: 100,
+                nLoadingItems: 10,
+                numItemsPerPage: 10,
+                expectedCallCount: 0,
+            },
+            {
+                description: 'should not call onLoadMoreItems initially when there are no loading items',
+                nLoadedItems: 100,
+                nLoadingItems: 0,
+                numItemsPerPage: 10,
+                expectedCallCount: 0,
+            },
+        ])('$description', ({ nLoadedItems, nLoadingItems, numItemsPerPage, expectedCallCount }) => {
+            const onLoadMoreItemsSpy = sandbox.spy();
+            const items = [
+                ...Array.from({ length: nLoadedItems }, () => ({ isLoading: false })),
+                ...Array.from({ length: nLoadingItems }, () => ({ isLoading: true })),
+            ];
+
+            renderComponent({
+                onLoadMoreItems: onLoadMoreItemsSpy,
+                items,
+                numItemsPerPage,
+                numTotalItems: items.length,
+            });
+
+            expect(onLoadMoreItemsSpy.callCount).toBe(expectedCallCount);
         });
     });
 });


### PR DESCRIPTION
Infinite scroll in Content Explorer (feature) was not working correctly. We were passing incorrect function checking if row is loaded to `infiniteLoaderProps`. This function must return at least once `false` for the `onLoadMoreItems` function to be potentially invoked. Our old function was `getRow` which always returned an object (row), so it never was `false`

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
