### PR TITLE
feat(video-annotations): sidebar support for video annotations

### DIFF
--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -129,7 +129,7 @@ const AnnotationActivity = ({
     };
 
     const isVideoAnnotation = target?.location?.type === 'frame';
-    const annotationsMillisecondTimestampInHHMMSS = isVideoAnnotation
+    const annotationsMillisecondTimestampInHMMSS = isVideoAnnotation
         ? convertMillisecondsToHMMSS(target.location.value)
         : null;
 
@@ -195,7 +195,7 @@ const AnnotationActivity = ({
                             <ActivityMessage
                                 getUserProfileUrl={getUserProfileUrl}
                                 id={id}
-                                annotationsMillisecondTimestamp={annotationsMillisecondTimestampInHHMMSS}
+                                annotationsMillisecondTimestamp={annotationsMillisecondTimestampInHMMSS}
                                 onClick={handleSelect}
                                 isEdited={isEdited && !isResolved}
                                 tagged_message={message}

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -129,8 +129,10 @@ const AnnotationActivity = ({
     };
 
     const isVideoAnnotation = target?.location?.type === 'frame';
-    const annotationsMillisecondTimestampInHHMMSS =
-        isVideoAnnotation && convertMillisecondsToHMMSS(target.location.value);
+    const annotationsMillisecondTimestampInHHMMSS = isVideoAnnotation
+        ? convertMillisecondsToHMMSS(target.location.value)
+        : null;
+
     return (
         <>
             <SelectableActivityCard

--- a/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/AnnotationActivity.js
@@ -24,6 +24,7 @@ import type { GetAvatarUrlCallback, GetProfileUrlCallback } from '../../../commo
 import type { SelectorItems, User, BoxItem } from '../../../../common/types/core';
 
 import IconAnnotation from '../../../../icons/two-toned/IconAnnotation';
+import { convertMillisecondsToHMMSS } from '../../../../utils/timestamp';
 
 import './AnnotationActivity.scss';
 
@@ -127,6 +128,9 @@ const AnnotationActivity = ({
         targetAttachment: 'bottom right',
     };
 
+    const isVideoAnnotation = target?.location?.type === 'frame';
+    const annotationsMillisecondTimestampInHHMMSS =
+        isVideoAnnotation && convertMillisecondsToHMMSS(target.location.value);
     return (
         <>
             <SelectableActivityCard
@@ -158,7 +162,7 @@ const AnnotationActivity = ({
                         </div>
                         <div className="bcs-AnnotationActivity-timestamp">
                             <ActivityTimestamp date={createdAtTimestamp} />
-                            {hasVersions && (
+                            {hasVersions && !isVideoAnnotation && (
                                 <AnnotationActivityLink
                                     className="bcs-AnnotationActivity-link"
                                     data-resin-target="annotationLink"
@@ -189,6 +193,8 @@ const AnnotationActivity = ({
                             <ActivityMessage
                                 getUserProfileUrl={getUserProfileUrl}
                                 id={id}
+                                annotationsMillisecondTimestamp={annotationsMillisecondTimestampInHHMMSS}
+                                onClick={handleSelect}
                                 isEdited={isEdited && !isResolved}
                                 tagged_message={message}
                             />

--- a/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
+++ b/src/elements/content-sidebar/activity-feed/annotations/__tests__/AnnotationActivity.test.js
@@ -367,4 +367,153 @@ describe('elements/content-sidebar/ActivityFeed/annotations/AnnotationActivity',
             expect(event.stopPropagation).not.toHaveBeenCalled();
         });
     });
+
+    describe('video annotations', () => {
+        const mockVideoAnnotation = {
+            ...mockAnnotation,
+            target: {
+                location: {
+                    type: 'frame',
+                    value: 60000, // 1 minute in milliseconds
+                },
+            },
+        };
+
+        test('should detect video annotation when target location type is frame', () => {
+            const wrapper = getWrapper({ item: mockVideoAnnotation });
+            const activityMessage = wrapper.find('ForwardRef(withFeatureConsumer(ActivityMessage))');
+
+            expect(activityMessage.prop('annotationsMillisecondTimestamp')).toBe('0:01:00');
+        });
+
+        test('should not show version link for video annotations even when hasVersions is true', () => {
+            const wrapper = getWrapper({
+                item: mockVideoAnnotation,
+                hasVersions: true,
+                isCurrentVersion: true,
+            });
+
+            expect(wrapper.exists('AnnotationActivityLink')).toBe(false);
+        });
+
+        test('should pass correct timestamp format to ActivityMessage for video annotations', () => {
+            const videoAnnotationWithTimestamp = {
+                ...mockVideoAnnotation,
+                target: {
+                    location: {
+                        type: 'frame',
+                        value: 3661000, // 1 hour, 1 minute, 1 second
+                    },
+                },
+            };
+
+            const wrapper = getWrapper({ item: videoAnnotationWithTimestamp });
+            const activityMessage = wrapper.find('ForwardRef(withFeatureConsumer(ActivityMessage))');
+
+            expect(activityMessage.prop('annotationsMillisecondTimestamp')).toBe('1:01:01');
+        });
+
+        test('should handle zero timestamp for video annotations', () => {
+            const videoAnnotationWithZeroTimestamp = {
+                ...mockVideoAnnotation,
+                target: {
+                    location: {
+                        type: 'frame',
+                        value: 0,
+                    },
+                },
+            };
+
+            const wrapper = getWrapper({ item: videoAnnotationWithZeroTimestamp });
+            const activityMessage = wrapper.find('ForwardRef(withFeatureConsumer(ActivityMessage))');
+
+            expect(activityMessage.prop('annotationsMillisecondTimestamp')).toBe('0:00:00');
+        });
+
+        test('should handle undefined timestamp for video annotations', () => {
+            const videoAnnotationWithUndefinedTimestamp = {
+                ...mockVideoAnnotation,
+                target: {
+                    location: {
+                        type: 'frame',
+                        value: undefined,
+                    },
+                },
+            };
+
+            const wrapper = getWrapper({ item: videoAnnotationWithUndefinedTimestamp });
+            const activityMessage = wrapper.find('ForwardRef(withFeatureConsumer(ActivityMessage))');
+
+            expect(activityMessage.prop('annotationsMillisecondTimestamp')).toBe('0:00:00');
+        });
+
+        test('should not pass timestamp to ActivityMessage for non-video annotations', () => {
+            const regularAnnotation = {
+                ...mockAnnotation,
+                target: {
+                    location: {
+                        type: 'page',
+                        value: 1,
+                    },
+                },
+            };
+
+            const wrapper = getWrapper({ item: regularAnnotation });
+            const activityMessage = wrapper.find('ForwardRef(withFeatureConsumer(ActivityMessage))');
+
+            expect(activityMessage.prop('annotationsMillisecondTimestamp')).toBeFalsy();
+        });
+
+        test('should not pass timestamp to ActivityMessage when target location type is missing', () => {
+            const annotationWithoutType = {
+                ...mockAnnotation,
+                target: {
+                    location: {
+                        value: 60000,
+                    },
+                },
+            };
+
+            const wrapper = getWrapper({ item: annotationWithoutType });
+            const activityMessage = wrapper.find('ForwardRef(withFeatureConsumer(ActivityMessage))');
+
+            expect(activityMessage.prop('annotationsMillisecondTimestamp')).toBeFalsy();
+        });
+
+        test('should not pass timestamp to ActivityMessage when target is missing', () => {
+            const annotationWithoutTarget = {
+                ...mockAnnotation,
+                target: {
+                    location: {
+                        value: 1,
+                    },
+                },
+            };
+
+            const wrapper = getWrapper({ item: annotationWithoutTarget });
+            const activityMessage = wrapper.find('ForwardRef(withFeatureConsumer(ActivityMessage))');
+
+            expect(activityMessage.prop('annotationsMillisecondTimestamp')).toBeFalsy();
+        });
+
+        test('should show version link for non-video annotations when hasVersions is true', () => {
+            const regularAnnotation = {
+                ...mockAnnotation,
+                target: {
+                    location: {
+                        type: 'page',
+                        value: 1,
+                    },
+                },
+            };
+
+            const wrapper = getWrapper({
+                item: regularAnnotation,
+                hasVersions: true,
+                isCurrentVersion: true,
+            });
+
+            expect(wrapper.exists('AnnotationActivityLink')).toBe(true);
+        });
+    });
 });

--- a/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.tsx
+++ b/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.tsx
@@ -7,7 +7,7 @@ import LoadingIndicator, { LoadingIndicatorSize } from '../../../../../component
 import ShowOriginalButton from './ShowOriginalButton';
 import TranslateButton from './TranslateButton';
 
-import formatTaggedMessage from '../../utils/formatTaggedMessage';
+import formatTaggedMessage, { renderTimestampWithText } from '../../utils/formatTaggedMessage';
 import { withFeatureConsumer, isFeatureEnabled } from '../../../../common/feature-checking';
 
 import messages from './messages';
@@ -22,11 +22,13 @@ export interface ActivityMessageProps extends WrappedComponentProps {
     getUserProfileUrl?: GetProfileUrlCallback;
     id: string;
     isEdited?: boolean;
+    onClick?: () => void;
     onTranslate?: ({ id, tagged_message }: { id: string; tagged_message: string }) => void;
     tagged_message: string;
     translatedTaggedMessage?: string;
     translationEnabled?: boolean;
     translationFailed?: boolean | null;
+    annotationsMillisecondTimestamp?: number;
 }
 
 type State = {
@@ -92,6 +94,8 @@ class ActivityMessage extends React.Component<ActivityMessageProps, State> {
             id,
             intl,
             isEdited,
+            onClick = noop,
+            annotationsMillisecondTimestamp,
             tagged_message,
             translatedTaggedMessage,
             translationEnabled,
@@ -110,7 +114,14 @@ class ActivityMessage extends React.Component<ActivityMessageProps, State> {
         ) : (
             <div className="bcs-ActivityMessage">
                 <MessageWrapper>
-                    {formatTaggedMessage(commentToDisplay, id, false, getUserProfileUrl, intl)}
+                    {annotationsMillisecondTimestamp
+                        ? renderTimestampWithText(
+                              annotationsMillisecondTimestamp,
+                              onClick,
+                              intl,
+                              ` ${commentToDisplay}`,
+                          )
+                        : formatTaggedMessage(commentToDisplay, id, false, getUserProfileUrl, intl)}
                     {isEdited && (
                         <span className="bcs-ActivityMessage-edited">
                             <FormattedMessage {...messages.activityMessageEdited} />
@@ -121,6 +132,8 @@ class ActivityMessage extends React.Component<ActivityMessageProps, State> {
             </div>
         );
     }
+
+    d;
 }
 
 export { ActivityMessage };

--- a/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.tsx
+++ b/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.tsx
@@ -28,7 +28,7 @@ export interface ActivityMessageProps extends WrappedComponentProps {
     translatedTaggedMessage?: string;
     translationEnabled?: boolean;
     translationFailed?: boolean | null;
-    annotationsMillisecondTimestamp?: number;
+    annotationsMillisecondTimestamp?: string;
 }
 
 type State = {
@@ -132,8 +132,6 @@ class ActivityMessage extends React.Component<ActivityMessageProps, State> {
             </div>
         );
     }
-
-    d;
 }
 
 export { ActivityMessage };

--- a/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.tsx
+++ b/src/elements/content-sidebar/activity-feed/common/activity-message/ActivityMessage.tsx
@@ -28,7 +28,7 @@ export interface ActivityMessageProps extends WrappedComponentProps {
     translatedTaggedMessage?: string;
     translationEnabled?: boolean;
     translationFailed?: boolean | null;
-    annotationsMillisecondTimestamp?: string;
+    annotationsMillisecondTimestamp?: string | null;
 }
 
 type State = {

--- a/src/elements/content-sidebar/activity-feed/common/activity-message/__tests__/ActivityMessage.test.js
+++ b/src/elements/content-sidebar/activity-feed/common/activity-message/__tests__/ActivityMessage.test.js
@@ -1,5 +1,6 @@
 import React, { act } from 'react';
 import { mount, shallow } from 'enzyme';
+import { createIntl } from 'react-intl';
 
 import { ActivityMessage } from '../ActivityMessage';
 
@@ -183,5 +184,34 @@ describe('elements/content-sidebar/ActivityFeed/common/activity-message', () => 
         const wrapper = shallow(<ActivityMessage id="123" {...comment} />);
 
         expect(wrapper.exists({ id: 'be.contentSidebar.activityFeed.common.editedMessage' })).toBe(expected);
+    });
+
+    describe('video annotation', () => {
+        test('should render timestamp with text when annotationsMillisecondTimestamp is provided', () => {
+            const onClick = jest.fn();
+            const videoAnnotation = {
+                annotationsMillisecondTimestamp: '0:01:00',
+                tagged_message: 'test',
+                onClick,
+            };
+
+            const intl = createIntl({ locale: 'en' });
+            const wrapper = mount(<ActivityMessage id="123" {...videoAnnotation} intl={intl} />);
+            expect(wrapper.find('button[aria-label="Seek to video timestamp"]').length).toBe(1);
+            expect(wrapper.find('button[aria-label="Seek to video timestamp"]').text()).toBe('0:01:00');
+            wrapper.find('button[aria-label="Seek to video timestamp"]').simulate('click');
+            expect(onClick).toHaveBeenCalled();
+        });
+
+        test('should render original message when annotationsMillisecondTimestamp is not provided', () => {
+            const comment = {
+                annotationsMillisecondTimestamp: undefined,
+                tagged_message: 'test',
+            };
+            const intl = createIntl({ locale: 'en' });
+            const wrapper = mount(<ActivityMessage id="123" {...comment} intl={intl} />);
+            expect(wrapper.find('button[aria-label="Seek to video timestamp"]').length).toBe(0);
+            expect(wrapper.find('.bcs-ActivityMessage').text()).toBe('test');
+        });
     });
 });

--- a/src/elements/content-sidebar/activity-feed/utils/formatTaggedMessage.js
+++ b/src/elements/content-sidebar/activity-feed/utils/formatTaggedMessage.js
@@ -12,6 +12,34 @@ import messages from '../common/activity-message/messages';
 import { convertTimestampToSeconds, convertMillisecondsToHMMSS } from '../../../../utils/timestamp';
 
 /**
+ * Renders the timestamp button and remaining text
+ * @param timestampInHHMMSS The formatted timestamp string (HH:MM:SS)
+ * @param timestampLabel The aria label for the timestamp button
+ * @param handleClick The click handler for the timestamp button
+ * @param textAfterTimestamp The text that comes after the timestamp
+ * @returns A React Fragment with timestamp button and text
+ */
+export const renderTimestampWithText = (
+    timestampInHHMMSS: string,
+    handleClick: (e: SyntheticMouseEvent<HTMLButtonElement>) => void,
+    intl: IntlShape,
+    textAfterTimestamp: string,
+): React$Element<any> => (
+    <>
+        <div className="bcs-ActivityMessage-timestamp">
+            <button
+                aria-label={intl.formatMessage(messages.activityMessageTimestampLabel)}
+                type="button"
+                onClick={handleClick}
+            >
+                {timestampInHHMMSS}
+            </button>
+        </div>
+        {textAfterTimestamp}
+    </>
+);
+
+/**
  * Formats text containing a timestamp by wrapping the timestamp in a Link component
  * @param text The text containing the timestamp
  * @param timestamp The timestamp string
@@ -51,17 +79,7 @@ const formatTimestamp = (text: string, timestamp: string, intl: IntlShape): Reac
         }
     };
 
-    const timestampLabel = intl.formatMessage(messages.activityMessageTimestampLabel);
-    return (
-        <>
-            <div className="bcs-ActivityMessage-timestamp">
-                <button aria-label={timestampLabel} type="button" onClick={handleClick}>
-                    {timestampInHHMMSS}
-                </button>
-            </div>
-            {textAfterTimestamp}
-        </>
-    );
+    return renderTimestampWithText(timestampInHHMMSS, handleClick, intl, textAfterTimestamp);
 };
 
 // this regex matches one of the following regular expressions:


### PR DESCRIPTION
This PR adds timestamp support for video annotations in the activity sidebar. For video annotations, those with location type frame, we won't display the page link in the upper right like we do with documents. Instead, we will display the annotation timestamp in the message similar to how we do for timestamped comments.

Preserving document functionality 

<img width="548" height="397" alt="Screenshot 2025-09-30 at 12 16 46 PM" src="https://github.com/user-attachments/assets/8a81c17f-78f2-4788-9d4e-a4627bb383a5" />



Video Annotation Activity



![2025-09-30 12 14 54](https://github.com/user-attachments/assets/451e22db-c6e9-4f85-8ec9-4c5fd5e101e0)






<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Video annotations in the activity feed show readable HH:MM:SS timestamps and a "Seek to video timestamp" control; activity messages accept a click handler to jump to the referenced moment.

- Bug Fixes
  - Annotation link is suppressed for versioned video annotations to reduce clutter.

- Refactor
  - Timestamp rendering extracted to a reusable helper and integrated into message rendering.

- Tests
  - Added tests for video annotation detection, timestamp formatting, conditional rendering, and click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->