### PR TITLE
feat(metadata-view): Added Metadata V2 button

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1812,6 +1812,8 @@ boxui.shareMenu.shortcutOnly = Shortcut Only
 boxui.shareMenu.viewAndDownload = View and Download
 # Description of permissions granted to users who have access to the shared link
 boxui.shareMenu.viewOnly = View Only
+# Text for metadata button that will open the metadata side panel
+boxui.subHeader.metadata = Metadata
 # Error message for empty time formats. "HH:MM A" should be localized.
 boxui.timeInput.emptyTimeError = Required field. Enter a time in the format HH:MM A.
 # Error message for invalid time formats. "HH:MM A" should be localized.

--- a/src/elements/common/sub-header/SubHeader.tsx
+++ b/src/elements/common/sub-header/SubHeader.tsx
@@ -5,7 +5,8 @@ import SubHeaderLeft from './SubHeaderLeft';
 import SubHeaderRight from './SubHeaderRight';
 import type { ViewMode } from '../flowTypes';
 import type { View, Collection } from '../../../common/types/core';
-import { VIEW_MODE_LIST } from '../../../constants';
+import { VIEW_MODE_LIST, VIEW_METADATA } from '../../../constants';
+import { useFeatureEnabled } from '../feature-checking';
 
 import './SubHeader.scss';
 
@@ -51,39 +52,49 @@ const SubHeader = ({
     rootName,
     view,
     viewMode = VIEW_MODE_LIST,
-}: SubHeaderProps) => (
-    <PageHeader.Root className="be-sub-header" data-testid="be-sub-header" variant="inline">
-        <PageHeader.StartElements>
-            <SubHeaderLeft
-                currentCollection={currentCollection}
-                isSmall={isSmall}
-                onItemClick={onItemClick}
-                portalElement={portalElement}
-                rootId={rootId}
-                rootName={rootName}
-                view={view}
-            />
-        </PageHeader.StartElements>
-        <PageHeader.EndElements>
-            <SubHeaderRight
-                canCreateNewFolder={canCreateNewFolder}
-                canUpload={canUpload}
-                currentCollection={currentCollection}
-                gridColumnCount={gridColumnCount}
-                gridMaxColumns={gridMaxColumns}
-                gridMinColumns={gridMinColumns}
-                maxGridColumnCountForWidth={maxGridColumnCountForWidth}
-                onCreate={onCreate}
-                onGridViewSliderChange={onGridViewSliderChange}
-                onSortChange={onSortChange}
-                onUpload={onUpload}
-                onViewModeChange={onViewModeChange}
-                portalElement={portalElement}
-                view={view}
-                viewMode={viewMode}
-            />
-        </PageHeader.EndElements>
-    </PageHeader.Root>
-);
+}: SubHeaderProps) => {
+    const isMetadataViewV2Feature = useFeatureEnabled('contentExplorer.metadataViewV2');
+
+    if (view === VIEW_METADATA && !isMetadataViewV2Feature) {
+        return null;
+    }
+
+    return (
+        <PageHeader.Root className="be-sub-header" data-testid="be-sub-header" variant="inline">
+            <PageHeader.StartElements>
+                {view !== VIEW_METADATA && !isMetadataViewV2Feature && (
+                    <SubHeaderLeft
+                        currentCollection={currentCollection}
+                        isSmall={isSmall}
+                        onItemClick={onItemClick}
+                        portalElement={portalElement}
+                        rootId={rootId}
+                        rootName={rootName}
+                        view={view}
+                    />
+                )}
+            </PageHeader.StartElements>
+            <PageHeader.EndElements>
+                <SubHeaderRight
+                    canCreateNewFolder={canCreateNewFolder}
+                    canUpload={canUpload}
+                    currentCollection={currentCollection}
+                    gridColumnCount={gridColumnCount}
+                    gridMaxColumns={gridMaxColumns}
+                    gridMinColumns={gridMinColumns}
+                    maxGridColumnCountForWidth={maxGridColumnCountForWidth}
+                    onCreate={onCreate}
+                    onGridViewSliderChange={onGridViewSliderChange}
+                    onSortChange={onSortChange}
+                    onUpload={onUpload}
+                    onViewModeChange={onViewModeChange}
+                    portalElement={portalElement}
+                    view={view}
+                    viewMode={viewMode}
+                />
+            </PageHeader.EndElements>
+        </PageHeader.Root>
+    );
+};
 
 export default SubHeader;

--- a/src/elements/common/sub-header/SubHeaderRight.tsx
+++ b/src/elements/common/sub-header/SubHeaderRight.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
+import { Button } from '@box/blueprint-web';
+import { Pencil } from '@box/blueprint-web-assets/icons/Fill';
+import { useIntl } from 'react-intl';
 import Sort from './Sort';
 import Add from './Add';
 import GridViewSlider from '../../../components/grid-view/GridViewSlider';
 import ViewModeChangeButton from './ViewModeChangeButton';
-import { VIEW_FOLDER, VIEW_MODE_GRID } from '../../../constants';
+import { VIEW_FOLDER, VIEW_MODE_GRID, VIEW_METADATA } from '../../../constants';
+import { useFeatureEnabled } from '../feature-checking';
+
 import type { ViewMode } from '../flowTypes';
 import type { SortBy, SortDirection, View, Collection } from '../../../common/types/core';
+
+import messages from './messages';
+
 import './SubHeaderRight.scss';
 
 export interface SubHeaderRightProps {
@@ -43,36 +51,49 @@ const SubHeaderRight = ({
     view,
     viewMode,
 }: SubHeaderRightProps) => {
+    const { formatMessage } = useIntl();
+    const isMetadataViewV2Feature = useFeatureEnabled('contentExplorer.metadataViewV2');
     const { items = [] }: Collection = currentCollection;
     const hasGridView: boolean = !!gridColumnCount;
     const hasItems: boolean = items.length > 0;
     const isFolder: boolean = view === VIEW_FOLDER;
     const showSort: boolean = isFolder && hasItems;
     const showAdd: boolean = (!!canUpload || !!canCreateNewFolder) && isFolder;
+    const isMetadataView: boolean = view === VIEW_METADATA;
     return (
         <div className="be-sub-header-right">
-            {hasItems && viewMode === VIEW_MODE_GRID && (
-                <GridViewSlider
-                    columnCount={gridColumnCount}
-                    gridMaxColumns={gridMaxColumns}
-                    gridMinColumns={gridMinColumns}
-                    maxColumnCount={maxGridColumnCountForWidth}
-                    onChange={onGridViewSliderChange}
-                />
+            {!isMetadataView && (
+                <>
+                    {hasItems && viewMode === VIEW_MODE_GRID && (
+                        <GridViewSlider
+                            columnCount={gridColumnCount}
+                            gridMaxColumns={gridMaxColumns}
+                            gridMinColumns={gridMinColumns}
+                            maxColumnCount={maxGridColumnCountForWidth}
+                            onChange={onGridViewSliderChange}
+                        />
+                    )}
+                    {hasItems && hasGridView && (
+                        <ViewModeChangeButton viewMode={viewMode} onViewModeChange={onViewModeChange} />
+                    )}
+                    {showSort && <Sort onSortChange={onSortChange} portalElement={portalElement} />}
+                    {showAdd && (
+                        <Add
+                            isDisabled={!isFolder}
+                            onCreate={onCreate}
+                            onUpload={onUpload}
+                            portalElement={portalElement}
+                            showCreate={canCreateNewFolder}
+                            showUpload={canUpload}
+                        />
+                    )}
+                </>
             )}
-            {hasItems && hasGridView && (
-                <ViewModeChangeButton viewMode={viewMode} onViewModeChange={onViewModeChange} />
-            )}
-            {showSort && <Sort onSortChange={onSortChange} portalElement={portalElement} />}
-            {showAdd && (
-                <Add
-                    isDisabled={!isFolder}
-                    onCreate={onCreate}
-                    onUpload={onUpload}
-                    portalElement={portalElement}
-                    showCreate={canCreateNewFolder}
-                    showUpload={canUpload}
-                />
+
+            {isMetadataView && isMetadataViewV2Feature && (
+                <Button icon={Pencil} size="large" variant="primary">
+                    {formatMessage(messages.metadata)}
+                </Button>
             )}
         </div>
     );

--- a/src/elements/common/sub-header/messages.ts
+++ b/src/elements/common/sub-header/messages.ts
@@ -1,0 +1,11 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+    metadata: {
+        defaultMessage: 'Metadata',
+        description: 'Text for metadata button that will open the metadata side panel',
+        id: 'boxui.subHeader.metadata',
+    },
+});
+
+export default messages;

--- a/src/elements/content-explorer/Content.tsx
+++ b/src/elements/content-explorer/Content.tsx
@@ -65,13 +65,13 @@ const Content = ({
     const isMetadataBasedView = view === VIEW_METADATA;
     const isListView = !isMetadataBasedView && viewMode === VIEW_MODE_LIST; // Folder view or Recents view
     const isGridView = !isMetadataBasedView && viewMode === VIEW_MODE_GRID; // Folder view or Recents view
-
+    const isMetadataViewV2Feature = isFeatureEnabled(features, 'contentExplorer.metadataViewV2');
     return (
         <div className="bce-content">
             {view === VIEW_ERROR || view === VIEW_SELECTED ? null : <ProgressBar percent={percentLoaded} />}
 
             {isViewEmpty && <EmptyView view={view} isLoading={percentLoaded !== 100} />}
-            {!isFeatureEnabled(features, 'contentExplorer.metadataViewV2') && !isViewEmpty && isMetadataBasedView && (
+            {!isMetadataViewV2Feature && !isViewEmpty && isMetadataBasedView && (
                 <MetadataBasedItemList
                     currentCollection={currentCollection}
                     fieldsToShow={fieldsToShow}
@@ -79,9 +79,7 @@ const Content = ({
                     {...rest}
                 />
             )}
-            {isFeatureEnabled(features, 'contentExplorer.metadataViewV2') && !isViewEmpty && isMetadataBasedView && (
-                <MetadataView />
-            )}
+            {isMetadataViewV2Feature && !isViewEmpty && isMetadataBasedView && <MetadataView />}
             {!isViewEmpty && isListView && (
                 <ItemList
                     items={items}

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -1649,32 +1649,30 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
                     <div id={this.id} className={styleClassName} ref={measureRef} data-testid="content-explorer">
                         <ThemingStyles selector={`#${this.id}`} theme={theme} />
                         <div className="be-app-element" onKeyDown={this.onKeyDown} tabIndex={0}>
-                            {!isDefaultViewMetadata && (
-                                <>
-                                    <Header view={view} logoUrl={logoUrl} onSearch={this.search} />
-                                    <SubHeader
-                                        view={view}
-                                        viewMode={viewMode}
-                                        rootId={rootFolderId}
-                                        isSmall={isSmall}
-                                        rootName={rootName}
-                                        currentCollection={currentCollection}
-                                        canUpload={allowUpload}
-                                        canCreateNewFolder={allowCreate}
-                                        gridColumnCount={gridColumnCount}
-                                        gridMaxColumns={GRID_VIEW_MAX_COLUMNS}
-                                        gridMinColumns={GRID_VIEW_MIN_COLUMNS}
-                                        maxGridColumnCountForWidth={maxGridColumnCount}
-                                        onUpload={this.upload}
-                                        onCreate={this.createFolder}
-                                        onGridViewSliderChange={this.onGridViewSliderChange}
-                                        onItemClick={this.fetchFolder}
-                                        onSortChange={this.sort}
-                                        onViewModeChange={this.changeViewMode}
-                                        portalElement={this.rootElement}
-                                    />
-                                </>
-                            )}
+                            {!isDefaultViewMetadata && <Header view={view} logoUrl={logoUrl} onSearch={this.search} />}
+
+                            <SubHeader
+                                view={view}
+                                viewMode={viewMode}
+                                rootId={rootFolderId}
+                                isSmall={isSmall}
+                                rootName={rootName}
+                                currentCollection={currentCollection}
+                                canUpload={allowUpload}
+                                canCreateNewFolder={allowCreate}
+                                gridColumnCount={gridColumnCount}
+                                gridMaxColumns={GRID_VIEW_MAX_COLUMNS}
+                                gridMinColumns={GRID_VIEW_MIN_COLUMNS}
+                                maxGridColumnCountForWidth={maxGridColumnCount}
+                                onUpload={this.upload}
+                                onCreate={this.createFolder}
+                                onGridViewSliderChange={this.onGridViewSliderChange}
+                                onItemClick={this.fetchFolder}
+                                onSortChange={this.sort}
+                                onViewModeChange={this.changeViewMode}
+                                portalElement={this.rootElement}
+                            />
+
                             <Content
                                 canDelete={canDelete}
                                 canDownload={canDownload}


### PR DESCRIPTION

<img width="684" height="167" alt="image" src="https://github.com/user-attachments/assets/9eb1684e-88f7-4022-8edf-6a5e085a8481" />


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "Metadata" button in the sub-header for the metadata view when the related feature flag is enabled.
  * Added localization support for the "Metadata" button label.

* **Bug Fixes**
  * Improved conditional rendering of header and sub-header components based on the current view and feature flags.

* **Tests**
  * Enhanced tests to verify the presence of the "Metadata" button and the absence of other controls when the feature flag is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->