### PR TITLE
fix(item-options): render correctly when item actions are filtered

### DIFF
--- a/src/elements/common/item/ItemOptions.tsx
+++ b/src/elements/common/item/ItemOptions.tsx
@@ -61,7 +61,25 @@ const ItemOptions = ({
     const isRenameEnabled = canRename && permissions[PERMISSION_CAN_RENAME];
     const isShareEnabled = canShare && permissions[PERMISSION_CAN_SHARE];
 
-    const hasActions = !!itemActions.length;
+    const actions = itemActions
+        .map(({ filter: actionFilter, label: actionLabel, onAction, type: actionType }) => {
+            if (actionType && actionType !== itemType) {
+                return null;
+            }
+
+            if (actionFilter && !actionFilter(item)) {
+                return null;
+            }
+
+            return (
+                <DropdownMenu.Item key={actionLabel + actionType} onClick={() => onAction(item)}>
+                    {actionLabel}
+                </DropdownMenu.Item>
+            );
+        })
+        .filter(action => action);
+
+    const hasActions = !!actions.length;
     const hasOptions =
         isDeleteEnabled || isDownloadEnabled || isOpenEnabled || isPreviewEnabled || isRenameEnabled || isShareEnabled;
 
@@ -122,21 +140,7 @@ const ItemOptions = ({
                     </DropdownMenu.Item>
                 )}
                 {hasActions && hasOptions && <DropdownMenu.Separator />}
-                {itemActions.map(({ filter: actionFilter, label: actionLabel, onAction, type: actionType }) => {
-                    if (actionType && actionType !== itemType) {
-                        return null;
-                    }
-
-                    if (actionFilter && !actionFilter(item)) {
-                        return null;
-                    }
-
-                    return (
-                        <DropdownMenu.Item key={actionLabel + actionType} onClick={() => onAction(item)}>
-                            {actionLabel}
-                        </DropdownMenu.Item>
-                    );
-                })}
+                {hasActions && actions}
             </DropdownMenu.Content>
         </DropdownMenu.Root>
     );

--- a/src/elements/common/item/ItemOptions.tsx
+++ b/src/elements/common/item/ItemOptions.tsx
@@ -61,23 +61,24 @@ const ItemOptions = ({
     const isRenameEnabled = canRename && permissions[PERMISSION_CAN_RENAME];
     const isShareEnabled = canShare && permissions[PERMISSION_CAN_SHARE];
 
-    const actions = itemActions
-        .map(({ filter: actionFilter, label: actionLabel, onAction, type: actionType }) => {
-            if (actionType && actionType !== itemType) {
-                return null;
-            }
+    const actions = itemActions.reduce((validActions, action) => {
+        const { filter: actionFilter, label: actionLabel, onAction, type: actionType } = action;
 
-            if (actionFilter && !actionFilter(item)) {
-                return null;
-            }
+        if (actionType && actionType !== itemType) {
+            return validActions;
+        }
 
-            return (
-                <DropdownMenu.Item key={actionLabel + actionType} onClick={() => onAction(item)}>
-                    {actionLabel}
-                </DropdownMenu.Item>
-            );
-        })
-        .filter(action => action);
+        if (actionFilter && !actionFilter(item)) {
+            return validActions;
+        }
+
+        return [
+            ...validActions,
+            <DropdownMenu.Item key={actionLabel + actionType} onClick={() => onAction(item)}>
+                {actionLabel}
+            </DropdownMenu.Item>,
+        ];
+    }, []);
 
     const hasActions = !!actions.length;
     const hasOptions =

--- a/src/elements/common/item/__tests__/ItemOptions.test.tsx
+++ b/src/elements/common/item/__tests__/ItemOptions.test.tsx
@@ -67,12 +67,14 @@ describe('elements/common/item/ItemOptions', () => {
     });
 
     test('renders component with custom actions', async () => {
+        const onAction = jest.fn();
+
         renderComponent({
             itemActions: [
                 { label: 'Archive', type: 'folder' }, // Should be filtered since there are no folder items
                 { label: 'Email', type: 'file' },
                 { filter: ({ extension }) => extension === 'pdf', label: 'Export' },
-                { label: 'Favorite', type: 'file' },
+                { label: 'Favorite', onAction, type: 'file' },
             ],
         });
 
@@ -81,5 +83,27 @@ describe('elements/common/item/ItemOptions', () => {
         expect(screen.queryByRole('menuitem', { name: 'Archive' })).not.toBeInTheDocument();
         expect(screen.getByRole('menuitem', { name: 'Email' })).toBeInTheDocument();
         expect(screen.getByRole('menuitem', { name: 'Favorite' })).toBeInTheDocument();
+
+        expect(onAction).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Favorite' }));
+
+        expect(onAction).toHaveBeenCalled();
+    });
+
+    test('renders an empty component if there are no applicable custom actions for the item', () => {
+        const { container } = renderComponent({
+            canDelete: false,
+            canDownload: false,
+            canPreview: false,
+            canRename: false,
+            canShare: false,
+            itemActions: [
+                { label: 'Archive', type: 'folder' },
+                { filter: ({ extension }) => extension === 'csv', label: 'Import' },
+            ],
+        });
+
+        expect(container).toBeEmptyDOMElement();
     });
 });


### PR DESCRIPTION
The extensibility feature for the row items ("More Options" button) in Content Explorer and Content Picker does not properly handle an empty state. e.g. if a developer passes in custom actions and utilizes the `type` or `filter` properties which results in an item with zero custom actions, it will still try to render the button with no dropdown menu items

This change will check if the filtered item actions list is empty and then return null so that the trigger button is not rendered.