### PR TITLE
fix: Incomplete string escaping or encoding

### DIFF
--- a/src/elements/content-explorer/MetadataQueryBuilder.ts
+++ b/src/elements/content-explorer/MetadataQueryBuilder.ts
@@ -33,7 +33,8 @@ const generateArgKey = (key: string, index: number): string => {
     return `arg_${purifyKey}_${index}`;
 };
 
-const escapeValue = (value: string): string => value.replace(/([_%])/g, '\\$1');
+const escapeValue = (value: string): string =>
+    value.replace(/\\/g, '\\\\').replace(/([_%])/g, '\\$1');
 
 export const getStringFilter = (filterValue: string, fieldKey: string, argIndexStart: number): QueryResult => {
     let currentArgIndex = argIndexStart;


### PR DESCRIPTION
Potential fix for [https://github.com/box/box-ui-elements/security/code-scanning/14](https://github.com/box/box-ui-elements/security/code-scanning/14)

To properly escape string input for use in a SQL LIKE clause, you must escape the backslash (`\`) itself *before* you escape any other special characters (`%` and `_`). This ensures that all literal backslashes in the original input are doubled so that they are not interpreted as escape characters for subsequent meta-characters. The fix should be to replace all backslashes with double backslashes (i.e., `'\\'` → `'\\\\'`), followed by escaping `%` and `_` as before. This change should be made in the `escapeValue` function definition (line 36 in the code sample). No new methods or imports are needed, as this can be implemented using chained `.replace()` calls with appropriate regular expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters in metadata filters. Values containing backslashes, underscores, and percent signs are now escaped correctly, leading to more accurate results in searches and filters that use wildcard operators (e.g., LIKE/ILIKE). This reduces unexpected matches or missed results when querying metadata with these characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->