### PR TITLE
fix(storybook): update brand url

### DIFF
--- a/.storybook/customTheme.ts
+++ b/.storybook/customTheme.ts
@@ -27,6 +27,6 @@ export default create({
     barBg: vars.bdlBoxBlue,
 
     brandTitle: 'Box Elements',
-    brandUrl: 'https://opensource.box.com/box-ui-elements',
+    brandUrl: 'https://opensource.box.com/box-ui-elements/',
     brandImage: 'https://repository-images.githubusercontent.com/95743138/c161b500-021b-11ea-8bf9-3aa8776acdec',
 });

--- a/src/components/menu/stories/Menu.stories.tsx
+++ b/src/components/menu/stories/Menu.stories.tsx
@@ -59,10 +59,10 @@ export const withSubmenuFlip = () => (
 export const withSelectMenu = () => (
     <Menu>
         <SelectMenuLinkItem isSelected>
-            <Link href="http://opensource.box.com/box-ui-elements/storybook">View Profile</Link>
+            <Link href="https://opensource.box.com/box-ui-elements/">View Profile</Link>
         </SelectMenuLinkItem>
         <SelectMenuLinkItem>
-            <Link href="http://opensource.box.com/box-ui-elements/storybook">Awesome Link</Link>
+            <Link href="https://opensource.box.com/box-ui-elements/">Awesome Link</Link>
         </SelectMenuLinkItem>
     </Menu>
 );

--- a/src/components/menu/stories/SelectMenuLinkItem.stories.tsx
+++ b/src/components/menu/stories/SelectMenuLinkItem.stories.tsx
@@ -9,10 +9,10 @@ import notes from './SelectMenuLinkItem.stories.md';
 export const basic = () => (
     <Menu>
         <SelectMenuLinkItem isSelected>
-            <Link href="http://opensource.box.com/box-ui-elements/storybook">View Profile</Link>
+            <Link href="https://opensource.box.com/box-ui-elements/">View Profile</Link>
         </SelectMenuLinkItem>
         <SelectMenuLinkItem>
-            <Link href="http://opensource.box.com/box-ui-elements/storybook">Awesome Link</Link>
+            <Link href="https://opensource.box.com/box-ui-elements/">Awesome Link</Link>
         </SelectMenuLinkItem>
     </Menu>
 );


### PR DESCRIPTION
fixes https://github.com/box/box-ui-elements/issues/4331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Storybook branding link to point to the main Box UI Elements site (uses HTTPS and the root site URL).
  * Updated menu/story links to point to the main Box UI Elements site (uses HTTPS and the root site URL) to ensure consistent external navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->