### PR TITLE
feat(content-sidebar): focus Box AI prompt on tab button click

### DIFF
--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -68,11 +68,21 @@ const SidebarNav = ({
     onPanelChange = noop,
 }: Props) => {
     const { enabled: hasBoxSign } = useFeatureConfig('boxSign');
-    const { disabledTooltip: boxAIDisabledTooltip, showOnlyNavButton: showOnlyBoxAINavButton } =
-        useFeatureConfig('boxai.sidebar');
+    const {
+        disabledTooltip: boxAIDisabledTooltip,
+        showOnlyNavButton: showOnlyBoxAINavButton,
+        useBoxAISidebarPrompt = () => ({}),
+    } = useFeatureConfig('boxai.sidebar');
+
+    const { focusBoxAISidebarPrompt = noop } = useBoxAISidebarPrompt();
 
     const handleSidebarNavButtonClick = (sidebarview: string) => {
         onPanelChange(sidebarview, false);
+
+        // If the Box AI sidebar is enabled, focus the Box AI sidebar prompt
+        if (sidebarview === SIDEBAR_VIEW_BOXAI) {
+            focusBoxAISidebarPrompt();
+        }
     };
 
     return (

--- a/src/elements/content-sidebar/__tests__/SidebarNav.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNav.test.js
@@ -138,6 +138,31 @@ describe('elements/content-sidebar/SidebarNav', () => {
         });
     });
 
+    test('should call focusBoxAISidebarPrompt when clicked on Box AI Tab', async () => {
+        const mockFocusBoxAISidebarPrompt = jest.fn();
+        const mockUseBoxAISidebarPrompt = () => ({ focusBoxAISidebarPrompt: mockFocusBoxAISidebarPrompt });
+
+        render(
+            getSidebarNav({
+                features: {
+                    boxai: {
+                        sidebar: {
+                            showOnlyNavButton: false,
+                            useBoxAISidebarPrompt: mockUseBoxAISidebarPrompt,
+                        },
+                    },
+                },
+                props: { hasBoxAI: true },
+            }),
+        );
+
+        const button = screen.getByTestId('sidebarboxai');
+
+        await userEvent.click(button);
+
+        expect(mockFocusBoxAISidebarPrompt).toHaveBeenCalled();
+    });
+
     test('should have multiple tabs', () => {
         const props = {
             hasActivity: true,


### PR DESCRIPTION
### Description

This change along, with EUA, makes Box AI prompt input focused upon clicking Box AI Sidebar tab button.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
