### PR TITLE
feat(doc-first-pages): Add webp xrep header

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -356,7 +356,7 @@ export const IS_ERROR_DISPLAYED = 'isErrorDisplayed'; // used to determine if us
 /* ------------- Representation Hints ------------------- */
 const X_REP_HINT_BASE = '[3d][pdf][text][mp3][json]';
 const X_REP_HINT_DOC_THUMBNAIL = '[jpg?dimensions=1024x1024&paged=false]';
-const X_REP_HINT_IMAGE = '[jpg?dimensions=2048x2048,png?dimensions=2048x2048]';
+const X_REP_HINT_IMAGE = '[webp?dimensions=1024x1024][jpg?dimensions=2048x2048,png?dimensions=2048x2048]';
 const X_REP_HINT_VIDEO_DASH = '[dash,mp4][filmstrip]';
 const X_REP_HINT_VIDEO_MP4 = '[mp4]';
 const videoHint = Browser.canPlayDash() ? X_REP_HINT_VIDEO_DASH : X_REP_HINT_VIDEO_MP4;


### PR DESCRIPTION

We need to add this header so that webp image reps will be generated by conversion. This is necessary for the doc first pages project for preview.
