### PR TITLE
fix(metadata-view): fix filtering file extensions and filters visibility

### DIFF
--- a/src/elements/content-explorer/MetadataQueryAPIHelper.ts
+++ b/src/elements/content-explorer/MetadataQueryAPIHelper.ts
@@ -172,17 +172,11 @@ export default class MetadataQueryAPIHelper {
     };
 
     getTemplateSchemaInfo = (data: MetadataQueryResponseData): Promise<MetadataTemplateSchemaResponse | void> => {
-        const { entries } = data;
         this.metadataQueryResponseData = data;
-        if (!entries || entries.length === 0) {
-            // Don't make metadata API call to get template info
-            return Promise.resolve();
-        }
 
-        const metadata = getProp(entries, '[0].metadata');
-        this.templateScope = Object.keys(metadata)[0];
-        const instance = metadata[this.templateScope];
-        this.templateKey = Object.keys(instance)[0];
+        const [scope, key] = this.metadataQuery.from.split('.');
+        this.templateScope = scope;
+        this.templateKey = key;
 
         return this.api.getMetadataAPI(true).getSchemaByTemplateKey(this.templateKey);
     };

--- a/src/elements/content-explorer/__tests__/MetadataQueryBuilder.test.ts
+++ b/src/elements/content-explorer/__tests__/MetadataQueryBuilder.test.ts
@@ -6,6 +6,7 @@ import {
     getSelectFilter,
     getMimeTypeFilter,
 } from '../MetadataQueryBuilder';
+import { getFileExtensions } from '../utils';
 
 describe('elements/content-explorer/MetadataQueryBuilder', () => {
     describe('mergeQueryParams', () => {
@@ -530,6 +531,18 @@ describe('elements/content-explorer/MetadataQueryBuilder', () => {
                 ],
                 keysGenerated: 2,
             });
+        });
+    });
+
+    describe('getFileExtensions', () => {
+        test('should return actual file extensions for single file type', () => {
+            const result = getFileExtensions('documentType');
+            expect(result).toEqual(['doc', 'docx', 'gdoc', 'rtf', 'txt']);
+        });
+
+        test('should handle empty array input', () => {
+            const result = getFileExtensions('');
+            expect(result).toEqual([]);
         });
     });
 });

--- a/src/elements/content-explorer/constants.ts
+++ b/src/elements/content-explorer/constants.ts
@@ -45,6 +45,4 @@ export const NON_FOLDER_FILE_TYPES_MAP = new Map([
     ['threedType', ['obj', 'fbx', 'stl', 'amf', 'iges']],
 ]);
 
-export const FILE_FOLDER_TYPES_MAP = new Map(NON_FOLDER_FILE_TYPES_MAP).set('folderType', ['folder']);
-
 export const NON_FOLDER_FILE_TYPES = Array.from(NON_FOLDER_FILE_TYPES_MAP.keys());

--- a/src/elements/content-explorer/utils.ts
+++ b/src/elements/content-explorer/utils.ts
@@ -11,11 +11,10 @@ import {
 } from '@box/metadata-editor';
 import type { MetadataFieldType } from '@box/metadata-view';
 import type { Selection } from 'react-aria-components';
-import { BoxItemSelection } from '@box/box-item-type-selector';
 import type { BoxItem, Collection } from '../../common/types/core';
 
 import messages from '../common/messages';
-import { FILE_FOLDER_TYPES_MAP, NON_FOLDER_FILE_TYPES } from './constants';
+import { NON_FOLDER_FILE_TYPES_MAP } from './constants';
 
 // Specific type for metadata field value in the item
 // Note: Item doesn't have field value in metadata object if that field is not set, so the value will be undefined in this case
@@ -196,17 +195,9 @@ export function useTemplateInstance(metadataTemplate: MetadataTemplate, selected
     };
 }
 
-export const mapFileTypes = (selectedFileTypes: BoxItemSelection) => {
-    const selectedFileTypesSet = new Set(selectedFileTypes);
-
-    const areAllNonFolderFileTypesSelected = NON_FOLDER_FILE_TYPES.every(key => selectedFileTypesSet.has(key));
-
-    if (areAllNonFolderFileTypesSelected) {
-        if (selectedFileTypes.includes('folderType')) {
-            return [];
-        }
-        return ['file'];
+export const getFileExtensions = (selectedFileType: string) => {
+    if (NON_FOLDER_FILE_TYPES_MAP.has(selectedFileType)) {
+        return NON_FOLDER_FILE_TYPES_MAP.get(selectedFileType).flat();
     }
-
-    return selectedFileTypes.map(fileType => FILE_FOLDER_TYPES_MAP.get(fileType as string) || []).flat();
+    return [];
 };


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added explicit folder filtering support in content explorer queries.

- Improvements
  - More accurate file-type filtering using real file extensions; extension filters applied only when relevant.
  - Query construction improved for correct combination of multiple filter conditions.
  - Metadata template lookup now derives scope/key from the query and fetches the template schema consistently.

- Tests
  - Added/expanded tests for file-extension mapping and template schema behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->