### PR TITLE
chore(metadata-view): Fix flaky title in subheader

### DIFF
--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -7,6 +7,7 @@ import noop from 'lodash/noop';
 
 import ContentExplorer from '../../ContentExplorer';
 import { DEFAULT_HOSTNAME_API } from '../../../../constants';
+import { mockRootFolder } from '../../../common/__mocks__/mockRootFolder';
 import { mockMetadata, mockSchema } from '../../../common/__mocks__/mockMetadata';
 
 // The intent behind relying on mockMetadata is to allow a developer to paste in their own metadata template schema for use with live API calls.
@@ -179,6 +180,9 @@ const meta: Meta<typeof ContentExplorer> = {
                 }),
                 http.get(`${DEFAULT_HOSTNAME_API}/2.0/metadata_templates/enterprise/templateName/schema`, () => {
                     return HttpResponse.json(mockSchema);
+                }),
+                http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/0`, () => {
+                    return HttpResponse.json(mockRootFolder);
                 }),
             ],
         },


### PR DESCRIPTION

<img width="1224" height="852" alt="Screenshot 2025-08-15 at 10 20 52 AM" src="https://github.com/user-attachments/assets/16e7ad61-7b2d-46de-a2c5-107fdb8bada1" />


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved visual story reliability by adding a mock for the root-folder API used by Metadata View.
  * Consolidated network handlers for metadata queries and schema retrieval in visual tests to reduce flakiness and speed UI feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->