### PR TITLE
chore(mergify): Updated mergify config with max-parallel

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,38 +1,43 @@
+merge_queue:
+    max_parallel_checks: 1
+
 pull_request_rules:
-  - name: Automatic merge queue
-    conditions:
-      - -draft
-      - base = master
-    actions:
-      queue:
+    - name: Automatic merge queue
+      conditions:
+          - -draft
+          - base = master
+      actions:
+          queue:
 
 queue_rules:
-  - name: Automatic boxmoji merge
-    queue_conditions:
-      - author = boxmoji
-      - title ~= ^(fix)\(i18n\)?:\supdate translations$
-      - files ~= ^i18n/
-      - label != do-not-merge
-      - status-success = license/cla
-      - status-success = lint_pull_request
-      - status-success = lint_test_build
-    merge_conditions:
-      - status-success = lint_test_build
-    merge_method: squash
+    - name: Automatic boxmoji merge
+      queue_conditions:
+          - author = boxmoji
+          - title ~= ^(fix)\(i18n\)?:\supdate translations$
+          - files ~= ^i18n/
+          - label != do-not-merge
+          - status-success = license/cla
+          - status-success = lint_pull_request
+          - status-success = lint_test_build
+      merge_conditions:
+          - status-success = lint_pull_request
+          - status-success = lint_test_build
+      merge_method: squash
 
-  - name: Automatic strict merge
-    queue_conditions:
-      - title ~= ^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?:\s.+$
-      - label = ready-to-merge
-      - label != do-not-merge
-      - status-success = license/cla
-      - status-success = lint_pull_request
-      - status-success = lint_test_build
-      - branch-protection-review-decision = APPROVED
-      - "#approved-reviews-by >= 2"
-      - "#changes-requested-reviews-by = 0"
-      - "#review-threads-unresolved = 0"
-    merge_conditions:
-      - status-success = license/cla
-      - status-success = lint_test_build
-    merge_method: squash
+    - name: Automatic strict merge
+      queue_conditions:
+          - title ~= ^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?:\s.+$
+          - label = ready-to-merge
+          - label != do-not-merge
+          - status-success = license/cla
+          - status-success = lint_pull_request
+          - status-success = lint_test_build
+          - branch-protection-review-decision = APPROVED
+          - "#approved-reviews-by >= 2"
+          - "#changes-requested-reviews-by = 0"
+          - "#review-threads-unresolved = 0"
+      merge_conditions:
+          - status-success = license/cla
+          - status-success = lint_pull_request
+          - status-success = lint_test_build
+      merge_method: squash


### PR DESCRIPTION
according to https://docs.mergify.com/merge-queue/parallel-checks/ if we set it the `max_parallel_checks` to 1 it wont try to create a new PR to batch commits together

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to improve consistency and add new merge queue settings.
  * Enhanced merge conditions to require successful lint checks before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->