### PR TITLE
fix(metadata-instance-fields): add minimal taxonomy support in metadata-instance-fields

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -80,7 +80,19 @@ const config: {
             }),
         );
 
-        return config;
+        // Add FIPS-compliant configuration
+        return {
+            ...config,
+            output: {
+                ...config.output,
+                hashFunction: 'sha256',
+                hashDigest: 'hex',
+            },
+            cache: {
+                type: 'filesystem',
+                hashAlgorithm: 'sha256',
+            },
+        };
     },
     typescript: {
         reactDocgen: 'react-docgen-typescript',

--- a/i18n/ja-JP.properties
+++ b/i18n/ja-JP.properties
@@ -1211,7 +1211,7 @@ boxui.itemDetails.urlPlaceholder = 有効なURLを入力
 # Label for comment options menu
 boxui.media.menuButtonArialLabel = オプション
 # Description for AI autofill toggle switch
-boxui.metadataInstanceEditor.aiAutofillDescription = Use Box AI to automatically extract metadata values.
+boxui.metadataInstanceEditor.aiAutofillDescription = Box AIを使用して自動的にメタデータ値を抽出します。
 # Learn more link for AI autofill
 boxui.metadataInstanceEditor.aiAutofillLearnMore = 詳細を表示
 # Informational text below collapsible header indicating that all fields for this template are hidden
@@ -1255,7 +1255,7 @@ boxui.metadataInstanceEditor.customValuePlaceholder = 例: 42
 # Text that shows in a tooltip above the edit pencil button.
 boxui.metadataInstanceEditor.editTooltip = メタデータを編集
 # Label for enable AI autofill toggle switch
-boxui.metadataInstanceEditor.enableAIAutofill = Box AI Autofill
+boxui.metadataInstanceEditor.enableAIAutofill = Box AI自動入力
 # Label for enable cascade policy toggle switch
 boxui.metadataInstanceEditor.enableCascadePolicy = カスケードポリシーを有効にする
 # Message for users who may attempt to remove a custom metadata instance for a file. Also non-recoverable
@@ -1959,9 +1959,9 @@ boxui.unifiedShare.previewerUploaderLevelText = プレビューアー/アップ�
 # Tooltip description to explain recommendation for sharing tooltip
 boxui.unifiedShare.recommendedSharingTooltipCalloutText = お客様の使用状況から、{fullName}さんにはこのファイルもお勧めです。
 # Description for confirmation modal to remove a collaborator
-boxui.unifiedShare.removeCollaboratorConfirmationDescription = Are you sure you want to remove {name} as a collaborator?
+boxui.unifiedShare.removeCollaboratorConfirmationDescription = コラボレータから{name}を削除してもよろしいですか?
 # Label for confirmation modal to remove a collaborator (title-case)
-boxui.unifiedShare.removeCollaboratorConfirmationTitle = Remove Collaborator
+boxui.unifiedShare.removeCollaboratorConfirmationTitle = コラボレータの削除
 # Description for confirmation modal to remove a shared link
 boxui.unifiedShare.removeLinkConfirmationDescription = これにより、共有リンクが完全に削除されます。この項目が他のサイトに埋め込まれている場合は、そのサイトでもアクセスできなくなります。カスタムプロパティ、設定、有効期限も削除されます。続行しますか?
 # Label for confirmation modal to remove a shared link (title-case)

--- a/package.json
+++ b/package.json
@@ -89,7 +89,11 @@
             "last 2 Edge versions",
             "last 2 iOS versions"
         ],
-        "development": ["last 1 Chrome versions", "last 1 Firefox versions", "last 1 Safari versions"]
+        "development": [
+            "last 1 Chrome versions",
+            "last 1 Firefox versions",
+            "last 1 Safari versions"
+        ]
     },
     "husky": {
         "hooks": {
@@ -119,16 +123,16 @@
         "@babel/preset-typescript": "^7.24.7",
         "@babel/template": "^7.24.7",
         "@babel/types": "^7.24.7",
-        "@box/blueprint-web": "^11.12.0",
-        "@box/blueprint-web-assets": "^4.44.1",
-        "@box/box-ai-agent-selector": "^0.31.0",
+        "@box/blueprint-web": "^12.7.1",
+        "@box/blueprint-web-assets": "^4.48.4",
+        "@box/box-ai-agent-selector": "^0.41.10",
         "@box/box-ai-content-answers": "^0.124.1",
         "@box/cldr-data": "^34.2.0",
         "@box/combobox-with-api": "^0.34.9",
         "@box/frontend": "^11.0.1",
         "@box/item-icon": "^0.9.83",
         "@box/languages": "^1.0.0",
-        "@box/metadata-editor": "^0.104.2",
+        "@box/metadata-editor": "^0.110.1",
         "@box/react-virtualized": "9.22.3-rc-box.9",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@chromatic-com/storybook": "^1.6.1",
@@ -291,14 +295,14 @@
         "worker-farm": "^1.7.0"
     },
     "peerDependencies": {
-        "@box/blueprint-web": "^11.12.0",
-        "@box/blueprint-web-assets": "^4.44.1",
-        "@box/box-ai-agent-selector": "^0.31.0",
+        "@box/blueprint-web": "^12.7.1",
+        "@box/blueprint-web-assets": "^4.48.4",
+        "@box/box-ai-agent-selector": "^0.41.10",
         "@box/box-ai-content-answers": "^0.124.1",
         "@box/cldr-data": ">=34.2.0",
         "@box/combobox-with-api": "^0.34.9",
         "@box/item-icon": "^0.9.83",
-        "@box/metadata-editor": "^0.104.2",
+        "@box/metadata-editor": "^0.110.1",
         "@box/react-virtualized": "9.22.3-rc-box.9",
         "@hapi/address": "^2.1.4",
         "axios": "^0.30.0",
@@ -355,6 +359,8 @@
         }
     },
     "msw": {
-        "workerDirectory": [".storybook/public"]
+        "workerDirectory": [
+            ".storybook/public"
+        ]
     }
 }

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -63,7 +63,6 @@ function getConfig(isReactExternalized) {
             path: outputPath,
             filename: `[name]${isReactExternalized ? noReactSuffix : ''}.js`,
             publicPath: `/${version}/${language}/`,
-            hashFunction: 'xxhash64',
         },
         resolve: {
             modules: ['src', 'node_modules'],

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -10,7 +10,6 @@ import BoxAISidebarContent from './BoxAISidebarContent';
 import { BoxAISidebarContext } from './context/BoxAISidebarContext';
 import { SPREADSHEET_FILE_EXTENSIONS } from '../common/content-answers/constants';
 import type { BoxAISidebarCache, BoxAISidebarCacheSetter } from './types/BoxAISidebarTypes';
-
 import messages from '../common/content-answers/messages';
 
 export interface BoxAISidebarProps {
@@ -57,6 +56,7 @@ export interface BoxAISidebarProps {
     recordAction: (params: RecordActionType) => void;
     setCacheValue: BoxAISidebarCacheSetter;
     shouldFeedbackFormIncludeFeedbackText?: boolean;
+    renderRemoteModule?: (elementId: string) => React.ReactNode;
     shouldPreinitSession?: boolean;
     setHasQuestions: (hasQuestions: boolean) => void;
 }
@@ -79,6 +79,7 @@ const BoxAISidebar = (props: BoxAISidebarProps) => {
         onFeedbackFormSubmit,
         onUserInteraction,
         recordAction,
+        renderRemoteModule,
         setCacheValue,
         shouldFeedbackFormIncludeFeedbackText,
         shouldPreinitSession = true,
@@ -129,6 +130,10 @@ const BoxAISidebar = (props: BoxAISidebarProps) => {
             setHasQuestions(questions.length > 0);
         }
     }, [questions.length, setHasQuestions]);
+
+    if (renderRemoteModule) {
+        return renderRemoteModule(elementId);
+    }
 
     let questionsWithoutInProgress = questions;
     if (questions.length > 0 && !questions[questions.length - 1].isCompleted) {

--- a/src/elements/content-sidebar/MetadataInstanceEditor.tsx
+++ b/src/elements/content-sidebar/MetadataInstanceEditor.tsx
@@ -29,6 +29,7 @@ export interface MetadataInstanceEditorProps {
     setIsUnsavedChangesModalOpen: (isUnsavedChangesModalOpen: boolean) => void;
     taxonomyOptionsFetcher: TaxonomyOptionsFetcher;
     template: MetadataTemplateInstance;
+    isAdvancedExtractAgentEnabled?: boolean;
 }
 
 const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
@@ -48,6 +49,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
     setIsUnsavedChangesModalOpen,
     taxonomyOptionsFetcher,
     template,
+    isAdvancedExtractAgentEnabled = false,
 }) => {
     return (
         <MetadataInstanceForm
@@ -68,6 +70,7 @@ const MetadataInstanceEditor: React.FC<MetadataInstanceEditorProps> = ({
             selectedTemplateInstance={template}
             setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
             taxonomyOptionsFetcher={taxonomyOptionsFetcher}
+            isAdvancedExtractAgentEnabled={isAdvancedExtractAgentEnabled}
         />
     );
 };

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -114,6 +114,7 @@ function MetadataSidebarRedesign({
     const isBoxAiSuggestionsEnabled: boolean = useFeatureEnabled('metadata.aiSuggestions.enabled');
     const isBetaLanguageEnabled: boolean = useFeatureEnabled('metadata.betaLanguage.enabled');
     const isMetadataMultiLevelTaxonomyFieldEnabled: boolean = useFeatureEnabled('metadata.multilevelTaxonomy.enabled');
+    const isAdvancedExtractAgentEnabled: boolean = useFeatureEnabled('metadata.extractAdvancedAgents.enabled');
     const isDeleteConfirmationModalCheckboxEnabled: boolean = useFeatureEnabled(
         'metadata.deleteConfirmationModalCheckbox.enabled',
     );
@@ -324,11 +325,13 @@ function MetadataSidebarRedesign({
                             setIsUnsavedChangesModalOpen={setIsUnsavedChangesModalOpen}
                             taxonomyOptionsFetcher={taxonomyOptionsFetcher}
                             template={editingTemplate}
+                            isAdvancedExtractAgentEnabled={isAdvancedExtractAgentEnabled}
                         />
                     )}
                     {showList && (
                         <MetadataInstanceList
                             areAiSuggestionsAvailable={areAiSuggestionsAvailable}
+                            isAdvancedExtractAgentEnabled={isAdvancedExtractAgentEnabled}
                             isAiSuggestionsFeatureEnabled={isBoxAiSuggestionsEnabled}
                             isBetaLanguageEnabled={isBetaLanguageEnabled}
                             onEdit={templateInstance => {

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -347,6 +347,26 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         expect(screen.queryByTestId('content-answers-modal')).not.toBeInTheDocument();
     });
 
+    describe('remote sidebar component', () => {
+        const MockRemoteSidebar = jest.fn(() => <div data-testid="remote-sidebar" />);
+        const renderRemoteModule = jest.fn(() => <MockRemoteSidebar elementId={mockProps.elementId} />);
+
+        test('should render remote sidebar component when provided', async () => {
+            await renderComponent({ renderRemoteModule });
+
+            expect(renderRemoteModule).toHaveBeenCalledWith(mockProps.elementId);
+            expect(screen.getByTestId('remote-sidebar')).toBeInTheDocument();
+        });
+
+        test('should not render default sidebar when remote component is provided', async () => {
+            await renderComponent({ renderRemoteModule });
+
+            expect(screen.queryByTestId('boxai-sidebar-title')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('sidebar-agent-selector')).not.toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: 'Clear conversation' })).not.toBeInTheDocument();
+        });
+    });
+
     describe('given shouldPreinitSession = false, should create session on user intent', () => {
         test('agents list open', async () => {
             MockBoxAiAgentSelectorWithApi.mockImplementation(({ onAgentsListOpen }) => {

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -425,6 +425,30 @@ export const MetadataInstanceEditorAIEnabled: StoryObj<typeof MetadataSidebarRed
     },
 };
 
+export const MetadataInstanceEditorAIEnabledAdvancedExtractAgent: StoryObj<typeof MetadataSidebarRedesign> = {
+    args: {
+        features: {
+            ...mockFeatures,
+            'metadata.aiSuggestions.enabled': true,
+            'metadata.extractAdvancedAgents.enabled': true,
+        },
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        // Edit one instance
+        const editButton = await canvas.findByRole('button', { name: 'Edit My Template' });
+        await userEvent.click(editButton);
+
+        // Find the SplitButton
+        const splitButton = await canvas.findByRole('button', { name: /Autofill/ });
+        expect(splitButton).toBeVisible();
+
+        await userEvent.hover(splitButton);
+        const dropdownButton = await canvas.findByRole('button', { name: 'See agent options.' });
+        expect(dropdownButton).toBeVisible();
+    },
+};
+
 export const ShowErrorWhenAIAPIIsUnavailable: StoryObj<typeof MetadataSidebarRedesign> = {
     args: {
         features: {

--- a/src/features/metadata-instance-editor/__tests__/CascadePolicy.test.js
+++ b/src/features/metadata-instance-editor/__tests__/CascadePolicy.test.js
@@ -7,6 +7,11 @@ import { screen, render, within } from '../../../test-utils/testing-library';
 import CascadePolicy from '../CascadePolicy';
 
 describe('features/metadata-instance-editor/CascadePolicy', () => {
+    beforeEach(() => {
+        // reset any previous tests that may have set localStorage
+        localStorage.removeItem('aiAgent');
+    });
+
     test('should correctly render cascade policy read only mode', () => {
         const wrapper = shallow(<CascadePolicy id="fakeId" isCascadingEnabled shouldShowCascadeOptions />);
         expect(wrapper).toMatchSnapshot();
@@ -100,12 +105,12 @@ describe('features/metadata-instance-editor/CascadePolicy', () => {
                     shouldShowCascadeOptions
                 />,
             );
-            expect(screen.getByRole('button', { name: 'Agent Basic' })).toBeInTheDocument();
+            expect(screen.getByRole('combobox', { name: 'Basic' })).toBeInTheDocument();
         });
 
         test('should not render AI agent selector when canUseAIFolderExtractionAgentSelector is false', () => {
             render(<CascadePolicy canEdit canUseAIFolderExtraction shouldShowCascadeOptions />);
-            expect(screen.queryByRole('button', { name: 'Agent Basic' })).not.toBeInTheDocument();
+            expect(screen.queryByRole('combobox', { name: 'Basic' })).not.toBeInTheDocument();
         });
     });
 

--- a/src/features/metadata-instance-editor/__tests__/Instance.test.js
+++ b/src/features/metadata-instance-editor/__tests__/Instance.test.js
@@ -863,7 +863,7 @@ describe('Instance Component - React Testing Library', () => {
             const editButton = screen.queryByRole('button', { name: 'Edit Metadata' });
             if (editButton) await userEvent.click(editButton); // Enter edit mode to ensure CascadePolicy options are visible
 
-            expect(screen.getByRole('button', { name: 'Agent Basic' })).toBeInTheDocument();
+            expect(screen.getByRole('combobox', { name: 'Basic' })).toBeInTheDocument();
         });
 
         test('should pass isExistingAIExtractionCascadePolicy=true to CascadePolicy if policy is ai_extract', async () => {

--- a/src/features/metadata-instance-editor/__tests__/Instances.test.js
+++ b/src/features/metadata-instance-editor/__tests__/Instances.test.js
@@ -265,7 +265,7 @@ describe('Instances component - canUseAIFolderExtractionAgentSelector prop', () 
         const editButton = screen.getByRole('button', { name: 'Edit Metadata' });
         await userEvent.click(editButton);
 
-        expect(screen.getByRole('button', { name: 'Agent Basic' })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: 'Basic' })).toBeInTheDocument();
     });
 
     test('should not show agent selector in child Instance if canUseAIFolderExtractionAgentSelector is false', async () => {
@@ -280,7 +280,7 @@ describe('Instances component - canUseAIFolderExtractionAgentSelector prop', () 
         const editButton = screen.getByRole('button', { name: 'Edit Metadata' });
         await userEvent.click(editButton);
 
-        expect(screen.queryByRole('button', { name: 'Agent Basic' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('combobox', { name: 'Basic' })).not.toBeInTheDocument();
     });
 
     test('should not show agent selector in child Instance if canUseAIFolderExtractionAgentSelector is undefined', async () => {
@@ -291,6 +291,6 @@ describe('Instances component - canUseAIFolderExtractionAgentSelector prop', () 
         const editButton = screen.getByRole('button', { name: 'Edit Metadata' });
         await userEvent.click(editButton);
 
-        expect(screen.queryByRole('button', { name: 'Agent Basic' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('combobox', { name: 'Basic' })).not.toBeInTheDocument();
     });
 });

--- a/src/features/metadata-instance-editor/__tests__/MetadataInstanceEditor.test.js
+++ b/src/features/metadata-instance-editor/__tests__/MetadataInstanceEditor.test.js
@@ -547,7 +547,7 @@ describe('MetadataInstanceEditor - canUseAIFolderExtractionAgentSelector prop', 
         const editButton = await screen.findByRole('button', { name: 'Edit Metadata' }, { timeout: 3000 });
         await userEvent.click(editButton);
 
-        expect(screen.getByRole('button', { name: 'Agent Basic' })).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: 'Basic' })).toBeInTheDocument();
     });
 
     test('should not show agent selector if canUseAIFolderExtractionAgentSelector is false', async () => {
@@ -562,7 +562,7 @@ describe('MetadataInstanceEditor - canUseAIFolderExtractionAgentSelector prop', 
         const editButton = await screen.findByRole('button', { name: 'Edit Metadata' });
         await userEvent.click(editButton);
 
-        expect(screen.queryByRole('button', { name: 'Agent Basic' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('combobox', { name: 'Basic' })).not.toBeInTheDocument();
     });
 
     test('should not show agent selector if canUseAIFolderExtractionAgentSelector is undefined', async () => {
@@ -573,6 +573,6 @@ describe('MetadataInstanceEditor - canUseAIFolderExtractionAgentSelector prop', 
         const editButton = await screen.findByRole('button', { name: 'Edit Metadata' });
         await userEvent.click(editButton);
 
-        expect(screen.queryByRole('button', { name: 'Agent Basic' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('combobox', { name: 'Basic' })).not.toBeInTheDocument();
     });
 });

--- a/src/features/metadata-instance-fields/MetadataField.js
+++ b/src/features/metadata-instance-fields/MetadataField.js
@@ -21,6 +21,7 @@ import {
     FIELD_TYPE_STRING,
     FIELD_TYPE_DATE,
     FIELD_TYPE_MULTISELECT,
+    FIELD_TYPE_TAXONOMY,
 } from './constants';
 
 type Props = {
@@ -157,6 +158,19 @@ const MetadataField = ({
                     isDisabled={isDisabled}
                     onChange={onChange}
                     onRemove={onRemove}
+                />
+            );
+
+        // The taxonomy field is a valid field type which,
+        // although not yet supported here, should not trigger an error message.
+        // For this reason, we are currently setting it to read-only.
+        case FIELD_TYPE_TAXONOMY:
+            return (
+                <ReadOnlyMetadataField
+                    dataValue={dataValue}
+                    description={description}
+                    displayName={displayName}
+                    type={type}
                 />
             );
 

--- a/src/features/metadata-instance-fields/__tests__/MetadataField.test.js
+++ b/src/features/metadata-instance-fields/__tests__/MetadataField.test.js
@@ -33,6 +33,12 @@ describe('features/metadata-instance-editor/fields/MetadataField', () => {
         );
         expect(wrapper).toMatchSnapshot();
     });
+    test('should correctly render a taxonomy field - for the time being, in read-only mode', () => {
+        const wrapper = shallow(
+            <MetadataField canEdit dataValue="value" onChange={onChange} onRemove={onRemove} type="taxonomy" />,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
     test('should correctly render a float field', () => {
         const wrapper = shallow(
             <MetadataField canEdit dataValue="value" onChange={onChange} onRemove={onRemove} type="float" />,

--- a/src/features/metadata-instance-fields/__tests__/__snapshots__/MetadataField.test.js.snap
+++ b/src/features/metadata-instance-fields/__tests__/__snapshots__/MetadataField.test.js.snap
@@ -37,6 +37,13 @@ exports[`features/metadata-instance-editor/fields/MetadataField should correctly
 />
 `;
 
+exports[`features/metadata-instance-editor/fields/MetadataField should correctly render a taxonomy field - for the time being, in read-only mode 1`] = `
+<ReadOnlyMetadataField
+  dataValue="value"
+  type="taxonomy"
+/>
+`;
+
 exports[`features/metadata-instance-editor/fields/MetadataField should correctly render a text field 1`] = `
 <TextMetadataField
   dataValue="value"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,19 +1437,19 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@box/blueprint-web-assets@^4.44.0", "@box/blueprint-web-assets@^4.44.1":
-  version "4.44.1"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.44.1.tgz#c674784f3a4b10f47bbea6be64e1e6dfb512d8b0"
-  integrity sha512-v88exZ1HWzEi4TBFDyHuM/yE29ID1U3gQTAgzSaKJseZCrhIDdgygHMIEsEwswDEUvLLFznRme4sgrbKlrT5Rg==
+"@box/blueprint-web-assets@^4.48.0", "@box/blueprint-web-assets@^4.48.4":
+  version "4.48.4"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.48.4.tgz#2fc9ed248b05c9969da6364605b37b969a71ef1d"
+  integrity sha512-74CA5X/81owelMLl4vXQIokS5QF6WpsCq5aS3y6BDtii9wi5EIkMx+R6LrjfZ2pfNToh7vkr+oZVvtcFlo53Qg==
 
-"@box/blueprint-web@^11.12.0":
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-11.12.0.tgz#7b03eaa111554df8efb8dad240432f7db9f8cf66"
-  integrity sha512-uTSBZ4eXdmlw7wOAxjL6brWQIkDnCwZq2gSM44iqCRZlUnUjvqIXuK6NUA1Py0oOFMsu/EYl7sUKHwIeS3g/4w==
+"@box/blueprint-web@^12.7.1":
+  version "12.7.1"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-12.7.1.tgz#5e85f95ed55ed3e40048aa20441d57174e38596e"
+  integrity sha512-4L2aSXwDA9R3Taf3d+YqEKj8ayQggcvh6ROUD3qnDZgbJhfgWaQ3QaCKmdRGqSQ8BwmHPFDofVwsgK/Rgm2D7g==
   dependencies:
     "@ariakit/react" "0.4.15"
     "@ariakit/react-core" "0.4.15"
-    "@box/blueprint-web-assets" "^4.44.0"
+    "@box/blueprint-web-assets" "^4.48.0"
     "@internationalized/date" "^3.7.0"
     "@radix-ui/react-accordion" "1.1.2"
     "@radix-ui/react-checkbox" "1.0.4"
@@ -1478,10 +1478,10 @@
     tabbable "^4.0.0"
     type-fest "^3.2.0"
 
-"@box/box-ai-agent-selector@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@box/box-ai-agent-selector/-/box-ai-agent-selector-0.31.0.tgz#a2ef6c3c7284529ae268b609d04b6000348bb294"
-  integrity sha512-4+M/4g8LHJfZkP+7ISBKveQs2q5HeGvXv8B6/N8yFb9cpYuOjpKFxRvHyILdQWjwictHZbgY2XrNrpxbYGEXRQ==
+"@box/box-ai-agent-selector@^0.41.10":
+  version "0.41.16"
+  resolved "https://registry.yarnpkg.com/@box/box-ai-agent-selector/-/box-ai-agent-selector-0.41.16.tgz#041d83f4c438080d6d845db94811c35069f38f1a"
+  integrity sha512-q8cMjv/rU/yzwiyBp2/toRw0jXAX1HbmbE3oM9PWCnsS0cyBJtxKokLkcyw8hRbfXHcgi+KcRBpGhjOPYG+0cQ==
 
 "@box/box-ai-content-answers@^0.124.1":
   version "0.124.1"
@@ -1520,10 +1520,10 @@
   resolved "https://registry.yarnpkg.com/@box/languages/-/languages-1.1.2.tgz#cd4266b3da62da18560d881e10b429653186be29"
   integrity sha512-d64TGosx+KRmrLZj4CIyLp42LUiEbgBJ8n8cviMQwTJmfU0g+UwZqLjmQZR1j+Q9D64yV4xHzY9K1t5nInWWeQ==
 
-"@box/metadata-editor@^0.104.2":
-  version "0.104.2"
-  resolved "https://registry.yarnpkg.com/@box/metadata-editor/-/metadata-editor-0.104.2.tgz#07cc27ce992d510a7ada2cff482b2c4d748bee71"
-  integrity sha512-71BhSFHJc5SrgGb3LjGvOpuTeuPzw0Epg9OUr8FX2/vjH8Z5maf1UVaG3W9FXm0gmIgRqZJ8zqXxW76UaF4brQ==
+"@box/metadata-editor@^0.110.1":
+  version "0.110.1"
+  resolved "https://registry.yarnpkg.com/@box/metadata-editor/-/metadata-editor-0.110.1.tgz#73fe32f1f6068df62abecefa5c3b7afe065ddb26"
+  integrity sha512-C/GbyxtWxE8urU0RSakWrcksua8ObwDR/+SOmiTIZfcG9/jKHsftNPqLhcxxFJ1HRMPLQy7XN56ey9Y7ObiI0Q==
 
 "@box/react-virtualized@9.22.3-rc-box.9":
   version "9.22.3-rc-box.9"
@@ -18254,7 +18254,7 @@ string-replace-loader@^3.1.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18288,15 +18288,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -18404,7 +18395,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18431,13 +18422,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -20020,7 +20004,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20050,15 +20034,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Currently, although we have a `taxonomy` field type in Metadata Templates, it is not yet available within `metadata-instance-fields`. However, we do not want users to see an error message about an invalid type, so we are temporarily introducing minimal support for this field in a `read-only` form, regardless of whether we are in edit mode or not.

<img width="557" alt="Screenshot 2025-06-02 at 09 56 31" src="https://github.com/user-attachments/assets/c144a452-dcc5-4a2c-9ed2-3b3eb251e8b3" />


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying taxonomy metadata fields in read-only mode.

- **Tests**
  - Introduced a new test to verify correct rendering of taxonomy metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->