### PR TITLE
fix: Throttle create folder to avoid rapid clicks

### DIFF
--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -6,6 +6,7 @@ import debounce from 'lodash/debounce';
 import flow from 'lodash/flow';
 import getProp from 'lodash/get';
 import noop from 'lodash/noop';
+import throttle from 'lodash/throttle';
 import uniqueid from 'lodash/uniqueId';
 import { TooltipProvider } from '@box/blueprint-web';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
@@ -1177,7 +1178,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
      * @return {void}
      */
     createFolder = (): void => {
-        this.createFolderCallback();
+        this.throttledCreateFolderCallback();
     };
 
     /**
@@ -1242,6 +1243,15 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
             },
         );
     };
+
+    /**
+     * Throttled version of createFolderCallback to prevent errors from rapid clicking.
+     *
+     * @private
+     * @param {string} [name] - folder name
+     * @return {void}
+     */
+    throttledCreateFolderCallback = throttle(this.createFolderCallback, 500, { trailing: false });
 
     /**
      * Selects the clicked file and then shares it
@@ -1736,7 +1746,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
                         {allowCreate && !!this.appElement ? (
                             <CreateFolderDialog
                                 isOpen={isCreateFolderModalOpen}
-                                onCreate={this.createFolderCallback}
+                                onCreate={this.throttledCreateFolderCallback}
                                 onCancel={this.closeModals}
                                 isLoading={isLoading}
                                 errorCode={errorCode}


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder creation process to prevent multiple folders from being created rapidly by limiting how often the create action can be triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->