### PR TITLE
fix: improve accessibility in sidebar content and tags components

### DIFF
--- a/src/elements/content-sidebar/DocGenSidebar/TagTree.tsx
+++ b/src/elements/content-sidebar/DocGenSidebar/TagTree.tsx
@@ -16,23 +16,36 @@ const TagTree = ({ data, level = 0 }: TagTreeProps) => {
     }
 
     return (
-        <Accordion
-            type='multiple'
-            className="bcs-DocGen-accordion"
-        >
+        <Accordion type="multiple" className="bcs-DocGen-accordion">
             {Object.keys(data)
                 .sort()
                 .map(key => {
                     if (isEmpty(data[key])) {
-                        return(
-                            <Accordion.Item value={key} key={`${key}-${level}`} style={{ paddingLeft: `${level * 12}px` }} fixed className="bcs-DocGen-collapsible">
-                                <span className="bcs-DocGen-tagPath">{key}</span>
+                        return (
+                            <Accordion.Item
+                                value={key}
+                                key={`${key}-${level}`}
+                                style={{ paddingLeft: `${level * 12}px` }}
+                                fixed
+                                className="bcs-DocGen-collapsible"
+                            >
+                                <span className="bcs-DocGen-tagPath" tabIndex={0} role="button" aria-disabled="true">
+                                    {key}
+                                </span>
                             </Accordion.Item>
-                        )
+                        );
                     }
-                    return (<Accordion.Item value={key} title={key} key={`${key}-${level}`} style={{ paddingLeft: `${level * 12}px` }} className="bcs-DocGen-collapsible">
-                        {data[key] &&  <TagTree data={data[key]} level={level + 1} />}
-                    </Accordion.Item>)
+                    return (
+                        <Accordion.Item
+                            value={key}
+                            title={key}
+                            key={`${key}-${level}`}
+                            style={{ paddingLeft: `${level * 12}px` }}
+                            className="bcs-DocGen-collapsible"
+                        >
+                            {data[key] && <TagTree data={data[key]} level={level + 1} />}
+                        </Accordion.Item>
+                    );
                 })}
         </Accordion>
     );

--- a/src/elements/content-sidebar/SidebarContent.js
+++ b/src/elements/content-sidebar/SidebarContent.js
@@ -31,7 +31,7 @@ const SidebarContent = ({ actions, children, className, elementId, sidebarView, 
             {...rest}
         >
             <div className="bcs-content-header">
-                {title && <h3 className="bcs-title">{title}</h3>}
+                {title && <h2 className="bcs-title">{title}</h2>}
                 {actions}
             </div>
             {subheader && <div className="bcs-content-subheader">{subheader}</div>}

--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -173,6 +173,7 @@ const SidebarNav = ({
                     )}
                     {hasDocGen && (
                         <SidebarNavButton
+                            elementId=""
                             data-resin-target={SIDEBAR_NAV_TARGETS.DOCGEN}
                             data-target-id="SidebarNavButton-docGen"
                             data-testid="sidebardocgen"

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -139,7 +139,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
     test('should render title', () => {
         renderComponent();
 
-        expect(screen.getByRole('heading', { level: 3, name: 'Metadata' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Metadata' })).toBeInTheDocument();
     });
 
     test('should have accessible "All templates" combobox trigger button', () => {
@@ -229,7 +229,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         const errorMessage = { id: 'error', defaultMessage: 'error message' };
         renderComponent();
 
-        expect(screen.getByRole('heading', { level: 3, name: 'Metadata' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Metadata' })).toBeInTheDocument();
         expect(screen.getByText(errorMessage.defaultMessage)).toBeInTheDocument();
     });
 
@@ -250,7 +250,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
         renderComponent();
 
-        expect(screen.getByRole('heading', { level: 3, name: 'Metadata' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Metadata' })).toBeInTheDocument();
         expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
         expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
     });
@@ -315,7 +315,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
         renderComponent();
 
-        expect(screen.getByRole('heading', { level: 3, name: 'Metadata' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Metadata' })).toBeInTheDocument();
         expect(screen.getByRole('heading', { level: 4, name: 'Custom Metadata' })).toBeInTheDocument();
         expect(screen.getByText(mockCustomTemplateInstance.fields[0].key)).toBeInTheDocument();
         expect(screen.getByText(mockCustomTemplateInstance.fields[1].key)).toBeInTheDocument();
@@ -391,7 +391,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
         renderComponent({ filteredTemplateIds });
 
-        expect(screen.getByRole('heading', { level: 3, name: 'Metadata' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Metadata' })).toBeInTheDocument();
         expect(screen.getByRole('heading', { level: 4, name: 'Visible Template' })).toBeInTheDocument();
         expect(screen.queryByRole('heading', { level: 4, name: 'Custom Metadata' })).not.toBeInTheDocument();
     });
@@ -415,7 +415,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
 
         renderComponent({ filteredTemplateIds });
 
-        expect(screen.getByRole('heading', { level: 3, name: 'Metadata' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { level: 2, name: 'Metadata' })).toBeInTheDocument();
         expect(screen.getByRole('heading', { level: 4, name: 'Custom Metadata' })).toBeInTheDocument();
         expect(screen.getByText(mockCustomTemplateInstance.fields[0].key)).toBeInTheDocument();
         expect(screen.getByText(mockCustomTemplateInstance.fields[1].key)).toBeInTheDocument();

--- a/src/elements/content-sidebar/__tests__/__snapshots__/SidebarContent.test.js.snap
+++ b/src/elements/content-sidebar/__tests__/__snapshots__/SidebarContent.test.js.snap
@@ -11,11 +11,11 @@ exports[`elements/content-sidebar/SidebarContent should render sidebar content c
   <div
     className="bcs-content-header"
   >
-    <h3
+    <h2
       className="bcs-title"
     >
       title
-    </h3>
+    </h2>
   </div>
   <div
     className="bcs-scroll-content-wrapper"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


This PR addresses accessibility and navigation issues:
- Invalid aria-controls Attribute
- Broken Heading Hierarchy
- Tags Section Keyboard Accessibility

### Changes
- [x] Updated the `aria-controls` and `id` on the docgen sidemenu button to reference the correct ID: `docgen` instead of `bcs_xxx_docgen`.
- [x] follows semantic hierarchy for better accessibility.
- [x] Made the tags section navigable via keyboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility and keyboard/ARIA behavior for tag navigation and nested accordion items, including clearer focusable/disabled states for empty branches.

* **Style**
  * Adjusted sidebar heading from h3 to h2 for improved document structure and semantic correctness.

* **Tests**
  * Updated tests to reflect the revised heading level and sidebar structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->