### PR TITLE
feat(content-explorer-modal-container): add noItemsRenderer prop

### DIFF
--- a/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
+++ b/src/features/content-explorer/content-explorer-modal-container/ContentExplorerModalContainer.js
@@ -153,6 +153,8 @@ class ContentExplorerModalContainer extends Component {
         chooseButtonText: PropTypes.node,
         /** Text for the informational notice, defaults to empty string, which makes notice not visible */
         infoNoticeText: PropTypes.string,
+        /** Used to render the no items state. Overrides the default no items state. */
+        noItemsRenderer: PropTypes.func,
     };
 
     static defaultProps = {

--- a/src/features/content-explorer/content-explorer-modal-container/__tests__/ContentExplorerModalContainer.test.js
+++ b/src/features/content-explorer/content-explorer-modal-container/__tests__/ContentExplorerModalContainer.test.js
@@ -66,22 +66,25 @@ describe('features/content-explorer/content-explorer-modal-container/ContentExpl
             expect(wrapper.find('NewFolderModal').prop('parentFolderName')).toEqual(parentFolderName);
         });
 
-        test('should pass searchInputProps, chooseButtonText, onSelectItem, and onSelectedClick to ContentExplorerModal', () => {
+        test('should pass searchInputProps, chooseButtonText, onSelectItem, onSelectedClick and noItemsRenderer to ContentExplorerModal', () => {
             const searchInputProps = { placeholder: 'test' };
             const chooseButtonText = 'test';
             const onSelectedClick = () => {};
             const onSelectItem = () => {};
+            const noItemsRenderer = () => <div>No items</div>;
             const wrapper = renderComponent({
                 searchInputProps,
                 chooseButtonText,
                 onSelectedClick,
                 onSelectItem,
+                noItemsRenderer,
             });
 
             expect(wrapper.find('ContentExplorerModal').prop('searchInputProps')).toEqual(searchInputProps);
             expect(wrapper.find('ContentExplorerModal').prop('chooseButtonText')).toEqual(chooseButtonText);
             expect(wrapper.find('ContentExplorerModal').prop('onSelectedClick')).toEqual(onSelectedClick);
             expect(wrapper.find('ContentExplorerModal').prop('onSelectItem')).toEqual(onSelectItem);
+            expect(wrapper.find('ContentExplorerModal').prop('noItemsRenderer')).toEqual(noItemsRenderer);
         });
 
         test('should render ContentExplorerModal and NewFolderModal in Portal by default', () => {

--- a/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
+++ b/src/features/content-explorer/content-explorer-modal/ContentExplorerModal.js
@@ -36,6 +36,7 @@ type Props = {
     shouldNotUsePortal?: boolean,
     title?: string,
     infoNoticeText?: string,
+    noItemsRenderer?: Function,
 };
 
 const ContentExplorerModal = ({

--- a/src/features/content-explorer/content-explorer-modal/__tests__/ContentExplorerModal.test.js
+++ b/src/features/content-explorer/content-explorer-modal/__tests__/ContentExplorerModal.test.js
@@ -63,18 +63,18 @@ describe('features/content-explorer/content-explorer-modal/ContentExplorerModal'
             expect(wrapper).toMatchSnapshot();
         });
 
-        test('should pass onSelectedClick and onSelectItem to ContentExplorer', () => {
+        test('should pass onSelectedClick, onSelectItem, infoNoticeText and noItemsRenderer to ContentExplorer', () => {
             const onSelectedClick = () => {};
             const onSelectItem = () => {};
-            const wrapper = renderComponent({ onSelectedClick, onSelectItem });
+            const infoNoticeText = 'info notice text';
+            const noItemsRenderer = () => <div>No items</div>;
+
+            const wrapper = renderComponent({ onSelectedClick, onSelectItem, infoNoticeText, noItemsRenderer });
+
             expect(wrapper.find('ContentExplorer').prop('onSelectedClick')).toEqual(onSelectedClick);
             expect(wrapper.find('ContentExplorer').prop('onSelectItem')).toEqual(onSelectItem);
-        });
-
-        test('should pass infoNoticeText to ContentExplorer', () => {
-            const infoNoticeText = 'info notice text';
-            const wrapper = renderComponent({ infoNoticeText });
             expect(wrapper.find('ContentExplorer').prop('infoNoticeText')).toEqual(infoNoticeText);
+            expect(wrapper.find('ContentExplorer').prop('noItemsRenderer')).toEqual(noItemsRenderer);
         });
     });
 });

--- a/src/features/content-explorer/content-explorer/ContentExplorer.js
+++ b/src/features/content-explorer/content-explorer/ContentExplorer.js
@@ -161,6 +161,8 @@ class ContentExplorer extends Component {
         searchInputProps: PropTypes.object,
         /** Text for the informational notice, defaults to empty string, which makes notice not visible */
         infoNoticeText: PropTypes.string,
+        /** Used to render the no items state. Overrides the default no items state. */
+        noItemsRenderer: PropTypes.func,
     };
 
     static defaultProps = {
@@ -500,6 +502,7 @@ class ContentExplorer extends Component {
             listHeight,
             searchInputProps,
             infoNoticeText,
+            noItemsRenderer,
             ...rest
         } = this.props;
         const { isInSearchMode, foldersPath, isSelectAllChecked } = this.state;
@@ -600,7 +603,7 @@ class ContentExplorer extends Component {
                     itemNameLinkRenderer={itemNameLinkRenderer}
                     items={items}
                     itemRowRenderer={itemRowRenderer}
-                    noItemsRenderer={this.renderItemListEmptyState}
+                    noItemsRenderer={noItemsRenderer || this.renderItemListEmptyState}
                     numItemsPerPage={numItemsPerPage}
                     numTotalItems={numTotalItems}
                     onItemClick={this.handleItemClick}

--- a/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
+++ b/src/features/content-explorer/content-explorer/__tests__/ContentExplorer.test.js
@@ -579,6 +579,27 @@ describe('features/content-explorer/content-explorer/ContentExplorer', () => {
         });
     });
 
+    describe('noItemsRenderer', () => {
+        const customEmptyStateClassName = 'custom-empty-state';
+
+        test('should render custom empty state when specified', () => {
+            const wrapper = renderComponent(
+                { noItemsRenderer: () => <div className={customEmptyStateClassName} /> },
+                true,
+            );
+
+            expect(wrapper.exists(`.${customEmptyStateClassName}`)).toBe(true);
+            expect(wrapper.exists('ContentExplorerEmptyState')).toBe(false);
+        });
+
+        test('should render default empty state when not specified', () => {
+            const wrapper = renderComponent({}, true);
+
+            expect(wrapper.exists('ContentExplorerEmptyState')).toBe(true);
+            expect(wrapper.exists(`.${customEmptyStateClassName}`)).toBe(false);
+        });
+    });
+
     describe('handleDocumentClick', () => {
         test('should deselect when the click did not occur inside the content explorer and not in multi select mode', () => {
             const item = { id: 'id', name: 'name' };


### PR DESCRIPTION
This PR adds `noItemsRenderer` prop to `ContentExplorerModalContainer`. When this prop is passed, it will be used instead of the default value. `noItemsRenderer` will only be rendered when `items` array is empty. This will be useful for specifying custom empty states.

This implements an idea suggested in https://github.com/box/box-ui-elements/pull/3241.

Here is an example:

![Screenshot 2025-02-21 at 18 38 52](https://github.com/user-attachments/assets/7196fd57-d242-4a3e-b4b7-7a7770019611)

To recreate this example, add the following line of code to `examples/src/ContentExplorerMultiSelectModalContainerExamples.js`:

```
noItemsRenderer={() => <p>This is a no items renderer</p>}
```

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
