### PR TITLE
fix(ai-sidebar): Add callback for selected agent

### DIFF
--- a/src/elements/content-sidebar/BoxAISidebarContent.tsx
+++ b/src/elements/content-sidebar/BoxAISidebarContent.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import flow from 'lodash/flow';
 import { useIntl } from 'react-intl';
 import classNames from 'classnames';
-import { BoxAiAgentSelectorWithApi, useAgents } from '@box/box-ai-agent-selector';
+import { BoxAiAgentSelectorWithApi, useAgents, type AgentType } from '@box/box-ai-agent-selector';
 import { IconButton, Tooltip } from '@box/blueprint-web';
 import { ArrowsExpand } from '@box/blueprint-web-assets/icons/Fill';
 import {
@@ -34,11 +34,17 @@ const MARK_NAME_JS_READY: string = `${ORIGIN_BOXAI_SIDEBAR}_${EVENT_JS_READY}`;
 
 mark(MARK_NAME_JS_READY);
 
-function BoxAISidebarContent(props: ApiWrapperWithInjectedProps & { shouldShowLandingPage: boolean }) {
+function BoxAISidebarContent(
+    props: ApiWrapperWithInjectedProps & {
+        onSelectedAgentCallback: (selectedAgent: AgentType) => void;
+        shouldShowLandingPage: boolean;
+    },
+) {
     const {
         createSession,
         encodedSession,
         onClearAction,
+        onSelectedAgentCallback,
         getAIStudioAgents,
         hasRequestInProgress,
         hostAppName,
@@ -154,6 +160,11 @@ function BoxAISidebarContent(props: ApiWrapperWithInjectedProps & { shouldShowLa
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [encodedSession]);
+
+    React.useEffect(() => {
+        onSelectedAgentCallback?.(selectedAgent);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedAgent?.id]);
 
     const renderBoxAISidebarTitle = () => {
         return (

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -4,11 +4,15 @@ import { render, screen } from '../../../test-utils/testing-library';
 import BoxAISidebar, { BoxAISidebarProps } from '../BoxAISidebar';
 
 let MockBoxAiAgentSelectorWithApi: jest.Mock;
+let mockUseAgents: jest.Mock;
+
 jest.mock('@box/box-ai-agent-selector', () => {
     MockBoxAiAgentSelectorWithApi = jest.fn();
+    mockUseAgents = jest.fn();
     return {
         ...jest.requireActual('@box/box-ai-agent-selector'),
         BoxAiAgentSelectorWithApi: MockBoxAiAgentSelectorWithApi,
+        useAgents: mockUseAgents,
     };
 });
 
@@ -39,6 +43,7 @@ jest.mock('@box/box-ai-content-answers', () => ({
             onClearAction={mockOnClearAction}
             onCloseModal={jest.fn()}
             onSelectAgent={jest.fn()}
+            onSelectedAgentCallback={props.onSelectedAgentCallback}
             onSuggestedQuestionsFetched={props.onSuggestedQuestionsFetched}
             onAgentEditorToggle={jest.fn()}
             questions={props.restoredQuestions}
@@ -145,6 +150,12 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
 
     beforeEach(() => {
         MockBoxAiAgentSelectorWithApi.mockImplementation(() => <div data-testid="sidebar-agent-selector" />);
+        mockUseAgents.mockReturnValue({
+            agents: [],
+            selectedAgent: { id: '1', config: {}, name: 'Test Agent' },
+            setSelectedAgent: jest.fn(),
+            requestState: 'success',
+        });
     });
 
     afterEach(() => {
@@ -464,5 +475,15 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         await userEvent.keyboard('foo');
 
         expect(mockProps.onUserInteraction).toHaveBeenCalled();
+    });
+
+    test('Should call onSelectedAgentCallback on agent selected change', async () => {
+        const mockOnSelectedAgentCallback = jest.fn();
+
+        await renderComponent({
+            onSelectedAgentCallback: mockOnSelectedAgentCallback,
+        });
+
+        expect(mockOnSelectedAgentCallback).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Add a callback prop to BoxAiContentSidebar that is invoked whenever the selected agent changes. This allows the parent application to respond to agent selection updates accordingly.

Initial application for this will be to detect the selected agent change to change the suggested questions accordingly.


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The sidebar now notifies the parent component whenever the selected AI agent changes.

- **Tests**
  - Added tests to verify that the notification callback is triggered when the selected AI agent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->