### PR TITLE
feat(router): optional router in SidebarNav, SidebarNavTablist

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1812,6 +1812,8 @@ boxui.shareMenu.shortcutOnly = Shortcut Only
 boxui.shareMenu.viewAndDownload = View and Download
 # Description of permissions granted to users who have access to the shared link
 boxui.shareMenu.viewOnly = View Only
+# Text for metadata button that will open the metadata side panel
+boxui.subHeader.metadata = Metadata
 # Error message for empty time formats. "HH:MM A" should be localized.
 boxui.timeInput.emptyTimeError = Required field. Enter a time in the format HH:MM A.
 # Error message for invalid time formats. "HH:MM A" should be localized.

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -111,11 +111,8 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.BOXAI}
                             data-target-id="SidebarNavButton-boxAI"
                             data-testid="sidebarboxai"
-                            internalSidebarNavigation={internalSidebarNavigation}
-                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             isDisabled={showOnlyBoxAINavButton}
                             onClick={handleSidebarNavButtonClick}
-                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_BOXAI}
                             tooltip={
                                 showOnlyBoxAINavButton
@@ -131,10 +128,7 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.ACTIVITY}
                             data-target-id="SidebarNavButton-activity"
                             data-testid="sidebaractivity"
-                            internalSidebarNavigation={internalSidebarNavigation}
-                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
-                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_ACTIVITY}
                             tooltip={intl.formatMessage(messages.sidebarActivityTitle)}
                         >
@@ -146,10 +140,7 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.DETAILS}
                             data-target-id="SidebarNavButton-details"
                             data-testid="sidebardetails"
-                            internalSidebarNavigation={internalSidebarNavigation}
-                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
-                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_DETAILS}
                             tooltip={intl.formatMessage(messages.sidebarDetailsTitle)}
                         >
@@ -161,10 +152,7 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.SKILLS}
                             data-target-id="SidebarNavButton-skills"
                             data-testid="sidebarskills"
-                            internalSidebarNavigation={internalSidebarNavigation}
-                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
-                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_SKILLS}
                             tooltip={intl.formatMessage(messages.sidebarSkillsTitle)}
                         >
@@ -176,10 +164,7 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.METADATA}
                             data-target-id="SidebarNavButton-metadata"
                             data-testid="sidebarmetadata"
-                            internalSidebarNavigation={internalSidebarNavigation}
-                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
-                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_METADATA}
                             tooltip={intl.formatMessage(messages.sidebarMetadataTitle)}
                         >
@@ -191,10 +176,7 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.DOCGEN}
                             data-target-id="SidebarNavButton-docGen"
                             data-testid="sidebardocgen"
-                            internalSidebarNavigation={internalSidebarNavigation}
-                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
-                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_DOCGEN}
                             tooltip={intl.formatMessage(messages.sidebarDocGenTooltip)}
                         >

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -35,6 +35,7 @@ import {
 } from '../../constants';
 import { useFeatureConfig } from '../common/feature-checking';
 import type { NavigateOptions, AdditionalSidebarTab } from './flowTypes';
+import type { InternalSidebarNavigation, InternalSidebarNavigationHandler } from '../common/types/SidebarNavigation';
 import './SidebarNav.scss';
 import type { SignSidebarProps } from './SidebarNavSign';
 
@@ -49,10 +50,13 @@ type Props = {
     hasDocGen?: boolean,
     hasMetadata: boolean,
     hasSkills: boolean,
+    internalSidebarNavigation?: InternalSidebarNavigation,
+    internalSidebarNavigationHandler?: InternalSidebarNavigationHandler,
     intl: IntlShape,
     isOpen?: boolean,
     onNavigate?: (SyntheticEvent<>, NavigateOptions) => void,
     onPanelChange?: (name: string, isInitialState: boolean) => void,
+    routerDisabled?: boolean,
     signSidebarProps: SignSidebarProps,
 };
 
@@ -67,10 +71,13 @@ const SidebarNav = ({
     hasMetadata,
     hasSkills,
     hasDocGen = false,
+    internalSidebarNavigation,
+    internalSidebarNavigationHandler,
     intl,
     isOpen,
     onNavigate,
     onPanelChange = noop,
+    routerDisabled,
     signSidebarProps,
 }: Props) => {
     const { enabled: hasBoxSign } = signSidebarProps || {};
@@ -91,14 +98,24 @@ const SidebarNav = ({
     return (
         <div className="bcs-SidebarNav" aria-label={intl.formatMessage(messages.sidebarNavLabel)}>
             <div className="bcs-SidebarNav-tabs">
-                <SidebarNavTablist elementId={elementId} isOpen={isOpen} onNavigate={onNavigate}>
+                <SidebarNavTablist
+                    elementId={elementId}
+                    internalSidebarNavigation={internalSidebarNavigation}
+                    internalSidebarNavigationHandler={internalSidebarNavigationHandler}
+                    isOpen={isOpen}
+                    onNavigate={onNavigate}
+                    routerDisabled={routerDisabled}
+                >
                     {hasBoxAI && (
                         <SidebarNavButton
                             data-resin-target={SIDEBAR_NAV_TARGETS.BOXAI}
                             data-target-id="SidebarNavButton-boxAI"
                             data-testid="sidebarboxai"
+                            internalSidebarNavigation={internalSidebarNavigation}
+                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             isDisabled={showOnlyBoxAINavButton}
                             onClick={handleSidebarNavButtonClick}
+                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_BOXAI}
                             tooltip={
                                 showOnlyBoxAINavButton
@@ -114,7 +131,10 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.ACTIVITY}
                             data-target-id="SidebarNavButton-activity"
                             data-testid="sidebaractivity"
+                            internalSidebarNavigation={internalSidebarNavigation}
+                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
+                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_ACTIVITY}
                             tooltip={intl.formatMessage(messages.sidebarActivityTitle)}
                         >
@@ -126,7 +146,10 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.DETAILS}
                             data-target-id="SidebarNavButton-details"
                             data-testid="sidebardetails"
+                            internalSidebarNavigation={internalSidebarNavigation}
+                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
+                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_DETAILS}
                             tooltip={intl.formatMessage(messages.sidebarDetailsTitle)}
                         >
@@ -138,7 +161,10 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.SKILLS}
                             data-target-id="SidebarNavButton-skills"
                             data-testid="sidebarskills"
+                            internalSidebarNavigation={internalSidebarNavigation}
+                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
+                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_SKILLS}
                             tooltip={intl.formatMessage(messages.sidebarSkillsTitle)}
                         >
@@ -150,7 +176,10 @@ const SidebarNav = ({
                             data-resin-target={SIDEBAR_NAV_TARGETS.METADATA}
                             data-target-id="SidebarNavButton-metadata"
                             data-testid="sidebarmetadata"
+                            internalSidebarNavigation={internalSidebarNavigation}
+                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
+                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_METADATA}
                             tooltip={intl.formatMessage(messages.sidebarMetadataTitle)}
                         >
@@ -161,7 +190,11 @@ const SidebarNav = ({
                         <SidebarNavButton
                             data-resin-target={SIDEBAR_NAV_TARGETS.DOCGEN}
                             data-target-id="SidebarNavButton-docGen"
+                            data-testid="sidebardocgen"
+                            internalSidebarNavigation={internalSidebarNavigation}
+                            internalSidebarNavigationHandler={internalSidebarNavigationHandler}
                             onClick={handleSidebarNavButtonClick}
+                            routerDisabled={routerDisabled}
                             sidebarView={SIDEBAR_VIEW_DOCGEN}
                             tooltip={intl.formatMessage(messages.sidebarDocGenTooltip)}
                         >
@@ -177,13 +210,18 @@ const SidebarNav = ({
                 )}
 
                 {hasAdditionalTabs && (
-                    <div className="bcs-SidebarNav-overflow">
+                    <div className="bcs-SidebarNav-overflow" data-testid="additional-tabs-overflow">
                         <AdditionalTabs key={fileId} tabs={additionalTabs} />
                     </div>
                 )}
             </div>
             <div className="bcs-SidebarNav-footer">
-                <SidebarToggle isOpen={isOpen} />
+                <SidebarToggle
+                    internalSidebarNavigation={internalSidebarNavigation}
+                    internalSidebarNavigationHandler={internalSidebarNavigationHandler}
+                    isOpen={isOpen}
+                    routerDisabled={routerDisabled}
+                />
             </div>
         </div>
     );

--- a/src/elements/content-sidebar/SidebarNavTablist.js
+++ b/src/elements/content-sidebar/SidebarNavTablist.js
@@ -54,8 +54,8 @@ const SidebarNavTablist = ({
                 return;
         }
 
-        const nextSidebar = tablist[nextIndex];
-        history.push(`/${nextSidebar}`);
+        const nextTab = tablist[nextIndex];
+        history.push(`/${nextTab}`);
 
         if (refs.length > nextIndex) {
             refs[nextIndex].focus();
@@ -68,8 +68,8 @@ const SidebarNavTablist = ({
     const handleKeyDownWithoutRouter = (event: SyntheticKeyboardEvent<>): void => {
         if (!internalSidebarNavigationHandler) return;
 
-        const currentSidebar = internalSidebarNavigation?.sidebar;
-        const currentIndex = tablist.indexOf(currentSidebar);
+        const currentTab = internalSidebarNavigation?.sidebar;
+        const currentIndex = tablist.indexOf(currentTab);
         const { length } = tablist;
         let nextIndex = currentIndex;
 
@@ -84,9 +84,9 @@ const SidebarNavTablist = ({
                 return;
         }
 
-        const nextSidebar = tablist[nextIndex];
+        const nextTab = tablist[nextIndex];
         internalSidebarNavigationHandler({
-            sidebar: nextSidebar,
+            sidebar: nextTab,
         });
 
         if (refs.length > nextIndex) {

--- a/src/elements/content-sidebar/__tests__/SidebarNav.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNav.test.js
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import userEvent from '@testing-library/user-event';
 import { usePromptFocus } from '@box/box-ai-content-answers';
 
 import FeatureProvider from '../../common/feature-checking/FeatureProvider';
 import SidebarNav from '../SidebarNav';
 
-import { render, screen } from '../../../test-utils/testing-library';
+import { render, screen, userEvent } from '../../../test-utils/testing-library';
 
 jest.mock('@box/box-ai-content-answers');
 
@@ -70,6 +69,8 @@ describe('elements/content-sidebar/SidebarNav', () => {
         `(
             'given feature boxai.sidebar.showOnlyNavButton = true and boxai.sidebar.disabledTooltip = $disabledTooltip, should render box ai tab with disabled state and tooltip = $expectedTooltip',
             async ({ disabledTooltip, expectedTooltip }) => {
+                const user = userEvent();
+
                 renderSidebarNav({
                     features: { boxai: { sidebar: { disabledTooltip, showOnlyNavButton: true } } },
                     props: { hasBoxAI: true },
@@ -77,7 +78,7 @@ describe('elements/content-sidebar/SidebarNav', () => {
 
                 const button = screen.getByTestId('sidebarboxai');
 
-                await userEvent.hover(button);
+                await user.hover(button);
 
                 expect(button).toHaveAttribute('aria-disabled', 'true');
                 expect(screen.getByText(expectedTooltip)).toBeInTheDocument();
@@ -85,6 +86,8 @@ describe('elements/content-sidebar/SidebarNav', () => {
         );
 
         test('given feature boxai.sidebar.showOnlyNavButton = false, should render box ai tab with default tooltip', async () => {
+            const user = userEvent();
+
             renderSidebarNav({
                 features: { boxai: { sidebar: { showOnlyNavButton: false } } },
                 props: { hasBoxAI: true },
@@ -92,7 +95,7 @@ describe('elements/content-sidebar/SidebarNav', () => {
 
             const button = screen.getByTestId('sidebarboxai');
 
-            await userEvent.hover(button);
+            await user.hover(button);
 
             expect(button).not.toHaveAttribute('aria-disabled');
             expect(screen.getByText('Box AI')).toBeInTheDocument();
@@ -100,6 +103,8 @@ describe('elements/content-sidebar/SidebarNav', () => {
     });
 
     test('should call focusBoxAISidebarPrompt when clicked on Box AI Tab', async () => {
+        const user = userEvent();
+
         renderSidebarNav({
             features: {
                 boxai: {
@@ -113,7 +118,7 @@ describe('elements/content-sidebar/SidebarNav', () => {
 
         const button = screen.getByTestId('sidebarboxai');
 
-        await userEvent.click(button);
+        await user.click(button);
 
         expect(usePromptFocus).toHaveBeenCalledTimes(1);
         expect(usePromptFocus).toHaveBeenCalledWith('.be.bcs');

--- a/src/elements/content-sidebar/__tests__/SidebarNav.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNav.test.js
@@ -1,21 +1,11 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
-import { mount } from 'enzyme';
-import { BoxAiLogo } from '@box/blueprint-web-assets/icons/Logo';
 import { usePromptFocus } from '@box/box-ai-content-answers';
-import AdditionalTabPlaceholder from '../additional-tabs/AdditionalTabPlaceholder';
-import AdditionalTabs from '../additional-tabs';
-import AdditionalTabsLoading from '../additional-tabs/AdditionalTabsLoading';
+
 import FeatureProvider from '../../common/feature-checking/FeatureProvider';
-import DocGenIcon from '../../../icon/fill/DocGenIcon';
-import IconChatRound from '../../../icons/general/IconChatRound';
-import IconDocInfo from '../../../icons/general/IconDocInfo';
-import IconMagicWand from '../../../icons/general/IconMagicWand';
-import IconMetadataThick from '../../../icons/general/IconMetadataThick';
 import SidebarNav from '../SidebarNav';
-import SidebarNavButton from '../SidebarNavButton';
-import SidebarNavSignButton from '../SidebarNavSignButton';
+
 import { render, screen } from '../../../test-utils/testing-library';
 
 jest.mock('@box/box-ai-content-answers');
@@ -29,83 +19,46 @@ describe('elements/content-sidebar/SidebarNav', () => {
         });
     });
 
-    const getWrapper = (props = {}, active = '', features = {}) =>
-        mount(
-            <MemoryRouter initialEntries={[`/${active}`]}>
+    const renderSidebarNav = ({ path = '/', props = {}, features = {} } = {}) => {
+        return render(
+            <MemoryRouter initialEntries={[path]}>
                 <FeatureProvider features={features}>
                     <SidebarNav {...props} />
                 </FeatureProvider>
             </MemoryRouter>,
-        )
-            .find('SidebarNav')
-            .at(1);
+        );
+    };
 
-    const getSidebarNav = ({ path = '/', props, features }) => (
-        <MemoryRouter initialEntries={[path]}>
-            <FeatureProvider features={features}>
-                <SidebarNav {...props} />
-            </FeatureProvider>
-        </MemoryRouter>
-    );
-
-    test('should render skills tab', () => {
-        const props = {
-            hasSkills: true,
+    describe('individual tab rendering', () => {
+        const TABS_CONFIG = {
+            skills: { testId: 'sidebarskills', propName: 'hasSkills' },
+            details: { testId: 'sidebardetails', propName: 'hasDetails' },
+            activity: { testId: 'sidebaractivity', propName: 'hasActivity' },
+            metadata: { testId: 'sidebarmetadata', propName: 'hasMetadata' },
+            boxai: { testId: 'sidebarboxai', propName: 'hasBoxAI' },
+            docgen: { testId: 'sidebardocgen', propName: 'hasDocGen' },
         };
-        const wrapper = getWrapper(props);
-        expect(wrapper.find(BoxAiLogo)).toHaveLength(0);
-        expect(wrapper.find(IconMagicWand)).toHaveLength(1);
-        expect(wrapper.find(IconMetadataThick)).toHaveLength(0);
-        expect(wrapper.find(IconDocInfo)).toHaveLength(0);
-        expect(wrapper.find(IconChatRound)).toHaveLength(0);
-    });
 
-    test('should render details tab', () => {
-        const props = {
-            hasDetails: true,
-        };
-        const wrapper = getWrapper(props);
-        expect(wrapper.find(BoxAiLogo)).toHaveLength(0);
-        expect(wrapper.find(IconMagicWand)).toHaveLength(0);
-        expect(wrapper.find(IconMetadataThick)).toHaveLength(0);
-        expect(wrapper.find(IconDocInfo)).toHaveLength(1);
-        expect(wrapper.find(IconChatRound)).toHaveLength(0);
-    });
+        const tabNames = Object.keys(TABS_CONFIG);
 
-    test('should render activity tab', () => {
-        const props = {
-            hasActivity: true,
-        };
-        const wrapper = getWrapper(props);
-        expect(wrapper.find(BoxAiLogo)).toHaveLength(0);
-        expect(wrapper.find(IconMagicWand)).toHaveLength(0);
-        expect(wrapper.find(IconMetadataThick)).toHaveLength(0);
-        expect(wrapper.find(IconDocInfo)).toHaveLength(0);
-        expect(wrapper.find(IconChatRound)).toHaveLength(1);
-    });
+        test.each(tabNames)('should render %s tab', tabName => {
+            const { testId, propName } = TABS_CONFIG[tabName];
 
-    test('should render metadata tab', () => {
-        const props = {
-            hasMetadata: true,
-        };
-        const wrapper = getWrapper(props);
-        expect(wrapper.find(BoxAiLogo)).toHaveLength(0);
-        expect(wrapper.find(IconMagicWand)).toHaveLength(0);
-        expect(wrapper.find(IconMetadataThick)).toHaveLength(1);
-        expect(wrapper.find(IconDocInfo)).toHaveLength(0);
-        expect(wrapper.find(IconChatRound)).toHaveLength(0);
-    });
+            renderSidebarNav({
+                props: {
+                    [propName]: true,
+                },
+            });
 
-    test('should render box ai tab', () => {
-        const props = {
-            hasBoxAI: true,
-        };
-        const wrapper = getWrapper(props);
-        expect(wrapper.find(BoxAiLogo)).toHaveLength(1);
-        expect(wrapper.find(IconMagicWand)).toHaveLength(0);
-        expect(wrapper.find(IconMetadataThick)).toHaveLength(0);
-        expect(wrapper.find(IconDocInfo)).toHaveLength(0);
-        expect(wrapper.find(IconChatRound)).toHaveLength(0);
+            expect(screen.getByTestId(testId)).toBeInTheDocument();
+
+            tabNames
+                .filter(name => name !== tabName)
+                .forEach(otherTabName => {
+                    const otherTab = TABS_CONFIG[otherTabName];
+                    expect(screen.queryByTestId(otherTab.testId)).not.toBeInTheDocument();
+                });
+        });
     });
 
     describe('should render box ai tab with correct disabled state and tooltip', () => {
@@ -116,12 +69,10 @@ describe('elements/content-sidebar/SidebarNav', () => {
         `(
             'given feature boxai.sidebar.showOnlyNavButton = true and boxai.sidebar.disabledTooltip = $disabledTooltip, should render box ai tab with disabled state and tooltip = $expectedTooltip',
             async ({ disabledTooltip, expectedTooltip }) => {
-                render(
-                    getSidebarNav({
-                        features: { boxai: { sidebar: { disabledTooltip, showOnlyNavButton: true } } },
-                        props: { hasBoxAI: true },
-                    }),
-                );
+                renderSidebarNav({
+                    features: { boxai: { sidebar: { disabledTooltip, showOnlyNavButton: true } } },
+                    props: { hasBoxAI: true },
+                });
 
                 const button = screen.getByTestId('sidebarboxai');
 
@@ -133,12 +84,10 @@ describe('elements/content-sidebar/SidebarNav', () => {
         );
 
         test('given feature boxai.sidebar.showOnlyNavButton = false, should render box ai tab with default tooltip', async () => {
-            render(
-                getSidebarNav({
-                    features: { boxai: { sidebar: { showOnlyNavButton: false } } },
-                    props: { hasBoxAI: true },
-                }),
-            );
+            renderSidebarNav({
+                features: { boxai: { sidebar: { showOnlyNavButton: false } } },
+                props: { hasBoxAI: true },
+            });
 
             const button = screen.getByTestId('sidebarboxai');
 
@@ -150,18 +99,16 @@ describe('elements/content-sidebar/SidebarNav', () => {
     });
 
     test('should call focusBoxAISidebarPrompt when clicked on Box AI Tab', async () => {
-        render(
-            getSidebarNav({
-                features: {
-                    boxai: {
-                        sidebar: {
-                            showOnlyNavButton: false,
-                        },
+        renderSidebarNav({
+            features: {
+                boxai: {
+                    sidebar: {
+                        showOnlyNavButton: false,
                     },
                 },
-                props: { hasBoxAI: true },
-            }),
-        );
+            },
+            props: { hasBoxAI: true },
+        });
 
         const button = screen.getByTestId('sidebarboxai');
 
@@ -175,53 +122,52 @@ describe('elements/content-sidebar/SidebarNav', () => {
     });
 
     test('should have multiple tabs', () => {
-        const props = {
-            hasActivity: true,
-            hasBoxAI: true,
-            hasMetadata: true,
-            hasSkills: true,
-        };
-        const wrapper = getWrapper(props, 'activity');
-        expect(wrapper.find(IconMagicWand)).toHaveLength(1);
-        expect(wrapper.find(IconMetadataThick)).toHaveLength(1);
-        expect(wrapper.find(IconDocInfo)).toHaveLength(0);
-        expect(wrapper.find(IconChatRound)).toHaveLength(1);
-        expect(wrapper.find(BoxAiLogo)).toHaveLength(1);
-        expect(wrapper.find(SidebarNavButton)).toHaveLength(4);
+        renderSidebarNav({
+            path: '/activity',
+            props: {
+                hasActivity: true,
+                hasBoxAI: true,
+                hasMetadata: true,
+                hasSkills: true,
+            },
+        });
+
+        expect(screen.getByTestId('sidebaractivity')).toBeInTheDocument();
+        expect(screen.getByTestId('sidebarboxai')).toBeInTheDocument();
+        expect(screen.getByTestId('sidebarmetadata')).toBeInTheDocument();
+        expect(screen.getByTestId('sidebarskills')).toBeInTheDocument();
+
+        expect(screen.queryByTestId('sidebardetails')).not.toBeInTheDocument();
+
+        const navButtons = screen.getAllByRole('tab');
+        expect(navButtons).toHaveLength(4);
     });
 
     test('should render the additional tabs loading state', () => {
-        const props = {
-            additionalTabs: [],
-            hasAdditionalTabs: true,
-        };
-        const wrapper = getWrapper(props);
-        expect(wrapper.find(AdditionalTabs)).toHaveLength(1);
-        expect(wrapper.find(AdditionalTabsLoading)).toHaveLength(1);
-        expect(wrapper.find(AdditionalTabPlaceholder)).toHaveLength(5);
+        renderSidebarNav({
+            props: {
+                additionalTabs: [],
+                hasAdditionalTabs: true,
+            },
+        });
+
+        expect(screen.getByTestId('additional-tabs-overflow')).toBeInTheDocument();
+
+        const placeholders = screen.getAllByTestId('additionaltabplaceholder');
+        expect(placeholders).toHaveLength(5);
     });
 
     test('should render the Box Sign entry point if its feature is enabled', () => {
-        const props = {
-            signSidebarProps: {
-                enabled: true,
-                onClick: () => {},
+        renderSidebarNav({
+            props: {
+                signSidebarProps: {
+                    enabled: true,
+                    onClick: () => {},
+                },
             },
-        };
-        const wrapper = getWrapper(props);
+        });
 
-        expect(wrapper.exists(SidebarNavSignButton)).toBe(true);
-    });
-    test('should render docgen tab', () => {
-        const props = {
-            hasDocGen: true,
-        };
-        const wrapper = getWrapper(props);
-        expect(wrapper.find(IconMagicWand)).toHaveLength(0);
-        expect(wrapper.find(IconMetadataThick)).toHaveLength(0);
-        expect(wrapper.find(IconDocInfo)).toHaveLength(0);
-        expect(wrapper.find(IconChatRound)).toHaveLength(0);
-        expect(wrapper.find(BoxAiLogo)).toHaveLength(0);
-        expect(wrapper.find(DocGenIcon)).toHaveLength(1);
+        const boxSignSection = screen.getByRole('button', { name: /sign/i });
+        expect(boxSignSection).toBeInTheDocument();
     });
 });

--- a/src/elements/content-sidebar/__tests__/SidebarNav.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNav.test.js
@@ -14,6 +14,7 @@ describe('elements/content-sidebar/SidebarNav', () => {
     const focusBoxAISidebarPromptMock = jest.fn();
 
     beforeEach(() => {
+        jest.clearAllMocks();
         usePromptFocus.mockReturnValue({
             focusPrompt: focusBoxAISidebarPromptMock,
         });

--- a/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useHistory } from 'react-router-dom';
 import { render, screen, userEvent } from '../../../test-utils/testing-library';
 import SidebarNavTablist from '../SidebarNavTablist';
 import {
@@ -46,7 +46,7 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
         let historyRef;
 
         const HistoryCapture = () => {
-            const history = require('react-router-dom').useHistory();
+            const history = useHistory();
             historyRef = history;
             return null;
         };

--- a/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { createMemoryHistory } from 'history';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent } from '../../../test-utils/testing-library';
 import SidebarNavTablist from '../SidebarNavTablist';
 import {
     SIDEBAR_VIEW_SKILLS,
@@ -9,59 +10,169 @@ import {
     KEYS,
 } from '../../../constants';
 
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    withRouter: Component => Component,
-}));
+const MockTabComponent = React.forwardRef(
+    (
+        {
+            sidebarView,
+            elementId,
+            internalSidebarNavigation,
+            internalSidebarNavigationHandler,
+            isOpen,
+            onNavigate,
+            routerDisabled,
+            ...otherProps
+        },
+        ref,
+    ) => (
+        <button ref={ref} data-testid={`tab-${sidebarView}`} {...otherProps}>
+            {sidebarView}
+        </button>
+    ),
+);
 
 describe('elements/content-sidebar/SidebarNavTablist', () => {
-    test('should correctly render children', () => {
-        const MockChildren = () => <div />;
+    let testHistory;
 
-        const wrapper = shallow(
-            <SidebarNavTablist>
-                <MockChildren />
-            </SidebarNavTablist>,
-        );
-
-        expect(wrapper.type()).toEqual('div');
-        expect(wrapper.hasClass('bcs-SidebarNav-main')).toBe(true);
-        expect(wrapper.exists(MockChildren)).toBe(true);
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
-    describe('handleKeyDown', () => {
+    const renderSidebarNavTablist = ({
+        path = '/',
+        props = {},
+        children = [<MockTabComponent key="test" sidebarView="test" />],
+    } = {}) => {
+        let historyRef;
+
+        const HistoryCapture = () => {
+            const history = require('react-router-dom').useHistory();
+            historyRef = history;
+            return null;
+        };
+
+        const result = render(
+            <MemoryRouter initialEntries={[path]}>
+                <HistoryCapture />
+                <SidebarNavTablist {...props}>{children}</SidebarNavTablist>
+            </MemoryRouter>,
+        );
+
+        testHistory = historyRef;
+        return result;
+    };
+
+    test('should correctly render children', () => {
+        renderSidebarNavTablist({
+            props: { routerDisabled: false },
+            children: [<MockTabComponent key="test" sidebarView="test" />],
+        });
+
+        expect(screen.getByRole('tablist')).toBeInTheDocument();
+        expect(screen.getByTestId('tab-test')).toBeInTheDocument();
+    });
+
+    describe('handleKeyDown with router', () => {
         const viewList = [SIDEBAR_VIEW_ACTIVITY, SIDEBAR_VIEW_DETAILS, SIDEBAR_VIEW_SKILLS, SIDEBAR_VIEW_METADATA];
 
         test.each`
-            key                | route
-            ${KEYS.arrowUp}    | ${SIDEBAR_VIEW_ACTIVITY}
-            ${KEYS.arrowDown}  | ${SIDEBAR_VIEW_SKILLS}
-            ${KEYS.arrowRight} | ${SIDEBAR_VIEW_DETAILS}
-        `('should navigate to right sidebar panels when a user presses different arrow keys', ({ key, route }) => {
-            const history = createMemoryHistory({
-                initialEntries: [`/${SIDEBAR_VIEW_DETAILS}`],
+            key               | expectedPath
+            ${KEYS.arrowUp}   | ${`/${SIDEBAR_VIEW_ACTIVITY}`}
+            ${KEYS.arrowDown} | ${`/${SIDEBAR_VIEW_SKILLS}`}
+        `('should navigate to $expectedPath when user presses $key', async ({ key, expectedPath }) => {
+            const children = viewList.map(view => <MockTabComponent sidebarView={view} key={view} />);
+
+            renderSidebarNavTablist({
+                path: `/${SIDEBAR_VIEW_DETAILS}`,
+                props: { routerDisabled: false },
+                children,
             });
 
-            const wrapper = shallow(
-                <SidebarNavTablist history={history}>
-                    {viewList.map(view => {
-                        return <div sidebarView={view} key={view} />;
-                    })}
-                </SidebarNavTablist>,
-            );
+            const tablist = screen.getByRole('tablist');
 
-            const event = {
-                key,
-                preventDefault: jest.fn(),
-                stopPropagation: jest.fn(),
+            tablist.focus();
+            fireEvent.keyDown(tablist, { key });
+
+            expect(testHistory.location.pathname).toBe(expectedPath);
+        });
+
+        test('should not navigate when user presses arrow right', async () => {
+            const children = viewList.map(view => <MockTabComponent sidebarView={view} key={view} />);
+
+            renderSidebarNavTablist({
+                path: `/${SIDEBAR_VIEW_DETAILS}`,
+                props: { routerDisabled: false },
+                children,
+            });
+
+            const tablist = screen.getByRole('tablist');
+
+            tablist.focus();
+            fireEvent.keyDown(tablist, { key: KEYS.arrowRight });
+
+            expect(testHistory.location.pathname).toBe(`/${SIDEBAR_VIEW_DETAILS}`);
+        });
+    });
+
+    describe('handleKeyDown with routerDisabled', () => {
+        const viewList = [SIDEBAR_VIEW_ACTIVITY, SIDEBAR_VIEW_DETAILS, SIDEBAR_VIEW_SKILLS, SIDEBAR_VIEW_METADATA];
+
+        test.each`
+            key               | expectedView
+            ${KEYS.arrowUp}   | ${SIDEBAR_VIEW_ACTIVITY}
+            ${KEYS.arrowDown} | ${SIDEBAR_VIEW_SKILLS}
+        `(
+            'should use internal navigation when routerDisabled=true and user presses $key',
+            async ({ key, expectedView }) => {
+                const mockInternalSidebarNavigationHandler = jest.fn();
+                const internalSidebarNavigation = {
+                    sidebar: SIDEBAR_VIEW_DETAILS,
+                };
+
+                const children = viewList.map(view => <MockTabComponent sidebarView={view} key={view} />);
+
+                renderSidebarNavTablist({
+                    props: {
+                        routerDisabled: true,
+                        internalSidebarNavigation,
+                        internalSidebarNavigationHandler: mockInternalSidebarNavigationHandler,
+                    },
+                    children,
+                });
+
+                const tablist = screen.getByRole('tablist');
+
+                tablist.focus();
+                fireEvent.keyDown(tablist, { key });
+
+                expect(mockInternalSidebarNavigationHandler).toHaveBeenCalledWith({
+                    sidebar: expectedView,
+                });
+            },
+        );
+
+        test('should not call internal navigation handler when user presses arrow right', async () => {
+            const mockInternalSidebarNavigationHandler = jest.fn();
+            const internalSidebarNavigation = {
+                sidebar: SIDEBAR_VIEW_DETAILS,
             };
-            wrapper.props().onKeyDown(event);
 
-            if (key === KEYS.arrowUp || key === KEYS.arrowDown) {
-                expect(event.preventDefault).toBeCalled();
-                expect(event.stopPropagation).toBeCalled();
-            }
-            expect(history.location.pathname).toBe(`/${route}`);
+            const children = viewList.map(view => <MockTabComponent sidebarView={view} key={view} />);
+
+            renderSidebarNavTablist({
+                props: {
+                    routerDisabled: true,
+                    internalSidebarNavigation,
+                    internalSidebarNavigationHandler: mockInternalSidebarNavigationHandler,
+                },
+                children,
+            });
+
+            const tablist = screen.getByRole('tablist');
+
+            tablist.focus();
+            fireEvent.keyDown(tablist, { key: KEYS.arrowRight });
+
+            expect(mockInternalSidebarNavigationHandler).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen, fireEvent } from '../../../test-utils/testing-library';
+import { render, screen, userEvent } from '../../../test-utils/testing-library';
 import SidebarNavTablist from '../SidebarNavTablist';
 import {
     SIDEBAR_VIEW_SKILLS,
@@ -31,6 +31,7 @@ const MockTabComponent = React.forwardRef(
 );
 
 describe('elements/content-sidebar/SidebarNavTablist', () => {
+    const viewList = [SIDEBAR_VIEW_ACTIVITY, SIDEBAR_VIEW_DETAILS, SIDEBAR_VIEW_SKILLS, SIDEBAR_VIEW_METADATA];
     let testHistory;
 
     beforeEach(() => {
@@ -72,13 +73,12 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
     });
 
     describe('handleKeyDown with router', () => {
-        const viewList = [SIDEBAR_VIEW_ACTIVITY, SIDEBAR_VIEW_DETAILS, SIDEBAR_VIEW_SKILLS, SIDEBAR_VIEW_METADATA];
-
         test.each`
             key               | expectedPath
             ${KEYS.arrowUp}   | ${`/${SIDEBAR_VIEW_ACTIVITY}`}
             ${KEYS.arrowDown} | ${`/${SIDEBAR_VIEW_SKILLS}`}
         `('should navigate to $expectedPath when user presses $key', async ({ key, expectedPath }) => {
+            const user = userEvent();
             const children = viewList.map(view => <MockTabComponent sidebarView={view} key={view} />);
 
             renderSidebarNavTablist({
@@ -89,13 +89,14 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
 
             const tablist = screen.getByRole('tablist');
 
-            tablist.focus();
-            fireEvent.keyDown(tablist, { key });
+            await user.click(tablist);
+            await user.keyboard(`{${key}}`);
 
             expect(testHistory.location.pathname).toBe(expectedPath);
         });
 
         test('should not navigate when user presses arrow right', async () => {
+            const user = userEvent();
             const children = viewList.map(view => <MockTabComponent sidebarView={view} key={view} />);
 
             renderSidebarNavTablist({
@@ -106,16 +107,14 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
 
             const tablist = screen.getByRole('tablist');
 
-            tablist.focus();
-            fireEvent.keyDown(tablist, { key: KEYS.arrowRight });
+            await user.click(tablist);
+            await user.keyboard(`{${KEYS.arrowRight}}`);
 
             expect(testHistory.location.pathname).toBe(`/${SIDEBAR_VIEW_DETAILS}`);
         });
     });
 
     describe('handleKeyDown with routerDisabled', () => {
-        const viewList = [SIDEBAR_VIEW_ACTIVITY, SIDEBAR_VIEW_DETAILS, SIDEBAR_VIEW_SKILLS, SIDEBAR_VIEW_METADATA];
-
         test.each`
             key               | expectedView
             ${KEYS.arrowUp}   | ${SIDEBAR_VIEW_ACTIVITY}
@@ -123,6 +122,7 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
         `(
             'should use internal navigation when routerDisabled=true and user presses $key',
             async ({ key, expectedView }) => {
+                const user = userEvent();
                 const mockInternalSidebarNavigationHandler = jest.fn();
                 const internalSidebarNavigation = {
                     sidebar: SIDEBAR_VIEW_DETAILS,
@@ -141,8 +141,8 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
 
                 const tablist = screen.getByRole('tablist');
 
-                tablist.focus();
-                fireEvent.keyDown(tablist, { key });
+                await user.click(tablist);
+                await user.keyboard(`{${key}}`);
 
                 expect(mockInternalSidebarNavigationHandler).toHaveBeenCalledWith({
                     sidebar: expectedView,
@@ -151,6 +151,7 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
         );
 
         test('should not call internal navigation handler when user presses arrow right', async () => {
+            const user = userEvent();
             const mockInternalSidebarNavigationHandler = jest.fn();
             const internalSidebarNavigation = {
                 sidebar: SIDEBAR_VIEW_DETAILS,
@@ -169,8 +170,8 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
 
             const tablist = screen.getByRole('tablist');
 
-            tablist.focus();
-            fireEvent.keyDown(tablist, { key: KEYS.arrowRight });
+            await user.click(tablist);
+            await user.keyboard(`{${KEYS.arrowRight}}`);
 
             expect(mockInternalSidebarNavigationHandler).not.toHaveBeenCalled();
         });

--- a/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
+++ b/src/elements/content-sidebar/__tests__/SidebarNavTablist.test.js
@@ -150,6 +150,41 @@ describe('elements/content-sidebar/SidebarNavTablist', () => {
             },
         );
 
+        test.each`
+            currentView              | key               | expectedView
+            ${SIDEBAR_VIEW_ACTIVITY} | ${KEYS.arrowUp}   | ${SIDEBAR_VIEW_METADATA}
+            ${SIDEBAR_VIEW_METADATA} | ${KEYS.arrowDown} | ${SIDEBAR_VIEW_ACTIVITY}
+        `(
+            'should wrap around when navigating beyond tabs range: from $currentView with $key goes to $expectedView',
+            async ({ currentView, key, expectedView }) => {
+                const user = userEvent();
+                const mockInternalSidebarNavigationHandler = jest.fn();
+                const internalSidebarNavigation = {
+                    sidebar: currentView,
+                };
+
+                const children = viewList.map(view => <MockTabComponent sidebarView={view} key={view} />);
+
+                renderSidebarNavTablist({
+                    props: {
+                        routerDisabled: true,
+                        internalSidebarNavigation,
+                        internalSidebarNavigationHandler: mockInternalSidebarNavigationHandler,
+                    },
+                    children,
+                });
+
+                const tablist = screen.getByRole('tablist');
+
+                await user.click(tablist);
+                await user.keyboard(`{${key}}`);
+
+                expect(mockInternalSidebarNavigationHandler).toHaveBeenCalledWith({
+                    sidebar: expectedView,
+                });
+            },
+        );
+
         test('should not call internal navigation handler when user presses arrow right', async () => {
             const user = userEvent();
             const mockInternalSidebarNavigationHandler = jest.fn();


### PR DESCRIPTION
SidebarNav and SidebarNavTablist is now accepting routerDisabled prop and acts accordingly using routing handlers instead of ReactRouter. Tests were converted to RTL and expanded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar navigation now supports both internal navigation and an option to disable routing, offering more flexible navigation control.
  * New data attributes have been added for improved testing and accessibility.
  * Added a new localization string for a metadata button in the sidebar.

* **Tests**
  * Refactored sidebar navigation tests to use React Testing Library instead of Enzyme, improving test reliability and maintainability.
  * Enhanced test coverage for both routing-enabled and routing-disabled navigation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->