### PR TITLE
fix(metadata-editor): Handle new taxonomy API

### DIFF
--- a/src/elements/content-sidebar/__tests__/metadataTaxonomyFetcher.test.ts
+++ b/src/elements/content-sidebar/__tests__/metadataTaxonomyFetcher.test.ts
@@ -95,7 +95,8 @@ describe('metadataTaxonomyFetcher', () => {
     });
 });
 
-describe('metadataNodeTaxonomiesFetcher', () => {
+// TODO: delete whole section during clean up as for now we have to handle both new and old naming convention
+describe('metadataTaxonomyNodeAncestorsFetcher (old keys naming convention)', () => {
     const fileID = '12345';
     const scope = 'global';
     const taxonomyKey = 'taxonomy_123';
@@ -179,6 +180,112 @@ describe('metadataNodeTaxonomiesFetcher', () => {
             id: 'node_abc',
             level: 1,
             displayName: 'Node ABC',
+            ancestors: [],
+        };
+
+        apiMock.getMetadataAPI(false).getMetadataTaxonomy.mockResolvedValue(mockTaxonomy);
+        apiMock.getMetadataAPI(false).getMetadataTaxonomyNode.mockResolvedValue(mockTaxonomyNode);
+
+        const result = await metadataTaxonomyNodeAncestorsFetcher(apiMock, fileID, scope, taxonomyKey, nodeID);
+
+        const expectedResult = [
+            {
+                level: 1,
+                levelName: 'Level 1',
+                description: 'Description 1',
+                id: 'node_abc',
+                levelValue: 'Node ABC',
+            },
+        ];
+
+        expect(result).toEqual(expectedResult);
+    });
+});
+
+describe('metadataTaxonomyNodeAncestorsFetcher (new keys naming convention)', () => {
+    const fileID = '12345';
+    const scope = 'global';
+    const taxonomyKey = 'taxonomy_123';
+    const nodeID = 'node_abc';
+
+    let apiMock: jest.Mocked<API>;
+
+    beforeEach(() => {
+        apiMock = {
+            getMetadataAPI: jest.fn().mockReturnValue({
+                getMetadataTaxonomy: jest.fn(),
+                getMetadataTaxonomyNode: jest.fn(),
+            }),
+        };
+    });
+
+    test('should fetch taxonomy and node data and return formatted data', async () => {
+        const mockTaxonomy = {
+            display_name: 'Geography',
+            namespace: 'my_enterprise',
+            id: 'my_id',
+            key: 'geography',
+            levels: [
+                { level: 1, display_name: 'Level 1', description: 'Description 1' },
+                { level: 2, display_name: 'Level 2', description: 'Description 2' },
+                { level: 3, display_name: 'Level 3', description: 'Description 3' },
+            ],
+        };
+
+        const mockTaxonomyNode = {
+            id: 'node_abc',
+            level: 1,
+            display_name: 'Node ABC',
+            ancestors: [{ id: 'ancestor_1', level: 2, display_name: 'Ancestor 1' }],
+        };
+
+        apiMock.getMetadataAPI(false).getMetadataTaxonomy.mockResolvedValue(mockTaxonomy);
+        apiMock.getMetadataAPI(false).getMetadataTaxonomyNode.mockResolvedValue(mockTaxonomyNode);
+
+        const result = await metadataTaxonomyNodeAncestorsFetcher(apiMock, fileID, scope, taxonomyKey, nodeID);
+
+        const expectedResult = [
+            {
+                level: 1,
+                levelName: 'Level 1',
+                description: 'Description 1',
+                id: 'node_abc',
+                levelValue: 'Node ABC',
+            },
+            {
+                level: 2,
+                levelName: 'Level 2',
+                description: 'Description 2',
+                id: 'ancestor_1',
+                levelValue: 'Ancestor 1',
+            },
+        ];
+
+        expect(apiMock.getMetadataAPI).toHaveBeenCalledWith(false);
+        expect(apiMock.getMetadataAPI(false).getMetadataTaxonomy).toHaveBeenCalledWith(fileID, scope, taxonomyKey);
+        expect(apiMock.getMetadataAPI(false).getMetadataTaxonomyNode).toHaveBeenCalledWith(
+            fileID,
+            scope,
+            taxonomyKey,
+            nodeID,
+            true,
+        );
+        expect(result).toEqual(expectedResult);
+    });
+
+    test('should handle empty ancestors array', async () => {
+        const mockTaxonomy = {
+            display_name: 'Geography',
+            namespace: 'my_enterprise',
+            id: 'my_id',
+            key: 'geography',
+            levels: [{ level: 1, display_name: 'Level 1', description: 'Description 1' }],
+        };
+
+        const mockTaxonomyNode = {
+            id: 'node_abc',
+            level: 1,
+            display_name: 'Node ABC',
             ancestors: [],
         };
 

--- a/src/elements/content-sidebar/fetchers/metadataTaxonomyFetcher.ts
+++ b/src/elements/content-sidebar/fetchers/metadataTaxonomyFetcher.ts
@@ -53,7 +53,7 @@ export const metadataTaxonomyNodeAncestorsFetcher = async (
     for (const item of metadataTaxonomy.levels) {
         const levelData = {
             level: item.level,
-            levelName: item.displayName,
+            levelName: item.displayName || item.display_name,
             description: item.description,
         };
 
@@ -62,7 +62,7 @@ export const metadataTaxonomyNodeAncestorsFetcher = async (
             levelsMap.set(item.level, {
                 ...levelData,
                 id: metadataTaxonomyNode.id,
-                levelValue: metadataTaxonomyNode.displayName,
+                levelValue: metadataTaxonomyNode.displayName || metadataTaxonomyNode.display_name,
             });
             // If the level is not the metadataTaxonomyNode level, just add the level data
         } else {
@@ -75,7 +75,7 @@ export const metadataTaxonomyNodeAncestorsFetcher = async (
             const levelData = levelsMap.get(ancestor.level);
 
             if (levelData) {
-                levelsMap.set(ancestor.level, { ...levelData, levelValue: ancestor.displayName, id: ancestor.id });
+                levelsMap.set(ancestor.level, { ...levelData, levelValue: ancestor.displayName || ancestor.display_name, id: ancestor.id });
             }
         }
     }


### PR DESCRIPTION
Due to API response change all resource attributes are now following lower_snake_case naming e.g. `display_name`. This affected `metadataTaxonomyNodeAncestorsFetcher` and we needed to accommodate that. We have to handle both `displayName` and `display_name` for now due release process.

**Before fix**
<img width="300" alt="Screenshot 2025-04-03 at 12 29 58" src="https://github.com/user-attachments/assets/826ef16b-a009-4d25-9569-f569f8618319" /> <img width="300" alt="Screenshot 2025-04-03 at 12 29 47" src="https://github.com/user-attachments/assets/1d78a098-3575-4fa5-99c0-7198c4571bcf" />


**After fix**
<img width="300" alt="Screenshot 2025-04-03 at 12 28 17" src="https://github.com/user-attachments/assets/bdace620-de08-43aa-ace2-bf53a8779dac" /> <img width="300" alt="Screenshot 2025-04-03 at 12 28 25" src="https://github.com/user-attachments/assets/eceb7cea-e750-4cee-94e6-ab40bc87b61b" />


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
