### PR TITLE
feat(header-flyout): add animation

### DIFF
--- a/src/features/header-flyout/styles/HeaderFlyout.scss
+++ b/src/features/header-flyout/styles/HeaderFlyout.scss
@@ -12,6 +12,9 @@
 .header-flyout-overlay {
     width: $flyout-list-width;
     height: $flyout-list-height;
+    animation: bdl-open-flyout-animation 0.3s cubic-bezier(0.32, 0, 0.33, 1.3);
+    animation-fill-mode: both;
+    transform-origin: top right;
 
     .overlay {
         @include bdl-Overlay-container;
@@ -24,6 +27,18 @@
         padding-bottom: $flyout-header-spacer;
         font-size: $flyout-title-font-size;
         line-height: $flyout-title-line-height;
+    }
+}
+
+@keyframes bdl-open-flyout-animation {
+    from {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.95);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
     }
 }
 


### PR DESCRIPTION
### JIRA ticket link

https://jira.inside-box.net/browse/WEBAPP-33763

### Description

- add animation to `HeaderFlyout`

### Screenshots

_The change is very subtle. The new animation has a ⬇ direction._

| Before | After |
|--------|-------|
| ![old-open-animation](https://github.com/user-attachments/assets/7c37c0a6-9f94-47ae-944a-77d0455cb9dc) | ![new-open-animation](https://github.com/user-attachments/assets/a21fa7ec-6a80-48d3-92c3-36cd8ef1e07c) |


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.

Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
  - Introduced a smooth entrance animation for the header flyout overlay, featuring a fade-in, slight downward slide, and scale effect for improved visual appeal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->