### PR TITLE
fix(metadata-editor): Preserve field order when fetching taxonomy levels for fields

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -12,7 +12,6 @@ import getProp from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import keyBy from 'lodash/keyBy';
 import lodashMap from 'lodash/map';
-import partition from 'lodash/partition';
 import uniq from 'lodash/uniq';
 import uniqueId from 'lodash/uniqueId';
 import { getBadItemError, getBadPermissionsError, isUserCorrectableError } from '../utils/error';
@@ -288,14 +287,9 @@ class Metadata extends File {
         return lodashMap(templates, template => {
             if (!template.fields) return template;
 
-            const [fieldsToUpdate, restFields] = partition(
-                template.fields,
-                field => field.type === 'taxonomy' && !field.levels,
-            );
+            const updatedFields = lodashMap(template.fields, field => {
+                if (field.type !== 'taxonomy' || field.levels) return field;
 
-            if (isEmpty(fieldsToUpdate)) return template;
-
-            const updatedFields = lodashMap(fieldsToUpdate, field => {
                 const taxonomyPath = this.getTaxonomyPath(field.namespace, field.taxonomyKey || field.taxonomy_key);
                 const levels = taxonomyInfo[taxonomyPath]?.levels || [];
 
@@ -315,7 +309,7 @@ class Metadata extends File {
 
             return {
                 ...template,
-                fields: restFields.concat(updatedFields),
+                fields: updatedFields,
             };
         });
     }

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -298,7 +298,6 @@ describe('api/Metadata', () => {
                     id: 1,
                     hidden: false,
                     fields: [
-                        { type: 'string' },
                         {
                             type: 'taxonomy',
                             namespace: 'namespace1',
@@ -308,6 +307,7 @@ describe('api/Metadata', () => {
                                 { displayName: 'level 2', description: 'Another level' },
                             ],
                         },
+                        { type: 'string' },
                     ],
                 },
                 { id: 2, hidden: false, fields: [{ type: 'string', namespace: 'namespace2' }] },
@@ -352,7 +352,6 @@ describe('api/Metadata', () => {
                     id: 1,
                     hidden: false,
                     fields: [
-                        { type: 'string' },
                         {
                             type: 'taxonomy',
                             namespace: 'namespace1',
@@ -362,6 +361,7 @@ describe('api/Metadata', () => {
                                 { displayName: 'level 2', description: 'Another level' },
                             ],
                         },
+                        { type: 'string' },
                     ],
                 },
                 { id: 2, hidden: false, fields: [{ type: 'string', namespace: 'namespace2' }] },


### PR DESCRIPTION
## Description

This PR fixes a bug where field ordering was not preserved when enriching metadata templates with taxonomy levels. Previously, the code used `partition` to separate taxonomy fields that needed updating from other fields, then concatenated them back together, which resulted in updated taxonomy fields being moved to the end of the fields array. This change ensures that fields maintain their original order when taxonomy levels are fetched and added.

## Changes made

- Modified `_enrichTemplatesWithTaxonomyLevels` method in `Metadata.js` to map over all fields in order instead of partitioning and concatenating
- Removed unused `partition` import from lodash
- Updated test cases to verify field order preservation by reordering test data

## Type of change

_Check relevant options (✓)_

- [x] Bug fix (non-breaking change addressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Code refactor (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] CI/CD configuration change

## Testing done

_Describe the tests you've added or run to verify your changes._

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Screenshots/Videos

_Include any relevant visual evidence of your changes (if applicable)._

## Dependencies

_List new dependencies added or existing ones modified._
None

## Deployment notes

_Note any special considerations for deployment (configuration changes, migration steps, etc.)._
None

## How to test

_Provide guidance for reviewers on how to see and test the changes in a running app_

1. Create or view a metadata template with multiple fields including taxonomy fields
2. Verify that the field order in the metadata editor matches the original template field order
3. Ensure taxonomy fields with fetched levels maintain their position relative to other fields

## How to review

_Provide guidance for reviewers - what areas need particular attention? Is there a specific review sequence that would be helpful?_

- Review the logic change in `_enrichTemplatesWithTaxonomyLevels` to ensure field order is preserved
- Verify that the test updates correctly validate the fix
- Check that removing the `partition` import doesn't break any other code

## Self-review checklist

_Verify you've completed the following before requesting review._

- [x] Code follows the project's style guidelines
- [x] Code is properly documented (comments, JSDoc/docstrings, etc.)
- [x] Changes are covered by tests
- [x] All tests pass locally
- [x] No unnecessary console logs or debugging code
- [x] No sensitive information is exposed
- [x] No new warnings or errors are introduced
- [x] PR title follows conventional commit format

## Additional notes

_Any other information that would be helpful to the reviewer._
The fix ensures that when metadata templates are enriched with taxonomy levels, the original field ordering is maintained, which is important for UI consistency and user expectations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal field processing to streamline updates; preserves user-facing behavior and public APIs.
* **Tests**
  * Adjusted test expectations/order to reflect the internal processing change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->