### PR TITLE
feat(metadata-view): custom actions

### DIFF
--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { http, HttpResponse } from 'msw';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Download, SignMeOthers } from '@box/blueprint-web-assets/icons/Fill/index';
@@ -91,13 +90,6 @@ const metadataViewV2ElementProps = {
 
 export const metadataViewV2: Story = {
     args: metadataViewV2ElementProps,
-    render: args => {
-        return (
-            <div style={{ padding: '50px' }}>
-                <ContentExplorer {...args} />
-            </div>
-        );
-    },
 };
 
 export const metadataViewV2WithCustomActions: Story = {
@@ -129,13 +121,6 @@ export const metadataViewV2WithCustomActions: Story = {
                 ],
             },
         },
-    },
-    render: args => {
-        return (
-            <div style={{ padding: '50px' }}>
-                <ContentExplorer {...args} />
-            </div>
-        );
     },
     play: async ({ canvas }) => {
         await waitFor(() => {

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { http, HttpResponse } from 'msw';
 import type { Meta, StoryObj } from '@storybook/react';
+import { Download, SignMeOthers } from '@box/blueprint-web-assets/icons/Fill/index';
+import { Sign } from '@box/blueprint-web-assets/icons/Line';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import noop from 'lodash/noop';
 import ContentExplorer from '../../ContentExplorer';
 import { DEFAULT_HOSTNAME_API } from '../../../../constants';
 import { mockMetadata, mockSchema } from '../../../common/__mocks__/mockMetadata';
@@ -71,17 +75,58 @@ export const metadataView: Story = {
     },
 };
 
+const metadataViewV2ElementProps = {
+    metadataViewProps: {
+        columns,
+    },
+    metadataQuery,
+    fieldsToShow,
+    defaultView,
+    features: {
+        contentExplorer: {
+            metadataViewV2: true,
+        },
+    },
+};
+
 export const metadataViewV2: Story = {
+    args: metadataViewV2ElementProps,
+    render: args => {
+        return (
+            <div style={{ padding: '50px' }}>
+                <ContentExplorer {...args} />
+            </div>
+        );
+    },
+};
+
+export const metadataViewV2WithCustomActions: Story = {
     args: {
+        ...metadataViewV2ElementProps,
         metadataViewProps: {
             columns,
-        },
-        metadataQuery,
-        fieldsToShow,
-        defaultView,
-        features: {
-            contentExplorer: {
-                metadataViewV2: true,
+            tableProps: {
+                isSelectAllEnabled: true,
+            },
+            itemActionMenuProps: {
+                actions: [
+                    {
+                        label: 'Download',
+                        onClick: noop,
+                        icon: Download,
+                    },
+                ],
+                subMenuTrigger: {
+                    label: 'Sign',
+                    icon: Sign,
+                },
+                subMenuActions: [
+                    {
+                        label: 'Request Signature',
+                        onClick: noop,
+                        icon: SignMeOthers,
+                    },
+                ],
             },
         },
     },
@@ -91,6 +136,15 @@ export const metadataViewV2: Story = {
                 <ContentExplorer {...args} />
             </div>
         );
+    },
+    play: async ({ canvas }) => {
+        await waitFor(() => {
+            expect(canvas.getByRole('row', { name: /Child 2/i })).toBeInTheDocument();
+        });
+
+        const firstRow = canvas.getByRole('row', { name: /Child 2/i });
+        const ellipsesButton = within(firstRow).getByRole('button', { name: 'Action menu' });
+        userEvent.click(ellipsesButton);
     },
 };
 


### PR DESCRIPTION

<img width="1265" height="648" alt="Screenshot 2025-08-06 at 9 13 35 AM" src="https://github.com/user-attachments/assets/29183ce6-9a7b-4b62-8351-ad9e7666f81b" />


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new Storybook stories showcasing an enhanced metadata view with customizable actions in the Content Explorer component.
  * Introduced a story with custom table actions, including select-all, download, and a signature request submenu.
  * Enabled automated interaction testing for these new stories within Storybook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->