### PR TITLE
fix(content-explorer): Add default dimension to ItemListIcon

### DIFF
--- a/src/elements/common/item/IconCell.tsx
+++ b/src/elements/common/item/IconCell.tsx
@@ -13,7 +13,7 @@ import messages from '../messages';
 import './IconCell.scss';
 
 export interface IconCellProps {
-    dimension?: number;
+    dimension: number;
     rowData: BoxItem;
 }
 

--- a/src/features/content-explorer/item-list/ItemListIcon.js
+++ b/src/features/content-explorer/item-list/ItemListIcon.js
@@ -4,7 +4,14 @@ import PropTypes from 'prop-types';
 import { ItemTypePropType, ItemArchiveTypePropType } from '../prop-types';
 import IconCell from '../../../elements/common/item/IconCell';
 
-const ItemListIcon = ({ archiveType, extension, type, hasCollaborations = false, isExternallyOwned = false }) => {
+const ItemListIcon = ({
+    archiveType,
+    extension,
+    type,
+    hasCollaborations = false,
+    isExternallyOwned = false,
+    dimension = 32,
+}) => {
     const rowData = {
         type,
         extension,
@@ -12,7 +19,7 @@ const ItemListIcon = ({ archiveType, extension, type, hasCollaborations = false,
         is_externally_owned: isExternallyOwned,
         archive_type: archiveType,
     };
-    return <IconCell rowData={rowData} />;
+    return <IconCell rowData={rowData} dimension={dimension} />;
 };
 
 ItemListIcon.propTypes = {

--- a/src/features/content-explorer/item-list/__tests__/ItemListIcon.test.js
+++ b/src/features/content-explorer/item-list/__tests__/ItemListIcon.test.js
@@ -6,11 +6,18 @@ import { render, screen } from '../../../../test-utils/testing-library';
 describe('features/content-explorer/item-list/ItemListIcon', () => {
     const renderComponent = props => render(<ItemListIcon {...props} />);
 
+    const expectIconWithDefaultSize = icon => {
+        expect(icon).toBeVisible();
+        expect(icon).toHaveAttribute('width', '32');
+        expect(icon).toHaveAttribute('height', '32');
+    };
+
     describe('render()', () => {
         test('should render default file icon', () => {
             renderComponent({});
 
-            expect(screen.getByLabelText('File')).toBeInTheDocument();
+            const fileIcon = screen.getByLabelText('File');
+            expectIconWithDefaultSize(fileIcon);
         });
 
         test('should render archive icon', () => {
@@ -22,7 +29,8 @@ describe('features/content-explorer/item-list/ItemListIcon', () => {
             };
             renderComponent(rowData);
 
-            expect(screen.getByLabelText('Archive')).toBeVisible();
+            const archiveIcon = screen.getByLabelText('Archive');
+            expectIconWithDefaultSize(archiveIcon);
         });
 
         test('should render archived folder icon', () => {
@@ -34,7 +42,8 @@ describe('features/content-explorer/item-list/ItemListIcon', () => {
             };
             renderComponent(rowData);
 
-            expect(screen.getByLabelText('Archived Folder')).toBeVisible();
+            const archivedFolderIcon = screen.getByLabelText('Archived Folder');
+            expectIconWithDefaultSize(archivedFolderIcon);
         });
 
         test.each([
@@ -68,7 +77,8 @@ describe('features/content-explorer/item-list/ItemListIcon', () => {
         ])('should render $label folder icon', ({ rowData, label }) => {
             renderComponent(rowData);
 
-            expect(screen.getByLabelText(label)).toBeInTheDocument();
+            const folderIcon = screen.getByLabelText(label);
+            expectIconWithDefaultSize(folderIcon);
         });
 
         test('should render correct file icon', () => {
@@ -76,14 +86,16 @@ describe('features/content-explorer/item-list/ItemListIcon', () => {
             const rowData = { type: 'file', extension };
             renderComponent(rowData);
 
-            expect(screen.getByLabelText('BOXNOTE File')).toBeInTheDocument();
+            const fileIcon = screen.getByLabelText('BOXNOTE File');
+            expectIconWithDefaultSize(fileIcon);
         });
 
         test('should render correct bookmark icon', () => {
             const rowData = { type: 'web_link' };
             renderComponent(rowData);
 
-            expect(screen.getByLabelText('Bookmark')).toBeInTheDocument();
+            const bookmarkIcon = screen.getByLabelText('Bookmark');
+            expectIconWithDefaultSize(bookmarkIcon);
         });
     });
 });


### PR DESCRIPTION
This PR adds default dimension to `ItemListIcon`. Without this, icons for `Archive` and `FolderArchive` would render with height and width set to `undefined`. While this did not matter on most browsers (e.g. Chrome), because there the size of the icon was read from `viewBox`, on Safari the icons would not be displayed.

To verify the change add the following to `ContentExplorerMultiSelectModalContainerExamples.js` (starting from line 55):

```
{
    id: '7',
    name: 'Top level archive',
    type: 'folder',
    archiveType: 'archive',
},
{
    id: '8',
    name: 'Folder in archive',
    type: 'folder',
    archiveType: 'folder_archive',
}
```

Before (browser is Safari):

![Screenshot 2025-04-08 at 15 04 12](https://github.com/user-attachments/assets/e1c2224f-0025-47d4-89d4-09da8d856d77)

After (browser is Safari):

![Screenshot 2025-04-08 at 15 03 53](https://github.com/user-attachments/assets/291f6e95-8c46-433c-ace2-d4e5dec72d65)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
