### PR TITLE
fix(box-ai): Update box-ai-content-answers peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,7 +296,7 @@
         "@box/blueprint-web": "12.43.0",
         "@box/blueprint-web-assets": "4.61.5",
         "@box/box-ai-agent-selector": "^0.53.0",
-        "@box/box-ai-content-answers": "^0.124.1",
+        "@box/box-ai-content-answers": "^0.139.0",
         "@box/box-item-type-selector": "^0.63.12",
         "@box/cldr-data": ">=34.2.0",
         "@box/combobox-with-api": "^0.34.9",


### PR DESCRIPTION
Bumping the peer version of `@box/box-ai-content-answers` in order to match the changes from #4233