### PR TITLE
feat(message-center): Pass badgeCount to ButtonComponent

### DIFF
--- a/src/features/message-center/__tests__/MessageCenter.integration.test.js
+++ b/src/features/message-center/__tests__/MessageCenter.integration.test.js
@@ -172,4 +172,14 @@ describe('components/message-center/MessageCenter.integration', () => {
 
         expect(wrapper.find(Message)).toHaveLength(2);
     });
+
+    test('should render ButtonComponent with badgeCount prop passed from MessageCenter', async () => {
+        const wrapper = await getWrapper();
+        const badgeCount = countResponse.count;
+
+        await actWait();
+        wrapper.update();
+
+        expect(wrapper.find('ButtonComponent').props().badgeCount).toBe(badgeCount);
+    });
 });

--- a/src/features/message-center/components/MessageCenter.js
+++ b/src/features/message-center/components/MessageCenter.js
@@ -16,7 +16,7 @@ import Internationalize from '../../../elements/common/Internationalize';
 
 type Props = {|
     apiHost: string,
-    buttonComponent: React.ComponentType<{ render: () => React.Node }>,
+    buttonComponent: React.ComponentType<{ render: () => React.Node, badgeCount: null | number }>,
     contentPreviewProps?: ContentPreviewProps,
     getEligibleMessages: () => Promise<GetEligibleMessageCenterMessages>,
     getToken: (fileId: string) => Promise<Token>,
@@ -102,6 +102,7 @@ function MessageCenter({
 
     const icon = (
         <ButtonComponent
+            badgeCount={unreadMessageCount}
             data-resin-target="messageCenterOpenModal"
             data-testid="message-center-unread-count"
             onClick={handleOnClick}


### PR DESCRIPTION
In order to update header icon button to new design we need to get the content of the badge. This will be handled by buttonComponent that inside will be using Split flag to display the new buttons from Blueprint in EUA:
![image](https://github.com/user-attachments/assets/ad56c30d-a62a-478c-85a2-e822b2a1f753)
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
