### PR TITLE
feat(metadata-view): bulk custom actions

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1824,6 +1824,8 @@ boxui.shareMenu.shortcutOnly = Shortcut Only
 boxui.shareMenu.viewAndDownload = View and Download
 # Description of permissions granted to users who have access to the shared link
 boxui.shareMenu.viewOnly = View Only
+# Aria-label for the dropdown menu that shows actions for selected items
+boxui.subHeader.bulkItemActionMenuAriaLabel = Bulk actions
 # Text for metadata button that will open the metadata side panel
 boxui.subHeader.metadata = Metadata
 # Error message for empty time formats. "HH:MM A" should be localized.

--- a/src/elements/common/sub-header/BulkItemActionMenu.tsx
+++ b/src/elements/common/sub-header/BulkItemActionMenu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 
 import { Button, DropdownMenu } from '@box/blueprint-web';
-import { Ellipsis } from '@box/blueprint-web-assets/icons/Fill/index';
+import { Ellipsis } from '@box/blueprint-web-assets/icons/Fill';
 import type { Selection } from 'react-aria-components';
 
 import messages from '../../common/sub-header/messages';
@@ -22,7 +22,7 @@ export const BulkItemActionMenu = ({ actions, selectedItemIds }: BulkItemActionM
 
     return (
         <DropdownMenu.Root>
-            <DropdownMenu.Trigger className="be-bulkItemActionMenu-trigger">
+            <DropdownMenu.Trigger className="be-BulkItemActionMenu-trigger">
                 <Button
                     role="button"
                     aria-label={formatMessage(messages.bulkItemActionMenuAriaLabel)}

--- a/src/elements/common/sub-header/BulkItemActionMenu.tsx
+++ b/src/elements/common/sub-header/BulkItemActionMenu.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { useIntl } from 'react-intl';
+
+import { Button, DropdownMenu } from '@box/blueprint-web';
+import { Ellipsis } from '@box/blueprint-web-assets/icons/Fill/index';
+import type { Selection } from 'react-aria-components';
+
+import messages from '../../common/sub-header/messages';
+
+export interface BulkItemAction {
+    label: string;
+    onClick: (selectedItemIds: Selection) => void;
+}
+
+export interface BulkItemActionMenuProps {
+    actions: BulkItemAction[];
+    selectedItemIds: Selection;
+}
+
+export const BulkItemActionMenu = ({ actions, selectedItemIds }: BulkItemActionMenuProps) => {
+    const { formatMessage } = useIntl();
+
+    return (
+        <DropdownMenu.Root>
+            <DropdownMenu.Trigger className="be-bulkItemActionMenu-trigger">
+                <Button
+                    role="button"
+                    aria-label={formatMessage(messages.bulkItemActionMenuAriaLabel)}
+                    icon={Ellipsis}
+                    size="large"
+                    variant="secondary"
+                />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end">
+                {actions.map(({ label, onClick }) => {
+                    return (
+                        <DropdownMenu.Item key={label} onSelect={() => onClick(selectedItemIds)}>
+                            {label}
+                        </DropdownMenu.Item>
+                    );
+                })}
+            </DropdownMenu.Content>
+        </DropdownMenu.Root>
+    );
+};

--- a/src/elements/common/sub-header/SubHeader.tsx
+++ b/src/elements/common/sub-header/SubHeader.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { PageHeader } from '@box/blueprint-web';
 import type { Selection } from 'react-aria-components';
 
+import type { BulkItemAction } from './BulkItemActionMenu';
 import SubHeaderLeft from './SubHeaderLeft';
 import SubHeaderLeftV2 from './SubHeaderLeftV2';
 import SubHeaderRight from './SubHeaderRight';
@@ -15,6 +16,7 @@ import { useFeatureEnabled } from '../feature-checking';
 import './SubHeader.scss';
 
 export interface SubHeaderProps {
+    bulkItemActions?: BulkItemAction[];
     canCreateNewFolder: boolean;
     canUpload: boolean;
     currentCollection: Collection;
@@ -41,6 +43,7 @@ export interface SubHeaderProps {
 }
 
 const SubHeader = ({
+    bulkItemActions,
     canCreateNewFolder,
     canUpload,
     currentCollection,
@@ -101,6 +104,7 @@ const SubHeader = ({
             </PageHeader.StartElements>
             <PageHeader.EndElements>
                 <SubHeaderRight
+                    bulkItemActions={bulkItemActions}
                     canCreateNewFolder={canCreateNewFolder}
                     canUpload={canUpload}
                     currentCollection={currentCollection}

--- a/src/elements/common/sub-header/SubHeaderRight.scss
+++ b/src/elements/common/sub-header/SubHeaderRight.scss
@@ -19,4 +19,8 @@
     .bdl-ViewModeChangeButton {
         margin-left: 7px;
     }
+
+    .be-bulkItemActionMenu-trigger {
+        margin-right: var(--space-2);
+    }
 }

--- a/src/elements/common/sub-header/SubHeaderRight.scss
+++ b/src/elements/common/sub-header/SubHeaderRight.scss
@@ -20,7 +20,7 @@
         margin-left: 7px;
     }
 
-    .be-bulkItemActionMenu-trigger {
+    .be-BulkItemActionMenu-trigger {
         margin-right: var(--space-2);
     }
 }

--- a/src/elements/common/sub-header/SubHeaderRight.tsx
+++ b/src/elements/common/sub-header/SubHeaderRight.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import { useIntl } from 'react-intl';
+
 import { Button } from '@box/blueprint-web';
 import { Pencil } from '@box/blueprint-web-assets/icons/Fill';
-import { useIntl } from 'react-intl';
 import type { Selection } from 'react-aria-components';
+
+import { BulkItemAction, BulkItemActionMenu } from './BulkItemActionMenu';
 import Sort from './Sort';
 import Add from './Add';
 import GridViewSlider from '../../../components/grid-view/GridViewSlider';
@@ -18,6 +21,7 @@ import messages from './messages';
 import './SubHeaderRight.scss';
 
 export interface SubHeaderRightProps {
+    bulkItemActions?: BulkItemAction[];
     canCreateNewFolder: boolean;
     canUpload: boolean;
     currentCollection: Collection;
@@ -55,6 +59,7 @@ const SubHeaderRight = ({
     selectedItemIds,
     view,
     viewMode,
+    bulkItemActions,
 }: SubHeaderRightProps) => {
     const { formatMessage } = useIntl();
     const isMetadataViewV2Feature = useFeatureEnabled('contentExplorer.metadataViewV2');
@@ -97,9 +102,16 @@ const SubHeaderRight = ({
             )}
 
             {isMetadataView && isMetadataViewV2Feature && hasSelectedItems && (
-                <Button icon={Pencil} size="large" variant="primary" onClick={onMetadataSidePanelToggle}>
-                    {formatMessage(messages.metadata)}
-                </Button>
+                <>
+                    {(selectedItemIds === 'all' || (selectedItemIds instanceof Set && selectedItemIds.size > 0)) &&
+                        bulkItemActions &&
+                        bulkItemActions.length > 0 && (
+                            <BulkItemActionMenu actions={bulkItemActions} selectedItemIds={selectedItemIds} />
+                        )}
+                        <Button icon={Pencil} size="large" variant="primary" onClick={onMetadataSidePanelToggle}>
+                        {formatMessage(messages.metadata)}
+                    </Button>
+                </>
             )}
         </div>
     );

--- a/src/elements/common/sub-header/SubHeaderRight.tsx
+++ b/src/elements/common/sub-header/SubHeaderRight.tsx
@@ -5,7 +5,7 @@ import { Button } from '@box/blueprint-web';
 import { Pencil } from '@box/blueprint-web-assets/icons/Fill';
 import type { Selection } from 'react-aria-components';
 
-import { BulkItemAction, BulkItemActionMenu } from './BulkItemActionMenu';
+import { type BulkItemAction, BulkItemActionMenu } from './BulkItemActionMenu';
 import Sort from './Sort';
 import Add from './Add';
 import GridViewSlider from '../../../components/grid-view/GridViewSlider';
@@ -42,6 +42,7 @@ export interface SubHeaderRightProps {
 }
 
 const SubHeaderRight = ({
+    bulkItemActions,
     canCreateNewFolder,
     canUpload,
     currentCollection,
@@ -59,7 +60,6 @@ const SubHeaderRight = ({
     selectedItemIds,
     view,
     viewMode,
-    bulkItemActions,
 }: SubHeaderRightProps) => {
     const { formatMessage } = useIntl();
     const isMetadataViewV2Feature = useFeatureEnabled('contentExplorer.metadataViewV2');
@@ -108,7 +108,7 @@ const SubHeaderRight = ({
                         bulkItemActions.length > 0 && (
                             <BulkItemActionMenu actions={bulkItemActions} selectedItemIds={selectedItemIds} />
                         )}
-                        <Button icon={Pencil} size="large" variant="primary" onClick={onMetadataSidePanelToggle}>
+                    <Button icon={Pencil} size="large" variant="primary" onClick={onMetadataSidePanelToggle}>
                         {formatMessage(messages.metadata)}
                     </Button>
                 </>

--- a/src/elements/common/sub-header/SubHeaderRight.tsx
+++ b/src/elements/common/sub-header/SubHeaderRight.tsx
@@ -71,6 +71,7 @@ const SubHeaderRight = ({
     const showAdd: boolean = (!!canUpload || !!canCreateNewFolder) && isFolder;
     const isMetadataView: boolean = view === VIEW_METADATA;
     const hasSelectedItems: boolean = !!(selectedItemIds && (selectedItemIds === 'all' || selectedItemIds.size > 0));
+
     return (
         <div className="be-sub-header-right">
             {!isMetadataView && (

--- a/src/elements/common/sub-header/SubHeaderRight.tsx
+++ b/src/elements/common/sub-header/SubHeaderRight.tsx
@@ -104,11 +104,9 @@ const SubHeaderRight = ({
 
             {isMetadataView && isMetadataViewV2Feature && hasSelectedItems && (
                 <>
-                    {(selectedItemIds === 'all' || (selectedItemIds instanceof Set && selectedItemIds.size > 0)) &&
-                        bulkItemActions &&
-                        bulkItemActions.length > 0 && (
-                            <BulkItemActionMenu actions={bulkItemActions} selectedItemIds={selectedItemIds} />
-                        )}
+                    {bulkItemActions && bulkItemActions.length > 0 && (
+                        <BulkItemActionMenu actions={bulkItemActions} selectedItemIds={selectedItemIds} />
+                    )}
                     <Button icon={Pencil} size="large" variant="primary" onClick={onMetadataSidePanelToggle}>
                         {formatMessage(messages.metadata)}
                     </Button>

--- a/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
+++ b/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { render, screen, userEvent } from '../../../../test-utils/testing-library';
 import SubHeaderRight, { SubHeaderRightProps } from '../SubHeaderRight';
 import { VIEW_FOLDER, VIEW_METADATA, VIEW_MODE_GRID } from '../../../../constants';
-import { FeatureProvider } from '../../feature-checking';
 
 describe('elements/common/sub-header/SubHeaderRight', () => {
     const defaultProps = {
@@ -23,11 +22,7 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
     };
 
     const renderComponent = (props: Partial<SubHeaderRightProps> = {}, features = {}) =>
-        render(
-            <FeatureProvider features={features}>
-                <SubHeaderRight {...defaultProps} {...props} />
-            </FeatureProvider>,
-        );
+        render(<SubHeaderRight {...defaultProps} {...props} />, { wrapperProps: { features } });
 
     test('should render GridViewSlider when there are items and viewMode is grid', () => {
         renderComponent({
@@ -90,7 +85,6 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
 
     describe('metadataViewV2', () => {
         const metadataViewV2Props = {
-            ...defaultProps,
             selectedItemIds: 'all' as const,
             bulkItemActions: [
                 {
@@ -102,30 +96,26 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
             onMetadataSidePanelToggle: jest.fn(),
         };
 
-        test.each([
-            {
-                selectedItemIds: 'all' as const,
-            },
-            {
-                selectedItemIds: new Set(['1', '2']),
-            },
-        ])('should render bulkItemActionMenu when selectedItemIds is $selectedItemIds', async ({ selectedItemIds }) => {
-            const features = {
-                contentExplorer: {
-                    metadataViewV2: true, // enable the feature flag
-                },
-            };
+        test.each(['all' as const, new Set(['1', '2'])])(
+            'should render bulkItemActionMenu when selectedItemIds is $selectedItemIds',
+            async selectedItemIds => {
+                const features = {
+                    contentExplorer: {
+                        metadataViewV2: true, // enable the feature flag
+                    },
+                };
 
-            renderComponent(
-                {
-                    ...metadataViewV2Props,
-                    selectedItemIds,
-                },
-                features,
-            );
+                renderComponent(
+                    {
+                        ...metadataViewV2Props,
+                        selectedItemIds,
+                    },
+                    features,
+                );
 
-            expect(screen.getByRole('button', { name: 'Bulk actions' })).toBeInTheDocument();
-        });
+                expect(screen.getByRole('button', { name: 'Bulk actions' })).toBeInTheDocument();
+            },
+        );
 
         test('should call onClick when a bulk item action is clicked', async () => {
             const mockOnClick = jest.fn();
@@ -160,19 +150,14 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
             expect(mockOnClick).toHaveBeenCalledWith(expectedOnClickArgument);
         });
 
-        test('should not render metadata button when metadataViewV2 feature is disabled', async () => {
+        test('should not render metadata v2 features when metadataViewV2 feature is disabled', async () => {
             const features = {
                 contentExplorer: {
                     metadataViewV2: false, // Disable the feature flag
                 },
             };
 
-            renderComponent(
-                {
-                    ...metadataViewV2Props,
-                },
-                features,
-            );
+            renderComponent(metadataViewV2Props, features);
 
             expect(screen.queryByRole('button', { name: 'Bulk actions' })).not.toBeInTheDocument();
             expect(screen.queryByRole('button', { name: 'Metadata' })).not.toBeInTheDocument();

--- a/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
+++ b/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
@@ -140,9 +140,9 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
             );
 
             const ellipsisButton = await screen.findByRole('button', { name: 'Bulk actions' });
-            user.click(ellipsisButton);
+            await user.click(ellipsisButton);
 
-            const downloadAction = await screen.findByRole('menuitem', { name: 'Download' });
+            const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
             await user.click(downloadAction);
 
             const expectedOnClickArgument = 'all';

--- a/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
+++ b/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
@@ -139,11 +139,10 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
                 features,
             );
 
-            const ellipsisButton = screen.getByRole('button', { name: 'Bulk actions' });
+            const ellipsisButton = await screen.findByRole('button', { name: 'Bulk actions' });
+            user.click(ellipsisButton);
 
-            await user.click(ellipsisButton);
-
-            const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
+            const downloadAction = await screen.findByRole('menuitem', { name: 'Download' });
             await user.click(downloadAction);
 
             const expectedOnClickArgument = 'all';

--- a/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
+++ b/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
@@ -19,6 +19,7 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
         onViewModeChange: jest.fn(),
         view: VIEW_FOLDER,
         viewMode: VIEW_MODE_GRID,
+        selectedItemIds: new Set([]),
     };
 
     const renderComponent = (props: Partial<SubHeaderRightProps> = {}) =>

--- a/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
+++ b/src/elements/common/sub-header/__tests__/SubHeaderRight.test.tsx
@@ -19,7 +19,6 @@ describe('elements/common/sub-header/SubHeaderRight', () => {
         onViewModeChange: jest.fn(),
         view: VIEW_FOLDER,
         viewMode: VIEW_MODE_GRID,
-        selectedItemIds: new Set([]),
     };
 
     const renderComponent = (props: Partial<SubHeaderRightProps> = {}) =>

--- a/src/elements/common/sub-header/messages.ts
+++ b/src/elements/common/sub-header/messages.ts
@@ -1,6 +1,11 @@
 import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
+    bulkItemActionMenuAriaLabel: {
+        defaultMessage: 'Bulk actions',
+        description: 'Aria-label for the dropdown menu that shows actions for selected items',
+        id: 'boxui.subHeader.bulkItemActionMenuAriaLabel',
+    },
     metadata: {
         defaultMessage: 'Metadata',
         description: 'Text for metadata button that will open the metadata side panel',

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -78,7 +78,6 @@ import type { ViewMode } from '../common/flowTypes';
 import type { ItemAction } from '../common/item';
 import type { Theme } from '../common/theming';
 import type { MetadataQuery, FieldsToShow } from '../../common/types/metadataQueries';
-
 import type { MetadataFieldValue, MetadataTemplate } from '../../common/types/metadata';
 import type {
     View,

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -78,6 +78,7 @@ import type { ViewMode } from '../common/flowTypes';
 import type { ItemAction } from '../common/item';
 import type { Theme } from '../common/theming';
 import type { MetadataQuery, FieldsToShow } from '../../common/types/metadataQueries';
+
 import type { MetadataFieldValue, MetadataTemplate } from '../../common/types/metadata';
 import type {
     View,
@@ -91,6 +92,7 @@ import type {
     BoxItemPermission,
     BoxItem,
 } from '../../common/types/core';
+import type { BulkItemAction } from '../common/sub-header/BulkItemActionMenu';
 import type { ContentPreviewProps } from '../content-preview';
 import type { ContentUploaderProps } from '../content-uploader';
 import type { MetadataViewContainerProps } from './MetadataViewContainer';
@@ -107,6 +109,7 @@ export interface ContentExplorerProps {
     apiHost?: string;
     appHost?: string;
     autoFocus?: boolean;
+    bulkItemActions?: BulkItemAction[];
     canCreateNewFolder?: boolean;
     canDelete?: boolean;
     canDownload?: boolean;
@@ -1699,6 +1702,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
         const {
             apiHost,
             appHost,
+            bulkItemActions,
             canCreateNewFolder,
             canDelete,
             canDownload,
@@ -1791,6 +1795,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
                                 )}
 
                                 <SubHeader
+                                    bulkItemActions={bulkItemActions}
                                     view={view}
                                     viewMode={viewMode}
                                     rootId={rootFolderId}

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
@@ -505,6 +505,58 @@ describe('elements/content-explorer/ContentExplorer', () => {
 
                 expect(screen.getByRole('button', { name: 'Metadata' })).toBeInTheDocument();
             });
+
+            test('should call onClick when bulk item action is clicked', async () => {
+                const mockOnClick = jest.fn();
+                const metadataViewV2WithBulkItemActions = {
+                    ...metadataViewV2ElementProps,
+                    bulkItemActions: [
+                        {
+                            label: 'Download',
+                            onClick: mockOnClick,
+                        },
+                    ],
+                };
+
+                renderComponent(metadataViewV2WithBulkItemActions);
+
+                await waitFor(() => {
+                    expect(screen.getByTestId('content-explorer')).toBeInTheDocument();
+                });
+
+                await waitFor(() => {
+                    expect(screen.getByRole('row', { name: /Child 2/i })).toBeInTheDocument();
+                });
+
+                const firstRow = screen.getByRole('row', { name: /Child 2/i });
+                const checkbox = within(firstRow).getByRole('checkbox');
+                await userEvent.click(checkbox);
+
+                await waitFor(() => {
+                    expect(screen.getByRole('button', { name: 'Bulk actions' })).toBeInTheDocument();
+                });
+
+                const ellipsisButton = screen.getByRole('button', { name: 'Bulk actions' });
+                await userEvent.click(ellipsisButton);
+
+                await waitFor(() => {
+                    expect(screen.getByRole('menuitem', { name: 'Download' })).toBeInTheDocument();
+                });
+
+                const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
+                await userEvent.click(downloadAction);
+
+                const expectedOnClickArgument = new Set(['1188890835']);
+                await waitFor(() => {
+                    expect(mockOnClick).toHaveBeenCalled();
+
+                    // Array conversion from sets to avoid set comparison issues in Jest
+                    const argsForFirstMockCall = mockOnClick.mock.calls[0];
+                    const firstArgToMockOnClick = argsForFirstMockCall[0];
+
+                    expect(Array.from(firstArgToMockOnClick)).toEqual(Array.from(expectedOnClickArgument));
+                });
+            });
         });
     });
 

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
@@ -526,14 +526,13 @@ describe('elements/content-explorer/ContentExplorer', () => {
                 const firstRow = await screen.findByRole('row', { name: /Child 2/i });
                 expect(firstRow).toBeInTheDocument();
 
-                const checkbox = within(firstRow).getByRole('checkbox');
-                userEvent.click(checkbox);
+                await userEvent.click(within(firstRow).getByRole('checkbox'));
 
-                const ellipsisButton = await screen.findByRole('button', { name: 'Bulk actions' });
-                expect(ellipsisButton).toBeInTheDocument();
-                userEvent.click(ellipsisButton);
+                const bulkActionsButton = screen.getByRole('button', { name: 'Bulk actions' });
+                expect(bulkActionsButton).toBeInTheDocument();
+                await userEvent.click(bulkActionsButton);
 
-                const downloadAction = await screen.findByRole('menuitem', { name: 'Download' });
+                const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
                 expect(downloadAction).toBeInTheDocument();
                 await userEvent.click(downloadAction);
 

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
@@ -507,7 +507,10 @@ describe('elements/content-explorer/ContentExplorer', () => {
             });
 
             test('should call onClick when bulk item action is clicked', async () => {
-                const mockOnClick = jest.fn();
+                let mockOnClickArg;
+                const mockOnClick = jest.fn(arg => {
+                    mockOnClickArg = arg;
+                });
                 const metadataViewV2WithBulkItemActions = {
                     ...metadataViewV2ElementProps,
                     bulkItemActions: [
@@ -520,42 +523,26 @@ describe('elements/content-explorer/ContentExplorer', () => {
 
                 renderComponent(metadataViewV2WithBulkItemActions);
 
-                await waitFor(() => {
-                    expect(screen.getByTestId('content-explorer')).toBeInTheDocument();
-                });
+                await screen.findByTestId('content-explorer');
 
-                await waitFor(() => {
-                    expect(screen.getByRole('row', { name: /Child 2/i })).toBeInTheDocument();
-                });
+                await screen.findByRole('row', { name: /Child 2/i });
 
                 const firstRow = screen.getByRole('row', { name: /Child 2/i });
                 const checkbox = within(firstRow).getByRole('checkbox');
                 await userEvent.click(checkbox);
 
-                await waitFor(() => {
-                    expect(screen.getByRole('button', { name: 'Bulk actions' })).toBeInTheDocument();
-                });
+                await screen.findByRole('button', { name: 'Bulk actions' });
 
                 const ellipsisButton = screen.getByRole('button', { name: 'Bulk actions' });
                 await userEvent.click(ellipsisButton);
 
-                await waitFor(() => {
-                    expect(screen.getByRole('menuitem', { name: 'Download' })).toBeInTheDocument();
-                });
+                await screen.findByRole('menuitem', { name: 'Download' });
 
                 const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
                 await userEvent.click(downloadAction);
 
-                const expectedOnClickArgument = new Set(['1188890835']);
-                await waitFor(() => {
-                    expect(mockOnClick).toHaveBeenCalled();
-
-                    // Array conversion from sets to avoid set comparison issues in Jest
-                    const argsForFirstMockCall = mockOnClick.mock.calls[0];
-                    const firstArgToMockOnClick = argsForFirstMockCall[0];
-
-                    expect(Array.from(firstArgToMockOnClick)).toEqual(Array.from(expectedOnClickArgument));
-                });
+                expect(mockOnClick).toHaveBeenCalled();
+                expect(Array.from(mockOnClickArg)).toEqual(['1188890835']);
             });
         });
     });

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
@@ -523,22 +523,18 @@ describe('elements/content-explorer/ContentExplorer', () => {
 
                 renderComponent(metadataViewV2WithBulkItemActions);
 
-                await screen.findByTestId('content-explorer');
+                const firstRow = await screen.findByRole('row', { name: /Child 2/i });
+                expect(firstRow).toBeInTheDocument();
 
-                await screen.findByRole('row', { name: /Child 2/i });
-
-                const firstRow = screen.getByRole('row', { name: /Child 2/i });
                 const checkbox = within(firstRow).getByRole('checkbox');
-                await userEvent.click(checkbox);
+                userEvent.click(checkbox);
 
-                await screen.findByRole('button', { name: 'Bulk actions' });
+                const ellipsisButton = await screen.findByRole('button', { name: 'Bulk actions' });
+                expect(ellipsisButton).toBeInTheDocument();
+                userEvent.click(ellipsisButton);
 
-                const ellipsisButton = screen.getByRole('button', { name: 'Bulk actions' });
-                await userEvent.click(ellipsisButton);
-
-                await screen.findByRole('menuitem', { name: 'Download' });
-
-                const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
+                const downloadAction = await screen.findByRole('menuitem', { name: 'Download' });
+                expect(downloadAction).toBeInTheDocument();
                 await userEvent.click(downloadAction);
 
                 expect(mockOnClick).toHaveBeenCalled();

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -222,25 +222,18 @@ export const sidePanelOpenWithSingleItemSelected: Story = {
 export const metadataViewV2WithBulkItemActionMenuShowsItemActionMenu: Story = {
     args: metadataViewV2WithBulkItemActions,
     play: async ({ canvas }) => {
-        await waitFor(() => {
-            expect(canvas.getByRole('row', { name: /Child 2/i })).toBeInTheDocument();
-        });
+        const firstRow = await canvas.findByRole('row', { name: /Child 2/i });
+        expect(firstRow).toBeInTheDocument();
 
-        const firstRow = canvas.getByRole('row', { name: /Child 2/i });
         const checkbox = within(firstRow).getByRole('checkbox');
-        userEvent.click(checkbox);
-
-        await waitFor(() => {
-            expect(canvas.getByRole('button', { name: 'Bulk actions' })).toBeInTheDocument();
-        });
+        await userEvent.click(checkbox);
 
         const ellipsisButton = canvas.getByRole('button', { name: 'Bulk actions' });
+        expect(ellipsisButton).toBeInTheDocument();
+        await userEvent.click(ellipsisButton);
 
-        userEvent.click(ellipsisButton);
-
-        await waitFor(() => {
-            expect(screen.getByRole('menuitem', { name: 'Download' })).toBeInTheDocument();
-        });
+        const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
+        expect(downloadAction).toBeInTheDocument();
     },
 };
 

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -219,23 +219,6 @@ export const sidePanelOpenWithSingleItemSelected: Story = {
     },
 };
 
-export const metadataViewV2WithBulkItemActionMenuShowsEllipsis: Story = {
-    args: metadataViewV2WithBulkItemActions,
-    play: async ({ canvas }) => {
-        await waitFor(() => {
-            expect(canvas.getByRole('row', { name: /Child 2/i })).toBeInTheDocument();
-        });
-
-        const firstRow = canvas.getByRole('row', { name: /Child 2/i });
-        const checkbox = within(firstRow).getByRole('checkbox');
-        userEvent.click(checkbox);
-
-        await waitFor(() => {
-            expect(canvas.getByRole('button', { name: 'Bulk actions' })).toBeInTheDocument();
-        });
-    },
-};
-
 export const metadataViewV2WithBulkItemActionMenuShowsItemActionMenu: Story = {
     args: metadataViewV2WithBulkItemActions,
     play: async ({ canvas }) => {
@@ -257,37 +240,6 @@ export const metadataViewV2WithBulkItemActionMenuShowsItemActionMenu: Story = {
 
         await waitFor(() => {
             expect(screen.getByRole('menuitem', { name: 'Download' })).toBeInTheDocument();
-        });
-    },
-};
-
-export const metadataViewV2WithBulkItemActionMenuCallsOnClick: Story = {
-    args: metadataViewV2WithBulkItemActions,
-    play: async ({ canvas, args }) => {
-        await waitFor(() => {
-            expect(canvas.getByRole('row', { name: /Child 2/i })).toBeInTheDocument();
-        });
-
-        const firstRow = canvas.getByRole('row', { name: /Child 2/i });
-        const checkbox = within(firstRow).getByRole('checkbox');
-        userEvent.click(checkbox);
-
-        await waitFor(() => {
-            expect(canvas.getByRole('button', { name: 'Bulk actions' })).toBeInTheDocument();
-        });
-
-        const ellipsisButton = canvas.getByRole('button', { name: 'Bulk actions' });
-
-        userEvent.click(ellipsisButton);
-
-        await waitFor(() => {
-            expect(screen.getByRole('menuitem', { name: 'Download' })).toBeInTheDocument();
-        });
-        const downloadAction = screen.getByRole('menuitem', { name: 'Download' });
-        userEvent.click(downloadAction);
-
-        await waitFor(() => {
-            expect(args.bulkItemActions[0].onClick).toHaveBeenCalled();
         });
     },
 };


### PR DESCRIPTION
Assumptions:
* Ellipses icon should show when one or more rows have been selected
  * Therefore, the ellipses "bulk action" icon only shows if Select All is also enabled in the tableProps
* No icons or subactions
* Selecting an action triggers an onClick handler (provided by the consumer) which receives all selected Item Ids.

<img width="1760" height="914" alt="Screenshot 2025-08-15 at 10 10 47 AM" src="https://github.com/user-attachments/assets/834c1185-6356-41c3-a8ae-6a74f453987f" />



<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Bulk actions dropdown added to the Content Explorer sub-header and shown when items are selected; supports configurable actions.

- Accessibility
  - ARIA label added to the Bulk actions control for improved screen-reader support.

- Style
  - Added spacing to the Bulk actions trigger for improved layout.

- Tests
  - Storybook visuals and unit tests updated to cover bulk-action visibility, menu interactions, and callback invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->