### PR TITLE
fix(metadata-view): Enable sorting dropdown

### DIFF
--- a/src/elements/content-explorer/ContentExplorer.tsx
+++ b/src/elements/content-explorer/ContentExplorer.tsx
@@ -144,7 +144,7 @@ export interface ContentExplorerProps {
     metadataQuery?: MetadataQuery;
     metadataViewProps?: Omit<
         MetadataViewContainerProps,
-        'hasError' | 'currentCollection' | 'metadataTemplate' | 'onMetadataFilter'
+        'hasError' | 'currentCollection' | 'metadataTemplate' | 'selectedKeys'
     >;
     onCreate?: (item: BoxItem) => void;
     onDelete?: (item: BoxItem) => void;
@@ -1612,7 +1612,10 @@ class ContentExplorer extends Component<ContentExplorerProps, State> {
         return maxWidthColumns;
     };
 
-    getMetadataViewProps = (): ContentExplorerProps['metadataViewProps'] => {
+    getMetadataViewProps = (): Omit<
+        MetadataViewContainerProps,
+        'hasError' | 'currentCollection' | 'metadataTemplate'
+    > => {
         const { metadataViewProps } = this.props;
         const { onSelectionChange } = metadataViewProps ?? {};
         const { selectedItemIds } = this.state;

--- a/src/elements/content-explorer/MetadataViewContainer.tsx
+++ b/src/elements/content-explorer/MetadataViewContainer.tsx
@@ -155,6 +155,17 @@ const MetadataViewContainer = ({
         const clonedTemplate = cloneDeep(metadataTemplate);
         let fields = clonedTemplate?.fields || [];
 
+        // Filter fields to only include those that have corresponding columns
+        const columnIds = newColumns.map(col => col.id);
+        fields = fields.filter((field: MetadataTemplateField) => {
+            // For metadata fields, check if the column ID matches the field key
+            // Column IDs for metadata fields are typically in format: metadata.template.fieldKey
+            return columnIds.some(columnId => {
+                const trimmedColumnId = trimMetadataFieldPrefix(columnId);
+                return trimmedColumnId === field.key;
+            });
+        });
+
         // Check if item_name field already exists to avoid duplicates
         const hasItemNameField = fields.some((field: MetadataTemplateField) => field.key === ITEM_FILTER_NAME);
 
@@ -185,7 +196,7 @@ const MetadataViewContainer = ({
                     }) || [],
             },
         ];
-    }, [formatMessage, metadataTemplate]);
+    }, [formatMessage, metadataTemplate, newColumns]);
 
     const initialFilterValues = React.useMemo(
         () => transformInitialFilterValuesToInternal(initialFilterValuesProp),
@@ -202,20 +213,6 @@ const MetadataViewContainer = ({
         },
         [onFilterSubmit, onMetadataFilter],
     );
-
-    const transformedActionBarProps = React.useMemo(() => {
-        return {
-            ...actionBarProps,
-            initialFilterValues,
-            onFilterSubmit: handleFilterSubmit,
-            filterGroups,
-
-            predefinedFilterOptions: {
-                [PredefinedFilterName.KeywordSearchFilterGroup]: { isDisabled: true },
-                [PredefinedFilterName.LocationFilterGroup]: { isDisabled: true },
-            },
-        };
-    }, [actionBarProps, initialFilterValues, handleFilterSubmit, filterGroups]);
 
     // Create a wrapper function that calls both. The wrapper function should follow the signature of onSortChange from RAC
     const handleSortChange = React.useCallback(
@@ -238,6 +235,22 @@ const MetadataViewContainer = ({
         },
         [onSortChangeInternal, tableProps],
     );
+
+    const transformedActionBarProps = React.useMemo(() => {
+        return {
+            ...actionBarProps,
+            initialFilterValues,
+            onFilterSubmit: handleFilterSubmit,
+            filterGroups,
+            sortDropdownProps: {
+                onSortChange: handleSortChange,
+            },
+            predefinedFilterOptions: {
+                [PredefinedFilterName.KeywordSearchFilterGroup]: { isDisabled: true },
+                [PredefinedFilterName.LocationFilterGroup]: { isDisabled: true },
+            },
+        };
+    }, [actionBarProps, initialFilterValues, handleFilterSubmit, handleSortChange, filterGroups]);
 
     // Create new tableProps with our wrapper function
     const newTableProps = {

--- a/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
+++ b/src/elements/content-explorer/__tests__/ContentExplorer.test.tsx
@@ -442,12 +442,7 @@ describe('elements/content-explorer/ContentExplorer', () => {
                     'name',
                 ],
             };
-            const fieldsToShow = [
-                { key: `${metadataFieldNamePrefix}.name`, canEdit: false, displayName: 'Alias' },
-                { key: `${metadataFieldNamePrefix}.industry`, canEdit: true },
-                { key: `${metadataFieldNamePrefix}.last_contacted_at`, canEdit: true },
-                { key: `${metadataFieldNamePrefix}.role`, canEdit: true },
-            ];
+
             const columns = [
                 {
                     // Always include the name column
@@ -472,9 +467,9 @@ describe('elements/content-explorer/ContentExplorer', () => {
                 metadataViewProps: {
                     columns,
                     isSelectionEnabled: true,
+                    onMetadataFilter: jest.fn(),
                 },
                 metadataQuery,
-                fieldsToShow,
                 defaultView,
                 features: {
                     contentExplorer: {

--- a/src/elements/content-explorer/__tests__/MetadataViewContainer.test.tsx
+++ b/src/elements/content-explorer/__tests__/MetadataViewContainer.test.tsx
@@ -34,12 +34,6 @@ describe('elements/content-explorer/MetadataViewContainer', () => {
 
     const mockMetadataTemplateFields: MetadataTemplateField[] = [
         {
-            id: 'field1',
-            key: 'item.name',
-            displayName: 'Name',
-            type: 'string',
-        },
-        {
             id: 'field2',
             key: 'industry',
             displayName: 'Industry',
@@ -96,6 +90,30 @@ describe('elements/content-explorer/MetadataViewContainer', () => {
             {
                 textValue: 'Industry',
                 id: 'industry',
+                type: 'string',
+                allowsSorting: true,
+                minWidth: 250,
+                maxWidth: 250,
+            },
+            {
+                textValue: 'Contact Role',
+                id: 'role',
+                type: 'string',
+                allowsSorting: true,
+                minWidth: 250,
+                maxWidth: 250,
+            },
+            {
+                textValue: 'Status',
+                id: 'status',
+                type: 'string',
+                allowsSorting: true,
+                minWidth: 250,
+                maxWidth: 250,
+            },
+            {
+                textValue: 'Price',
+                id: 'price',
                 type: 'string',
                 allowsSorting: true,
                 minWidth: 250,
@@ -264,9 +282,10 @@ describe('elements/content-explorer/MetadataViewContainer', () => {
             actionBarProps: { initialFilterValues },
         });
 
-        expect(screen.getByRole('button', { name: 'All Filters 3' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'All Filters 2' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /Industry/i })).toHaveTextContent(/\(1\)/);
-        expect(screen.getByRole('button', { name: /Category/i })).toHaveTextContent(/\(2\)/);
+        // Category filter should not be present since there's no corresponding column
+        expect(screen.queryByRole('button', { name: /Category/i })).not.toBeInTheDocument();
     });
 
     test('should handle empty metadata template fields', () => {
@@ -335,12 +354,6 @@ describe('elements/content-explorer/MetadataViewContainer', () => {
             ...mockMetadataTemplate,
             fields: [
                 {
-                    id: 'field1',
-                    key: 'name',
-                    displayName: 'File Name',
-                    type: 'string',
-                },
-                {
                     id: 'field2',
                     key: 'industry',
                     displayName: 'Industry',
@@ -350,11 +363,11 @@ describe('elements/content-explorer/MetadataViewContainer', () => {
             ],
         };
 
-        renderComponent({ metadataTemplate: templateWithoutOptions });
+        renderComponent({
+            metadataTemplate: templateWithoutOptions,
+        });
 
         expect(screen.getByRole('button', { name: 'All Filters' })).toBeInTheDocument();
-        expect(screen.getAllByRole('button', { name: 'Name' })).toHaveLength(1); // Only the one added by component
-        expect(screen.getByRole('button', { name: 'File Name' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Industry' })).toBeInTheDocument();
     });
 
@@ -545,5 +558,54 @@ describe('elements/content-explorer/MetadataViewContainer', () => {
                 within(screen.getByRole('dialog')).queryByRole('button', { name: /location/i }),
             ).not.toBeInTheDocument();
         });
+    });
+
+    test('should filter fields based on columns provided', () => {
+        const template: MetadataTemplate = {
+            ...mockMetadataTemplate,
+            fields: [
+                {
+                    id: 'field1',
+                    key: 'status',
+                    displayName: 'Status',
+                    type: 'enum',
+                    options: [
+                        { id: 's1', key: 'Active' },
+                        { id: 's2', key: 'Inactive' },
+                    ],
+                },
+                {
+                    id: 'field2',
+                    key: 'price',
+                    displayName: 'Price',
+                    type: 'float',
+                },
+                {
+                    id: 'field3',
+                    key: 'category',
+                    displayName: 'Category',
+                    type: 'multiSelect',
+                    options: [
+                        { id: 'c1', key: 'tech' },
+                        { id: 'c2', key: 'finance' },
+                    ],
+                },
+            ],
+        };
+
+        // Only provide columns for 'status' and 'price', not 'category'
+        renderComponent({
+            metadataTemplate: template,
+        });
+
+        // Should show filters for fields that have corresponding columns
+        expect(screen.getByRole('button', { name: 'All Filters' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Status' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Price' })).toBeInTheDocument();
+
+        // Should NOT show filter for 'category' since there's no corresponding column
+        expect(screen.queryByRole('button', { name: 'Category' })).not.toBeInTheDocument();
+        // Should NOT show filter for 'industry' since it's not in the provided columns
+        expect(screen.queryByRole('button', { name: 'Industry' })).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
Fixed the column only filter chip bug
updated metadata-view package with new selection props 
enable sorting dropdown 

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Top-level selection controls in metadata views (selected items and selection-change callbacks).
  - Exposed sorting callbacks so external handlers receive sort changes.

- Bug Fixes
  - Filters now respect visible columns, hiding filters for non-visible fields.
  - Sorting changes consistently propagate through the action bar and table.

- Refactor
  - Flattened metadata view prop structure for simpler integration.

- Tests
  - Updated tests for column-driven filters, dynamic columns, and sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->