### PR TITLE
chore(storybook): use relative path for msw

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,7 +13,11 @@ global.FOLDER_ID = global.FOLDER_ID || '69083462919';
 // NOTE: The token used is a readonly token accessing public data in a demo enterprise. DO NOT PUT A WRITE TOKEN
 global.TOKEN = global.TOKEN || 'P1n3ID8nYMxHRWvenDatQ9k6JKzWzYrz';
 
-initialize();
+initialize({
+    serviceWorker: {
+        url: './mockServiceWorker.js',
+    },
+});
 
 const preview = {
     parameters: {

--- a/package.json
+++ b/package.json
@@ -343,8 +343,5 @@
         "dependencies": {
             "react-tether": "Version 2.x has too many breaking changes and requires forwardRef on all components"
         }
-    },
-    "msw": {
-        "workerDirectory": [".storybook/public"]
     }
 }

--- a/package.json
+++ b/package.json
@@ -343,5 +343,8 @@
         "dependencies": {
             "react-tether": "Version 2.x has too many breaking changes and requires forwardRef on all components"
         }
+    },
+    "msw": {
+        "workerDirectory": [".storybook/public"]
     }
 }


### PR DESCRIPTION
There is an error in the **published** storybook:

```
Error: [MSW] Failed to register a Service Worker for scope ('https://opensource.box.com/') with script ('https://opensource.box.com/mockServiceWorker.js'): Service Worker script does not exist at the given path.
```

This is because the `mockServiceWorker.js` is hosted at:
`https://opensource.box.com/box-ui-elements/mockServiceWorker.js`
but storybook is trying to find it at:
`https://opensource.box.com/mockServiceWorker.js`

solution:
https://github.com/mswjs/msw-storybook-addon/issues/77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for the mock service worker in Storybook to explicitly set the service worker script location.
  * Removed unused "msw" configuration from project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->