### PR TITLE
fix(content-explorer): improve theming feature

### DIFF
--- a/src/elements/common/item-grid/ItemGrid.tsx
+++ b/src/elements/common/item-grid/ItemGrid.tsx
@@ -21,6 +21,7 @@ export interface ItemGridProps extends ItemEventHandlers, ItemEventPermissions {
     isTouch?: boolean;
     itemActions?: ItemAction[];
     items: BoxItem[];
+    portalElement?: HTMLElement;
     view: View;
 }
 

--- a/src/elements/common/item-list/ItemList.tsx
+++ b/src/elements/common/item-list/ItemList.tsx
@@ -27,6 +27,7 @@ export interface ItemListProps extends ItemEventHandlers, ItemEventPermissions {
     itemActions?: ItemAction[];
     items: BoxItem[];
     onSortChange?: (sortBy: SortBy, sortDirection: SortDirection) => void;
+    portalElement?: HTMLElement;
     selectionMode?: SelectionMode;
     sortBy?: SortBy;
     sortDirection?: SortDirection;

--- a/src/elements/common/item/ItemOptions.tsx
+++ b/src/elements/common/item/ItemOptions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import noop from 'lodash/noop';
 
-import { ActionCell, DropdownMenu, GridList, IconButton } from '@box/blueprint-web';
+import { ActionCell, Cell, DropdownMenu, GridList, IconButton } from '@box/blueprint-web';
 import { Ellipsis } from '@box/blueprint-web-assets/icons/Fill';
 import type { IconButtonProps } from '@box/blueprint-web';
 
@@ -28,6 +28,7 @@ import type { ItemAction, ItemEventHandlers, ItemEventPermissions } from './type
 export interface ItemOptionsProps extends ItemEventHandlers, ItemEventPermissions {
     item: BoxItem;
     itemActions?: ItemAction[];
+    portalElement?: HTMLElement;
     viewMode?: VIEW_MODE_GRID | VIEW_MODE_LIST;
 }
 
@@ -44,13 +45,17 @@ const ItemOptions = ({
     onItemPreview = noop,
     onItemRename = noop,
     onItemShare = noop,
+    portalElement,
     viewMode,
 }: ItemOptionsProps) => {
     const { permissions, type: itemType } = item;
     const { formatMessage } = useIntl();
 
+    const isListView = viewMode === VIEW_MODE_LIST;
+    const isGridView = viewMode === VIEW_MODE_GRID;
+
     if (!permissions) {
-        return null;
+        return isListView ? <Cell /> : null;
     }
 
     const isDeleteEnabled = canDelete && permissions[PERMISSION_CAN_DELETE];
@@ -85,7 +90,7 @@ const ItemOptions = ({
         isDeleteEnabled || isDownloadEnabled || isOpenEnabled || isPreviewEnabled || isRenameEnabled || isShareEnabled;
 
     if (!hasActions && !hasOptions) {
-        return null;
+        return isListView ? <Cell /> : null;
     }
 
     const iconButtonProps = {
@@ -95,7 +100,6 @@ const ItemOptions = ({
         size: 'large',
     };
 
-    const isGridView = viewMode === VIEW_MODE_GRID;
     const OptionsGroup = isGridView ? GridList.Actions : ActionCell;
     const OptionsTrigger = isGridView ? GridList.ActionIconButton : IconButton;
     const optionsTriggerProps = isGridView ? {} : iconButtonProps;
@@ -109,7 +113,7 @@ const ItemOptions = ({
                     {...(optionsTriggerProps as IconButtonProps)}
                 />
             </DropdownMenu.Trigger>
-            <DropdownMenu.Content align="end">
+            <DropdownMenu.Content align="end" container={portalElement}>
                 {isPreviewEnabled && (
                     <DropdownMenu.Item onClick={() => onItemPreview(item)}>
                         {formatMessage(messages.preview)}

--- a/src/elements/common/item/__tests__/ItemOptions.test.tsx
+++ b/src/elements/common/item/__tests__/ItemOptions.test.tsx
@@ -3,6 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../../test-utils/testing-library';
 import ItemOptions from '../ItemOptions';
 
+jest.mock('@box/blueprint-web', () => ({
+    ...jest.requireActual('@box/blueprint-web'),
+    Cell: () => <div data-testid="be-ItemOptions-cell"></div>,
+}));
+
 describe('elements/common/item/ItemOptions', () => {
     const renderComponent = (props = {}) => {
         const defaultProps = {
@@ -52,6 +57,20 @@ describe('elements/common/item/ItemOptions', () => {
         });
 
         expect(container).toBeEmptyDOMElement();
+    });
+
+    test('renders a cell component if there are no permissions on the item in list view', () => {
+        renderComponent({
+            item: {
+                type: 'file',
+                id: '005',
+                name: 'Box file',
+                permissions: undefined,
+            },
+            viewMode: 'list',
+        });
+
+        expect(screen.getByTestId('be-ItemOptions-cell')).toBeInTheDocument();
     });
 
     test('renders an empty component if there are no options enabled for the item', () => {
@@ -105,5 +124,22 @@ describe('elements/common/item/ItemOptions', () => {
         });
 
         expect(container).toBeEmptyDOMElement();
+    });
+
+    test('renders a cell component if there are no applicable custom actions for the item in list view', () => {
+        renderComponent({
+            canDelete: false,
+            canDownload: false,
+            canPreview: false,
+            canRename: false,
+            canShare: false,
+            itemActions: [
+                { label: 'Archive', type: 'folder' },
+                { filter: ({ extension }) => extension === 'csv', label: 'Import' },
+            ],
+            viewMode: 'list',
+        });
+
+        expect(screen.getByTestId('be-ItemOptions-cell')).toBeInTheDocument();
     });
 });

--- a/src/elements/common/sub-header/Add.tsx
+++ b/src/elements/common/sub-header/Add.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { DropdownMenu, IconButton } from '@box/blueprint-web';
 import { Plus } from '@box/blueprint-web-assets/icons/Fill';
 
@@ -28,14 +28,10 @@ const Add = ({ isDisabled, onUpload, onCreate, showUpload = true, showCreate = t
             </DropdownMenu.Trigger>
             <DropdownMenu.Content>
                 {showUpload && (
-                    <DropdownMenu.Item onClick={onUpload}>
-                        <FormattedMessage {...messages.upload} />
-                    </DropdownMenu.Item>
+                    <DropdownMenu.Item onClick={onUpload}>{formatMessage(messages.upload)}</DropdownMenu.Item>
                 )}
                 {showCreate && (
-                    <DropdownMenu.Item onClick={onCreate}>
-                        <FormattedMessage {...messages.newFolder} />
-                    </DropdownMenu.Item>
+                    <DropdownMenu.Item onClick={onCreate}>{formatMessage(messages.newFolder)}</DropdownMenu.Item>
                 )}
             </DropdownMenu.Content>
         </DropdownMenu.Root>

--- a/src/elements/common/sub-header/Sort.tsx
+++ b/src/elements/common/sub-header/Sort.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { DropdownMenu, IconButton } from '@box/blueprint-web';
 import IconSort from '../../../icons/general/IconSort';
 import type { SortBy, SortDirection } from '../../../common/types/core';
@@ -39,7 +39,7 @@ const Sort = ({ onSortChange }: SortProps) => {
                             key={sortItemKey}
                             onClick={() => onSortChange(sortByValue, sortDirectionValue)}
                         >
-                            <FormattedMessage {...messages[sortItemKey]} />
+                            {formatMessage(messages[sortItemKey])}
                         </DropdownMenu.Item>
                     );
                 })}

--- a/src/elements/common/theming/ThemingStyles.tsx
+++ b/src/elements/common/theming/ThemingStyles.tsx
@@ -1,8 +1,8 @@
 import useCustomTheming from './useCustomTheming';
 import { ThemingProps } from './types';
 
-const ThemingStyles = ({ theme }: ThemingProps) => {
-    useCustomTheming({ theme });
+const ThemingStyles = ({ selector, theme }: ThemingProps) => {
+    useCustomTheming({ selector, theme });
 
     return null;
 };

--- a/src/elements/common/theming/types.ts
+++ b/src/elements/common/theming/types.ts
@@ -3,5 +3,6 @@ export type Theme = {
 };
 
 export interface ThemingProps {
+    selector?: string;
     theme?: Theme;
 }

--- a/src/elements/common/theming/useCustomTheming.ts
+++ b/src/elements/common/theming/useCustomTheming.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { convertTokensToCustomProperties } from './utils';
 import { ThemingProps } from './types';
 
-const useCustomTheming = ({ theme = {} }: ThemingProps) => {
+const useCustomTheming = ({ selector, theme = {} }: ThemingProps) => {
     const { tokens } = theme;
 
     const customProperties = convertTokensToCustomProperties(tokens);
@@ -18,12 +18,12 @@ const useCustomTheming = ({ theme = {} }: ThemingProps) => {
         const styleEl = document.createElement('style');
         document.head.appendChild(styleEl);
 
-        styleEl.sheet.insertRule(`:root { ${styles} }`);
+        styleEl.sheet.insertRule(`${selector ?? ':root'} { ${styles} }`);
 
         return () => {
             document.head.removeChild(styleEl);
         };
-    }, [styles]);
+    }, [selector, styles]);
 };
 
 export default useCustomTheming;

--- a/src/elements/content-explorer/Content.tsx
+++ b/src/elements/content-explorer/Content.tsx
@@ -40,6 +40,7 @@ export interface ContentProps extends Required<ItemEventHandlers>, Required<Item
         editedValue: MetadataFieldValue,
     ) => void;
     onSortChange: (sortBy: string, sortDirection: string) => void;
+    portalElement: HTMLElement;
     view: View;
     viewMode?: ViewMode;
 }

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -1644,7 +1644,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
         /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
         return (
             <Internationalize language={language} messages={messages}>
-                <TooltipProvider>
+                <TooltipProvider container={this.rootElement}>
                     <div id={this.id} className={styleClassName} ref={measureRef} data-testid="content-explorer">
                         <ThemingStyles theme={theme} />
                         <div className="be-app-element" onKeyDown={this.onKeyDown} tabIndex={0}>
@@ -1695,6 +1695,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
                                 onItemShare={this.share}
                                 onMetadataUpdate={this.updateMetadata}
                                 onSortChange={this.sort}
+                                portalElement={this.rootElement}
                                 view={view}
                                 viewMode={viewMode}
                             />

--- a/src/elements/content-explorer/__tests__/Content.test.tsx
+++ b/src/elements/content-explorer/__tests__/Content.test.tsx
@@ -32,6 +32,7 @@ const mockProps: ContentProps = {
     onItemShare: jest.fn(),
     onMetadataUpdate: jest.fn(),
     onSortChange: jest.fn(),
+    portalElement: null,
     view: VIEW_RECENTS,
     viewMode: VIEW_MODE_LIST,
 };

--- a/src/elements/content-explorer/stories/tests/ContentExplorer-visual.stories.js
+++ b/src/elements/content-explorer/stories/tests/ContentExplorer-visual.stories.js
@@ -251,20 +251,6 @@ export const errorEmptyState = {
     },
 };
 
-export const searchEmptyState = {
-    args: {
-        rootFolderId: '74729718131',
-    },
-    play: async ({ canvasElement }) => {
-        const canvas = within(canvasElement);
-        const searchBar = canvas.getByRole('searchbox', { name: 'Search files and folders' });
-        await userEvent.type(searchBar, 'foo');
-
-        expect(canvas.getByText('test')).toBeInTheDocument();
-        expect(canvas.getByText("Sorry, we couldn't find what you're looking for.")).toBeInTheDocument();
-    },
-};
-
 export const withTheming = {
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);


### PR DESCRIPTION
Fixed table rendering by adding an empty cell when there is no ActionCell for the list view. Issue was noticeable when updating the background color of the table.

Added a `portalElement` which is passed down to the floating components to be used as a container for mounting. This prevents components like DropdownMenu from portal-ing outside of ContentExplorer. This allows for easier styling of the floating components.

Added a selector functionality to the theming. this allows elements to be individually themed without conflicting with other elements. This is not enabled in any of the elements yet.