### PR TITLE
feat(metadata-view): pass-thru onSortChange

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -91,6 +91,16 @@ class Metadata extends File {
     }
 
     /**
+     * Creates a key for the metadata template schema cache
+     *
+     * @param {string} templateKey - template key
+     * @return {string} key
+     */
+    getMetadataTemplateSchemaCacheKey(templateKey: string): string {
+        return `${CACHE_PREFIX_METADATA}template_schema_${templateKey}`;
+    }
+
+    /**
      * API URL for metadata
      *
      * @param {string} id - a Box file id
@@ -337,9 +347,23 @@ class Metadata extends File {
      * @param {string} templateKey - template key
      * @return {Promise} Promise object of metadata template
      */
-    getSchemaByTemplateKey(templateKey: string): Promise<MetadataTemplateSchemaResponse> {
+    async getSchemaByTemplateKey(templateKey: string): Promise<MetadataTemplateSchemaResponse> {
+        const cache: APICache = this.getCache();
+        const key = this.getMetadataTemplateSchemaCacheKey(templateKey);
+
+        // Return cached value if it exists
+        if (cache.has(key)) {
+            return cache.get(key);
+        }
+
+        // Fetch from API if not cached
         const url = this.getMetadataTemplateSchemaUrl(templateKey);
-        return this.xhr.get({ url });
+        const response = await this.xhr.get({ url });
+
+        // Cache the response
+        cache.set(key, response);
+
+        return response;
     }
 
     /**

--- a/src/elements/content-explorer/Content.tsx
+++ b/src/elements/content-explorer/Content.tsx
@@ -89,6 +89,7 @@ const Content = ({
                     isLoading={percentLoaded !== 100}
                     hasError={view === VIEW_ERROR}
                     metadataTemplate={metadataTemplate}
+                    onSortChange={onSortChange}
                     {...metadataViewProps}
                 />
             )}

--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -10,7 +10,7 @@ import throttle from 'lodash/throttle';
 import uniqueid from 'lodash/uniqueId';
 import { TooltipProvider } from '@box/blueprint-web';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
-import type { Selection } from 'react-aria-components';
+import type { Key, Selection } from 'react-aria-components';
 
 import CreateFolderDialog from '../common/create-folder-dialog';
 import UploadDialog from '../common/upload-dialog';
@@ -152,7 +152,7 @@ export interface ContentExplorerProps {
     rootFolderId?: string;
     sharedLink?: string;
     sharedLinkPassword?: string;
-    sortBy?: SortBy;
+    sortBy?: SortBy | Key;
     sortDirection?: SortDirection;
     staticHost?: string;
     staticPath?: string;
@@ -895,7 +895,7 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
      * @param {string} sortDirection - sort direction
      * @return {void}
      */
-    sort = (sortBy: SortBy, sortDirection: SortDirection) => {
+    sort = (sortBy: SortBy | Key, sortDirection: SortDirection) => {
         const {
             currentCollection: { id },
             view,

--- a/src/elements/content-explorer/MetadataViewContainer.tsx
+++ b/src/elements/content-explorer/MetadataViewContainer.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import type { EnumType, FloatType, MetadataFormFieldValue, RangeType } from '@box/metadata-filter';
 import { MetadataView, type MetadataViewProps } from '@box/metadata-view';
+import { type Key } from '@react-types/shared';
 
+import { SortDescriptor } from 'react-aria-components';
 import type { Collection } from '../../common/types/core';
 import type { MetadataTemplate } from '../../common/types/metadata';
 
@@ -24,6 +26,21 @@ type ActionBarProps = Omit<
     initialFilterValues?: ExternalFilterValues;
     onFilterSubmit?: (filterValues: ExternalFilterValues) => void;
 };
+
+/**
+ * Helper function to trim metadataFieldNamePrefix from column names
+ * For example: 'metadata.enterprise_1515946.mdViewTemplate1.industry' -> 'industry'
+ */
+function trimMetadataFieldPrefix(column: string): string {
+    // Check if the column starts with 'metadata.' and contains at least 2 dots
+    if (column.startsWith('metadata.') && column.split('.').length >= 3) {
+        // Split by dots and take everything after the first 3 parts
+        // metadata.enterprise_1515946.mdViewTemplate1.industry -> industry
+        const parts = column.split('.');
+        return parts.slice(3).join('.');
+    }
+    return column;
+}
 
 function transformInitialFilterValuesToInternal(
     publicValues?: ExternalFilterValues,
@@ -55,6 +72,8 @@ export interface MetadataViewContainerProps extends Omit<MetadataViewProps, 'ite
     actionBarProps?: ActionBarProps;
     currentCollection: Collection;
     metadataTemplate: MetadataTemplate;
+    /* Internally controlled onSortChange prop for the MetadataView component. */
+    onSortChange?: (sortBy: Key, sortDirection: string) => void;
 }
 
 const MetadataViewContainer = ({
@@ -62,6 +81,7 @@ const MetadataViewContainer = ({
     columns,
     currentCollection,
     metadataTemplate,
+    onSortChange: onSortChangeBUIE,
     ...rest
 }: MetadataViewContainerProps) => {
     const { items = [] } = currentCollection;
@@ -111,7 +131,47 @@ const MetadataViewContainer = ({
         };
     }, [actionBarProps, initialFilterValues, onFilterSubmit, filterGroups]);
 
-    return <MetadataView actionBarProps={transformedActionBarProps} columns={columns} items={items} {...rest} />;
+    // Extract the original tableProps.onSortChange from rest
+    const { tableProps, ...otherRest } = rest;
+    const onSortChangeConsumer = tableProps?.onSortChange;
+
+    // Create a wrapper function that calls both. The wrapper function should follow the signature of onSortChange from RAC
+    const handleSortChange = React.useCallback(
+        ({ column, direction }: SortDescriptor) => {
+            // Call the internal onSortChange first
+            // API accepts asc/desc "https://developer.box.com/reference/post-metadata-queries-execute-read/"
+            if (onSortChangeBUIE) {
+                const trimmedColumn = trimMetadataFieldPrefix(String(column));
+                onSortChangeBUIE(trimmedColumn, direction === 'ascending' ? 'ASC' : 'DESC');
+            }
+
+            // Then call the original customer-provided onSortChange if it exists
+            // Accepts "ascending" / "descending" (https://react-spectrum.adobe.com/react-aria/Table.html)
+            if (onSortChangeConsumer) {
+                onSortChangeConsumer({
+                    column,
+                    direction,
+                });
+            }
+        },
+        [onSortChangeBUIE, onSortChangeConsumer],
+    );
+
+    // Create new tableProps with our wrapper function
+    const newTableProps = {
+        ...tableProps,
+        onSortChange: handleSortChange,
+    };
+
+    return (
+        <MetadataView
+            actionBarProps={transformedActionBarProps}
+            columns={columns}
+            items={items}
+            tableProps={newTableProps}
+            {...otherRest}
+        />
+    );
 };
 
 export default MetadataViewContainer;

--- a/src/elements/content-explorer/MetadataViewContainer.tsx
+++ b/src/elements/content-explorer/MetadataViewContainer.tsx
@@ -81,7 +81,7 @@ const MetadataViewContainer = ({
     columns,
     currentCollection,
     metadataTemplate,
-    onSortChange: onSortChangeBUIE,
+    onSortChange: onSortChangeInternal,
     ...rest
 }: MetadataViewContainerProps) => {
     const { items = [] } = currentCollection;
@@ -133,28 +133,28 @@ const MetadataViewContainer = ({
 
     // Extract the original tableProps.onSortChange from rest
     const { tableProps, ...otherRest } = rest;
-    const onSortChangeConsumer = tableProps?.onSortChange;
+    const onSortChangeExternal = tableProps?.onSortChange;
 
     // Create a wrapper function that calls both. The wrapper function should follow the signature of onSortChange from RAC
     const handleSortChange = React.useCallback(
         ({ column, direction }: SortDescriptor) => {
             // Call the internal onSortChange first
             // API accepts asc/desc "https://developer.box.com/reference/post-metadata-queries-execute-read/"
-            if (onSortChangeBUIE) {
+            if (onSortChangeInternal) {
                 const trimmedColumn = trimMetadataFieldPrefix(String(column));
-                onSortChangeBUIE(trimmedColumn, direction === 'ascending' ? 'ASC' : 'DESC');
+                onSortChangeInternal(trimmedColumn, direction === 'ascending' ? 'ASC' : 'DESC');
             }
 
             // Then call the original customer-provided onSortChange if it exists
             // Accepts "ascending" / "descending" (https://react-spectrum.adobe.com/react-aria/Table.html)
-            if (onSortChangeConsumer) {
-                onSortChangeConsumer({
+            if (onSortChangeExternal) {
+                onSortChangeExternal({
                     column,
                     direction,
                 });
             }
         },
-        [onSortChangeBUIE, onSortChangeConsumer],
+        [onSortChangeInternal, onSortChangeExternal],
     );
 
     // Create new tableProps with our wrapper function

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
@@ -507,17 +507,17 @@ describe('elements/content-explorer/ContentExplorer', () => {
             });
 
             test('should call both internal and user onSortChange callbacks when sorting by a metadata field', async () => {
-                const mockOnSortChangeBUIE = jest.fn();
-                const mockOnSortChangeConsumer = jest.fn();
+                const mockOnSortChangeInternal = jest.fn();
+                const mockOnSortChangeExternal = jest.fn();
 
                 renderComponent({
                     ...metadataViewV2ElementProps,
                     metadataViewProps: {
                         ...metadataViewV2ElementProps.metadataViewProps,
-                        onSortChange: mockOnSortChangeBUIE, // Internal callback - receives trimmed column name
+                        onSortChange: mockOnSortChangeInternal, // Internal callback - receives trimmed column name
                         tableProps: {
                             ...metadataViewV2ElementProps.metadataViewProps.tableProps,
-                            onSortChange: mockOnSortChangeConsumer, // User callback - receives full column ID
+                            onSortChange: mockOnSortChangeExternal, // User callback - receives full column ID
                         },
                     },
                 });
@@ -531,10 +531,10 @@ describe('elements/content-explorer/ContentExplorer', () => {
                 await userEvent.click(industryHeader);
 
                 // Internal callback gets trimmed version for API calls
-                expect(mockOnSortChangeBUIE).toHaveBeenCalledWith('industry', 'ASC');
+                expect(mockOnSortChangeInternal).toHaveBeenCalledWith('industry', 'ASC');
 
                 // User callback gets full column ID with direction
-                expect(mockOnSortChangeConsumer).toHaveBeenCalledWith({
+                expect(mockOnSortChangeExternal).toHaveBeenCalledWith({
                     column: 'metadata.enterprise_0.templateName.industry',
                     direction: 'ascending',
                 });

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
@@ -454,7 +454,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
                     textValue: 'Name',
                     id: 'name',
                     type: 'string' as const,
-                    allowSorting: true,
+                    allowsSorting: true,
                     minWidth: 150,
                     maxWidth: 150,
                 },
@@ -462,7 +462,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
                     textValue: field.displayName,
                     id: `${metadataFieldNamePrefix}.${field.key}`,
                     type: field.type as MetadataFieldType,
-                    allowSorting: true,
+                    allowsSorting: true,
                     minWidth: 150,
                     maxWidth: 150,
                 })),
@@ -504,6 +504,40 @@ describe('elements/content-explorer/ContentExplorer', () => {
                 await userEvent.click(selectAllCheckbox);
 
                 expect(screen.getByRole('button', { name: 'Metadata' })).toBeInTheDocument();
+            });
+
+            test('should call both internal and user onSortChange callbacks when sorting by a metadata field', async () => {
+                const mockOnSortChangeBUIE = jest.fn();
+                const mockOnSortChangeConsumer = jest.fn();
+
+                renderComponent({
+                    ...metadataViewV2ElementProps,
+                    metadataViewProps: {
+                        ...metadataViewV2ElementProps.metadataViewProps,
+                        onSortChange: mockOnSortChangeBUIE, // Internal callback - receives trimmed column name
+                        tableProps: {
+                            ...metadataViewV2ElementProps.metadataViewProps.tableProps,
+                            onSortChange: mockOnSortChangeConsumer, // User callback - receives full column ID
+                        },
+                    },
+                });
+
+                const industryHeader = await screen.findByRole('columnheader', { name: 'Industry' });
+                expect(industryHeader).toBeInTheDocument();
+
+                const firstRow = await screen.findByRole('row', { name: /Child 2/i });
+                expect(firstRow).toBeInTheDocument();
+
+                await userEvent.click(industryHeader);
+
+                // Internal callback gets trimmed version for API calls
+                expect(mockOnSortChangeBUIE).toHaveBeenCalledWith('industry', 'ASC');
+
+                // User callback gets full column ID with direction
+                expect(mockOnSortChangeConsumer).toHaveBeenCalledWith({
+                    column: 'metadata.enterprise_0.templateName.industry',
+                    direction: 'ascending',
+                });
             });
 
             test('should call onClick when bulk item action is clicked', async () => {

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -3,7 +3,9 @@ import { http, HttpResponse } from 'msw';
 import { Download, SignMeOthers } from '@box/blueprint-web-assets/icons/Fill/index';
 import { Sign } from '@box/blueprint-web-assets/icons/Line';
 import { expect, fn, userEvent, waitFor, within, screen } from 'storybook/test';
+
 import noop from 'lodash/noop';
+import orderBy from 'lodash/orderBy';
 
 import ContentExplorer from '../../ContentExplorer';
 import { DEFAULT_HOSTNAME_API } from '../../../../constants';
@@ -138,17 +140,16 @@ export const metadataViewV2: Story = {
     args: metadataViewV2ElementProps,
 };
 
-// @TODO Assert that rows are actually sorted in a different order, once handleSortChange is implemented
 export const metadataViewV2SortsFromHeader: Story = {
     args: metadataViewV2ElementProps,
     play: async ({ canvas }) => {
-        await waitFor(() => {
-            expect(canvas.getByRole('row', { name: /Industry/i })).toBeInTheDocument();
-        });
+        const industryHeader = await canvas.findByRole('columnheader', { name: 'Industry' });
+        expect(industryHeader).toBeInTheDocument();
 
-        const firstRow = canvas.getByRole('row', { name: /Industry/i });
-        const industryHeader = within(firstRow).getByRole('columnheader', { name: 'Industry' });
-        userEvent.click(industryHeader);
+        const firstRow = await canvas.findByRole('row', { name: /Child 2/i });
+        expect(firstRow).toBeInTheDocument();
+
+        await userEvent.click(industryHeader);
     },
 };
 
@@ -248,7 +249,21 @@ const meta: Meta<typeof ContentExplorer> = {
     parameters: {
         msw: {
             handlers: [
-                http.post(`${DEFAULT_HOSTNAME_API}/2.0/metadata_queries/execute_read`, () => {
+                // Note that the Metadata API backend normally handles the sorting. The mocks below simulate the sorting for specific cases, but may not 100% accurately reflect the backend behavior.
+                http.post(`${DEFAULT_HOSTNAME_API}/2.0/metadata_queries/execute_read`, async ({ request }) => {
+                    const body = await request.clone().json();
+                    const orderByDirection = body.order_by[0].direction;
+                    const orderByFieldKey = body.order_by[0].field_key;
+
+                    // Hardcoded case for sorting by industry
+                    if (orderByFieldKey === `${metadataFieldNamePrefix}.industry` && orderByDirection === 'ASC') {
+                        const sortedMetadata = orderBy(
+                            mockMetadata.entries,
+                            'metadata.enterprise_0.templateName.industry',
+                            'asc',
+                        );
+                        return HttpResponse.json({ ...mockMetadata, entries: sortedMetadata });
+                    }
                     return HttpResponse.json(mockMetadata);
                 }),
                 http.get(`${DEFAULT_HOSTNAME_API}/2.0/metadata_templates/enterprise/templateName/schema`, () => {

--- a/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
+++ b/src/elements/content-explorer/stories/tests/MetadataView-visual.stories.tsx
@@ -256,7 +256,7 @@ const meta: Meta<typeof ContentExplorer> = {
                     const orderByFieldKey = body.order_by[0].field_key;
 
                     // Hardcoded case for sorting by industry
-                    if (orderByFieldKey === `${metadataFieldNamePrefix}.industry` && orderByDirection === 'ASC') {
+                    if (orderByFieldKey === `industry` && orderByDirection === 'ASC') {
                         const sortedMetadata = orderBy(
                             mockMetadata.entries,
                             'metadata.enterprise_0.templateName.industry',


### PR DESCRIPTION
from the element to the shared-feature

Desired User Behavior:
* When a user clicks a header, the table should provide the selected column ID to Content Explorer's sort function, which calls the MD Query API.
* The customer-provided onSortChange should also be called at the same time, so that the customer may do things like update query parameters in the URL.
* The sorting behavior is handled by the metadata query API. Our element only makes the call and displays the data.

Previous State:
* A customer could provide an onSortChange, but neither the customer-provided callback nor the internally-managed onSortChange were called.
* When clicking a column header, we would call the GET template schema endpoint for each click. This caused a problem when clicking multiple times very quickly.

New State:
* Passes both internally-managed onSortChange and customer-provided onSortChange to a handleSortChange, which calls both.
* Updated column ID used in the MD query to match expected format.
** handleSortChange trims the column ID before passing the ID to the API.
* Cache result from GET template schema API call. We do not expect template schema to update in the timeframe that a user is interacting with MDV.

Verification:
* Comment out MSW handlers in VRT, replace folder ID and token, replace mockSchema with your schema

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata view exposes a public sort-change callback and Content Explorer forwards sort events so apps can react to column sorting.

* **Performance Improvements**
  * Client-side caching for metadata template schemas reduces redundant requests and speeds up metadata-driven views.

* **Tests**
  * Unit and visual tests updated to validate dual-sort behavior, rename sorting flags to allowsSorting, and simulate backend sorting for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->