### PR TITLE
feat(metadata-editor): expose custom agent in extractStructured payload

### DIFF
--- a/src/api/schemas/AiAgentReference.js
+++ b/src/api/schemas/AiAgentReference.js
@@ -1,0 +1,15 @@
+/**
+ * @flow
+ * @author Box
+ */
+
+export type AiAgentTypeField = 'ai_agent_id';
+
+export interface AiAgentReference {
+    /**
+     * AI Agent Reference to pass custom AI Agent ID to requests.
+     * See https://developer.box.com/reference/resources/ai-agent-reference/
+     */
+    +type: AiAgentTypeField;
+    +id: string;
+}

--- a/src/api/schemas/AiExtractStructured.js
+++ b/src/api/schemas/AiExtractStructured.js
@@ -4,6 +4,7 @@
  */
 
 import { AiAgentExtractStructured } from './AiAgentExtractStructured';
+import { AiAgentReference } from './AiAgentReference';
 import { AiItemBase } from './AiItemBase';
 
 export type AiExtractStructuredMetadataTemplateTypeField = 'metadata_template';
@@ -80,5 +81,9 @@ export interface AiExtractStructured {
      * The JSON blob that contains overrides for the agent config.
      */
     +agent_config?: string;
-    +ai_agent?: AiAgentExtractStructured;
+    /**
+     * The AI Agent to be used for extraction. Use AiAgentExtractStructured to customize Basic Text or Long Text agents.
+     * Use AiAgentReference to pass a custom AI Agent ID.
+     */
+    +ai_agent?: AiAgentExtractStructured | AiAgentReference;
 }

--- a/src/api/schemas/AiExtractStructured.js
+++ b/src/api/schemas/AiExtractStructured.js
@@ -82,8 +82,9 @@ export interface AiExtractStructured {
      */
     +agent_config?: string;
     /**
-     * The AI Agent to be used for extraction. Use AiAgentExtractStructured to customize Basic Text or Long Text agents.
-     * Use AiAgentReference to pass a custom AI Agent ID.
+     * * AI agent definition to use for extraction.
+     * – `AiAgentExtractStructured`: customise Basic-Text / Long-Text agents
+     * – `AiAgentReference`        : reference a custom AI-Agent by ID
      */
     +ai_agent?: AiAgentExtractStructured | AiAgentReference;
 }

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -29,6 +29,7 @@ import messages from '../../common/messages';
 
 import { type BoxItem } from '../../../common/types/core';
 import { type ErrorContextProps, type ExternalProps, type SuccessContextProps } from '../MetadataSidebarRedesign';
+import { type AiExtractStructured } from '../../../api/schemas/AiExtractStructured';
 
 export enum STATUS {
     IDLE = 'idle',
@@ -219,12 +220,14 @@ function useSidebarMetadataFetcher(
             setExtractErrorCode(null);
             let answer = null;
             const customAiAgent = agentId ? { ai_agent: { type: 'ai_agent_id', id: agentId } } : {};
+            const requestBody: AiExtractStructured = {
+                items: [{ id: file.id, type: file.type }],
+                metadata_template: { template_key: templateKey, scope, type: 'metadata_template' },
+                ...customAiAgent,
+            };
+
             try {
-                answer = (await aiAPI.extractStructured({
-                    items: [{ id: file.id, type: file.type }],
-                    metadata_template: { template_key: templateKey, scope, type: 'metadata_template' },
-                    ...customAiAgent,
-                })) as Record<string, MetadataFieldValue>;
+                answer = (await aiAPI.extractStructured(requestBody)) as Record<string, MetadataFieldValue>;
             } catch (error) {
                 // Axios makes the status code nested under the response object
                 if (error.response?.status === 408) {

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -45,7 +45,7 @@ interface DataFetcher {
         | ERROR_CODE_METADATA_PRECONDITION_FAILED
         | ERROR_CODE_UNKNOWN
         | null;
-    extractSuggestions: (templateKey: string, scope: string) => Promise<MetadataTemplateField[]>;
+    extractSuggestions: (templateKey: string, scope: string, agentId?: string) => Promise<MetadataTemplateField[]>;
     file: BoxItem | null;
     handleCreateMetadataInstance: (
         templateInstance: MetadataTemplateInstance,
@@ -214,15 +214,16 @@ function useSidebarMetadataFetcher(
 
     const [, setError] = React.useState();
     const extractSuggestions = React.useCallback(
-        async (templateKey: string, scope: string): Promise<MetadataTemplateField[]> => {
+        async (templateKey: string, scope: string, agentId?: string): Promise<MetadataTemplateField[]> => {
             const aiAPI = api.getIntelligenceAPI();
             setExtractErrorCode(null);
-
             let answer = null;
+            const customAiAgent = agentId ? { ai_agent: { type: 'ai_agent_id', id: agentId } } : {};
             try {
                 answer = (await aiAPI.extractStructured({
                     items: [{ id: file.id, type: file.type }],
                     metadata_template: { template_key: templateKey, scope, type: 'metadata_template' },
+                    ...customAiAgent,
                 })) as Record<string, MetadataFieldValue>;
             } catch (error) {
                 // Axios makes the status code nested under the response object

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -147,15 +147,29 @@ const CascadePolicy = ({
                         </div>
                         {canUseAIFolderExtractionAgentSelector && (
                             <div className="metadata-cascade-ai-agent-selector">
-                                <BoxAiAgentSelector
-                                    agents={agents}
-                                    onErrorAction={() => {}}
-                                    requestState="success"
-                                    selectedAgent={agents[0]}
-                                    variant="sidebar"
-                                />
+                                <TooltipProvider>
+                                    <BoxAiAgentSelector
+                                        agents={agents}
+                                        onErrorAction={() => {}}
+                                        requestState="success"
+                                        selectedAgent={agents[0]}
+                                        variant="sidebar"
+                                    />
+                                </TooltipProvider>
                             </div>
                         )}
+                        <InlineNotice className="metadata-cascade-ai-notice" variant="info">
+                            <FormattedMessage
+                                {...messages.aiAutofillNotice}
+                                values={{
+                                    pricingLink: (
+                                        <Link className="cascade-policy-link" href={PRICING_LINK} target="_blank">
+                                            <FormattedMessage {...messages.aiAutofillPricingDetails} />
+                                        </Link>
+                                    ),
+                                }}
+                            />
+                        </InlineNotice>
                     </div>
                 </div>
             )}

--- a/src/features/metadata-instance-editor/CascadePolicy.js
+++ b/src/features/metadata-instance-editor/CascadePolicy.js
@@ -147,29 +147,15 @@ const CascadePolicy = ({
                         </div>
                         {canUseAIFolderExtractionAgentSelector && (
                             <div className="metadata-cascade-ai-agent-selector">
-                                <TooltipProvider>
-                                    <BoxAiAgentSelector
-                                        agents={agents}
-                                        onErrorAction={() => {}}
-                                        requestState="success"
-                                        selectedAgent={agents[0]}
-                                        variant="sidebar"
-                                    />
-                                </TooltipProvider>
+                                <BoxAiAgentSelector
+                                    agents={agents}
+                                    onErrorAction={() => {}}
+                                    requestState="success"
+                                    selectedAgent={agents[0]}
+                                    variant="sidebar"
+                                />
                             </div>
                         )}
-                        <InlineNotice className="metadata-cascade-ai-notice" variant="info">
-                            <FormattedMessage
-                                {...messages.aiAutofillNotice}
-                                values={{
-                                    pricingLink: (
-                                        <Link className="cascade-policy-link" href={PRICING_LINK} target="_blank">
-                                            <FormattedMessage {...messages.aiAutofillPricingDetails} />
-                                        </Link>
-                                    ),
-                                }}
-                            />
-                        </InlineNotice>
                     </div>
                 </div>
             )}


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
Updating API Schema to reflect correct way of passing in custom agent:  either https://developer.box.com/reference/resources/ai-agent-reference/ or https://developer.box.com/reference/resources/ai-agent-extract-structured/

Update `extractSuggestions` from `useSidebarMetadataFetcher` to take in optional `agentId` param + format `agentId` into valid `AiAgentReference` to pass to `extractStructured` payload. This allows API consumers to pass in custom agent ids to use for MD Extraction in Preview Sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom AI Agent ID when extracting structured data, allowing more flexible AI agent selection.
- **Tests**
  - Introduced new tests to verify correct handling of the optional AI Agent ID in extraction requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->