### PR TITLE
feat(opensource): update default route to use storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ npm-error.log
 reports
 scripts/rsync.json
 styleguide
+storybook
 test/screenshots
 test/videos
 test/dev.html

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "build:prod:dist": "NODE_ENV=production webpack --config scripts/webpack.config.js --mode production",
         "build:prod:examples": "LANGUAGE=en-US REACT=true NODE_ENV=production node --max_old_space_size=8192 node_modules/.bin/styleguidist build --config scripts/styleguide.config.js --mode production",
         "build:prod:npm": "BABEL_ENV=production OUTPUT=dist LANGUAGE=en-US REACT=true yarn build:prod:dist",
-        "build:prod:storybook": "LANGUAGE=en-US REACT=true BROWSERSLIST_ENV=production BABEL_ENV=development NODE_ENV=development storybook build -c .storybook -o styleguide/storybook",
+        "build:prod:storybook": "LANGUAGE=en-US REACT=true BROWSERSLIST_ENV=production BABEL_ENV=development NODE_ENV=development storybook build -c .storybook -o storybook",
         "build:sync": "LANGUAGE=en-US BABEL_ENV=development NODE_ENV=development RSYNC=true webpack --config scripts/webpack.config.js --mode development",
         "chromatic": "chromatic",
         "clean": "rm -rf dist es i18n/json i18n/*.js reports styleguide",

--- a/scripts/cut_release.sh
+++ b/scripts/cut_release.sh
@@ -130,30 +130,27 @@ push_to_npm() {
     printf "${green}Published npm using dist-tag=${DISTTAG}!${end}"
 }
 
-build_examples() {
-    printf "${blue}Building styleguide...${end}"
-    yarn build:prod:examples || return 1
-    printf "${green}Built styleguide!${end}"
+build_storybook() {
     printf "${blue}Building storybook...${end}"
     yarn build:prod:storybook || return 1
     printf "${green}Built storybook!${end}"
 }
 
 push_to_gh_pages() {
-    printf "${blue}Pushing styleguide to gh-pages...${end}"
+    printf "${blue}Pushing storybook to gh-pages...${end}"
     if [[ $(git branch | grep -w "gh-pages") != "" ]] ; then
         git branch -D gh-pages || return 1
         printf "${green}Deleted existing gh-pages branch!${end}"
     fi
     git checkout -b gh-pages || return 1
     rm -rf build
-    cp -R styleguide/. ./ || return 1
-    cp examples/gitignore .gitignore || return 1
+    cp -R storybook/. ./ || return 1
+    cp examples/gitignore .gitignore || return 1 # Move this when we remove styleguidist
     git rm -rf --cached . || return 1
     git add -A || return 1
-    git commit --no-verify -am "build(examples): v$VERSION" || return 1
+    git commit --no-verify -am "build(storybook): v$VERSION" || return 1
     git push release gh-pages --force --no-verify || return 1
-    printf "${blue}Pushed styleguide to gh-pages...${end}"
+    printf "${blue}Pushed storybook to gh-pages...${end}"
 }
 
 check_untracked_files() {
@@ -272,15 +269,15 @@ push_new_release() {
     # Check untracked files
     check_untracked_files || return 1
 
-    # Build examples
-    if ! build_examples; then
-        printf "${red}Failed building styleguide!${end}"
+    # Build storybook
+    if ! build_storybook; then
+        printf "${red}Failed building storybook!${end}"
         return 1
     fi
 
     # Publish gh-pages
     if ! push_to_gh_pages; then
-        printf "${red}Failed pushing styleguide to gh-pages!${end}"
+        printf "${red}Failed pushing storybook to gh-pages!${end}"
         return 1
     fi
 


### PR DESCRIPTION
Moved https://opensource.box.com/box-ui-elements/storybook -> https://opensource.box.com/box-ui-elements

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
