### PR TITLE
chore(mergify): update configuration

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
     main:
+        if: github.actor != 'mergify[bot]'
         name: lint_pull_request
         runs-on: ubuntu-latest
         steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,12 +6,9 @@ pull_request_rules:
       conditions:
           - -draft
           - base = master
-          - author != mergify[bot]
           - label != do-not-merge
           - status-success = license/cla
           - status-success = lint_pull_request
-          - status-success = lint_test_build
-          - branch-protection-review-decision = APPROVED
       actions:
           queue:
 
@@ -19,7 +16,6 @@ queue_rules:
     - name: Automatic boxmoji merge
       queue_conditions:
           - author = boxmoji
-          - author != mergify[bot]
           - title ~= ^(fix)\(i18n\)?:\supdate translations$
           - files ~= ^i18n/
           - status-success = lint_test_build
@@ -29,9 +25,10 @@ queue_rules:
 
     - name: Automatic strict merge
       queue_conditions:
-          - author != mergify[bot]
           - title ~= ^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?:\s.+$
           - label = ready-to-merge
+          - status-success = lint_test_build
+          - branch-protection-review-decision = APPROVED
           - "#approved-reviews-by >= 2"
           - "#changes-requested-reviews-by = 0"
           - "#review-threads-unresolved = 0"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI updated to skip redundant checks for automated merge actions, reducing unnecessary runs.
  * Automation can now participate in merges where appropriate, improving workflow efficiency.
  * Select merge queues now require successful build checks and explicit approval before merging, strengthening safeguards.
  * Streamlines pull request merging while maintaining reliability and compliance with branch protection.
  * No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->