### PR TITLE
Revert "chore(mergify): update circleci and mergify configuration (#4…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,20 +135,15 @@ workflows:
       - lint:
           requires:
             - setup
-          context: github-checks
       - flow:
           requires:
             - setup
-          context: github-checks
       - build-unit-tests:
           requires:
             - setup
-          context: github-checks
       - e2e-tests:
           requires:
             - setup
-          context: github-checks
       - chromatic-deploy:
           requires:
             - setup
-          context: github-checks

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,17 +18,10 @@ queue_rules:
           - label != do-not-merge
           - status-success = license/cla
           - status-success = lint_pull_request
-          - "check-success = ci/circleci: lint"
-          - "check-success = ci/circleci: flow"
-          - "check-success = ci/circleci: build-unit-tests"
-          - "check-success = ci/circleci: e2e-tests"
-          - "check-success = ci/circleci: chromatic-deploy"
+          - status-success = lint_test_build
       merge_conditions:
-          - "check-success = ci/circleci: lint"
-          - "check-success = ci/circleci: flow"
-          - "check-success = ci/circleci: build-unit-tests"
-          - "check-success = ci/circleci: e2e-tests"
-          - "check-success = ci/circleci: chromatic-deploy"
+          - status-success = lint_pull_request
+          - status-success = lint_test_build
       merge_method: squash
 
     - name: Automatic strict merge
@@ -38,20 +31,13 @@ queue_rules:
           - label != do-not-merge
           - status-success = license/cla
           - status-success = lint_pull_request
-          - "check-success = ci/circleci: lint"
-          - "check-success = ci/circleci: flow"
-          - "check-success = ci/circleci: build-unit-tests"
-          - "check-success = ci/circleci: e2e-tests"
-          - "check-success = ci/circleci: chromatic-deploy"
+          - status-success = lint_test_build
           - branch-protection-review-decision = APPROVED
           - "#approved-reviews-by >= 2"
           - "#changes-requested-reviews-by = 0"
           - "#review-threads-unresolved = 0"
       merge_conditions:
           - status-success = license/cla
-          - "check-success = ci/circleci: lint"
-          - "check-success = ci/circleci: flow"
-          - "check-success = ci/circleci: build-unit-tests"
-          - "check-success = ci/circleci: e2e-tests"
-          - "check-success = ci/circleci: chromatic-deploy"
+          - status-success = lint_pull_request
+          - status-success = lint_test_build
       merge_method: squash


### PR DESCRIPTION
…295)"

This reverts commit 1356ea671c7abba1a4606ed3bbf45b09bf2fbd64.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
