### PR TITLE
chore(feature-flag): Added Feature Flag hook

### DIFF
--- a/src/elements/common/feature-checking/__tests__/useFeatureConfig.test.tsx
+++ b/src/elements/common/feature-checking/__tests__/useFeatureConfig.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { renderHook } from '../../../../test-utils/testing-library';
+import useFeatureConfig from '../useFeatureConfig';
+import FeatureProvider from '../FeatureProvider';
+
+describe('useFeatureConfig', () => {
+    const mockFeatures = {
+        testFeature: true,
+        disabledFeature: false,
+        something: {
+            more: { complex: true },
+        },
+        'dot.dot.dot': true,
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <FeatureProvider features={mockFeatures}>{children}</FeatureProvider>
+    );
+
+    test('should return true for enabled feature', () => {
+        const { result } = renderHook(() => useFeatureConfig('testFeature'), { wrapper });
+        expect(result.current).toBe(true);
+    });
+
+    test('should return true for object features', () => {
+        const { result } = renderHook(() => useFeatureConfig('something.more'), { wrapper });
+        expect(result.current).toEqual({ complex: true });
+    });
+
+    test('should return true for string literal with periods between the words', () => {
+        const { result } = renderHook(() => useFeatureConfig('dot.dot.dot'), { wrapper });
+        expect(result.current).toBe(true);
+    });
+
+    test('should return false for disabled feature', () => {
+        const { result } = renderHook(() => useFeatureConfig('disabledFeature'), { wrapper });
+        expect(result.current).toBe(false);
+    });
+
+    test('should return false for non-existent feature', () => {
+        const { result } = renderHook(() => useFeatureConfig('nonExistentFeature'), { wrapper });
+        expect(result.current).toEqual({});
+    });
+
+    test('should return default value when used outside FeatureProvider', () => {
+        const { result } = renderHook(() => useFeatureConfig('testFeature'));
+        expect(result.current).toEqual({});
+    });
+});

--- a/src/elements/common/feature-checking/__tests__/useFeatureEnabled.test.tsx
+++ b/src/elements/common/feature-checking/__tests__/useFeatureEnabled.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { renderHook } from '../../../../test-utils/testing-library';
+import useFeatureEnabled from '../useFeatureEnabled';
+import FeatureProvider from '../FeatureProvider';
+
+describe('useFeatureEnabled', () => {
+    const mockFeatures = {
+        testFeature: true,
+        disabledFeature: false,
+        something: {
+            more: { complex: true },
+        },
+        'dot.dot.dot': true,
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <FeatureProvider features={mockFeatures}>{children}</FeatureProvider>
+    );
+
+    test('should return true for enabled feature', () => {
+        const { result } = renderHook(() => useFeatureEnabled('testFeature'), { wrapper });
+        expect(result.current).toBe(true);
+    });
+
+    test('should return true for object features', () => {
+        const { result } = renderHook(() => useFeatureEnabled('something.more.complex'), { wrapper });
+        expect(result.current).toBe(true);
+    });
+
+    test('should return true for string literal with periods between the words', () => {
+        const { result } = renderHook(() => useFeatureEnabled('dot.dot.dot'), { wrapper });
+        expect(result.current).toBe(true);
+    });
+
+    test('should return false for disabled feature', () => {
+        const { result } = renderHook(() => useFeatureEnabled('disabledFeature'), { wrapper });
+        expect(result.current).toBe(false);
+    });
+
+    test('should return false for non-existent feature', () => {
+        const { result } = renderHook(() => useFeatureEnabled('nonExistentFeature'), { wrapper });
+        expect(result.current).toBe(false);
+    });
+
+    test('should return default value when used outside FeatureProvider', () => {
+        const { result } = renderHook(() => useFeatureEnabled('testFeature'));
+        expect(result.current).toBe(false);
+    });
+});

--- a/src/elements/common/feature-checking/index.js
+++ b/src/elements/common/feature-checking/index.js
@@ -4,6 +4,8 @@ export { default as FeatureFlag } from './FeatureFlag';
 export { default as FeatureProvider } from './FeatureProvider';
 export { default as withFeatureConsumer } from './withFeatureConsumer';
 export { default as withFeatureProvider } from './withFeatureProvider';
+export { default as useFeatureEnabled } from './useFeatureEnabled';
+export { default as useFeatureConfig } from './useFeatureConfig';
 export { isFeatureEnabled, getFeatureConfig } from './util';
 export * from './flowTypes';
 export * from './hooks';

--- a/src/elements/common/feature-checking/useFeatureConfig.ts
+++ b/src/elements/common/feature-checking/useFeatureConfig.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import FeatureContext from './FeatureContext';
+import { getFeatureConfig } from './util';
+import type FeatureConfig from './flowTypes';
+
+/**
+ * Hook to access feature config from the FeatureProvider
+ * @param featureName - The beginning of the object path of the feature flags you want to check
+ * @returns (FeatureConfig | boolean) - drilling down to the features based on the given featureName | indicating if the feature is enabled
+ */
+const useFeatureConfig = (featureName: string): FeatureConfig | boolean => {
+    const features = useContext(FeatureContext);
+    return getFeatureConfig(features, featureName);
+};
+
+export default useFeatureConfig;

--- a/src/elements/common/feature-checking/useFeatureEnabled.ts
+++ b/src/elements/common/feature-checking/useFeatureEnabled.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+import FeatureContext from './FeatureContext';
+import { isFeatureEnabled } from './util';
+
+/**
+ * Hook to access feature flags from the FeatureProvider
+ * @param featureName - The name of the feature flag to check
+ * @returns boolean - indicating if the feature is enabled
+ */
+const useFeatureEnabled = (featureName: string): boolean => {
+    const features = useContext(FeatureContext);
+    return isFeatureEnabled(features, featureName);
+};
+
+export default useFeatureEnabled;


### PR DESCRIPTION
Added `useFeatureFlag` hook that we can use in functional component without having to use `withFeatureConsumer`
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
