### PR TITLE
fix(content-sidebar): fix notification for Box AI feedback form

### DIFF
--- a/src/elements/common/Providers.js.flow
+++ b/src/elements/common/Providers.js.flow
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { Notification, TooltipProvider } from '@box/blueprint-web';
+import Portal from '../../components/portal';
 
 export interface ProvideProps {
     children: React.Node;
@@ -11,7 +12,9 @@ const Provide = ({ children, hasProviders }: ProvideProps) => {
     if (hasProviders) {
         return (
             <Notification.Provider>
-                <Notification.Viewport />
+                <Portal>
+                    <Notification.Viewport />
+                </Portal>
                 <TooltipProvider>{children}</TooltipProvider>
             </Notification.Provider>
         );

--- a/src/elements/common/Providers.tsx
+++ b/src/elements/common/Providers.tsx
@@ -1,5 +1,6 @@
 import React, { Children } from 'react';
 import { Notification, TooltipProvider } from '@box/blueprint-web';
+import Portal from '../../components/portal';
 
 export interface ProvideProps {
     children: React.ReactNode;
@@ -10,7 +11,9 @@ const Providers = ({ children, hasProviders = true }: ProvideProps) => {
     if (hasProviders) {
         return (
             <Notification.Provider>
-                <Notification.Viewport />
+                <Portal>
+                    <Notification.Viewport />
+                </Portal>
                 <TooltipProvider>{children}</TooltipProvider>
             </Notification.Provider>
         );


### PR DESCRIPTION
Updated `Providers` logic to display `Notification.Viewport` inside `Portal`.
Thanks to that notifications, which are displayed at the time when Modal is visible, are now displayed "above" the Modal backdrop. This change applies to all Notifications and should have no negative implications.

Before:
![image](https://github.com/user-attachments/assets/b47665b6-1614-4da0-ae37-8f32036ad1ed)

After:
![image](https://github.com/user-attachments/assets/7ccf964d-2bfb-47d5-a4b9-14e3263e34a8)

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
