### PR TITLE
fix(metadata-instance-fields): add minimal taxonomy support in metada-instance-fields

### DIFF
--- a/src/features/metadata-instance-fields/MetadataField.js
+++ b/src/features/metadata-instance-fields/MetadataField.js
@@ -21,6 +21,7 @@ import {
     FIELD_TYPE_STRING,
     FIELD_TYPE_DATE,
     FIELD_TYPE_MULTISELECT,
+    FIELD_TYPE_TAXONOMY,
 } from './constants';
 
 type Props = {
@@ -157,6 +158,19 @@ const MetadataField = ({
                     isDisabled={isDisabled}
                     onChange={onChange}
                     onRemove={onRemove}
+                />
+            );
+
+        // The taxonomy field is a valid field type which,
+        // although not yet supported here, should not trigger an error message.
+        // For this reason, we are currently setting it to read-only.
+        case FIELD_TYPE_TAXONOMY:
+            return (
+                <ReadOnlyMetadataField
+                    dataValue={dataValue}
+                    description={description}
+                    displayName={displayName}
+                    type={type}
                 />
             );
 

--- a/src/features/metadata-instance-fields/__tests__/MetadataField.test.js
+++ b/src/features/metadata-instance-fields/__tests__/MetadataField.test.js
@@ -33,6 +33,12 @@ describe('features/metadata-instance-editor/fields/MetadataField', () => {
         );
         expect(wrapper).toMatchSnapshot();
     });
+    test('should correctly render a taxonomy field - for the time being, in read-only mode', () => {
+        const wrapper = shallow(
+            <MetadataField canEdit dataValue="value" onChange={onChange} onRemove={onRemove} type="taxonomy" />,
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
     test('should correctly render a float field', () => {
         const wrapper = shallow(
             <MetadataField canEdit dataValue="value" onChange={onChange} onRemove={onRemove} type="float" />,

--- a/src/features/metadata-instance-fields/__tests__/__snapshots__/MetadataField.test.js.snap
+++ b/src/features/metadata-instance-fields/__tests__/__snapshots__/MetadataField.test.js.snap
@@ -37,6 +37,13 @@ exports[`features/metadata-instance-editor/fields/MetadataField should correctly
 />
 `;
 
+exports[`features/metadata-instance-editor/fields/MetadataField should correctly render a taxonomy field - for the time being, in read-only mode 1`] = `
+<ReadOnlyMetadataField
+  dataValue="value"
+  type="taxonomy"
+/>
+`;
+
 exports[`features/metadata-instance-editor/fields/MetadataField should correctly render a text field 1`] = `
 <TextMetadataField
   dataValue="value"


### PR DESCRIPTION
Currently, although we have a `taxonomy` field type in Metadata Templates, it is not yet available within `metadata-instance-fields`. However, we do not want users to see an error message about an invalid type, so we are temporarily introducing minimal support for this field in a `read-only` form, regardless of whether we are in edit mode or not.

<img width="557" alt="Screenshot 2025-06-02 at 09 56 31" src="https://github.com/user-attachments/assets/c144a452-dcc5-4a2c-9ed2-3b3eb251e8b3" />


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying taxonomy metadata fields in read-only mode.
  - Enabled replacing the AI sidebar content with remote modules.
  - Introduced an advanced extract agent feature flag affecting metadata editing.
  - Added a visual test story for AI-enabled advanced extract agent UI elements.

- **Localization**
  - Updated Japanese translations for Box AI autofill and collaborator removal confirmations.

- **Tests**
  - Introduced a new test to verify correct rendering of taxonomy metadata fields.
  - Added tests ensuring remote sidebar module rendering and default sidebar suppression.
  - Updated tests to reflect UI changes from button to combobox for AI agent selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->