### PR TITLE
fix(content-sharing): Collaborator current user

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -200,6 +200,7 @@ export const PERMISSION_CAN_VIEW_ANNOTATIONS = 'can_view_annotations';
 
 /* --------------------- Invitee roles --------------------------- */
 export const INVITEE_ROLE_EDITOR: 'editor' = 'editor';
+export const INVITEE_ROLE_OWNER: 'owner' = 'owner';
 
 /* ------------- Delimiters for bread crumbs ---------------- */
 export const DELIMITER_SLASH: 'slash' = 'slash';

--- a/src/elements/content-sharing/ContentSharingV2.tsx
+++ b/src/elements/content-sharing/ContentSharingV2.tsx
@@ -46,17 +46,21 @@ function ContentSharingV2({
     const [collaborationRoles, setCollaborationRoles] = React.useState<CollaborationRole[] | null>(null);
     const [collaborators, setCollaborators] = React.useState<Collaborator[] | null>(null);
     const [collaboratorsData, setCollaboratorsData] = React.useState<Collaborations | null>(null);
+    const [owner, setOwner] = React.useState({ ownerId: '', ownerEmail: '', ownerName: '' });
 
     // Handle successful GET requests to /files or /folders
     const handleGetItemSuccess = React.useCallback(itemData => {
         const {
             collaborationRoles: collaborationRolesFromAPI,
             item: itemFromAPI,
+            owned_by,
             sharedLink: sharedLinkFromAPI,
         } = convertItemResponse(itemData);
+
         setItem(itemFromAPI);
         setSharedLink(sharedLinkFromAPI);
         setCollaborationRoles(collaborationRolesFromAPI);
+        setOwner({ ownerId: owned_by.id, ownerEmail: owned_by.login, ownerName: owned_by.name });
     }, []);
 
     // Reset state if the API has changed
@@ -122,13 +126,17 @@ function ContentSharingV2({
         })();
     }, [api, avatarURLMap, collaboratorsData, itemID]);
 
-    // Return processed data when both are ready
     React.useEffect(() => {
-        if (collaboratorsData && avatarURLMap) {
-            const collaboratorsWithAvatars = convertCollabsResponse(collaboratorsData, avatarURLMap);
+        if (avatarURLMap && collaboratorsData && currentUser && owner) {
+            const collaboratorsWithAvatars = convertCollabsResponse(
+                collaboratorsData,
+                currentUser.id,
+                owner,
+                avatarURLMap,
+            );
             setCollaborators(collaboratorsWithAvatars);
         }
-    }, [collaboratorsData, avatarURLMap]);
+    }, [avatarURLMap, collaboratorsData, currentUser, owner]);
 
     const config = { sharedLinkEmail: false };
 

--- a/src/elements/content-sharing/ContentSharingV2.tsx
+++ b/src/elements/content-sharing/ContentSharingV2.tsx
@@ -46,21 +46,21 @@ function ContentSharingV2({
     const [collaborationRoles, setCollaborationRoles] = React.useState<CollaborationRole[] | null>(null);
     const [collaborators, setCollaborators] = React.useState<Collaborator[] | null>(null);
     const [collaboratorsData, setCollaboratorsData] = React.useState<Collaborations | null>(null);
-    const [owner, setOwner] = React.useState({ ownerId: '', ownerEmail: '', ownerName: '' });
+    const [owner, setOwner] = React.useState({ id: '', email: '', name: '' });
 
     // Handle successful GET requests to /files or /folders
     const handleGetItemSuccess = React.useCallback(itemData => {
         const {
             collaborationRoles: collaborationRolesFromAPI,
             item: itemFromAPI,
-            owned_by,
+            ownedBy,
             sharedLink: sharedLinkFromAPI,
         } = convertItemResponse(itemData);
 
         setItem(itemFromAPI);
         setSharedLink(sharedLinkFromAPI);
         setCollaborationRoles(collaborationRolesFromAPI);
-        setOwner({ ownerId: owned_by.id, ownerEmail: owned_by.login, ownerName: owned_by.name });
+        setOwner({ id: ownedBy.id, email: ownedBy.login, name: ownedBy.name });
     }, []);
 
     // Reset state if the API has changed

--- a/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
+++ b/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
@@ -32,8 +32,8 @@ export const mockAvatarURLMap = {
 };
 
 export const mockOwnerEmail = 'aotter@example.com';
-
-export const mockCurrentUserID = 789;
+export const mockOwnerName = 'Astronaut Otter';
+export const mockOwnerId = 789;
 
 export const collabUser1 = {
     id: 456,
@@ -44,7 +44,7 @@ export const collabUser1 = {
 
 export const collabUser2 = {
     id: 457,
-    login: 'rqueen@example.com',
+    login: 'rqueen@external.com',
     name: 'Raccoon Queen',
 };
 
@@ -54,13 +54,13 @@ export const collabUser3 = {
     name: 'Dancing Penguin',
 };
 
-export const collabUser4 = {
-    id: mockCurrentUserID,
+export const mockOwner = {
+    id: mockOwnerId,
     login: mockOwnerEmail,
-    name: 'Astronaut Otter',
+    name: mockOwnerName,
 };
 
-export const MOCK_COLLABORATORS = [collabUser4, collabUser1, collabUser2, collabUser3];
+export const MOCK_COLLABORATORS = [collabUser1, collabUser2, collabUser3];
 
 export const MOCK_COLLABORATIONS_RESPONSE = {
     entries: MOCK_COLLABORATORS.map(user => ({
@@ -68,12 +68,12 @@ export const MOCK_COLLABORATIONS_RESPONSE = {
         accessible_by: user,
         expires_at: user.expires_at,
         created_by: {
-            id: mockCurrentUserID,
+            id: mockOwnerId,
             login: mockOwnerEmail,
-            name: 'Astronaut Otter',
+            name: mockOwnerName,
             type: 'user',
         },
-        role: user.id === mockCurrentUserID ? 'owner' : 'editor',
+        role: user.id === mockOwnerId ? 'owner' : 'editor',
         status: 'accepted',
         type: user.type,
     })),
@@ -99,6 +99,7 @@ export const DEFAULT_ITEM_API_RESPONSE = {
     classification: null,
     id: MOCK_ITEM.id,
     name: MOCK_ITEM.name,
+    owned_by: mockOwner,
     permissions: MOCK_PERMISSIONS,
     shared_link: null,
     shared_link_features: { password: true },

--- a/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
+++ b/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
@@ -44,7 +44,7 @@ export const collabUser1 = {
 
 export const collabUser2 = {
     id: 457,
-    login: 'rqueen@external.com',
+    login: 'rqueen@external.example.com',
     name: 'Raccoon Queen',
 };
 

--- a/src/elements/content-sharing/utils/__tests__/convertCollaborators.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertCollaborators.test.ts
@@ -5,28 +5,69 @@ import {
     collabUser2,
     collabUser3,
     mockAvatarURLMap,
-    mockCurrentUserID,
+    mockOwnerId,
     mockOwnerEmail,
+    mockOwnerName,
 } from '../__mocks__/ContentSharingV2Mocks';
 
-import type { Collaboration, Collaborations } from '../../../../common/types/core';
+import type { Collaborations } from '../../../../common/types/core';
 
-describe('convertCollaborators', () => {
-    describe('convertCollab', () => {
-        const mockCollab: Collaboration = {
-            id: '123', // collab record id
+const ownerEmailDomain = 'example.com';
+const ownerFromAPI = {
+    ownerId: mockOwnerId,
+    ownerEmail: mockOwnerEmail,
+    ownerName: mockOwnerName,
+};
+const itemOwner = {
+    status: STATUS_ACCEPTED,
+    role: 'owner',
+    accessible_by: {
+        id: mockOwnerId,
+        login: mockOwnerEmail,
+        name: mockOwnerName,
+    },
+};
+
+const mockCollaborationsFromAPI: Collaborations = {
+    entries: [
+        {
+            id: '123',
             role: 'editor',
             status: STATUS_ACCEPTED,
             expires_at: '2024-12-31T23:59:59Z',
             accessible_by: collabUser1,
-        };
+            created_by: ownerFromAPI,
+        },
+        {
+            id: '124',
+            role: 'viewer',
+            status: STATUS_ACCEPTED,
+            expires_at: null,
+            accessible_by: collabUser2,
+            created_by: ownerFromAPI,
+        },
+        {
+            id: '125',
+            role: 'editor',
+            status: 'pending',
+            expires_at: '2024-12-31T23:59:59Z',
+            accessible_by: collabUser3,
+            created_by: ownerFromAPI,
+        },
+    ],
+};
 
+const mockCollaborations = [itemOwner, ...mockCollaborationsFromAPI.entries];
+
+describe('convertCollaborators', () => {
+    describe('convertCollab', () => {
         test('should convert a valid collaboration to Collaborator format', () => {
             const result = convertCollab({
-                collab: mockCollab,
+                collab: mockCollaborations[1],
+                currentUserId: mockOwnerId,
+                isCurrentUserOwner: false,
+                ownerEmailDomain,
                 avatarURLMap: mockAvatarURLMap,
-                ownerEmail: mockOwnerEmail,
-                currentUserID: mockCurrentUserID,
             });
 
             expect(result).toEqual({
@@ -46,16 +87,12 @@ describe('convertCollaborators', () => {
         });
 
         test('should return null for collaboration with non-accepted status', () => {
-            const pendingCollab = {
-                ...mockCollab,
-                status: 'pending',
-            };
-
             const result = convertCollab({
-                collab: pendingCollab,
+                collab: mockCollaborations[3],
+                currentUserId: mockOwnerId,
+                isCurrentUserOwner: false,
+                ownerEmailDomain,
                 avatarURLMap: mockAvatarURLMap,
-                ownerEmail: mockOwnerEmail,
-                currentUserID: mockCurrentUserID,
             });
 
             expect(result).toBeNull();
@@ -64,40 +101,30 @@ describe('convertCollaborators', () => {
         test.each([undefined, null])('should return null for %s collaboration', collab => {
             const result = convertCollab({
                 collab,
+                currentUserId: mockOwnerId,
+                isCurrentUserOwner: false,
+                ownerEmailDomain,
                 avatarURLMap: mockAvatarURLMap,
-                ownerEmail: mockOwnerEmail,
-                currentUserID: mockCurrentUserID,
             });
 
             expect(result).toBeNull();
         });
 
         test('should identify current user correctly', () => {
-            const currentUserCollab = {
-                ...mockCollab,
-                role: 'owner',
-                accessible_by: {
-                    ...mockCollab.accessible_by,
-                    id: mockCurrentUserID,
-                    login: mockOwnerEmail,
-                    name: 'Astronaut Otter',
-                },
-            };
-
             const result = convertCollab({
-                collab: currentUserCollab,
+                collab: mockCollaborations[0],
+                currentUserId: mockOwnerId,
+                isCurrentUserOwner: true,
+                ownerEmailDomain,
                 avatarURLMap: mockAvatarURLMap,
-                ownerEmail: mockOwnerEmail,
-                currentUserID: mockCurrentUserID,
             });
 
             expect(result).toEqual({
                 avatarUrl: undefined,
                 email: 'aotter@example.com',
-                expiresAt: '2024-12-31T23:59:59Z',
                 hasCustomAvatar: false,
                 hasCustomRole: true,
-                id: '123',
+                id: '0',
                 isCurrentUser: true,
                 isExternal: false,
                 isPending: false,
@@ -108,19 +135,12 @@ describe('convertCollaborators', () => {
         });
 
         test('should identify external user correctly', () => {
-            const externalCollab = {
-                ...mockCollab,
-                accessible_by: {
-                    ...mockCollab.accessible_by,
-                    login: 'external@differentdomain.com',
-                },
-            };
-
             const result = convertCollab({
-                collab: externalCollab,
+                collab: mockCollaborations[2],
+                currentUserId: mockOwnerId,
+                isCurrentUserOwner: false,
+                ownerEmailDomain,
                 avatarURLMap: mockAvatarURLMap,
-                ownerEmail: mockOwnerEmail,
-                currentUserID: mockCurrentUserID,
             });
 
             expect(result.isExternal).toBe(true);
@@ -130,10 +150,11 @@ describe('convertCollaborators', () => {
             'should handle %s avatar URL map',
             avatarURLMap => {
                 const result = convertCollab({
-                    collab: mockCollab,
+                    collab: mockCollaborations[1],
+                    currentUserId: mockOwnerId,
+                    isCurrentUserOwner: false,
+                    ownerEmailDomain,
                     avatarURLMap,
-                    ownerEmail: mockOwnerEmail,
-                    currentUserID: mockCurrentUserID,
                 });
 
                 expect(result.avatarUrl).toBeUndefined();
@@ -143,15 +164,16 @@ describe('convertCollaborators', () => {
 
         test('should handle missing expiration date', () => {
             const collabWithoutExpiration = {
-                ...mockCollab,
+                ...mockCollaborations[1],
                 expires_at: null,
             };
 
             const result = convertCollab({
                 collab: collabWithoutExpiration,
+                currentUserId: mockOwnerId,
+                isCurrentUserOwner: false,
+                ownerEmailDomain,
                 avatarURLMap: mockAvatarURLMap,
-                ownerEmail: mockOwnerEmail,
-                currentUserID: mockCurrentUserID,
             });
 
             expect(result.expiresAt).toBeNull();
@@ -159,44 +181,30 @@ describe('convertCollaborators', () => {
     });
 
     describe('convertCollabsResponse', () => {
-        const created_by = {
-            id: mockCurrentUserID,
-            login: mockOwnerEmail,
-        };
-        const mockCollaborations: Collaborations = {
-            entries: [
-                {
-                    id: '123',
-                    role: 'editor',
-                    status: STATUS_ACCEPTED,
-                    expires_at: '2024-12-31T23:59:59Z',
-                    accessible_by: collabUser1,
-                    created_by,
-                },
-                {
-                    id: '124',
-                    role: 'viewer',
-                    status: STATUS_ACCEPTED,
-                    expires_at: null,
-                    accessible_by: collabUser2,
-                    created_by,
-                },
-                {
-                    id: '125',
-                    role: 'editor',
-                    status: 'pending',
-                    expires_at: '2024-12-31T23:59:59Z',
-                    accessible_by: collabUser3,
-                    created_by,
-                },
-            ],
-        };
-
         test('should convert valid collaborations data to Collaborator array', () => {
-            const result = convertCollabsResponse(mockCollaborations, mockAvatarURLMap);
+            const result = convertCollabsResponse(
+                mockCollaborationsFromAPI,
+                mockOwnerId,
+                ownerFromAPI,
+                mockAvatarURLMap,
+            );
 
-            expect(result).toHaveLength(2); // Only accepted collaborations
+            expect(result).toHaveLength(3); // Only accepted collaborations
             expect(result).toEqual([
+                {
+                    avatarUrl: undefined,
+                    email: 'aotter@example.com',
+                    expiresAt: undefined,
+                    hasCustomAvatar: false,
+                    hasCustomRole: true,
+                    id: '0',
+                    isCurrentUser: true,
+                    isExternal: false,
+                    isPending: false,
+                    name: 'Astronaut Otter',
+                    role: 'Owner',
+                    userId: '789',
+                },
                 {
                     avatarUrl: 'https://example.com/avatar.jpg',
                     email: 'dparrot@example.com',
@@ -213,7 +221,7 @@ describe('convertCollaborators', () => {
                 },
                 {
                     avatarUrl: undefined, // does not exist in the avatar URL map
-                    email: 'rqueen@example.com',
+                    email: 'rqueen@external.com',
                     expiresAt: null,
                     hasCustomAvatar: false,
                     hasCustomRole: true,
@@ -230,19 +238,19 @@ describe('convertCollaborators', () => {
 
         test('should return empty array for empty entries', () => {
             const emptyCollaborations: Collaborations = { entries: [] };
-            const result = convertCollabsResponse(emptyCollaborations, mockAvatarURLMap);
+            const result = convertCollabsResponse(emptyCollaborations, mockOwnerId, ownerFromAPI, mockAvatarURLMap);
 
             expect(result).toEqual([]);
         });
 
         test('should handle null avatar URL map', () => {
-            const result = convertCollabsResponse(mockCollaborations, null);
+            const collabs = convertCollabsResponse(mockCollaborationsFromAPI, mockOwnerId, ownerFromAPI, null);
 
-            expect(result).toHaveLength(2);
-            expect(result[0].avatarUrl).toBeUndefined();
-            expect(result[0].hasCustomAvatar).toBe(false);
-            expect(result[1].avatarUrl).toBeUndefined();
-            expect(result[1].hasCustomAvatar).toBe(false);
+            collabs.map(collab => {
+                expect(collab.avatarUrl).toBeUndefined();
+                expect(collab.hasCustomAvatar).toBeFalsy();
+                return collab.avatarUrl;
+            });
         });
     });
 });

--- a/src/elements/content-sharing/utils/__tests__/convertCollaborators.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertCollaborators.test.ts
@@ -14,11 +14,12 @@ import type { Collaborations } from '../../../../common/types/core';
 
 const ownerEmailDomain = 'example.com';
 const ownerFromAPI = {
-    ownerId: mockOwnerId,
-    ownerEmail: mockOwnerEmail,
-    ownerName: mockOwnerName,
+    id: mockOwnerId,
+    email: mockOwnerEmail,
+    name: mockOwnerName,
 };
 const itemOwner = {
+    id: mockOwnerEmail,
     status: STATUS_ACCEPTED,
     role: 'owner',
     accessible_by: {
@@ -124,7 +125,7 @@ describe('convertCollaborators', () => {
                 email: 'aotter@example.com',
                 hasCustomAvatar: false,
                 hasCustomRole: true,
-                id: '0',
+                id: 'aotter@example.com',
                 isCurrentUser: true,
                 isExternal: false,
                 isPending: false,
@@ -197,7 +198,7 @@ describe('convertCollaborators', () => {
                     expiresAt: undefined,
                     hasCustomAvatar: false,
                     hasCustomRole: true,
-                    id: '0',
+                    id: 'aotter@example.com',
                     isCurrentUser: true,
                     isExternal: false,
                     isPending: false,
@@ -221,7 +222,7 @@ describe('convertCollaborators', () => {
                 },
                 {
                     avatarUrl: undefined, // does not exist in the avatar URL map
-                    email: 'rqueen@external.com',
+                    email: 'rqueen@external.example.com',
                     expiresAt: null,
                     hasCustomAvatar: false,
                     hasCustomRole: true,

--- a/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
@@ -2,6 +2,9 @@ import {
     DEFAULT_ITEM_API_RESPONSE,
     MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK,
     MOCK_ITEM_API_RESPONSE_WITH_CLASSIFICATION,
+    mockOwnerId,
+    mockOwnerEmail,
+    mockOwnerName,
 } from '../__mocks__/ContentSharingV2Mocks';
 import { convertItemResponse } from '../convertItemResponse';
 
@@ -32,6 +35,11 @@ describe('convertItemResponse', () => {
                     canShare: true,
                 },
                 type: 'file',
+            },
+            owned_by: {
+                id: mockOwnerId,
+                login: mockOwnerEmail,
+                name: mockOwnerName,
             },
         });
     });

--- a/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
@@ -36,7 +36,7 @@ describe('convertItemResponse', () => {
                 },
                 type: 'file',
             },
-            owned_by: {
+            ownedBy: {
                 id: mockOwnerId,
                 login: mockOwnerEmail,
                 name: mockOwnerName,

--- a/src/elements/content-sharing/utils/convertCollaborators.ts
+++ b/src/elements/content-sharing/utils/convertCollaborators.ts
@@ -24,7 +24,7 @@ export const convertCollab = ({
 
     const {
         accessible_by: { id: collabId, login: collabEmail, name: collabName },
-        id = 0,
+        id,
         expires_at: executeAt,
         role,
     } = collab;
@@ -53,17 +53,18 @@ export const convertCollab = ({
 export const convertCollabsResponse = (
     collabsAPIData: Collaborations,
     currentUserId: string,
-    owner: { ownerId: string; ownerEmail: string; ownerName: string },
+    owner: { id: string; email: string; name: string },
     avatarURLMap?: AvatarURLMap,
 ): Collaborator[] => {
     const { entries = [] } = collabsAPIData;
     if (!entries.length) return [];
 
-    const { ownerId, ownerEmail, ownerName } = owner;
+    const { id: ownerId, email: ownerEmail, name: ownerName } = owner;
     const isCurrentUserOwner = currentUserId === ownerId;
     const ownerEmailDomain = ownerEmail && /@/.test(ownerEmail) ? ownerEmail.split('@')[1] : null;
 
     const itemOwner = {
+        id: ownerEmail,
         status: STATUS_ACCEPTED,
         role: INVITEE_ROLE_OWNER,
         accessible_by: {

--- a/src/elements/content-sharing/utils/convertCollaborators.ts
+++ b/src/elements/content-sharing/utils/convertCollaborators.ts
@@ -1,36 +1,37 @@
 import { Collaborator } from '@box/unified-share-modal';
 
-import { STATUS_ACCEPTED } from '../../../constants';
+import { INVITEE_ROLE_OWNER, STATUS_ACCEPTED } from '../../../constants';
 
 import type { Collaboration, Collaborations } from '../../../common/types/core';
 import type { AvatarURLMap } from '../types';
 
 export interface ConvertCollabProps {
     collab: Collaboration;
-    currentUserID: number;
-    ownerEmail: string;
+    currentUserId: string;
+    isCurrentUserOwner: boolean;
+    ownerEmailDomain: string;
     avatarURLMap?: AvatarURLMap;
 }
 
 export const convertCollab = ({
     collab,
-    currentUserID,
-    ownerEmail,
+    currentUserId,
+    isCurrentUserOwner,
+    ownerEmailDomain,
     avatarURLMap,
 }: ConvertCollabProps): Collaborator | null => {
     if (!collab || collab.status !== STATUS_ACCEPTED) return null;
 
     const {
         accessible_by: { id: collabId, login: collabEmail, name: collabName },
-        id,
+        id = 0,
         expires_at: executeAt,
         role,
     } = collab;
 
-    const isCurrentUser = collabId === currentUserID;
-    const ownerEmailDomain = ownerEmail && /@/.test(ownerEmail) ? ownerEmail.split('@')[1] : null;
+    const isCurrentUser = collabId === currentUserId;
     const isExternal =
-        !isCurrentUser && collabEmail && ownerEmailDomain && collabEmail.split('@')[1] !== ownerEmailDomain;
+        !isCurrentUserOwner && collabEmail && ownerEmailDomain && collabEmail.split('@')[1] !== ownerEmailDomain;
     const avatarUrl = avatarURLMap ? avatarURLMap[collabId] : undefined;
 
     return {
@@ -49,14 +50,32 @@ export const convertCollab = ({
     };
 };
 
-export const convertCollabsResponse = (collabsAPIData: Collaborations, avatarURLMap?: AvatarURLMap): Collaborator[] => {
+export const convertCollabsResponse = (
+    collabsAPIData: Collaborations,
+    currentUserId: string,
+    owner: { ownerId: string; ownerEmail: string; ownerName: string },
+    avatarURLMap?: AvatarURLMap,
+): Collaborator[] => {
     const { entries = [] } = collabsAPIData;
     if (!entries.length) return [];
 
-    const { created_by } = entries[0];
-    const { id: currentUserID, login: ownerEmail } = created_by || {};
+    const { ownerId, ownerEmail, ownerName } = owner;
+    const isCurrentUserOwner = currentUserId === ownerId;
+    const ownerEmailDomain = ownerEmail && /@/.test(ownerEmail) ? ownerEmail.split('@')[1] : null;
+
+    const itemOwner = {
+        status: STATUS_ACCEPTED,
+        role: INVITEE_ROLE_OWNER,
+        accessible_by: {
+            id: ownerId,
+            login: ownerEmail,
+            name: ownerName,
+        },
+    };
+    entries.unshift(itemOwner);
+
     return entries.flatMap(collab => {
-        const converted = convertCollab({ collab, currentUserID, ownerEmail, avatarURLMap });
+        const converted = convertCollab({ collab, currentUserId, isCurrentUserOwner, ownerEmailDomain, avatarURLMap });
         return converted ? [converted] : [];
     });
 };

--- a/src/elements/content-sharing/utils/convertItemResponse.ts
+++ b/src/elements/content-sharing/utils/convertItemResponse.ts
@@ -13,6 +13,7 @@ export const convertItemResponse = (itemAPIData: ContentSharingItemAPIResponse):
         classification,
         id,
         name,
+        owned_by,
         permissions,
         shared_link,
         shared_link_features,
@@ -99,5 +100,6 @@ export const convertItemResponse = (itemAPIData: ContentSharingItemAPIResponse):
             type,
         },
         sharedLink,
+        owned_by,
     };
 };

--- a/src/elements/content-sharing/utils/convertItemResponse.ts
+++ b/src/elements/content-sharing/utils/convertItemResponse.ts
@@ -13,7 +13,7 @@ export const convertItemResponse = (itemAPIData: ContentSharingItemAPIResponse):
         classification,
         id,
         name,
-        owned_by,
+        owned_by: ownedBy,
         permissions,
         shared_link,
         shared_link_features,
@@ -100,6 +100,6 @@ export const convertItemResponse = (itemAPIData: ContentSharingItemAPIResponse):
             type,
         },
         sharedLink,
-        owned_by,
+        ownedBy,
     };
 };


### PR DESCRIPTION
## What
- Fix the collaboration passed into the USM shared feature
  - USM shared feature collaborators prop expect all collaborators including the owner
  - The initial data (get from fetchItem in ContentSharingV2) should have the correct owner properties to be leveraged in convertCollaborators file

## Testing
Notes: shared with should render collaborators without the owner, whereas the managed collaborators view should render all collaborators including the owner
- Should see 3 avatar
  - <img width="511" height="443" alt="Screenshot 2025-10-06 at 4 44 58 PM" src="https://github.com/user-attachments/assets/aa44c45f-7968-45d5-b33e-f7a1a9ac18d9" />
- Should see 4 entries including the owner
  - <img width="511" height="502" alt="Screenshot 2025-10-06 at 4 45 44 PM" src="https://github.com/user-attachments/assets/1c859995-60ea-4ee9-8bc9-596e3416d725" />




<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content Sharing now shows the item owner (name and email) and includes the owner in the collaborators list with an Owner role.
  * Item details include an “Owned by” field sourced from the API for clearer ownership visibility.

* **Improvements**
  * Collaborator detection refined for more accurate current-user and external-user identification.

* **Tests**
  * Tests and mocks updated to cover owner-driven API data and new ownership scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->