### PR TITLE
feat(box-ai): Bump box-ai-content-answers version

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
         "@box/blueprint-web": "12.43.0",
         "@box/blueprint-web-assets": "4.61.5",
         "@box/box-ai-agent-selector": "^0.53.0",
-        "@box/box-ai-content-answers": "^0.124.1",
+        "@box/box-ai-content-answers": "^0.139.0",
         "@box/box-item-type-selector": "^0.63.12",
         "@box/cldr-data": "^34.2.0",
         "@box/combobox-with-api": "^0.34.9",

--- a/src/elements/common/content-answers/ContentAnswersModal.tsx
+++ b/src/elements/common/content-answers/ContentAnswersModal.tsx
@@ -27,7 +27,6 @@ import messages from './messages';
 export interface ExternalProps {
     isCitationsEnabled?: boolean;
     isMarkdownEnabled?: boolean;
-    isResetChatEnabled?: boolean;
     onAsk?: () => void;
     onClearConversation?: () => void;
     onRequestClose?: () => void;
@@ -50,7 +49,6 @@ const ContentAnswersModal = ({
     suggestedQuestions,
     isCitationsEnabled = true,
     isMarkdownEnabled = true,
-    isResetChatEnabled = true,
 }: ContentAnswersModalProps) => {
     const { formatMessage } = useIntl();
     const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -176,7 +174,6 @@ const ContentAnswersModal = ({
             hasRequestInProgress={isLoading}
             isCitationsEnabled={isCitationsEnabled}
             isMarkdownEnabled={isMarkdownEnabled}
-            isResetChatEnabled={isResetChatEnabled}
             onClearAction={handleClearConversation}
             onOpenChange={handleOnRequestClose}
             open={isOpen}

--- a/src/elements/common/content-answers/__tests__/ContentAnswersModal.test.tsx
+++ b/src/elements/common/content-answers/__tests__/ContentAnswersModal.test.tsx
@@ -16,7 +16,12 @@ import {
 import APIContext from '../../api-context';
 
 describe('elements/common/content-answers/ContentAnswersModal', () => {
-    const mockQuestion = { isCompleted: false, isLoading: true, prompt: 'summarize another question' };
+    const mockQuestion = {
+        isCompleted: false,
+        isLoading: true,
+        prompt: 'summarize another question',
+        promptType: 'user_input',
+    };
     const renderComponent = (api = mockApi, props?: {}) => {
         render(
             <Notification.Provider>
@@ -137,7 +142,7 @@ describe('elements/common/content-answers/ContentAnswersModal', () => {
         await userEvent.click(submitButton);
 
         expect(mockApi.getIntelligenceAPI().ask).lastCalledWith(
-            { isCompleted: false, isLoading: true, prompt: 'Another question?' },
+            { isCompleted: false, isLoading: true, prompt: 'Another question?', promptType: 'user_input' },
             [{ id: mockFile.id, type: 'file' }],
             [{ answer: 'summarize answer', created_at: '', prompt: 'summarize another question' }],
             {

--- a/src/elements/content-sidebar/BoxAISidebar.tsx
+++ b/src/elements/content-sidebar/BoxAISidebar.tsx
@@ -45,7 +45,6 @@ export interface BoxAISidebarProps {
     isFeedbackFormEnabled: boolean;
     isIntelligentQueryMode: boolean;
     isMarkdownEnabled: boolean;
-    isResetChatEnabled: boolean;
     isStopResponseEnabled?: boolean;
     isStreamingEnabled: boolean;
     items: Array<ItemType>;

--- a/src/elements/content-sidebar/BoxAISidebarContent.tsx
+++ b/src/elements/content-sidebar/BoxAISidebarContent.tsx
@@ -50,7 +50,6 @@ function BoxAISidebarContent(
         hostAppName,
         isAIStudioAgentSelectorEnabled,
         isLoading,
-        isResetChatEnabled,
         onSelectAgent,
         questions,
         shouldShowLandingPage,
@@ -191,7 +190,7 @@ function BoxAISidebarContent(
     const renderActions = () => (
         <>
             {renderBoxAISidebarTitle()}
-            {isResetChatEnabled && <ClearConversationButton onClick={onClearAction} />}
+            <ClearConversationButton onClick={onClearAction} />
             <Tooltip content={formatMessage(messages.sidebarBoxAISwitchToModalView)} variant="standard">
                 <IconButton
                     aria-label={formatMessage(messages.sidebarBoxAISwitchToModalView)}
@@ -248,7 +247,6 @@ function BoxAISidebarContent(
                 isAIStudioAgentSelectorEnabled={isAIStudioAgentSelectorEnabled}
                 isFeedbackEnabled={isFeedbackEnabled}
                 isFeedbackFormEnabled={isFeedbackFormEnabled}
-                isResetChatEnabled={isResetChatEnabled}
                 isStopResponseEnabled={isStopResponseEnabled}
                 items={items}
                 itemSize={itemSize}

--- a/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
+++ b/src/elements/content-sidebar/__tests__/BoxAISidebar.test.tsx
@@ -36,7 +36,6 @@ jest.mock('@box/box-ai-content-answers', () => ({
             isMarkdownEnabled={props.isMarkdownEnabled}
             isLoading={props.isLoading}
             isOpen
-            isResetChatEnabled={props.isResetChatEnabled}
             isStreamingEnabled={props.isStreamingEnabled}
             itemID={props.itemID}
             itemIDs={props.itemIDs}
@@ -120,7 +119,6 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         isFeedbackFormEnabled: true,
         isIntelligentQueryMode: true,
         isMarkdownEnabled: true,
-        isResetChatEnabled: true,
         isStopResponseEnabled: true,
         isStreamingEnabled: true,
         onFeedbackFormSubmit: jest.fn(),
@@ -184,12 +182,6 @@ describe('elements/content-sidebar/BoxAISidebar', () => {
         await renderComponent();
 
         expect(screen.getByRole('button', { name: 'Clear conversation' })).toBeInTheDocument();
-    });
-
-    test('should not have accessible "Clear" button if isResetChatEnabled is false', async () => {
-        await renderComponent({ isResetChatEnabled: false });
-
-        expect(screen.queryByRole('button', { name: 'Clear' })).not.toBeInTheDocument();
     });
 
     test('should call recordAction on load if provided', async () => {

--- a/src/elements/content-sidebar/stories/BoxAISidebar.stories.tsx
+++ b/src/elements/content-sidebar/stories/BoxAISidebar.stories.tsx
@@ -43,7 +43,6 @@ export default {
             isFeedbackEnabled: true,
             isIntelligentQueryMode: false,
             isMarkdownEnabled: true,
-            isResetChatEnabled: true,
             isStopResponseEnabled: true,
             isStreamingEnabled: false,
             items: [{ id: '123', name: 'Document (PDF).pdf', type: 'file', fileType: 'pdf', status: 'supported' }],

--- a/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
+++ b/src/elements/content-sidebar/stories/tests/BoxAISidebar-visual.stories.tsx
@@ -49,7 +49,6 @@ const meta: Meta<typeof ContentSidebar> & { parameters: { msw: { handlers: HttpH
             isDebugModeEnabled: true,
             isIntelligentQueryMode: false,
             isMarkdownEnabled: true,
-            isResetChatEnabled: true,
             isStopResponseEnabled: true,
             isStreamingEnabled: false,
             items: [{ id: '123', name: 'Document (PDF).pdf', type: 'file', fileType: 'pdf', status: 'supported' }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,10 +1470,10 @@
   resolved "https://registry.yarnpkg.com/@box/box-ai-agent-selector/-/box-ai-agent-selector-0.53.0.tgz#60c8b441b94c41363858e7cf8c9d4c4e8e9e0806"
   integrity sha512-XWBB+CZ54O+RPH6phftD64/ztuelR575kgTsBsEA0TRlckiR+rCmMOq8gHgo66ApUPUWct1TdoEkGJRwlglA/Q==
 
-"@box/box-ai-content-answers@^0.124.1":
-  version "0.124.5"
-  resolved "https://registry.yarnpkg.com/@box/box-ai-content-answers/-/box-ai-content-answers-0.124.5.tgz#664a34d8338569be6801c1433295f858d8f054ad"
-  integrity sha512-0p1j2JW9ig0rhM4tiOyEFN6dbiHa7wuX8PmKTjPbgU5MQDibGSbNeZS7IxZlJLYs2BmJ+IncUrPN+zlnsfaRgw==
+"@box/box-ai-content-answers@^0.139.0":
+  version "0.139.5"
+  resolved "https://registry.yarnpkg.com/@box/box-ai-content-answers/-/box-ai-content-answers-0.139.5.tgz#8c14536c73b6c96be3f49910bb3a7ced0ffc39d8"
+  integrity sha512-fpMfIAGgPSGx67p/4xlpGtSzALFwn0IhYlpVyuSlxV3R7SxXlQmvVsRS6TEZAiPnelqRzztFKOo9D2K2UbFBFg==
 
 "@box/box-item-type-selector@^0.63.12":
   version "0.63.13"
@@ -18225,7 +18225,7 @@ string-replace-loader@^3.1.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18259,6 +18259,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -18366,7 +18375,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18393,6 +18402,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -19946,7 +19962,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19976,6 +19992,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
BREAKING CHANGE: isResetChatEnabled prop removed

Bumping `@box/box-ai-content-answers` package to version `0.139.5`. This requires removing the `isResetChatEnabled` prop, which has been deprecated.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “Clear conversation” is now always available in the Box AI sidebar and Content Answers modal, removing the need for any configuration toggle.
* **Tests**
  * Updated unit and visual tests/stories to reflect the always-on Clear action and new prompt metadata.
* **Chores**
  * Bumped the AI content answers development dependency to a newer version for improved compatibility and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->