### PR TITLE
feat(metadataeditor): add agent selector

### DIFF
--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
 import { InlineNotice, TooltipProvider } from '@box/blueprint-web';
@@ -16,19 +16,6 @@ import './CascadePolicy.scss';
 const COMMUNITY_LINK = 'https://support.box.com/hc/en-us/articles/360044195873-Cascading-metadata-in-folders';
 const AI_LINK = 'https://www.box.com/ai';
 const PRICING_LINK = 'https://www.box.com/pricing';
-
-const agents = [
-    {
-        id: '1',
-        name: 'Basic',
-        isEnterpriseDefault: true,
-    },
-    {
-        id: '2',
-        name: 'Enhanced (Gemini 2.5 Pro)',
-        isEnterpriseDefault: false,
-    },
-];
 
 type Props = {
     canEdit: boolean,
@@ -55,6 +42,21 @@ const CascadePolicy = ({
     onCascadeModeChange,
     shouldShowCascadeOptions,
 }: Props) => {
+    const intl = useIntl();
+
+    const agents = [
+        {
+            id: '1',
+            name: intl.formatMessage(messages.aiAgentBasic),
+            isEnterpriseDefault: true,
+        },
+        {
+            id: '2',
+            name: intl.formatMessage(messages.aiAgentEnhanced),
+            isEnterpriseDefault: false,
+        },
+    ];
+
     const readOnlyState = isCascadingEnabled ? (
         <div className="metadata-cascade-notice">
             <FormattedMessage {...messages.metadataCascadePolicyEnabledInfo} />

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -143,15 +143,17 @@ const CascadePolicy = ({
                                 <FormattedMessage {...messages.aiAutofillLearnMore} />
                             </Link>
                         </div>
-                        <TooltipProvider>
-                            <BoxAiAgentSelector
-                                agents={agents}
-                                onErrorAction={() => {}}
-                                requestState="success"
-                                selectedAgent={agents[0]}
-                                variant="sidebar"
-                            />
-                        </TooltipProvider>
+                        <div className="metadata-cascade-ai-agent-selector">
+                            <TooltipProvider>
+                                <BoxAiAgentSelector
+                                    agents={agents}
+                                    onErrorAction={() => {}}
+                                    requestState="success"
+                                    selectedAgent={agents[0]}
+                                    variant="sidebar"
+                                />
+                            </TooltipProvider>
+                        </div>
                         <InlineNotice className="metadata-cascade-ai-notice" variant="info">
                             <FormattedMessage
                                 {...messages.aiAutofillNotice}

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -21,13 +21,11 @@ const agents = [
     {
         id: '1',
         name: 'Basic',
-        description: 'General support for all queries and documents.',
         isEnterpriseDefault: true,
     },
     {
         id: '2',
-        name: 'Advanced',
-        description: 'Advanced support for all queries and documents.',
+        name: 'Enhanced (Gemini 2.5 Pro)',
         isEnterpriseDefault: false,
     },
 ];

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -2,7 +2,8 @@
 import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { InlineNotice } from '@box/blueprint-web';
+import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
+import { InlineNotice, TooltipProvider } from '@box/blueprint-web';
 import BoxAiLogo from '@box/blueprint-web-assets/icons/Logo/BoxAiLogo';
 
 import Toggle from '../../components/toggle';
@@ -15,6 +16,22 @@ import './CascadePolicy.scss';
 const COMMUNITY_LINK = 'https://support.box.com/hc/en-us/articles/360044195873-Cascading-metadata-in-folders';
 const AI_LINK = 'https://www.box.com/ai';
 const PRICING_LINK = 'https://www.box.com/pricing';
+
+const agents = [
+    {
+        id: '1',
+        name: 'Basic',
+        description: 'General support for all queries and documents.',
+        isEnterpriseDefault: true,
+    },
+    {
+        id: '2',
+        name: 'Advanced',
+        description: 'Advanced support for all queries and documents.',
+        isEnterpriseDefault: false,
+    },
+];
+
 type Props = {
     canEdit: boolean,
     canUseAIFolderExtraction: boolean,
@@ -126,6 +143,15 @@ const CascadePolicy = ({
                                 <FormattedMessage {...messages.aiAutofillLearnMore} />
                             </Link>
                         </div>
+                        <TooltipProvider>
+                            <BoxAiAgentSelector
+                                agents={agents}
+                                onErrorAction={() => {}}
+                                requestState="success"
+                                selectedAgent={agents[0]}
+                                variant="sidebar"
+                            />
+                        </TooltipProvider>
                         <InlineNotice className="metadata-cascade-ai-notice" variant="info">
                             <FormattedMessage
                                 {...messages.aiAutofillNotice}

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
 import { InlineNotice, TooltipProvider } from '@box/blueprint-web';
@@ -16,6 +16,19 @@ import './CascadePolicy.scss';
 const COMMUNITY_LINK = 'https://support.box.com/hc/en-us/articles/360044195873-Cascading-metadata-in-folders';
 const AI_LINK = 'https://www.box.com/ai';
 const PRICING_LINK = 'https://www.box.com/pricing';
+
+const agents = [
+    {
+        id: '1',
+        name: 'Basic',
+        isEnterpriseDefault: true,
+    },
+    {
+        id: '2',
+        name: 'Enhanced (Gemini 2.5 Pro)',
+        isEnterpriseDefault: false,
+    },
+];
 
 type Props = {
     canEdit: boolean,
@@ -42,21 +55,6 @@ const CascadePolicy = ({
     onCascadeModeChange,
     shouldShowCascadeOptions,
 }: Props) => {
-    const intl = useIntl();
-
-    const agents = [
-        {
-            id: '1',
-            name: intl.formatMessage(messages.aiAgentBasic),
-            isEnterpriseDefault: true,
-        },
-        {
-            id: '2',
-            name: intl.formatMessage(messages.aiAgentEnhanced),
-            isEnterpriseDefault: false,
-        },
-    ];
-
     const readOnlyState = isCascadingEnabled ? (
         <div className="metadata-cascade-notice">
             <FormattedMessage {...messages.metadataCascadePolicyEnabledInfo} />

--- a/src/features/metadata-instance-editor/CascadePolicy.scss
+++ b/src/features/metadata-instance-editor/CascadePolicy.scss
@@ -78,3 +78,7 @@ $cascade-policy-background: #f1e2fd;
         }
     }
 }
+
+.metadata-cascade-ai-agent-selector {
+    margin-top: 4px;
+}

--- a/src/features/metadata-instance-editor/__tests__/CascadePolicy.test.js
+++ b/src/features/metadata-instance-editor/__tests__/CascadePolicy.test.js
@@ -92,4 +92,11 @@ describe('features/metadata-instance-editor/CascadePolicy', () => {
             expect(pricingLink.closest('a')).toHaveAttribute('target', '_blank');
         });
     });
+
+    describe('AI Agent Selector', () => {
+        test('should render AI agent selector with default to basic when AI features are enabled', () => {
+            render(<CascadePolicy canEdit canUseAIFolderExtraction shouldShowCascadeOptions />);
+            expect(screen.getByRole('button', { name: 'Agent Basic' })).toBeInTheDocument();
+        });
+    });
 });

--- a/src/features/metadata-instance-editor/messages.js
+++ b/src/features/metadata-instance-editor/messages.js
@@ -194,6 +194,16 @@ const messages = defineMessages({
         description: 'Pricing details link for AI autofill',
         id: 'boxui.metadataInstanceEditor.aiAutofillPricingDetails',
     },
+    aiAgentBasic: {
+        defaultMessage: 'Basic',
+        description: 'Basic AI agent',
+        id: 'boxui.metadataInstanceEditor.aiAgentBasic',
+    },
+    aiAgentEnhanced: {
+        defaultMessage: 'Enhanced (Gemini 2.5 Pro)',
+        description: 'Enhanced AI agent',
+        id: 'boxui.metadataInstanceEditor.aiAgentEnhanced',
+    },
     applyCascadePolicyText: {
         defaultMessage:
             'Apply template and its values to all new and existing items in this folder and its subfolders.',

--- a/src/features/metadata-instance-editor/messages.js
+++ b/src/features/metadata-instance-editor/messages.js
@@ -194,16 +194,6 @@ const messages = defineMessages({
         description: 'Pricing details link for AI autofill',
         id: 'boxui.metadataInstanceEditor.aiAutofillPricingDetails',
     },
-    aiAgentBasic: {
-        defaultMessage: 'Basic',
-        description: 'Basic AI agent',
-        id: 'boxui.metadataInstanceEditor.aiAgentBasic',
-    },
-    aiAgentEnhanced: {
-        defaultMessage: 'Enhanced (Gemini 2.5 Pro)',
-        description: 'Enhanced AI agent',
-        id: 'boxui.metadataInstanceEditor.aiAgentEnhanced',
-    },
     applyCascadePolicyText: {
         defaultMessage:
             'Apply template and its values to all new and existing items in this folder and its subfolders.',


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an AI agent selection option within the AI folder extraction section, allowing users to choose between "Basic" and "Enhanced (Gemini 2.5 Pro)" AI agents.

- **Style**
  - Added spacing above the new AI agent selector for improved visual layout.

- **Tests**
  - Added tests to ensure the AI agent selector appears when AI folder extraction features are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->