### PR TITLE
fix(box-ai): Fix suggested questions not appearing

### DIFF
--- a/src/elements/common/content-answers/ContentAnswersModal.tsx
+++ b/src/elements/common/content-answers/ContentAnswersModal.tsx
@@ -180,6 +180,7 @@ const ContentAnswersModal = ({
             questions={questions}
             retryQuestion={handleRetry}
             setAnswerFeedback={noop}
+            shouldShowLandingPage={questions.length === 0}
             submitQuestion={handleAsk}
             suggestedQuestions={suggestedQuestions || localizedQuestions}
             warningNotice={spreadsheetNotice}

--- a/src/elements/common/content-answers/__tests__/ContentAnswersModal.test.tsx
+++ b/src/elements/common/content-answers/__tests__/ContentAnswersModal.test.tsx
@@ -152,7 +152,7 @@ describe('elements/common/content-answers/ContentAnswersModal', () => {
     });
 
     // Skipping those tests, since now suggested questions will be a part of a new landing page, which is turned off for ContentAnswersModal
-    describe.skip('should render suggested questions', () => {
+    describe('should render suggested questions', () => {
         test('renders suggested questions when provided', () => {
             const suggestedQuestions = [{ id: '1', label: 'Suggested Question 1', prompt: 'Prompt 1' }];
             renderComponent(mockApi, { suggestedQuestions });

--- a/src/elements/common/content-answers/__tests__/ContentAnswersModal.test.tsx
+++ b/src/elements/common/content-answers/__tests__/ContentAnswersModal.test.tsx
@@ -151,7 +151,6 @@ describe('elements/common/content-answers/ContentAnswersModal', () => {
         );
     });
 
-    // Skipping those tests, since now suggested questions will be a part of a new landing page, which is turned off for ContentAnswersModal
     describe('should render suggested questions', () => {
         test('renders suggested questions when provided', () => {
             const suggestedQuestions = [{ id: '1', label: 'Suggested Question 1', prompt: 'Prompt 1' }];


### PR DESCRIPTION
This PR fixes an issue where suggested questions were not appearing in the Box AI ContentAnswersModal component. The problem was that the shouldShowLandingPage prop was not being passed to the underlying IntelligenceModal component, which controls whether the landing page (containing suggested questions) should be displayed.

Changes Made:

- Added shouldShowLandingPage={questions.length === 0} to the IntelligenceModal component. This ensures the landing page with suggested questions is shown when there are no existing questions in the conversation
- Uncommented the describe('should render suggested questions') test block that was previously skipped. The tests verify that suggested questions are properly rendered when provided and that localized questions are shown as fallback


https://github.com/user-attachments/assets/b1648108-9abe-4307-bc44-6c9424a36564




<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The AI Answers modal now shows a landing/empty-state page when no questions exist, improving first-time and empty-view guidance.

* **Tests**
  * Re-enabled the suggested-questions test suite to restore coverage and verify suggested-questions behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->