### PR TITLE
chore(circleci): conditional to mergify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,19 @@ jobs:
       - build-locales
       - run:
           name: Commit lint
-          command: /buie/scripts/commitlint.sh
+          command: |
+            if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
+              CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
+              PULL_REQUEST_DETAILS=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER})
+              AUTHOR=$(node -pe 'JSON.parse(process.argv[1]).user.login' "${PULL_REQUEST_DETAILS}")
+              if [ "$AUTHOR" != "mergify[bot]" ]; then
+                /buie/scripts/commitlint.sh
+              else
+                echo "Skipping commitlint for Mergify bot PR"
+              fi
+            else
+              /buie/scripts/commitlint.sh
+            fi
       - run:
           name: Code lint
           command: yarn --cwd /buie lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,4 +105,4 @@ Keep in mind that we like to see one issue addressed per pull request, as this h
 
 ### Step 8: Add `ready-to-merge` label
 
-After your pull request has been approved and the check statuses are green, please add the `ready-to-merge` label instead of using the merge button. This will add your pull request to the merge queue and merge your pull request when it is safe. If you are unable to add the `ready-to-merge` label, please ask an approver or maintainer for assistance.
+After your pull request has been approved and the check statuses are green, please add the `ready-to-merge` label instead of using the merge button. This will add your pull request to the merge queue and merge your pull request when it is safe. If you are unable to add the `ready-to-merge` label, please ask an approver or maintainer for assistance


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI commit-linting to automatically skip checks on PRs opened by an automation bot, while preserving existing behavior for all other PRs. This reduces noise and improves pipeline reliability.
* **Documentation**
  * Minor punctuation cleanup in the contributing guide; no changes to the contribution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->