### PR TITLE
feat(content-explorer): Add feature flag for MetadataViewList redesign

### DIFF
--- a/.storybook/typings.d.ts
+++ b/.storybook/typings.d.ts
@@ -2,7 +2,7 @@
 // @ts-nocheck
 
 declare const global: {
-    FEATURES: Record<string, boolean>;
+    FEATURE_FLAGS: Record<string, boolean>;
     FILE_ID: string;
     FOLDER_ID: string;
     TOKEN: string;

--- a/src/elements/content-explorer/Content.tsx
+++ b/src/elements/content-explorer/Content.tsx
@@ -4,6 +4,8 @@ import ItemGrid from '../common/item-grid';
 import ItemList from '../common/item-list';
 import ProgressBar from '../common/progress-bar';
 import MetadataBasedItemList from '../../features/metadata-based-view';
+import MetadataView from './MetadataView';
+import { isFeatureEnabled, type FeatureConfig } from '../common/feature-checking';
 import { VIEW_ERROR, VIEW_METADATA, VIEW_MODE_LIST, VIEW_MODE_GRID, VIEW_SELECTED } from '../../constants';
 import type { ViewMode } from '../common/flowTypes';
 import type { ItemAction, ItemEventHandlers, ItemEventPermissions } from '../common/item';
@@ -27,6 +29,7 @@ function isEmpty(view: View, currentCollection: Collection, fieldsToShow: Fields
 
 export interface ContentProps extends Required<ItemEventHandlers>, Required<ItemEventPermissions> {
     currentCollection: Collection;
+    features?: FeatureConfig;
     fieldsToShow?: FieldsToShow;
     gridColumnCount?: number;
     isMedium: boolean;
@@ -47,6 +50,7 @@ export interface ContentProps extends Required<ItemEventHandlers>, Required<Item
 
 const Content = ({
     currentCollection,
+    features,
     fieldsToShow = [],
     gridColumnCount,
     onMetadataUpdate,
@@ -67,13 +71,16 @@ const Content = ({
             {view === VIEW_ERROR || view === VIEW_SELECTED ? null : <ProgressBar percent={percentLoaded} />}
 
             {isViewEmpty && <EmptyView view={view} isLoading={percentLoaded !== 100} />}
-            {!isViewEmpty && isMetadataBasedView && (
+            {!isFeatureEnabled(features, 'contentExplorer.metadataViewV2') && !isViewEmpty && isMetadataBasedView && (
                 <MetadataBasedItemList
                     currentCollection={currentCollection}
                     fieldsToShow={fieldsToShow}
                     onMetadataUpdate={onMetadataUpdate}
                     {...rest}
                 />
+            )}
+            {isFeatureEnabled(features, 'contentExplorer.metadataViewV2') && !isViewEmpty && isMetadataBasedView && (
+                <MetadataView />
             )}
             {!isViewEmpty && isListView && (
                 <ItemList

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -1582,6 +1582,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
             contentPreviewProps,
             contentUploaderProps,
             defaultView,
+            features,
             isMedium,
             isSmall,
             isTouch,
@@ -1680,6 +1681,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
                                 canRename={canRename}
                                 canShare={canShare}
                                 currentCollection={currentCollection}
+                                features={features}
                                 gridColumnCount={Math.min(gridColumnCount, maxGridColumnCount)}
                                 isMedium={isMedium}
                                 isSmall={isSmall}

--- a/src/elements/content-explorer/MetadataView.tsx
+++ b/src/elements/content-explorer/MetadataView.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const MetadataView = () => {
+    return <>new Metadata</>;
+};
+
+export default MetadataView;

--- a/src/elements/content-explorer/__tests__/Content.test.tsx
+++ b/src/elements/content-explorer/__tests__/Content.test.tsx
@@ -83,4 +83,34 @@ describe('Content Component', () => {
         expect(screen.getByText('Viewed Oct 10, 2023')).toBeInTheDocument();
         expect(screen.getByLabelText('File')).toBeInTheDocument();
     });
+
+    describe('contentExplorer.metadataViewV2 feature', () => {
+        const features = {
+            contentExplorer: { metadataViewV2: true },
+        };
+
+        test('does not render MetadataBasedItemList when contentExplorer.metadataViewV2 is enabled', () => {
+            const collection = { boxItem: {}, id: '0', items: [{ id: 1 }], name: 'name' };
+            renderComponent({
+                features,
+                currentCollection: collection,
+                fieldsToShow: ['id'],
+                view: VIEW_METADATA,
+            });
+
+            expect(screen.queryByTestId('metadata-based-item-list')).not.toBeInTheDocument();
+        });
+
+        test('renders new metadata view when contentExplorer.metadataViewV2 is enabled', () => {
+            const collection = { boxItem: {}, id: '0', items: [{ id: 1 }], name: 'name' };
+            renderComponent({
+                features,
+                currentCollection: collection,
+                fieldsToShow: ['id'],
+                view: VIEW_METADATA,
+            });
+
+            expect(screen.getByText('new Metadata')).toBeInTheDocument();
+        });
+    });
 });

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -1,0 +1,78 @@
+import { http, HttpResponse } from 'msw';
+import ContentExplorer from '../../ContentExplorer';
+import { DEFAULT_HOSTNAME_API } from '../../../../constants';
+import { mockMetadata, mockSchema } from '../../../common/__mocks__/mockMetadata';
+
+const EID = '0';
+const templateName = 'templateName';
+const metadataSource = `enterprise_${EID}.${templateName}`;
+const metadataSourceFieldName = `metadata.${metadataSource}`;
+
+const metadataQuery = {
+    from: metadataSource,
+
+    // // Filter items in the folder by existing metadata key
+    // query: 'key = :arg1',
+    //
+    // // Display items with value
+    // query_params: { arg1: 'value' },
+
+    ancestor_folder_id: '313259567207',
+    fields: [
+        `${metadataSourceFieldName}.name`,
+        `${metadataSourceFieldName}.industry`,
+        `${metadataSourceFieldName}.last_contacted_at`,
+        `${metadataSourceFieldName}.role`,
+    ],
+};
+
+const fieldsToShow = [
+    { key: `${metadataSourceFieldName}.name`, canEdit: false, displayName: 'Alias' },
+    { key: `${metadataSourceFieldName}.industry`, canEdit: true },
+    { key: `${metadataSourceFieldName}.last_contacted_at`, canEdit: true },
+    { key: `${metadataSourceFieldName}.role`, canEdit: true },
+];
+const defaultView = 'metadata'; // Required prop to paint the metadata view. If not provided, you'll get regular folder view.
+
+export const metadataView = {
+    args: {
+        metadataQuery,
+        fieldsToShow,
+        defaultView,
+    },
+};
+
+export const withNewMetadataView = {
+    args: {
+        metadataQuery,
+        fieldsToShow,
+        defaultView,
+        features: {
+            contentExplorer: {
+                metadataViewV2: true,
+            },
+        },
+    },
+};
+
+export default {
+    title: 'Elements/ContentExplorer/tests/ContentExplorer/visual/MetadataView',
+    component: ContentExplorer,
+    args: {
+        features: global.FEATURE_FLAGS,
+        rootFolderId: global.FOLDER_ID,
+        token: global.TOKEN,
+    },
+    parameters: {
+        msw: {
+            handlers: [
+                http.post(`${DEFAULT_HOSTNAME_API}/2.0/metadata_queries/execute_read`, () => {
+                    return HttpResponse.json(mockMetadata);
+                }),
+                http.get(`${DEFAULT_HOSTNAME_API}/2.0/metadata_templates/enterprise/templateName/schema`, () => {
+                    return HttpResponse.json(mockSchema);
+                }),
+            ],
+        },
+    },
+};

--- a/src/elements/content-sidebar/stories/tests/ContentSidebar-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/ContentSidebar-visual.stories.tsx
@@ -13,7 +13,7 @@ export default {
             hasClassification: true,
             hasRetentionPolicy: true,
         },
-        features: global.FEATURES,
+        features: global.FEATURE_FLAGS,
         fileId: global.FILE_ID,
         hasActivityFeed: true,
         hasMetadata: true,
@@ -26,7 +26,7 @@ export default {
 export const ContentSidebarWithBoxAIDisabled: StoryObj<typeof BoxAISidebar> = {
     args: {
         features: {
-            ...global.FEATURES,
+            ...global.FEATURE_FLAGS,
             'boxai.sidebar.enabled': false,
             'metadata.redesign.enabled': true,
         },
@@ -36,7 +36,7 @@ export const ContentSidebarWithBoxAIDisabled: StoryObj<typeof BoxAISidebar> = {
 export const ContentSidebarWithBoxAIEnabled: StoryObj<typeof BoxAISidebar> = {
     args: {
         features: {
-            ...global.FEATURES,
+            ...global.FEATURE_FLAGS,
             'boxai.sidebar.enabled': true,
             'metadata.redesign.enabled': true,
         },


### PR DESCRIPTION
Added `contentExplorer.metadataViewV2` feature flag 
Added VRTs for the new and the old metadata view


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
