### PR TITLE
feat(metadata-view): default sortBy

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -168,6 +168,19 @@ export const FIELD_CLASSIFICATION: 'classification' = 'classification';
 export const FIELD_ENTERPRISE: 'enterprise' = 'enterprise';
 export const FIELD_HOSTNAME: 'hostname' = 'hostname';
 
+/* ----------------------- Item-Prefixed Fields for MD Query API --------------------------- */
+const ITEM_PREFIX = 'item.';
+export const FIELD_ITEM_TYPE = `${ITEM_PREFIX}${FIELD_TYPE}`;
+export const FIELD_ITEM_NAME = `${ITEM_PREFIX}${FIELD_NAME}`;
+export const FIELD_ITEM_DESCRIPTION = `${ITEM_PREFIX}${FIELD_DESCRIPTION}`;
+export const FIELD_ITEM_EXTENSION = `${ITEM_PREFIX}${FIELD_EXTENSION}`;
+export const FIELD_ITEM_OWNED_BY = `${ITEM_PREFIX}${FIELD_OWNED_BY}`;
+export const FIELD_ITEM_CREATED_AT = `${ITEM_PREFIX}${FIELD_CREATED_AT}`;
+export const FIELD_ITEM_MODIFIED_AT = `${ITEM_PREFIX}${FIELD_MODIFIED_AT}`;
+export const FIELD_ITEM_CONTENT_CREATED_AT = `${ITEM_PREFIX}${FIELD_CONTENT_CREATED_AT}`;
+export const FIELD_ITEM_CONTENT_MODIFIED_AT = `${ITEM_PREFIX}${FIELD_CONTENT_MODIFIED_AT}`;
+export const FIELD_ITEM_QUICK_SEARCH_CONTENT = `${ITEM_PREFIX}quick_search_content`;
+
 /* ----------------------- Permissions --------------------------- */
 export const PERMISSION_CAN_COMMENT = 'can_comment';
 export const PERMISSION_CAN_CREATE_ANNOTATIONS = 'can_create_annotations';

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -455,13 +455,6 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
             metadataQueryClone.limit = DEFAULT_PAGE_SIZE;
         }
 
-        metadataQueryClone.order_by = [
-            {
-                // Default to the prefixed name field for metadata view v2 only, while not touching the default sortBy for other views.
-                field_key: sortBy === FIELD_NAME ? FIELD_ITEM_NAME : sortBy,
-                direction: sortDirection,
-            },
-        ];
         // Reset search state, the view and show busy indicator
         this.setState({
             searchQuery: '',
@@ -470,8 +463,22 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
         });
 
         if (isFeatureEnabled(features, 'contentExplorer.metadataViewV2')) {
+            metadataQueryClone.order_by = [
+                {
+                    // Default to the prefixed name field for metadata view v2 only, while not touching the default sortBy for other views.
+                    field_key: sortBy === FIELD_NAME ? FIELD_ITEM_NAME : sortBy,
+                    direction: sortDirection,
+                },
+            ];
+
             this.metadataQueryAPIHelper = new MetadataQueryAPIHelperV2(this.api);
         } else {
+            metadataQueryClone.order_by = [
+                {
+                    field_key: sortBy,
+                    direction: sortDirection,
+                },
+            ];
             this.metadataQueryAPIHelper = new MetadataQueryAPIHelper(this.api);
         }
 

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -49,6 +49,7 @@ import {
     DEFAULT_HOSTNAME_STATIC,
     DEFAULT_SEARCH_DEBOUNCE,
     SORT_ASC,
+    FIELD_ITEM_NAME,
     FIELD_NAME,
     FIELD_PERMISSIONS_CAN_SHARE,
     FIELD_SHARED_LINK,
@@ -456,7 +457,8 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
 
         metadataQueryClone.order_by = [
             {
-                field_key: sortBy,
+                // Default to the prefixed name field for metadata view v2 only, while not touching the default sortBy for other views.
+                field_key: sortBy === FIELD_NAME ? FIELD_ITEM_NAME : sortBy,
                 direction: sortDirection,
             },
         ];

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -108,7 +108,6 @@ export const metadataViewV2SortsFromHeader: Story = {
     },
 };
 
-// @TODO Fix shared feature to never allow multi and single select to sort
 export const metadataViewV2WithCustomActions: Story = {
     args: {
         ...metadataViewV2ElementProps,

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -21,7 +21,7 @@ const metadataFieldNamePrefix = `metadata.${metadataScopeAndKey}`;
 const metadataQuery = {
     from: metadataScopeAndKey,
     ancestor_folder_id: '0',
-    sort_by: [
+    order_by: [
         {
             field_key: `${metadataFieldNamePrefix}.${mockSchema.fields[0].key}`, // Default to sorting by the first field in the schema
             direction: 'asc',
@@ -49,7 +49,7 @@ const columns = [
         textValue: 'Name',
         id: 'name',
         type: 'string',
-        allowSorting: true,
+        allowsSorting: true,
         minWidth: 150,
         maxWidth: 150,
     },
@@ -57,7 +57,7 @@ const columns = [
         textValue: field.displayName,
         id: `${metadataFieldNamePrefix}.${field.key}`,
         type: field.type,
-        allowSorting: true,
+        allowsSorting: true,
         minWidth: 150,
         maxWidth: 150,
     })),
@@ -94,6 +94,21 @@ export const metadataViewV2: Story = {
     args: metadataViewV2ElementProps,
 };
 
+// @TODO Assert that rows are actually sorted in a different order, once handleSortChange is implemented
+export const metadataViewV2SortsFromHeader: Story = {
+    args: metadataViewV2ElementProps,
+    play: async ({ canvas }) => {
+        await waitFor(() => {
+            expect(canvas.getByRole('row', { name: /Industry/i })).toBeInTheDocument();
+        });
+
+        const firstRow = canvas.getByRole('row', { name: /Industry/i });
+        const industryHeader = within(firstRow).getByRole('columnheader', { name: 'Industry' });
+        userEvent.click(industryHeader);
+    },
+};
+
+// @TODO Fix shared feature to never allow multi and single select to sort
 export const metadataViewV2WithCustomActions: Story = {
     args: {
         ...metadataViewV2ElementProps,


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added item-prefixed metadata fields (e.g., item name, type, description, timestamps, quick search content).
  - Added new permission flags (delete, download, edit, preview, rename, resolve, set share access, share, upload, view annotations).

- Bug Fixes
  - Improved sorting behavior in metadata view v2 so sorting by Name uses the correct item field.

- Tests
  - Added a visual story/test to exercise header-triggered sorting in the metadata v2 view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->