### PR TITLE
feat(bp-assets): Bump BP assets to 4.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "@babel/template": "^7.24.7",
         "@babel/types": "^7.24.7",
         "@box/blueprint-web": "^10.3.1",
-        "@box/blueprint-web-assets": "4.36.0",
+        "@box/blueprint-web-assets": "^4.39.0",
         "@box/box-ai-agent-selector": "^0.31.0",
         "@box/box-ai-content-answers": "^0.124.1",
         "@box/cldr-data": "^34.2.0",

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw';
+import type { Meta, StoryObj } from '@storybook/react';
 import ContentExplorer from '../../ContentExplorer';
 import { DEFAULT_HOSTNAME_API } from '../../../../constants';
 import { mockMetadata, mockSchema } from '../../../common/__mocks__/mockMetadata';
@@ -34,7 +35,9 @@ const fieldsToShow = [
 ];
 const defaultView = 'metadata'; // Required prop to paint the metadata view. If not provided, you'll get regular folder view.
 
-export const metadataView = {
+type Story = StoryObj<typeof ContentExplorer>;
+
+export const metadataView: Story = {
     args: {
         metadataQuery,
         fieldsToShow,
@@ -42,7 +45,7 @@ export const metadataView = {
     },
 };
 
-export const withNewMetadataView = {
+export const withNewMetadataView: Story = {
     args: {
         metadataQuery,
         fieldsToShow,
@@ -55,7 +58,7 @@ export const withNewMetadataView = {
     },
 };
 
-export default {
+const meta: Meta<typeof ContentExplorer> = {
     title: 'Elements/ContentExplorer/tests/ContentExplorer/visual/MetadataView',
     component: ContentExplorer,
     args: {
@@ -76,3 +79,5 @@ export default {
         },
     },
 };
+
+export default meta;

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -4,7 +4,7 @@ import {
     type JSONPatchOperations,
     type MetadataTemplateInstance,
 } from '@box/metadata-editor';
-import { type TaxonomyOptionsFetcher } from '@box/metadata-editor/dist/types/lib/components/metadata-editor-fields/components/metadata-taxonomy-field/types';
+import { TaxonomyOptionsFetcher } from '@box/metadata-editor/lib/components/metadata-editor-fields/components/metadata-taxonomy-field/types.js';
 import React from 'react';
 import {
     ERROR_CODE_METADATA_AUTOFILL_TIMEOUT,

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -8,7 +8,9 @@ import * as React from 'react';
 import { injectIntl } from 'react-intl';
 import type { IntlShape } from 'react-intl';
 import noop from 'lodash/noop';
+// $FlowFixMe
 import { BoxAiLogo } from '@box/blueprint-web-assets/icons/Logo';
+// $FlowFixMe
 import { Size6 } from '@box/blueprint-web-assets/tokens/tokens';
 import { usePromptFocus } from '@box/box-ai-content-answers';
 import AdditionalTabs from './additional-tabs';

--- a/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
+++ b/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
@@ -41,7 +41,7 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render ic
     onClick={[Function]}
     type="button"
   >
-    <SvgPlus />
+    <ForwardRef(SvgPlus) />
   </PlainButton>
 </AdditionalTabTooltip>
 `;

--- a/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
+++ b/src/elements/content-sidebar/stories/MetadataSidebarRedesign.stories.tsx
@@ -1,7 +1,8 @@
-import { type StoryObj } from '@storybook/react';
+import { type StoryObj, Meta } from '@storybook/react';
 import { fn, userEvent, within } from '@storybook/test';
 import React, { type ComponentProps } from 'react';
 import { http, HttpResponse } from 'msw';
+import type { HttpHandler } from 'msw';
 import MetadataSidebarRedesign from '../MetadataSidebarRedesign';
 import ContentSidebar from '../ContentSidebar';
 import {
@@ -32,7 +33,7 @@ const defaultMetadataSidebarProps: ComponentProps<typeof MetadataSidebarRedesign
     onSuccess: fn(),
 };
 
-export default {
+const meta: Meta<typeof ContentSidebar> & { parameters: { msw: { handlers: HttpHandler[] } } } = {
     title: 'Elements/ContentSidebar/MetadataSidebarRedesign',
     component: ContentSidebar,
     args: {
@@ -65,6 +66,8 @@ export default {
         return <ContentSidebar {...args} />;
     },
 };
+
+export default meta;
 
 export const Basic: StoryObj<typeof MetadataSidebarRedesign> = {
     play: async ({ canvasElement }) => {

--- a/src/elements/content-sidebar/stories/__mocks__/TaxonomyMocks.ts
+++ b/src/elements/content-sidebar/stories/__mocks__/TaxonomyMocks.ts
@@ -1,4 +1,5 @@
 import { http, HttpResponse } from 'msw';
+import type { HttpHandler } from 'msw';
 
 import { DEFAULT_HOSTNAME_API } from '../../../../constants';
 import { fileIdWithMetadata, mockFileRequest } from './MetadataSidebarRedesignedMocks';
@@ -395,7 +396,7 @@ export const mockSinglelevelTaxonomyNodes = {
     },
 };
 
-export const taxonomyMockHandlers = [
+export const taxonomyMockHandlers: HttpHandler[] = [
     http.get(mockFileRequest.url, () => {
         return HttpResponse.json(mockFileRequest.response);
     }),

--- a/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
@@ -1,6 +1,7 @@
 import { expect, within } from '@storybook/test';
-import { type StoryObj } from '@storybook/react';
+import { type StoryObj, type Meta } from '@storybook/react';
 import { http, HttpResponse } from 'msw';
+import type { HttpHandler } from 'msw';
 import ContentSidebar from '../../ContentSidebar';
 import BoxAISidebar from '../../BoxAISidebar';
 import { mockFileRequest, mockUserRequest } from '../../../common/__mocks__/mockRequests';
@@ -25,7 +26,7 @@ export const basic: StoryObj<typeof BoxAISidebar> = {
     },
 };
 
-export default {
+const meta: Meta<typeof ContentSidebar> & { parameters: { msw: { handlers: HttpHandler[] } } } = {
     title: 'Elements/ContentSidebar/BoxAISidebar/tests/visual-regression-tests',
     component: ContentSidebar,
     args: {
@@ -90,3 +91,5 @@ export default {
         },
     },
 };
+
+export default meta;

--- a/src/elements/content-sidebar/stories/tests/ContentSidebar-e2e.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/ContentSidebar-e2e.stories.tsx
@@ -1,5 +1,7 @@
 // @flow
 import { http, HttpResponse } from 'msw';
+import type { HttpHandler } from 'msw';
+import type { Meta } from '@storybook/react';
 import ContentSidebar from '../../ContentSidebar';
 import { mockFileRequest } from '../__mocks__/ContentSidebarMocks';
 import { testFileIds } from '../../../../../test/support/constants';
@@ -33,7 +35,7 @@ export const fileVersion = {
     },
 };
 
-export default {
+const meta: Meta<typeof ContentSidebar> & { parameters: { msw: { handlers: HttpHandler[] } } } = {
     title: 'Elements/ContentSidebar/tests/e2e',
     component: ContentSidebar,
     args: defaultArgs,
@@ -47,3 +49,5 @@ export default {
         },
     },
 };
+
+export default meta;

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -1,7 +1,8 @@
 import { act, type ComponentProps } from 'react';
 import { http, HttpResponse } from 'msw';
 import { expect, userEvent, waitFor, within, fn, screen } from '@storybook/test';
-import { type StoryObj } from '@storybook/react';
+import { type StoryObj, Meta } from '@storybook/react';
+import type { HttpHandler } from 'msw';
 import ContentSidebar from '../../ContentSidebar';
 import MetadataSidebarRedesign from '../../MetadataSidebarRedesign';
 import {
@@ -451,7 +452,7 @@ export const ShowErrorWhenAIAPIIsUnavailable: StoryObj<typeof MetadataSidebarRed
         const autofillButton = await canvas.findByRole('button', { name: 'Autofill My Template with Box AI' });
         await userEvent.click(autofillButton);
 
-        const errorAlert = await canvas.findByText('We’re sorry, something went wrong.');
+        const errorAlert = await canvas.findByText("We're sorry, something went wrong.");
         expect(errorAlert).toBeInTheDocument();
     },
 };
@@ -720,7 +721,7 @@ export const EditSinglelevelTaxonomy: StoryObj<typeof MetadataSidebarRedesign> =
     },
 };
 
-export default {
+const meta: Meta<typeof ContentSidebar> & { parameters: { msw: { handlers: HttpHandler[] } } } = {
     title: 'Elements/ContentSidebar/MetadataSidebarRedesign/tests/visual-regression-tests',
     component: ContentSidebar,
     args: {
@@ -739,3 +740,5 @@ export default {
         },
     },
 };
+
+export default meta;

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -452,7 +452,7 @@ export const ShowErrorWhenAIAPIIsUnavailable: StoryObj<typeof MetadataSidebarRed
         const autofillButton = await canvas.findByRole('button', { name: 'Autofill My Template with Box AI' });
         await userEvent.click(autofillButton);
 
-        const errorAlert = await canvas.findByText("We're sorry, something went wrong.");
+        const errorAlert = await canvas.findByText('We’re sorry, something went wrong.');
         expect(errorAlert).toBeInTheDocument();
     },
 };

--- a/src/elements/content-uploader/IconInProgress.tsx
+++ b/src/elements/content-uploader/IconInProgress.tsx
@@ -1,19 +1,23 @@
 import * as React from 'react';
+import type { ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react';
 import { useIntl } from 'react-intl';
 import { LoadingIndicator } from '@box/blueprint-web';
 import { IconCtaIconHover, Size5 } from '@box/blueprint-web-assets/tokens/tokens';
 import { XMark } from '@box/blueprint-web-assets/icons/Fill';
 import messages from '../common/messages';
 
-const IconInProgress = () => {
-    const { formatMessage } = useIntl();
+const IconInProgress: ForwardRefExoticComponent<SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>> =
+    React.forwardRef(() => {
+        const { formatMessage } = useIntl();
 
-    return (
-        <div className="bcu-IconInProgress">
-            <XMark color={IconCtaIconHover} height={Size5} width={Size5} />
-            <LoadingIndicator aria-label={formatMessage(messages.loading)} className="bcu-IconInProgress-loading" />
-        </div>
-    );
-};
+        return (
+            <div className="bcu-IconInProgress">
+                <XMark color={IconCtaIconHover} height={Size5} width={Size5} />
+                <LoadingIndicator aria-label={formatMessage(messages.loading)} className="bcu-IconInProgress-loading" />
+            </div>
+        );
+    });
+
+IconInProgress.displayName = 'IconInProgress';
 
 export default IconInProgress;

--- a/src/elements/content-uploader/ItemAction.tsx
+++ b/src/elements/content-uploader/ItemAction.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react';
 import { useIntl } from 'react-intl';
 import { AxiosError } from 'axios';
 import { Button, IconButton, LoadingIndicator, Tooltip } from '@box/blueprint-web';
@@ -30,6 +31,8 @@ export interface ItemActionProps {
     status: UploadStatus;
 }
 
+type IconComponent = ForwardRefExoticComponent<SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>>;
+
 const ItemAction = ({
     error,
     isFolder = false,
@@ -41,11 +44,11 @@ const ItemAction = ({
     const { formatMessage } = useIntl();
     const { code } = error || {};
 
-    const LoadingIndicatorIcon = () => (
+    const LoadingIndicatorIcon = React.forwardRef<SVGSVGElement>(() => (
         <LoadingIndicator aria-label={formatMessage(messages.loading)} className="bcu-ItemAction-loading" />
-    );
+    ));
 
-    let Icon = XMark;
+    let Icon: IconComponent = XMark;
     let tooltip;
 
     if (isFolder && status !== STATUS_PENDING) {
@@ -54,14 +57,14 @@ const ItemAction = ({
 
     switch (status) {
         case STATUS_COMPLETE:
-            Icon = () => (
+            Icon = React.forwardRef<SVGSVGElement>(() => (
                 <Checkmark
                     aria-label={formatMessage(messages.complete)}
                     color={SurfaceStatusSurfaceSuccess}
                     height={Size5}
                     width={Size5}
                 />
-            );
+            ));
             if (!isResumableUploadsEnabled) {
                 tooltip = messages.remove;
             }
@@ -75,7 +78,7 @@ const ItemAction = ({
             if (isResumableUploadsEnabled) {
                 Icon = LoadingIndicatorIcon;
             } else {
-                Icon = IconInProgress;
+                Icon = IconInProgress as IconComponent;
                 tooltip = messages.uploadsCancelButtonTooltip;
             }
             break;

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
 import { InlineNotice, TooltipProvider } from '@box/blueprint-web';
+// $FlowFixMe
 import BoxAiLogo from '@box/blueprint-web-assets/icons/Logo/BoxAiLogo';
 
 import Toggle from '../../components/toggle';

--- a/src/icons/file-icon/FileIcon.tsx
+++ b/src/icons/file-icon/FileIcon.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react';
 
 import {
     FileAdobeExpress,
@@ -40,7 +41,9 @@ import { useIntl } from 'react-intl';
 
 import messages from '../../elements/common/messages';
 
-const Components: { [key: string]: (props: React.SVGProps<SVGSVGElement>) => JSX.Element } = {
+type FileIconComponent = ForwardRefExoticComponent<SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>>;
+
+const Components: { [key: string]: FileIconComponent } = {
     FileAdobeExpress,
     FileAudio,
     FileBookmark,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "allowJs": false, // https://github.com/microsoft/TypeScript/issues/35470
         "checkJs": false,
         "rootDir": ".",
+        "moduleResolution": "bundler",
         "paths": {
             "box-locale-data": ["node_modules/@box/cldr-data/locale-data/en-US"],
             "react": ["node_modules/@types/react"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,11 +1453,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@box/blueprint-web-assets@4.36.0":
-  version "4.36.0"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.36.0.tgz#4bd12f00f193af300fcbca0db291bff85dd95c96"
-  integrity sha512-iMFyNzRWW7bI+u/CrKYDxFMmcWjouU5UKNPJG8kWKlJwYZ25H0bwcqcZAvs/daPyIqtVuzdlcDvE3sJHBF3rfg==
-
 "@box/blueprint-web-assets@^4.39.0":
   version "4.41.6"
   resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.41.6.tgz#b0fae4020120bb752c1eb6063fcd32c15745dac5"
@@ -20110,8 +20105,7 @@ string-replace-loader@^3.1.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20145,6 +20139,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -20252,8 +20255,7 @@ stringify-object@^3.2.0, stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -20280,6 +20282,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -22071,8 +22080,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22102,6 +22110,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency version range for improved compatibility.
  - Adjusted TypeScript configuration for module resolution.
  - Added Flow suppression comments to reduce type errors on specific imports.
- **Refactor**
  - Improved type safety and clarity in Storybook stories and mock handlers through explicit type annotations.
  - Enhanced typing and ref forwarding for icon components in uploader and file icon features.
  - Updated import statements and internal type aliases for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->