### PR TITLE
feat(metadataeditor): remove ai pricing notice

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1214,10 +1214,6 @@ boxui.media.menuButtonArialLabel = Options
 boxui.metadataInstanceEditor.aiAutofillDescription = Use Box AI to automatically extract metadata values.
 # Learn more link for AI autofill
 boxui.metadataInstanceEditor.aiAutofillLearnMore = Learn more
-# Notice for AI autofill toggle switch
-boxui.metadataInstanceEditor.aiAutofillNotice = Enabling this feature may involve additional charges. Please review our {pricingLink} for more information.
-# Pricing details link for AI autofill
-boxui.metadataInstanceEditor.aiAutofillPricingDetails = pricing details
 # Informational text below collapsible header indicating that all fields for this template are hidden
 boxui.metadataInstanceEditor.allAttributesAreHidden = All attributes in this template have been hidden.
 # Informational text below enable cascade policy toggle switch

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
-import { InlineNotice, TooltipProvider } from '@box/blueprint-web';
+import { TooltipProvider } from '@box/blueprint-web';
 // $FlowFixMe
 import BoxAiLogo from '@box/blueprint-web-assets/icons/Logo/BoxAiLogo';
 
@@ -16,7 +16,6 @@ import './CascadePolicy.scss';
 
 const COMMUNITY_LINK = 'https://support.box.com/hc/en-us/articles/360044195873-Cascading-metadata-in-folders';
 const AI_LINK = 'https://www.box.com/ai';
-const PRICING_LINK = 'https://www.box.com/pricing';
 
 const agents = [
     {
@@ -160,18 +159,6 @@ const CascadePolicy = ({
                                 </TooltipProvider>
                             </div>
                         )}
-                        <InlineNotice className="metadata-cascade-ai-notice" variant="info">
-                            <FormattedMessage
-                                {...messages.aiAutofillNotice}
-                                values={{
-                                    pricingLink: (
-                                        <Link className="cascade-policy-link" href={PRICING_LINK} target="_blank">
-                                            <FormattedMessage {...messages.aiAutofillPricingDetails} />
-                                        </Link>
-                                    ),
-                                }}
-                            />
-                        </InlineNotice>
                     </div>
                 </div>
             )}

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { BoxAiAgentSelector } from '@box/box-ai-agent-selector';
-import { TooltipProvider } from '@box/blueprint-web';
 // $FlowFixMe
 import BoxAiLogo from '@box/blueprint-web-assets/icons/Logo/BoxAiLogo';
 
@@ -148,15 +147,13 @@ const CascadePolicy = ({
                         </div>
                         {canUseAIFolderExtractionAgentSelector && (
                             <div className="metadata-cascade-ai-agent-selector">
-                                <TooltipProvider>
-                                    <BoxAiAgentSelector
-                                        agents={agents}
-                                        onErrorAction={() => {}}
-                                        requestState="success"
-                                        selectedAgent={agents[0]}
-                                        variant="sidebar"
-                                    />
-                                </TooltipProvider>
+                                <BoxAiAgentSelector
+                                    agents={agents}
+                                    onErrorAction={() => {}}
+                                    requestState="success"
+                                    selectedAgent={agents[0]}
+                                    variant="sidebar"
+                                />
                             </div>
                         )}
                     </div>

--- a/src/features/metadata-instance-editor/CascadePolicy.scss
+++ b/src/features/metadata-instance-editor/CascadePolicy.scss
@@ -46,10 +46,6 @@ $cascade-policy-background: #f1e2fd;
         top: 3px;
         margin-right: 3px;
     }
-
-    .metadata-cascade-ai-notice {
-        margin-top: 12px;
-    }
 }
 
 .toggle-container.metadata-cascade-toggle {

--- a/src/features/metadata-instance-editor/__tests__/CascadePolicy.test.js
+++ b/src/features/metadata-instance-editor/__tests__/CascadePolicy.test.js
@@ -77,8 +77,8 @@ describe('features/metadata-instance-editor/CascadePolicy', () => {
         },
     );
 
-    describe('AI Autofill Links', () => {
-        test('should render AI and pricing links when AI features are enabled', () => {
+    describe('AI Autofill Learn More Link', () => {
+        test('should render AI learn more link when AI features are enabled', () => {
             render(<CascadePolicy canEdit canUseAIFolderExtraction shouldShowCascadeOptions />);
 
             // Find link within the AI autofill section since there are two links with the same text in the component
@@ -87,11 +87,6 @@ describe('features/metadata-instance-editor/CascadePolicy', () => {
             expect(aiLink).toBeInTheDocument();
             expect(aiLink.closest('a')).toHaveAttribute('href', 'https://www.box.com/ai');
             expect(aiLink.closest('a')).toHaveAttribute('target', '_blank');
-
-            const pricingLink = screen.getByText('pricing details');
-            expect(pricingLink).toBeInTheDocument();
-            expect(pricingLink.closest('a')).toHaveAttribute('href', 'https://www.box.com/pricing');
-            expect(pricingLink.closest('a')).toHaveAttribute('target', '_blank');
         });
     });
 

--- a/src/features/metadata-instance-editor/messages.js
+++ b/src/features/metadata-instance-editor/messages.js
@@ -178,21 +178,10 @@ const messages = defineMessages({
         description: 'Description for AI autofill toggle switch',
         id: 'boxui.metadataInstanceEditor.aiAutofillDescription',
     },
-    aiAutofillNotice: {
-        defaultMessage:
-            'Enabling this feature may involve additional charges. Please review our {pricingLink} for more information.',
-        description: 'Notice for AI autofill toggle switch',
-        id: 'boxui.metadataInstanceEditor.aiAutofillNotice',
-    },
     aiAutofillLearnMore: {
         defaultMessage: 'Learn more',
         description: 'Learn more link for AI autofill',
         id: 'boxui.metadataInstanceEditor.aiAutofillLearnMore',
-    },
-    aiAutofillPricingDetails: {
-        defaultMessage: 'pricing details',
-        description: 'Pricing details link for AI autofill',
-        id: 'boxui.metadataInstanceEditor.aiAutofillPricingDetails',
     },
     applyCascadePolicyText: {
         defaultMessage:


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the informational notice and pricing details link related to AI autofill from the metadata instance editor.
- **Style**
	- Updated styles to remove spacing previously used for the AI autofill notice.
- **Tests**
	- Updated tests to reflect the removal of the AI autofill pricing details link and notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->