### PR TITLE
fix(content-explorer): Fix flaky SubheaderV2 folder title

### DIFF
--- a/src/elements/content-explorer/stories/MetadataView.stories.tsx
+++ b/src/elements/content-explorer/stories/MetadataView.stories.tsx
@@ -5,6 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import ContentExplorer from '../ContentExplorer';
 import { DEFAULT_HOSTNAME_API } from '../../../constants';
 import { mockMetadata, mockSchema } from '../../common/__mocks__/mockMetadata';
+import { mockRootFolder } from '../../common/__mocks__/mockRootFolder';
 
 const EID = '0';
 const templateName = 'templateName';
@@ -119,6 +120,9 @@ const meta: Meta<typeof ContentExplorer> = {
                 }),
                 http.get(`${DEFAULT_HOSTNAME_API}/2.0/metadata_templates/enterprise/templateName/schema`, () => {
                     return HttpResponse.json(mockSchema);
+                }),
+                http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/:id`, () => {
+                    return HttpResponse.json(mockRootFolder);
                 }),
             ],
         },

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -8,6 +8,7 @@ import noop from 'lodash/noop';
 import ContentExplorer from '../../ContentExplorer';
 import { DEFAULT_HOSTNAME_API } from '../../../../constants';
 import { mockMetadata, mockSchema } from '../../../common/__mocks__/mockMetadata';
+import { mockRootFolder } from '../../../common/__mocks__/mockRootFolder';
 
 // The intent behind relying on mockMetadata is to allow a developer to paste in their own metadata template schema for use with live API calls.
 const { scope: templateScope, templateKey } = mockSchema;
@@ -179,6 +180,9 @@ const meta: Meta<typeof ContentExplorer> = {
                 }),
                 http.get(`${DEFAULT_HOSTNAME_API}/2.0/metadata_templates/enterprise/templateName/schema`, () => {
                     return HttpResponse.json(mockSchema);
+                }),
+                http.get(`${DEFAULT_HOSTNAME_API}/2.0/folders/:id`, () => {
+                    return HttpResponse.json(mockRootFolder);
                 }),
             ],
         },


### PR DESCRIPTION
All of our API calls delete each other when run, so we can't run them concurrently or we run into race conditions. This fixes the flaky test by running the fetchFolderFields after the metadata query finishes.

Also updates the metadata view story to use a mocked folder to show this title.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the root-folder name in the Content Explorer metadata view by deferring its retrieval until after metadata results load and ensuring the newer metadata view path correctly populates the displayed name.

* **Tests**
  * Added stable network mocks for root-folder requests in Metadata View stories to stabilize visual previews and ensure consistent test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->