### PR TITLE
fix(content-picker): broken folder navigation

### DIFF
--- a/src/elements/common/item/ItemName.tsx
+++ b/src/elements/common/item/ItemName.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import { TextButton } from '@box/blueprint-web';
 import { TYPE_FOLDER, TYPE_WEBLINK } from '../../../constants';
 import type { BoxItem } from '../../../common/types/core';
+import { PlainButton } from '../../../components';
 
 import './ItemName.scss';
 
@@ -20,9 +20,9 @@ const ItemName = ({ item, onClick, onFocus, canPreview, isTouch }: ItemNameProps
     const onItemClick = (): void => onClick(item);
 
     return type === TYPE_FOLDER || (!isTouch && (type === TYPE_WEBLINK || canPreview)) ? (
-        <TextButton className="be-item-label" inheritFont onClick={onItemClick} onFocus={onItemFocus}>
+        <PlainButton className="be-item-label" onClick={onItemClick} onFocus={onItemFocus}>
             {name}
-        </TextButton>
+        </PlainButton>
     ) : (
         <span className="be-item-label">{name}</span>
     );

--- a/src/elements/content-picker/stories/tests/ContentPicker-e2e.test.stories.tsx
+++ b/src/elements/content-picker/stories/tests/ContentPicker-e2e.test.stories.tsx
@@ -1,3 +1,5 @@
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import sleep from '../../../../utils/sleep';
 import ContentPicker from '../../ContentPicker';
 
 export const basic = {
@@ -9,6 +11,30 @@ export const basic = {
 export const withPagination = {
     args: {
         initialPageSize: 3,
+    },
+};
+
+// This test covers a regression where different values for type would sometimes result in broken folder navigation
+// where clicking on a folder would trigger the API call but not refresh the UI
+export const singleSelectWithItemTypes = {
+    args: {
+        maxSelectable: 1,
+        type: 'file,folder',
+    },
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        await waitFor(
+            () => {
+                expect(canvas.getByRole('button', { name: 'An Ordered Folder' })).toBeInTheDocument();
+            },
+            { timeout: 10000 },
+        );
+        await sleep(1000);
+        userEvent.click(canvas.getByRole('button', { name: 'An Ordered Folder' }));
+
+        await waitFor(() => {
+            expect(canvas.getByRole('gridcell', { name: 'Audio.mp3' })).toBeInTheDocument();
+        });
     },
 };
 


### PR DESCRIPTION
**Steps to Reproduce**

Fetch latest BUIE and yarn install
Add "type: 'file,folder'" to ContentPicker.stories.js

```
--- a/src/elements/content-picker/stories/ContentPicker.stories.js
+++ b/src/elements/content-picker/stories/ContentPicker.stories.js
@@ -16,5 +16,6 @@ export default {
         features: global.FEATURE_FLAGS,
         rootFolderId: global.FOLDER_ID,
         token: global.TOKEN,
+        type: 'file,folder'
     },
 };
```

Navigate to http://localhost:6060/?path=/story/elements-contentpicker--basic, ensure that "type file,folder" now shows under the controls.
Attempt to select a folder
Note that the icon actually switches and the folder never loads

**The Fix**
Switch from TextButton (blueprint component) to PlainButton (buie component)
Note that the folder loads immediately

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
