### PR TITLE
fix(content-sidebar): Clean up taxonomy fetchers

### DIFF
--- a/src/common/types/metadata.js
+++ b/src/common/types/metadata.js
@@ -138,13 +138,13 @@ type MetadataSuggestion = {
 
 type MetadataOptionEntryAncestor = {
     id: string,
-    display_name: string,
+    displayName: string,
     level: string,
 };
 
 type MetadataOptionEntry = {
     id: string,
-    display_name: string,
+    displayName: string,
     level: number,
     ancestors: MetadataOptionEntryAncestor[],
     deprecated: boolean,

--- a/src/elements/content-sidebar/__tests__/metadataTaxonomyFetcher.test.ts
+++ b/src/elements/content-sidebar/__tests__/metadataTaxonomyFetcher.test.ts
@@ -24,7 +24,7 @@ describe('metadataTaxonomyFetcher', () => {
             entries: [
                 { 
                     id: 'opt1', 
-                    display_name: 'Option 1', 
+                    displayName: 'Option 1', 
                     level: '1', 
                     parentId: 'parent1',
                     nodePath: ['node1', 'node2'],
@@ -34,12 +34,12 @@ describe('metadataTaxonomyFetcher', () => {
                 },
                 { 
                     id: 'opt2', 
-                    display_name: 'Option 2', 
+                    displayName: 'Option 2', 
                     level: '2', 
                     parentId: 'parent2',
                     nodePath: ['node1', 'node3'],
                     deprecated: true,
-                    ancestors: [{ display_name: 'Option 1', foo: 'bar' }], 
+                    ancestors: [{ displayName: 'Option 1', foo: 'bar' }], 
                     selectable: true 
                 },
             ],
@@ -185,7 +185,7 @@ describe('metadataTaxonomyFetcher', () => {
             entries: [
                 { 
                     id: 'opt1', 
-                    display_name: 'Option 1', 
+                    displayName: 'Option 1', 
                     level: '1', 
                     parentId: 'parent1',
                 },
@@ -220,7 +220,7 @@ describe('metadataTaxonomyFetcher', () => {
         const mockMetadataOptions = {
             entries: [{ 
                 id: 'opt1', 
-                display_name: 'Option 1',
+                displayName: 'Option 1',
                 parentId: undefined,
                 nodePath: undefined,
                 deprecated: undefined,
@@ -250,7 +250,7 @@ describe('metadataTaxonomyFetcher', () => {
             entries: [
                 { 
                     id: 'opt1', 
-                    display_name: 'Option 1', 
+                    displayName: 'Option 1', 
                     level: '1', 
                     ancestors: null, 
                     selectable: false
@@ -291,113 +291,6 @@ describe('metadataTaxonomyFetcher', () => {
     });
 });
 
-// TODO: delete whole section during clean up as for now we have to handle both new and old naming convention
-describe('metadataTaxonomyNodeAncestorsFetcher (old keys naming convention)', () => {
-    const fileID = '12345';
-    const scope = 'global';
-    const taxonomyKey = 'taxonomy_123';
-    const nodeID = 'node_abc';
-
-    let apiMock: jest.Mocked<API>;
-
-    beforeEach(() => {
-        apiMock = {
-            getMetadataAPI: jest.fn().mockReturnValue({
-                getMetadataTaxonomy: jest.fn(),
-                getMetadataTaxonomyNode: jest.fn(),
-            }),
-        };
-    });
-
-    test('should fetch taxonomy and node data and return formatted data', async () => {
-        const mockTaxonomy = {
-            display_name: 'Geography',
-            namespace: 'my_enterprise',
-            id: 'my_id',
-            key: 'geography',
-            levels: [
-                { level: 1, display_name: 'Level 1', description: 'Description 1' },
-                { level: 2, display_name: 'Level 2', description: 'Description 2' },
-                { level: 3, display_name: 'Level 3', description: 'Description 3' },
-            ],
-        };
-
-        const mockTaxonomyNode = {
-            id: 'node_abc',
-            level: 1,
-            display_name: 'Node ABC',
-            ancestors: [{ id: 'ancestor_1', level: 2, display_name: 'Ancestor 1' }],
-        };
-
-        apiMock.getMetadataAPI(false).getMetadataTaxonomy.mockResolvedValue(mockTaxonomy);
-        apiMock.getMetadataAPI(false).getMetadataTaxonomyNode.mockResolvedValue(mockTaxonomyNode);
-
-        const result = await metadataTaxonomyNodeAncestorsFetcher(apiMock, fileID, scope, taxonomyKey, nodeID);
-
-        const expectedResult = [
-            {
-                level: 1,
-                levelName: 'Level 1',
-                description: 'Description 1',
-                id: 'node_abc',
-                levelValue: 'Node ABC',
-            },
-            {
-                level: 2,
-                levelName: 'Level 2',
-                description: 'Description 2',
-                id: 'ancestor_1',
-                levelValue: 'Ancestor 1',
-            },
-        ];
-
-        expect(apiMock.getMetadataAPI).toHaveBeenCalledWith(false);
-        expect(apiMock.getMetadataAPI(false).getMetadataTaxonomy).toHaveBeenCalledWith(fileID, scope, taxonomyKey);
-        expect(apiMock.getMetadataAPI(false).getMetadataTaxonomyNode).toHaveBeenCalledWith(
-            fileID,
-            scope,
-            taxonomyKey,
-            nodeID,
-            true,
-        );
-        expect(result).toEqual(expectedResult);
-    });
-
-    test('should handle empty ancestors array', async () => {
-        const mockTaxonomy = {
-            display_name: 'Geography',
-            namespace: 'my_enterprise',
-            id: 'my_id',
-            key: 'geography',
-            levels: [{ level: 1, display_name: 'Level 1', description: 'Description 1' }],
-        };
-
-        const mockTaxonomyNode = {
-            id: 'node_abc',
-            level: 1,
-            display_name: 'Node ABC',
-            ancestors: [],
-        };
-
-        apiMock.getMetadataAPI(false).getMetadataTaxonomy.mockResolvedValue(mockTaxonomy);
-        apiMock.getMetadataAPI(false).getMetadataTaxonomyNode.mockResolvedValue(mockTaxonomyNode);
-
-        const result = await metadataTaxonomyNodeAncestorsFetcher(apiMock, fileID, scope, taxonomyKey, nodeID);
-
-        const expectedResult = [
-            {
-                level: 1,
-                levelName: 'Level 1',
-                description: 'Description 1',
-                id: 'node_abc',
-                levelValue: 'Node ABC',
-            },
-        ];
-
-        expect(result).toEqual(expectedResult);
-    });
-});
-
 describe('metadataTaxonomyNodeAncestorsFetcher (new keys naming convention)', () => {
     const fileID = '12345';
     const scope = 'global';
@@ -417,22 +310,22 @@ describe('metadataTaxonomyNodeAncestorsFetcher (new keys naming convention)', ()
 
     test('should fetch taxonomy and node data and return formatted data', async () => {
         const mockTaxonomy = {
-            display_name: 'Geography',
+            displayName: 'Geography',
             namespace: 'my_enterprise',
             id: 'my_id',
             key: 'geography',
             levels: [
-                { level: 1, display_name: 'Level 1', description: 'Description 1' },
-                { level: 2, display_name: 'Level 2', description: 'Description 2' },
-                { level: 3, display_name: 'Level 3', description: 'Description 3' },
+                { level: 1, displayName: 'Level 1', description: 'Description 1' },
+                { level: 2, displayName: 'Level 2', description: 'Description 2' },
+                { level: 3, displayName: 'Level 3', description: 'Description 3' },
             ],
         };
 
         const mockTaxonomyNode = {
             id: 'node_abc',
             level: 1,
-            display_name: 'Node ABC',
-            ancestors: [{ id: 'ancestor_1', level: 2, display_name: 'Ancestor 1' }],
+            displayName: 'Node ABC',
+            ancestors: [{ id: 'ancestor_1', level: 2, displayName: 'Ancestor 1' }],
         };
 
         apiMock.getMetadataAPI(false).getMetadataTaxonomy.mockResolvedValue(mockTaxonomy);
@@ -471,17 +364,17 @@ describe('metadataTaxonomyNodeAncestorsFetcher (new keys naming convention)', ()
 
     test('should handle empty ancestors array', async () => {
         const mockTaxonomy = {
-            display_name: 'Geography',
+            displayName: 'Geography',
             namespace: 'my_enterprise',
             id: 'my_id',
             key: 'geography',
-            levels: [{ level: 1, display_name: 'Level 1', description: 'Description 1' }],
+            levels: [{ level: 1, displayName: 'Level 1', description: 'Description 1' }],
         };
 
         const mockTaxonomyNode = {
             id: 'node_abc',
             level: 1,
-            display_name: 'Node ABC',
+            displayName: 'Node ABC',
             ancestors: [],
         };
 

--- a/src/elements/content-sidebar/fetchers/metadataTaxonomyFetcher.ts
+++ b/src/elements/content-sidebar/fetchers/metadataTaxonomyFetcher.ts
@@ -19,12 +19,12 @@ export const metadataTaxonomyFetcher = async (
     return {
         options: metadataOptions.entries.map((metadataOption: MetadataOptionEntry) => ({
             value: metadataOption.id,
-            displayValue: metadataOption.display_name || metadataOption.displayName,
+            displayValue: metadataOption.displayName,
             level: metadataOption.level,
             parentId: metadataOption.parentId,
             nodePath: metadataOption.nodePath,
             deprecated: metadataOption.deprecated,
-            ancestors: metadataOption.ancestors?.map(({display_name, displayName, ...rest}) => ({...rest, displayName: display_name || displayName })),
+            ancestors: metadataOption.ancestors?.map(({displayName, ...rest}) => ({...rest, displayName })),
             selectable: metadataOption.selectable,
         })),
         marker,
@@ -62,7 +62,7 @@ export const metadataTaxonomyNodeAncestorsFetcher = async (
     for (const item of metadataTaxonomy.levels) {
         const levelData = {
             level: item.level,
-            levelName: item.displayName || item.display_name,
+            levelName: item.displayName,
             description: item.description,
         };
 
@@ -71,7 +71,7 @@ export const metadataTaxonomyNodeAncestorsFetcher = async (
             levelsMap.set(item.level, {
                 ...levelData,
                 id: metadataTaxonomyNode.id,
-                levelValue: metadataTaxonomyNode.displayName || metadataTaxonomyNode.display_name,
+                levelValue: metadataTaxonomyNode.displayName,
             });
             // If the level is not the metadataTaxonomyNode level, just add the level data
         } else {
@@ -84,7 +84,7 @@ export const metadataTaxonomyNodeAncestorsFetcher = async (
             const levelData = levelsMap.get(ancestor.level);
 
             if (levelData) {
-                levelsMap.set(ancestor.level, { ...levelData, levelValue: ancestor.displayName || ancestor.display_name, id: ancestor.id });
+                levelsMap.set(ancestor.level, { ...levelData, levelValue: ancestor.displayName, id: ancestor.id });
             }
         }
     }


### PR DESCRIPTION
### Description
As a part of Metadata pubic API changes, after successful launch of a new API with new naming we need to cleanup old `display_name` naming for `metadataTaxonomyFetcher`

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized metadata label to a single naming convention across taxonomy fetching and shaping, removing legacy fallbacks so sidebar metadata is consistent.

* **Tests**
  * Updated test fixtures and expectations to the new naming convention and removed deprecated legacy-key cases.

* **Bug Fixes**
  * Fixed mixed-naming inconsistencies that caused missing or incorrect metadata labels; result counts and limits are now surfaced when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->