### PR TITLE
fix(content-preview): prevent item icon shrinking on small screens

### DIFF
--- a/src/elements/content-preview/preview-header/FileInfo.scss
+++ b/src/elements/content-preview/preview-header/FileInfo.scss
@@ -1,6 +1,10 @@
 .bcpr-FileInfo {
     display: flex;
     align-items: center;
+
+    svg {
+        flex-shrink: 0;
+    }
 }
 
 .bcpr-FileInfo-name {


### PR DESCRIPTION
Before
<img width="306" alt="Screenshot 2025-05-21 at 3 35 25 PM" src="https://github.com/user-attachments/assets/0479ed83-01af-4349-807f-e86faed8c7a1" />

After
<img width="306" alt="Screenshot 2025-05-21 at 3 35 35 PM" src="https://github.com/user-attachments/assets/580a42ee-f824-4d39-9ebe-076e68f9398b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout consistency by preventing SVG icons in file info headers from shrinking when the container is resized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->