### PR TITLE
fix(content-explorer): remove base styles

### DIFF
--- a/src/elements/common/base.scss
+++ b/src/elements/common/base.scss
@@ -66,12 +66,6 @@
 .be {
     @include reset;
 
-    // links have tag styles
-    @import '../../styles/common/links';
-
-    // Forms have tag styles
-    @import '../../styles/common/forms';
-    @include be-content;
     /* stylelint-disable declaration-no-important */
     box-sizing: border-box !important;
     width: 100%;
@@ -83,6 +77,16 @@
     background: $white;
     border: 0 none;
     outline: none;
+
+    // Elements migrated to Blueprint should not use base styles
+    &:not(.bce) {
+        // links have tag styles
+        @import '../../styles/common/links';
+
+        // Forms have tag styles
+        @import '../../styles/common/forms';
+        @include be-content;
+    }
 
     .ReactModal__Body--open & {
         position: relative;

--- a/src/elements/common/base.scss
+++ b/src/elements/common/base.scss
@@ -78,19 +78,23 @@
     border: 0 none;
     outline: none;
 
-    // Elements migrated to Blueprint should not use base styles
-    &:not(.bce) {
-        // links have tag styles
-        @import '../../styles/common/links';
-
-        // Forms have tag styles
-        @import '../../styles/common/forms';
-        @include be-content;
-    }
-
     .ReactModal__Body--open & {
         position: relative;
     }
+}
+
+// Elements migrated to Blueprint should not use base styles
+.bcow,
+.bcp,
+.bcpr,
+.bcs,
+.bdl-UnifiedShareForm {
+    // links have tag styles
+    @import '../../styles/common/links';
+
+    // Forms have tag styles
+    @import '../../styles/common/forms';
+    @include be-content;
 }
 
 .be-modal {


### PR DESCRIPTION
Some Blueprint styles were not being applied because there are BUIE "base" styles that are taking priority. These base styles were used with the BUIE atomic components. But now that ContentExplorer is migrated to Blueprint, it should not use these base styles.

Compare the <ins>search bar</ins> in the below screenshots.

**Before**
<img width="1032" alt="Screenshot 2025-04-16 at 4 15 41 PM" src="https://github.com/user-attachments/assets/55b936d7-eed1-4160-8463-a68c0828eafc" />

**After**
<img width="1031" alt="Screenshot 2025-04-16 at 4 16 52 PM" src="https://github.com/user-attachments/assets/be4e1d87-7436-4829-97ad-b78e49ea63ca" />