### PR TITLE
fix: Add throttling to createFolderCallback

### DIFF
--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -6,6 +6,7 @@ import debounce from 'lodash/debounce';
 import flow from 'lodash/flow';
 import getProp from 'lodash/get';
 import noop from 'lodash/noop';
+import throttle from 'lodash/throttle';
 import uniqueid from 'lodash/uniqueId';
 import { TooltipProvider } from '@box/blueprint-web';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
@@ -1171,16 +1172,6 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
     };
 
     /**
-     * Creates a new folder
-     *
-     * @private
-     * @return {void}
-     */
-    createFolder = (): void => {
-        this.createFolderCallback();
-    };
-
-    /**
      * New folder callback
      *
      * @private
@@ -1241,6 +1232,22 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
                 });
             },
         );
+    };
+
+    /**
+     * Throttled version of createFolderCallback to prevent errors from rapid clicking.
+     * @param {string} [name] - folder name
+     */
+    throttledCreateFolderCallback = throttle(this.createFolderCallback, 500);
+
+    /**
+     * Creates a new folder
+     *
+     * @private
+     * @return {void}
+     */
+    createFolder = (): void => {
+        this.throttledCreateFolderCallback();
     };
 
     /**
@@ -1738,7 +1745,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
                         {allowCreate && !!this.appElement ? (
                             <CreateFolderDialog
                                 isOpen={isCreateFolderModalOpen}
-                                onCreate={this.createFolderCallback}
+                                onCreate={this.throttledCreateFolderCallback}
                                 onCancel={this.closeModals}
                                 isLoading={isLoading}
                                 errorCode={errorCode}

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -1172,6 +1172,16 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
     };
 
     /**
+     * Creates a new folder
+     *
+     * @private
+     * @return {void}
+     */
+    createFolder = (): void => {
+        this.throttledCreateFolderCallback();
+    };
+
+    /**
      * New folder callback
      *
      * @private
@@ -1239,16 +1249,6 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
      * @param {string} [name] - folder name
      */
     throttledCreateFolderCallback = throttle(this.createFolderCallback, 500);
-
-    /**
-     * Creates a new folder
-     *
-     * @private
-     * @return {void}
-     */
-    createFolder = (): void => {
-        this.throttledCreateFolderCallback();
-    };
 
     /**
      * Selects the clicked file and then shares it


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
