### PR TITLE
feat(notification-redesign): Add logic for use of BP icons

### DIFF
--- a/src/components/notification/Notification.js
+++ b/src/components/notification/Notification.js
@@ -3,9 +3,15 @@ import * as React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 
+import Information from '@box/blueprint-web-assets/icons/Medium/Information';
+import Check from '@box/blueprint-web-assets/icons/Medium/Check';
+import AlertTriangle from '@box/blueprint-web-assets/icons/Medium/AlertTriangle';
+import AlertBadge from '@box/blueprint-web-assets/icons/Medium/AlertBadge';
+
 import InfoBadge16 from '../../icon/line/InfoBadge16';
 import CircleCheck16 from '../../icon/line/CircleCheck16';
 import TriangleAlert16 from '../../icon/line/TriangleAlert16';
+
 import XBadge16 from '../../icon/line/XBadge16';
 import X16 from '../../icon/fill/X16';
 
@@ -34,6 +40,13 @@ const ICON_RENDERER: { [string]: Function } = {
     [TYPE_ERROR]: () => <XBadge16 />,
     [TYPE_INFO]: () => <CircleCheck16 />,
     [TYPE_WARN]: () => <TriangleAlert16 />,
+};
+
+const ICON_RENDERER_V2: { [string]: Function } = {
+    [TYPE_DEFAULT]: () => <Information />,
+    [TYPE_ERROR]: () => <AlertBadge />,
+    [TYPE_INFO]: () => <Check />,
+    [TYPE_WARN]: () => <AlertTriangle />,
 };
 
 const messages = defineMessages({
@@ -69,6 +82,7 @@ type Props = {
      */
     type: NotificationType,
     overflow?: 'wrap' | 'ellipsis',
+    useV2Icons?: boolean,
 };
 
 class Notification extends React.Component<Props> {
@@ -101,14 +115,16 @@ class Notification extends React.Component<Props> {
 
     render() {
         const contents = this.getChildren();
-        const { intl, type, overflow, className } = this.props;
+        const { intl, type, overflow, className, useV2Icons } = this.props;
         const { formatMessage } = intl;
         const classes = classNames('notification', type, overflow, className);
+        const iconRenderer = useV2Icons ? ICON_RENDERER_V2[type] : ICON_RENDERER[type];
+        const iconColor = useV2Icons ? '#222' : '#fff';
 
         return (
             <div className={classes}>
-                {React.cloneElement(ICON_RENDERER[type](), {
-                    color: '#fff',
+                {React.cloneElement(iconRenderer(), {
+                    color: iconColor,
                     height: 20,
                     width: 20,
                 })}

--- a/src/components/notification/Notification.js
+++ b/src/components/notification/Notification.js
@@ -3,11 +3,8 @@ import * as React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import classNames from 'classnames';
 
-import Information from '@box/blueprint-web-assets/icons/Medium/Information';
-import Check from '@box/blueprint-web-assets/icons/Medium/Check';
-import AlertTriangle from '@box/blueprint-web-assets/icons/Medium/AlertTriangle';
-import AlertBadge from '@box/blueprint-web-assets/icons/Medium/AlertBadge';
-import XMark from '@box/blueprint-web-assets/icons/Medium/XMark';
+// $FlowFixMe
+import { Information, Check, AlertTriangle, AlertBadge, XMark } from '@box/blueprint-web-assets/icons/Medium';
 
 import InfoBadge16 from '../../icon/line/InfoBadge16';
 import CircleCheck16 from '../../icon/line/CircleCheck16';

--- a/src/components/notification/Notification.js
+++ b/src/components/notification/Notification.js
@@ -7,6 +7,7 @@ import Information from '@box/blueprint-web-assets/icons/Medium/Information';
 import Check from '@box/blueprint-web-assets/icons/Medium/Check';
 import AlertTriangle from '@box/blueprint-web-assets/icons/Medium/AlertTriangle';
 import AlertBadge from '@box/blueprint-web-assets/icons/Medium/AlertBadge';
+import XMark from '@box/blueprint-web-assets/icons/Medium/XMark';
 
 import InfoBadge16 from '../../icon/line/InfoBadge16';
 import CircleCheck16 from '../../icon/line/CircleCheck16';
@@ -36,17 +37,10 @@ const DURATION_TIMES = {
 };
 
 const ICON_RENDERER: { [string]: Function } = {
-    [TYPE_DEFAULT]: () => <InfoBadge16 />,
-    [TYPE_ERROR]: () => <XBadge16 />,
-    [TYPE_INFO]: () => <CircleCheck16 />,
-    [TYPE_WARN]: () => <TriangleAlert16 />,
-};
-
-const ICON_RENDERER_V2: { [string]: Function } = {
-    [TYPE_DEFAULT]: () => <Information />,
-    [TYPE_ERROR]: () => <AlertBadge />,
-    [TYPE_INFO]: () => <Check />,
-    [TYPE_WARN]: () => <AlertTriangle />,
+    [TYPE_DEFAULT]: useV2Icons => (useV2Icons ? <Information /> : <InfoBadge16 />),
+    [TYPE_ERROR]: useV2Icons => (useV2Icons ? <AlertBadge /> : <XBadge16 />),
+    [TYPE_INFO]: useV2Icons => (useV2Icons ? <Check /> : <CircleCheck16 />),
+    [TYPE_WARN]: useV2Icons => (useV2Icons ? <AlertTriangle /> : <TriangleAlert16 />),
 };
 
 const messages = defineMessages({
@@ -118,12 +112,12 @@ class Notification extends React.Component<Props> {
         const { intl, type, overflow, className, useV2Icons } = this.props;
         const { formatMessage } = intl;
         const classes = classNames('notification', type, overflow, className);
-        const iconRenderer = useV2Icons ? ICON_RENDERER_V2[type] : ICON_RENDERER[type];
+        const iconRenderer = ICON_RENDERER[type](useV2Icons);
         const iconColor = useV2Icons ? '#222' : '#fff';
 
         return (
             <div className={classes}>
-                {React.cloneElement(iconRenderer(), {
+                {React.cloneElement(iconRenderer, {
                     color: iconColor,
                     height: 20,
                     width: 20,
@@ -135,7 +129,7 @@ class Notification extends React.Component<Props> {
                     onClick={this.onClose}
                     type="button"
                 >
-                    <X16 />
+                    {useV2Icons ? <XMark height={32} width={32} /> : <X16 />}
                 </button>
             </div>
         );

--- a/src/components/notification/__tests__/Notification.test.js
+++ b/src/components/notification/__tests__/Notification.test.js
@@ -46,7 +46,7 @@ describe('components/notification/Notification', () => {
             expect(component.find('div.notification').hasClass(type)).toBe(true);
         });
 
-        test('should render a correct icon when initialized', () => {
+        test('should render local icons per notification type', () => {
             const component = mount(<Notification type={type}>test</Notification>);
             const infoBadge16Count = type === TYPE_DEFAULT ? 1 : 0;
             const CircleCheck16Count = type === TYPE_INFO ? 1 : 0;
@@ -57,6 +57,25 @@ describe('components/notification/Notification', () => {
             expect(component.find('XBadge16').length).toBe(XBadge16Count);
             expect(component.find('CircleCheck16').length).toBe(CircleCheck16Count);
             expect(component.find('TriangleAlert16').length).toBe(TriangleAlert16Count);
+
+            // Does not render v2 icons
+            expect(component.find(`svg[role="img"]`).length).toBe(0);
+        });
+
+        test('should render v2 icons when useV2Icons is true', () => {
+            const component = mount(
+                <Notification type={type} useV2Icons={true}>
+                    test
+                </Notification>,
+            );
+
+            expect(component.find(`svg[role="img"]`).length).toBe(1);
+
+            // Does not render local icons
+            expect(component.find('InfoBadge16').length).toBe(0);
+            expect(component.find('XBadge16').length).toBe(0);
+            expect(component.find('CircleCheck16').length).toBe(0);
+            expect(component.find('TriangleAlert16').length).toBe(0);
         });
     });
 

--- a/src/components/notification/__tests__/Notification.test.js
+++ b/src/components/notification/__tests__/Notification.test.js
@@ -69,7 +69,8 @@ describe('components/notification/Notification', () => {
                 </Notification>,
             );
 
-            expect(component.find(`svg[role="img"]`).length).toBe(1);
+            // Type icon and Close button
+            expect(component.find(`svg[role="img"]`).length).toBe(2);
 
             // Does not render local icons
             expect(component.find('InfoBadge16').length).toBe(0);


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for toggling between two sets of notification icons via an optional setting.
- **Bug Fixes**
  - Ensured correct icons display based on the selected icon set.
- **Tests**
  - Enhanced tests to verify icon rendering for both legacy and new icon sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->