### PR TITLE
feat(router): optional router in withRouterAndRef hoc

### DIFF
--- a/src/elements/common/routing/__tests__/withRouterAndRef.test.js
+++ b/src/elements/common/routing/__tests__/withRouterAndRef.test.js
@@ -1,26 +1,78 @@
 // @flow
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { mount } from 'enzyme';
+import { render } from '../../../../test-utils/testing-library';
 import withRouterAndRef from '../withRouterAndRef';
 
 describe('elements/common/routing/withRouterAndRef', () => {
     type Props = {
         value: string,
+        routerDisabled?: boolean,
     };
 
-    const TestComponent = React.forwardRef(({ value }: Props, ref) => <div ref={ref}>{value}</div>);
+    const TestComponent = React.forwardRef(({ value, staticContext, routerDisabled, ...props }: Props, ref) => (
+        <div ref={ref} data-testid="test-component" data-router-disabled={routerDisabled} {...props}>
+            {value}
+        </div>
+    ));
+    TestComponent.displayName = 'TestComponent';
+    
     const WithRouterComponent = withRouterAndRef(TestComponent);
 
-    test('should pass ref down to wrapped component', () => {
-        const ref = React.createRef();
-        const wrapper = mount(
-            <MemoryRouter>
-                <WithRouterComponent ref={ref} value="foo" />
-            </MemoryRouter>,
-        );
-        const referenced = wrapper.find('div').getDOMNode();
-        expect(ref.current).toEqual(referenced);
-        expect(referenced.innerHTML).toEqual('foo');
+    describe('router enabled (default)', () => {
+        test('should pass ref and router props to wrapped component', () => {
+            const ref = React.createRef();
+            const { getByTestId } = render(
+                <MemoryRouter initialEntries={['/test']}>
+                    <WithRouterComponent ref={ref} value="test" />
+                </MemoryRouter>,
+            );
+            
+            const element = getByTestId('test-component');
+            expect(ref.current).toBe(element);
+            expect(element).toHaveTextContent('test');
+            expect(element).not.toHaveAttribute('data-router-disabled');
+        });
+    });
+
+    describe('router disabled', () => {
+        test('should pass ref down to wrapped component without router', () => {
+            const ref = React.createRef();
+            const { getByTestId } = render(
+                <WithRouterComponent ref={ref} value="foo" routerDisabled />
+            );
+            
+            const element = getByTestId('test-component');
+            expect(ref.current).toBe(element);
+            expect(element).toHaveTextContent('foo');
+            expect(element).toHaveAttribute('data-router-disabled', 'true');
+        });
+
+        test('should render component directly without Route wrapper', () => {
+            const { getByTestId } = render(
+                <WithRouterComponent value="direct" routerDisabled />
+            );
+            
+            const element = getByTestId('test-component');
+            expect(element).toHaveTextContent('direct');
+            expect(element).toHaveAttribute('data-router-disabled', 'true');
+        });
+
+        test('should pass through all props including routerDisabled', () => {
+            const { getByTestId } = render(
+                <WithRouterComponent 
+                    value="test" 
+                    routerDisabled 
+                    data-custom="custom-value"
+                    className="test-class"
+                />
+            );
+            
+            const element = getByTestId('test-component');
+            expect(element).toHaveTextContent('test');
+            expect(element).toHaveAttribute('data-custom', 'custom-value');
+            expect(element).toHaveClass('test-class');
+            expect(element).toHaveAttribute('data-router-disabled', 'true');
+        });
     });
 });

--- a/src/elements/common/routing/withRouterAndRef.js
+++ b/src/elements/common/routing/withRouterAndRef.js
@@ -5,9 +5,17 @@ import { Route } from 'react-router-dom';
 // Basically a workaround for the fact that react-router's withRouter cannot forward ref's through
 // functional components. Use this instead to gain the benefits of withRouter but also ref forwarding
 export default function withRouterAndRef(Wrapped: React.ComponentType<any>) {
-    const WithRouterAndRef = React.forwardRef<Object, React.Ref<any>>((props, ref) => (
-        <Route>{routeProps => <Wrapped ref={ref} {...routeProps} {...props} />}</Route>
-    ));
+    const WithRouterAndRef = React.forwardRef<Object, React.Ref<any>>((props, ref) => {
+        const { routerDisabled } = props;
+        
+        // If router is disabled, return component directly without Route wrapper
+        if (routerDisabled) {
+            return <Wrapped ref={ref} {...props} />;
+        }
+        
+        // Default behavior: wrap with Route to get router props
+        return <Route>{routeProps => <Wrapped ref={ref} {...routeProps} {...props} />}</Route>;
+    });
     const name = Wrapped.displayName || Wrapped.name || 'Component';
     WithRouterAndRef.displayName = `withRouterAndRef(${name})`;
     return WithRouterAndRef;

--- a/src/elements/content-explorer/stories/tests/ContentExplorer-visual.stories.js
+++ b/src/elements/content-explorer/stories/tests/ContentExplorer-visual.stories.js
@@ -5,6 +5,7 @@ import ContentExplorer from '../../ContentExplorer';
 import { mockEmptyRootFolder, mockRootFolder } from '../../../common/__mocks__/mockRootFolder';
 import mockSubfolder from '../../../common/__mocks__/mockSubfolder';
 import mockRecentItems from '../../../common/__mocks__/mockRecentItems';
+import { mockUserRequest } from '../../../common/__mocks__/mockRequests';
 
 import { DEFAULT_HOSTNAME_API } from '../../../../constants';
 
@@ -227,9 +228,37 @@ export const closeCreateFolderDialog = {
 //     },
 // };
 
+const defaultHandlers = [
+    http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/69083462919`, () => {
+        return HttpResponse.json(mockRootFolder);
+    }),
+    http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/73426618530`, () => {
+        return HttpResponse.json(mockSubfolder);
+    }),
+    http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/74729718131`, () => {
+        return HttpResponse.json(mockEmptyRootFolder);
+    }),
+    http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/191354690948`, () => {
+        return new HttpResponse('Internal Server Error', { status: 500 });
+    }),
+    http.get(`${DEFAULT_HOSTNAME_API}/2.0/recent_items`, () => {
+        return HttpResponse.json(mockRecentItems);
+    }),
+];
+
 export const emptyState = {
     args: {
         rootFolderId: '74729718131',
+    },
+    parameters: {
+        msw: {
+            handlers: [
+                ...defaultHandlers,
+                http.get(mockUserRequest.url, () => {
+                    return HttpResponse.json(mockUserRequest.response);
+                }),
+            ],
+        },
     },
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
@@ -271,23 +300,7 @@ export default {
     },
     parameters: {
         msw: {
-            handlers: [
-                http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/69083462919`, () => {
-                    return HttpResponse.json(mockRootFolder);
-                }),
-                http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/73426618530`, () => {
-                    return HttpResponse.json(mockSubfolder);
-                }),
-                http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/74729718131`, () => {
-                    return HttpResponse.json(mockEmptyRootFolder);
-                }),
-                http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/191354690948`, () => {
-                    return new HttpResponse('Internal Server Error', { status: 500 });
-                }),
-                http.get(`${DEFAULT_HOSTNAME_API}/2.0/recent_items`, () => {
-                    return HttpResponse.json(mockRecentItems);
-                }),
-            ],
+            handlers: defaultHandlers,
         },
     },
 };

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -543,7 +543,7 @@ export const SuggestionForNewlyCreatedTemplateInstance: StoryObj<typeof Metadata
         const autofillButton = await canvas.findByRole('button', { name: 'Autofill' });
         userEvent.click(autofillButton);
 
-        const suggestion = await canvas.findByText('4/1/2024');
+        const suggestion = await canvas.findByText('4/1/2024', {}, { timeout: 5000 });
         expect(suggestion).toBeInTheDocument();
     },
 };

--- a/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/MetadataSidebarRedesign-visual.stories.tsx
@@ -344,6 +344,19 @@ export const SwitchEditingTemplateInstances: StoryObj<typeof MetadataSidebarRede
         fileId: '416047501580',
         metadataSidebarProps: defaultMetadataSidebarProps,
     },
+    parameters: {
+        msw: {
+            handlers: [
+                ...defaultMockHandlers,
+                http.get(`/2.0/files/416047501580`, () => {
+                    return HttpResponse.json(mockFileRequest.response);
+                }),
+                http.get(`/2.0/files/416047501580/metadata`, () => {
+                    return HttpResponse.json(mockMetadataInstances.response);
+                }),
+            ],
+        },
+    },
     play: async ({ canvasElement }) => {
         const canvas = within(canvasElement);
         // open and edit a new template


### PR DESCRIPTION
withRouterAndRef is now accepting routerDisabled prop and acts accordingly. For now it just passes throught provided component. After react-router removal it could be removed whatsoever.

In addition, small change to flaky tests hoping it will become more robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for disabling router context in components, allowing them to render without router props when specified.

* **Tests**
  * Updated tests to improve clarity and coverage for components with and without router context.
  * Increased timeout for a visual test to better accommodate slower rendering scenarios.
  * Enhanced visual test stories with consistent mock data handlers and consolidated request handlers for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->