### PR TITLE
fix(metadata-view): fix filtering folders and files

### DIFF
--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -34,7 +34,7 @@ import Content from './Content';
 import { isThumbnailAvailable } from '../common/utils';
 import { isFocusableElement, isInputElement, focus } from '../../utils/dom';
 import { FILE_SHARED_LINK_FIELDS_TO_FETCH } from '../../utils/fields';
-import CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH from './constants';
+import { CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH } from './constants';
 import LocalStore from '../../utils/LocalStore';
 import {
     withFeatureConsumer,

--- a/src/elements/content-explorer/__tests__/MetadataQueryAPIHelper.test.ts
+++ b/src/elements/content-explorer/__tests__/MetadataQueryAPIHelper.test.ts
@@ -673,14 +673,20 @@ describe('elements/content-explorer/MetadataQueryAPIHelper', () => {
             const filters = {
                 'mimetype-filter': {
                     fieldType: 'enum',
-                    value: ['pdf', 'doc'],
+                    value: ['pdfType', 'documentType'],
                 },
             };
 
             const result = metadataQueryAPIHelper.buildMetadataQueryParams(filters);
-            expect(result.query).toBe('(item.extension IN (:arg_mimetype_filter_1, :arg_mimetype_filter_2))');
+            expect(result.query).toBe(
+                '(item.extension IN (:arg_mimetype_filter_1, :arg_mimetype_filter_2, :arg_mimetype_filter_3, :arg_mimetype_filter_4, :arg_mimetype_filter_5, :arg_mimetype_filter_6))',
+            );
             expect(result.queryParams.arg_mimetype_filter_1).toBe('pdf');
             expect(result.queryParams.arg_mimetype_filter_2).toBe('doc');
+            expect(result.queryParams.arg_mimetype_filter_3).toBe('docx');
+            expect(result.queryParams.arg_mimetype_filter_4).toBe('gdoc');
+            expect(result.queryParams.arg_mimetype_filter_5).toBe('rtf');
+            expect(result.queryParams.arg_mimetype_filter_6).toBe('txt');
         });
 
         test('should handle multiple filters of different types', () => {

--- a/src/elements/content-explorer/__tests__/MetadataQueryBuilder.test.ts
+++ b/src/elements/content-explorer/__tests__/MetadataQueryBuilder.test.ts
@@ -228,19 +228,6 @@ describe('elements/content-explorer/MetadataQueryBuilder', () => {
             });
         });
 
-        test('should handle mimetype-filter field key specially', () => {
-            const filterValue = ['pdf', 'doc'];
-            const result = getSelectFilter(filterValue, 'mimetype-filter', 0);
-            expect(result).toEqual({
-                queryParams: {
-                    arg_mimetype_filter_1: 'pdf',
-                    arg_mimetype_filter_2: 'doc',
-                },
-                queries: ['(item.extension HASANY (:arg_mimetype_filter_1, :arg_mimetype_filter_2))'],
-                keysGenerated: 2,
-            });
-        });
-
         test('should handle single value array', () => {
             const filterValue = ['single_value'];
             const result = getSelectFilter(filterValue, 'field_name', 0);
@@ -309,44 +296,51 @@ describe('elements/content-explorer/MetadataQueryBuilder', () => {
     });
 
     describe('getMimeTypeFilter', () => {
-        test('should generate mime type filter and remove "Type" suffix', () => {
-            const filterValue = ['pdfType', 'docType', 'txtType'];
+        test('should generate mime type filter using mapFileTypes', () => {
+            const filterValue = ['pdfType', 'documentType'];
             const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
             expect(result).toEqual({
                 queryParams: {
                     arg_mimetype_1: 'pdf',
                     arg_mimetype_2: 'doc',
-                    arg_mimetype_3: 'txt',
+                    arg_mimetype_3: 'docx',
+                    arg_mimetype_4: 'gdoc',
+                    arg_mimetype_5: 'rtf',
+                    arg_mimetype_6: 'txt',
                 },
-                queries: ['(item.extension IN (:arg_mimetype_1, :arg_mimetype_2, :arg_mimetype_3))'],
-                keysGenerated: 3,
+                queries: [
+                    '(item.extension IN (:arg_mimetype_1, :arg_mimetype_2, :arg_mimetype_3, :arg_mimetype_4, :arg_mimetype_5, :arg_mimetype_6))',
+                ],
+                keysGenerated: 6,
             });
         });
 
-        test('should handle values without "Type" suffix', () => {
+        test('should handle values that are not in FILE_FOLDER_TYPES_MAP', () => {
             const filterValue = ['pdf', 'doc'];
             const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
             expect(result).toEqual({
-                queryParams: {
-                    arg_mimetype_1: 'pdf',
-                    arg_mimetype_2: 'doc',
-                },
-                queries: ['(item.extension IN (:arg_mimetype_1, :arg_mimetype_2))'],
-                keysGenerated: 2,
+                queryParams: {},
+                queries: [],
+                keysGenerated: 0,
             });
         });
 
-        test('should handle mixed values with and without "Type" suffix', () => {
-            const filterValue = ['pdfType', 'doc', 'txtType'];
+        test('should handle mixed valid and invalid values', () => {
+            const filterValue = ['pdfType', 'doc', 'documentType'];
             const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
             expect(result).toEqual({
                 queryParams: {
                     arg_mimetype_1: 'pdf',
                     arg_mimetype_2: 'doc',
-                    arg_mimetype_3: 'txt',
+                    arg_mimetype_3: 'docx',
+                    arg_mimetype_4: 'gdoc',
+                    arg_mimetype_5: 'rtf',
+                    arg_mimetype_6: 'txt',
                 },
-                queries: ['(item.extension IN (:arg_mimetype_1, :arg_mimetype_2, :arg_mimetype_3))'],
-                keysGenerated: 3,
+                queries: [
+                    '(item.extension IN (:arg_mimetype_1, :arg_mimetype_2, :arg_mimetype_3, :arg_mimetype_4, :arg_mimetype_5, :arg_mimetype_6))',
+                ],
+                keysGenerated: 6,
             });
         });
 
@@ -360,16 +354,13 @@ describe('elements/content-explorer/MetadataQueryBuilder', () => {
             });
         });
 
-        test('should handle numeric values converted to strings', () => {
+        test('should handle numeric values that are not in FILE_FOLDER_TYPES_MAP', () => {
             const filterValue = ['123', '456'];
             const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
             expect(result).toEqual({
-                queryParams: {
-                    arg_mimetype_1: '123',
-                    arg_mimetype_2: '456',
-                },
-                queries: ['(item.extension IN (:arg_mimetype_1, :arg_mimetype_2))'],
-                keysGenerated: 2,
+                queryParams: {},
+                queries: [],
+                keysGenerated: 0,
             });
         });
 
@@ -402,15 +393,140 @@ describe('elements/content-explorer/MetadataQueryBuilder', () => {
         });
 
         test('should handle field names with special characters', () => {
-            const filterValue = ['pdfType', 'docType'];
+            const filterValue = ['pdfType', 'documentType'];
             const result = getMimeTypeFilter(filterValue, 'mime-type.with/special_chars', 0);
             expect(result).toEqual({
                 queryParams: {
                     arg_mime_type_with_special_chars_1: 'pdf',
                     arg_mime_type_with_special_chars_2: 'doc',
+                    arg_mime_type_with_special_chars_3: 'docx',
+                    arg_mime_type_with_special_chars_4: 'gdoc',
+                    arg_mime_type_with_special_chars_5: 'rtf',
+                    arg_mime_type_with_special_chars_6: 'txt',
                 },
                 queries: [
-                    '(item.extension IN (:arg_mime_type_with_special_chars_1, :arg_mime_type_with_special_chars_2))',
+                    '(item.extension IN (:arg_mime_type_with_special_chars_1, :arg_mime_type_with_special_chars_2, :arg_mime_type_with_special_chars_3, :arg_mime_type_with_special_chars_4, :arg_mime_type_with_special_chars_5, :arg_mime_type_with_special_chars_6))',
+                ],
+                keysGenerated: 6,
+            });
+        });
+
+        // New tests for folderType functionality
+        test('should handle folderType only', () => {
+            const filterValue = ['folderType'];
+            const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
+            expect(result).toEqual({
+                queryParams: {
+                    arg_mime_folderType_1: 'folder',
+                },
+                queries: ['(item.type = :arg_mime_folderType_1)'],
+                keysGenerated: 1,
+            });
+        });
+
+        test('should handle folderType with file types', () => {
+            const filterValue = ['folderType', 'pdfType', 'documentType'];
+            const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
+            expect(result).toEqual({
+                queryParams: {
+                    arg_mime_folderType_1: 'folder',
+                    arg_mimetype_2: 'pdf',
+                    arg_mimetype_3: 'doc',
+                    arg_mimetype_4: 'docx',
+                    arg_mimetype_5: 'gdoc',
+                    arg_mimetype_6: 'rtf',
+                    arg_mimetype_7: 'txt',
+                },
+                queries: [
+                    '((item.type = :arg_mime_folderType_1) OR (item.extension IN (:arg_mimetype_2, :arg_mimetype_3, :arg_mimetype_4, :arg_mimetype_5, :arg_mimetype_6, :arg_mimetype_7)))',
+                ],
+                keysGenerated: 7,
+            });
+        });
+
+        test('should handle folderType with mixed valid and invalid file types', () => {
+            const filterValue = ['folderType', 'pdfType', 'doc', 'documentType'];
+            const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
+            expect(result).toEqual({
+                queryParams: {
+                    arg_mime_folderType_1: 'folder',
+                    arg_mimetype_2: 'pdf',
+                    arg_mimetype_3: 'doc',
+                    arg_mimetype_4: 'docx',
+                    arg_mimetype_5: 'gdoc',
+                    arg_mimetype_6: 'rtf',
+                    arg_mimetype_7: 'txt',
+                },
+                queries: [
+                    '((item.type = :arg_mime_folderType_1) OR (item.extension IN (:arg_mimetype_2, :arg_mimetype_3, :arg_mimetype_4, :arg_mimetype_5, :arg_mimetype_6, :arg_mimetype_7)))',
+                ],
+                keysGenerated: 7,
+            });
+        });
+
+        test('should handle folderType with single file type', () => {
+            const filterValue = ['folderType', 'pdfType'];
+            const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
+            expect(result).toEqual({
+                queryParams: {
+                    arg_mime_folderType_1: 'folder',
+                    arg_mimetype_2: 'pdf',
+                },
+                queries: ['((item.type = :arg_mime_folderType_1) OR (item.extension IN (:arg_mimetype_2)))'],
+                keysGenerated: 2,
+            });
+        });
+
+        test('should handle folderType with file types using correct arg index', () => {
+            const filterValue = ['folderType', 'pdfType', 'documentType'];
+            const result = getMimeTypeFilter(filterValue, 'mimetype', 5);
+            expect(result).toEqual({
+                queryParams: {
+                    arg_mime_folderType_6: 'folder',
+                    arg_mimetype_7: 'pdf',
+                    arg_mimetype_8: 'doc',
+                    arg_mimetype_9: 'docx',
+                    arg_mimetype_10: 'gdoc',
+                    arg_mimetype_11: 'rtf',
+                    arg_mimetype_12: 'txt',
+                },
+                queries: [
+                    '((item.type = :arg_mime_folderType_6) OR (item.extension IN (:arg_mimetype_7, :arg_mimetype_8, :arg_mimetype_9, :arg_mimetype_10, :arg_mimetype_11, :arg_mimetype_12)))',
+                ],
+                keysGenerated: 7,
+            });
+        });
+
+        test('should handle multiple folderType entries (should only process one)', () => {
+            const filterValue = ['folderType', 'pdfType', 'folderType', 'documentType'];
+            const result = getMimeTypeFilter(filterValue, 'mimetype', 0);
+            expect(result).toEqual({
+                queryParams: {
+                    arg_mime_folderType_1: 'folder',
+                    arg_mimetype_2: 'pdf',
+                    arg_mimetype_3: 'doc',
+                    arg_mimetype_4: 'docx',
+                    arg_mimetype_5: 'gdoc',
+                    arg_mimetype_6: 'rtf',
+                    arg_mimetype_7: 'txt',
+                },
+                queries: [
+                    '((item.type = :arg_mime_folderType_1) OR (item.extension IN (:arg_mimetype_2, :arg_mimetype_3, :arg_mimetype_4, :arg_mimetype_5, :arg_mimetype_6, :arg_mimetype_7)))',
+                ],
+                keysGenerated: 7,
+            });
+        });
+
+        test('should handle folderType with field names containing special characters', () => {
+            const filterValue = ['folderType', 'pdfType'];
+            const result = getMimeTypeFilter(filterValue, 'mime-type.with/special_chars', 0);
+            expect(result).toEqual({
+                queryParams: {
+                    arg_mime_folderType_1: 'folder',
+                    arg_mime_type_with_special_chars_2: 'pdf',
+                },
+                queries: [
+                    '((item.type = :arg_mime_folderType_1) OR (item.extension IN (:arg_mime_type_with_special_chars_2)))',
                 ],
                 keysGenerated: 2,
             });

--- a/src/elements/content-explorer/constants.ts
+++ b/src/elements/content-explorer/constants.ts
@@ -2,7 +2,7 @@ import { FIELD_FILE_VERSION, FIELD_SHA1, FIELD_SHARED_LINK, FIELD_WATERMARK_INFO
 import { FOLDER_FIELDS_TO_FETCH } from '../../utils/fields';
 
 // Fields needed for Content Explorer folder requests
-const CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH = [
+export const CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH = [
     ...FOLDER_FIELDS_TO_FETCH,
     FIELD_FILE_VERSION,
     FIELD_SHA1,
@@ -10,4 +10,41 @@ const CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH = [
     FIELD_WATERMARK_INFO,
 ];
 
-export default CONTENT_EXPLORER_FOLDER_FIELDS_TO_FETCH;
+export const NON_FOLDER_FILE_TYPES_MAP = new Map([
+    ['boxnoteType', ['boxnote']],
+    ['boxcanvasType', ['boxcanvas']],
+    ['pdfType', ['pdf']],
+    ['documentType', ['doc', 'docx', 'gdoc', 'rtf', 'txt']],
+    ['spreadsheetType', ['xls', 'xlsx', 'xlsm', 'csv', 'gsheet']],
+    ['presentationType', ['ppt', 'pptx', 'odp']],
+    ['imageType', ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'tif', 'tiff']],
+    ['audioType', ['mp3', 'm4a', 'm4p', 'wav', 'mid', 'wma']],
+    [
+        'videoType',
+        [
+            'mp4',
+            'mpeg',
+            'mpg',
+            'wmv',
+            '3g2',
+            '3gp',
+            'avi',
+            'm2v',
+            'm4v',
+            'mkv',
+            'mov',
+            'ogg',
+            'mts',
+            'qt',
+            'ts',
+            'flv',
+            'rm',
+        ],
+    ],
+    ['drawingType', ['dwg', 'dxf']],
+    ['threedType', ['obj', 'fbx', 'stl', 'amf', 'iges']],
+]);
+
+export const FILE_FOLDER_TYPES_MAP = new Map(NON_FOLDER_FILE_TYPES_MAP).set('folderType', ['folder']);
+
+export const NON_FOLDER_FILE_TYPES = Array.from(NON_FOLDER_FILE_TYPES_MAP.keys());

--- a/src/elements/content-explorer/utils.ts
+++ b/src/elements/content-explorer/utils.ts
@@ -11,9 +11,11 @@ import {
 } from '@box/metadata-editor';
 import type { MetadataFieldType } from '@box/metadata-view';
 import type { Selection } from 'react-aria-components';
+import { BoxItemSelection } from '@box/box-item-type-selector';
 import type { BoxItem, Collection } from '../../common/types/core';
 
 import messages from '../common/messages';
+import { FILE_FOLDER_TYPES_MAP, NON_FOLDER_FILE_TYPES } from './constants';
 
 // Specific type for metadata field value in the item
 // Note: Item doesn't have field value in metadata object if that field is not set, so the value will be undefined in this case
@@ -193,3 +195,18 @@ export function useTemplateInstance(metadataTemplate: MetadataTemplate, selected
         type,
     };
 }
+
+export const mapFileTypes = (selectedFileTypes: BoxItemSelection) => {
+    const selectedFileTypesSet = new Set(selectedFileTypes);
+
+    const areAllNonFolderFileTypesSelected = NON_FOLDER_FILE_TYPES.every(key => selectedFileTypesSet.has(key));
+
+    if (areAllNonFolderFileTypesSelected) {
+        if (selectedFileTypes.includes('folderType')) {
+            return [];
+        }
+        return ['file'];
+    }
+
+    return selectedFileTypes.map(fileType => FILE_FOLDER_TYPES_MAP.get(fileType as string) || []).flat();
+};


### PR DESCRIPTION
when selecting folders or files via the filter chip, they will be added to the query correctly now

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Filtering now expands logical file-type selections into their mapped extensions and supports combining folder-type and file-type filters in a single query; introduces explicit file/folder type mappings to improve matching.

- Bug Fixes
  - Standardized mimetype-filter behavior for mixed folder/file selections and field names with special characters; unmapped values now yield no matches.

- Tests
  - Expanded coverage for mapped types, folder+file combos, indexing offsets, special-character field names, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->