### PR TITLE
fix(blueprint): resolve bug with metadata blueprint via updating blueprint version (BIQ-5766)

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "@babel/preset-typescript": "^7.24.7",
         "@babel/template": "^7.24.7",
         "@babel/types": "^7.24.7",
-        "@box/blueprint-web": "12.43.0",
+        "@box/blueprint-web": "12.62.0",
         "@box/blueprint-web-assets": "4.61.5",
         "@box/box-ai-agent-selector": "^0.53.0",
         "@box/box-ai-content-answers": "^0.139.0",
@@ -293,7 +293,7 @@
         "webpack-dev-server": "^5.2.1"
     },
     "peerDependencies": {
-        "@box/blueprint-web": "12.43.0",
+        "@box/blueprint-web": "12.62.0",
         "@box/blueprint-web-assets": "4.61.5",
         "@box/box-ai-agent-selector": "^0.53.0",
         "@box/box-ai-content-answers": "^0.139.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,19 +1424,19 @@
   resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.61.5.tgz#7e2813fc39f8940f63881ed24df1f8509f340c27"
   integrity sha512-BFQ8ek2y/tPVWuq1tDxPJfuFgLQsYlGxtas5k/bKHDK5XBQrfktPqzusqjif9doVERhB/pKWZ34XMNmjVtzHzA==
 
-"@box/blueprint-web-assets@^4.60.0":
-  version "4.62.1"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.62.1.tgz#76e870dfeadf7d985c275c2b1371a3c5af60f0ad"
-  integrity sha512-ftIs27yZhIXsVt/88BR5+j4gxe01/td5o5qDTZpUrvUL1Kr1DTGP71xkZx7Jaor0tazcWZUfibmEfN97KJ2Yyw==
+"@box/blueprint-web-assets@^4.64.0":
+  version "4.64.7"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web-assets/-/blueprint-web-assets-4.64.7.tgz#1c1a24e8047f17f6cf0d8d74d2b434a4a6778b5b"
+  integrity sha512-8Ztn0IpBvT1IIGv3j9yVdGvbkVcGBErTKqmAwQ44me1kUWb9Rp32LBIsmk7z8F8i+jnygDmeTxZ6VZJQUgC/FQ==
 
-"@box/blueprint-web@12.43.0":
-  version "12.43.0"
-  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-12.43.0.tgz#9febd397c1d5d4cfee936dd070a50a0b352eadcc"
-  integrity sha512-PQ3eAwhE+J2XalLIwQ67TKC1wwpszOM+MYYRzv3Xs/occm0uCeS5ry9F8tsA7KTjHsGSlbR4lIlmycKOBIwv5w==
+"@box/blueprint-web@12.62.0":
+  version "12.62.0"
+  resolved "https://registry.yarnpkg.com/@box/blueprint-web/-/blueprint-web-12.62.0.tgz#53dd34712253462e2c52f5995b96355433bcae4d"
+  integrity sha512-LthepWaxZGpuqDVpqgm/qaMe1vCRzNnFe15HSbmIa3HkzoPj5vv2f2FSc35k+ZHDHm/O0lXX7/mrOxHabOqCcw==
   dependencies:
     "@ariakit/react" "0.4.15"
     "@ariakit/react-core" "0.4.15"
-    "@box/blueprint-web-assets" "^4.60.0"
+    "@box/blueprint-web-assets" "^4.64.0"
     "@internationalized/date" "^3.7.0"
     "@radix-ui/react-accordion" "1.1.2"
     "@radix-ui/react-checkbox" "1.0.4"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the underlying UI library to a newer version, bringing the latest stability, performance, and accessibility improvements.
  * No intentional user-facing changes; minor visual refinements may be noticeable due to upstream updates.
  * Enhances compatibility with modern environments and keeps dependencies current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->