### PR TITLE
feat(metadata-editor): apply custom logic for multiple confidence scores and target locations

### DIFF
--- a/src/elements/content-sidebar/__tests__/useMetadataFieldSelection.test.ts
+++ b/src/elements/content-sidebar/__tests__/useMetadataFieldSelection.test.ts
@@ -267,6 +267,53 @@ describe('useMetadataFieldSelection', () => {
             expect(mockHideBoundingBoxHighlights).toHaveBeenCalled();
         });
 
+        test('should filter out target location entries without boundingBox', () => {
+            const { result } = renderHook(() => useMetadataFieldSelection(getPreview));
+
+            act(() => {
+                result.current.handleSelectMetadataField(
+                    createMockField({
+                        targetLocation: [
+                            {
+                                itemId: 'item-1',
+                                page: 0,
+                                text: 'first',
+                                boundingBox: { left: 0.1, top: 0.2, right: 0.5, bottom: 0.6 },
+                            },
+                            {
+                                itemId: 'item-2',
+                                page: 1,
+                                text: 'second',
+                            },
+                        ],
+                    }),
+                );
+            });
+
+            expect(mockShowBoundingBoxHighlights).toHaveBeenCalledWith([
+                { id: 'bbox-field-1-1', x: 9.75, y: 19.75, width: 40.5, height: 40.5, pageNumber: 1 },
+            ]);
+        });
+
+        test('should deselect when all target location entries lack boundingBox', () => {
+            const { result } = renderHook(() => useMetadataFieldSelection(getPreview));
+
+            act(() => {
+                result.current.handleSelectMetadataField(
+                    createMockField({
+                        targetLocation: [
+                            { itemId: 'item-1', page: 0, text: 'first' },
+                            { itemId: 'item-2', page: 1, text: 'second' },
+                        ],
+                    }),
+                );
+            });
+
+            expect(result.current.selectedMetadataFieldId).toBeNull();
+            expect(mockShowBoundingBoxHighlights).not.toHaveBeenCalled();
+            expect(mockHideBoundingBoxHighlights).toHaveBeenCalled();
+        });
+
         test('should clamp bounding box values to valid percentage range', () => {
             const { result } = renderHook(() => useMetadataFieldSelection(getPreview));
 

--- a/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
+++ b/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
@@ -815,6 +815,120 @@ describe('useSidebarMetadataFetcher', () => {
             ]);
         });
 
+        test('should pick the lowest confidence score when confidence_score is an array', async () => {
+            mockAPI.extractStructured.mockResolvedValue({
+                answer: { field1: 'value1', field2: 'value2' },
+                created_at: '2026-03-27T08:10:14.106-07:00',
+                confidence_score: {
+                    field1: [
+                        { level: 'HIGH', score: 1 },
+                        { level: 'LOW', score: 0.3 },
+                        { level: 'MEDIUM', score: 0.7 },
+                    ],
+                    field2: { level: 'MEDIUM', score: 0.6 },
+                },
+                completion_reason: 'done',
+            });
+
+            const { result } = setupHook('123', true);
+            await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
+
+            const suggestions = await result.current.extractSuggestions('templateKey', 'global');
+
+            expect(suggestions).toEqual([
+                {
+                    ...mockTemplates[0].fields[0],
+                    aiSuggestion: 'value1',
+                    aiSuggestionConfidenceScore: { value: 0.3, level: 'LOW', isAccepted: false },
+                },
+                {
+                    ...mockTemplates[0].fields[1],
+                    aiSuggestion: 'value2',
+                    aiSuggestionConfidenceScore: { value: 0.6, level: 'MEDIUM', isAccepted: false },
+                },
+            ]);
+        });
+
+        test('should pick the lowest confidence score from array with two equal scores', async () => {
+            mockAPI.extractStructured.mockResolvedValue({
+                answer: { field1: 'value1' },
+                created_at: '2026-03-27T08:10:14.106-07:00',
+                confidence_score: {
+                    field1: [
+                        { level: 'HIGH', score: 1 },
+                        { level: 'HIGH', score: 1 },
+                    ],
+                },
+                completion_reason: 'done',
+            });
+
+            const { result } = setupHook('123', true);
+            await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
+
+            const suggestions = await result.current.extractSuggestions('templateKey', 'global');
+
+            expect(suggestions[0].aiSuggestionConfidenceScore).toEqual({
+                value: 1,
+                level: 'HIGH',
+                isAccepted: false,
+            });
+        });
+
+        test('should flatten nested arrays of references', async () => {
+            mockAPI.extractStructured.mockResolvedValue({
+                answer: { field1: 'value1' },
+                created_at: '2026-03-27T08:10:14.106-07:00',
+                confidence_score: {
+                    field1: { level: 'HIGH', score: 0.9 },
+                },
+                reference: {
+                    field1: [
+                        [
+                            { itemId: 'file_123', page: 0, text: 'ref 1' },
+                            { itemId: 'file_123', page: 1, text: 'ref 2' },
+                        ],
+                        [{ itemId: 'file_456', page: 0, text: 'ref 3' }],
+                    ],
+                },
+                completion_reason: 'done',
+            });
+
+            const { result } = setupHook('123', true);
+            await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
+
+            const suggestions = await result.current.extractSuggestions('templateKey', 'global');
+
+            expect(suggestions[0].targetLocation).toEqual([
+                { itemId: 'file_123', page: 0, text: 'ref 1' },
+                { itemId: 'file_123', page: 1, text: 'ref 2' },
+                { itemId: 'file_456', page: 0, text: 'ref 3' },
+            ]);
+        });
+
+        test('should handle flat array of references without nesting', async () => {
+            mockAPI.extractStructured.mockResolvedValue({
+                answer: { field1: 'value1' },
+                created_at: '2026-03-27T08:10:14.106-07:00',
+                reference: {
+                    field1: [
+                        { itemId: 'file_123', page: 0, text: 'ref 1' },
+                        { itemId: 'file_123', page: 1, text: 'ref 2' },
+                    ],
+                },
+                completion_reason: 'done',
+            });
+
+            const { result } = setupHook('123', true);
+            await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
+
+            const suggestions = await result.current.extractSuggestions('templateKey', 'global');
+
+            expect(suggestions[0].targetLocation).toEqual([
+                { itemId: 'file_123', page: 0, text: 'ref 1' },
+                { itemId: 'file_123', page: 1, text: 'ref 2' },
+            ]);
+        });
+
         test('should handle reference entries without bounding box', async () => {
             mockAPI.extractStructured.mockResolvedValue({
                 answer: { field1: 'value1' },

--- a/src/elements/content-sidebar/hooks/useMetadataFieldSelection.ts
+++ b/src/elements/content-sidebar/hooks/useMetadataFieldSelection.ts
@@ -4,6 +4,13 @@ import clampPercentage from '../utils/clampPercentage';
 
 import type { BoxAnnotationsBoundingBox, GetPreviewForMetadataReturnType } from '../types/BoxAISidebarTypes';
 
+type TargetLocationEntryWithBoundingBoxRequired = MetadataTargetLocationEntry &
+    Required<Pick<MetadataTargetLocationEntry, 'boundingBox'>>;
+
+function checkHasBoundingBox(entry: MetadataTargetLocationEntry): entry is TargetLocationEntryWithBoundingBoxRequired {
+    return !!entry.boundingBox;
+}
+
 function convertTargetLocationToBoundingBox(
     id: string,
     targetLocationEntries?: MetadataTargetLocationEntry[],
@@ -13,7 +20,7 @@ function convertTargetLocationToBoundingBox(
     }
 
     // Adding extra space (-0.25 for left and top, +0.5 for width and height) to provide paddings for bounding boxes
-    return targetLocationEntries.map((item: MetadataTargetLocationEntry, index: number) => ({
+    return targetLocationEntries.filter(checkHasBoundingBox).map((item, index: number) => ({
         id: `bbox-${id}-${index + 1}`,
         x: clampPercentage(item.boundingBox.left * 100 - 0.25),
         y: clampPercentage(item.boundingBox.top * 100 - 0.25),
@@ -75,7 +82,7 @@ function useMetadataFieldSelection(getPreview: () => GetPreviewForMetadataReturn
 
             const boundingBoxes = convertTargetLocationToBoundingBox(field.id, field.targetLocation);
 
-            if (!boundingBoxes) {
+            if (!boundingBoxes || boundingBoxes.length === 0) {
                 handleDeselectMetadataField();
                 return;
             }

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -284,16 +284,20 @@ function useSidebarMetadataFetcher(
 
                 const fieldConfidence = confidenceScores?.[field.key];
                 if (fieldConfidence) {
+                    const lowestConfidence = Array.isArray(fieldConfidence)
+                        ? fieldConfidence.reduce((min, curr) => (curr.score < min.score ? curr : min))
+                        : fieldConfidence;
                     result.aiSuggestionConfidenceScore = {
-                        value: fieldConfidence.score,
-                        level: fieldConfidence.level,
+                        value: lowestConfidence.score,
+                        level: lowestConfidence.level,
                         isAccepted: false,
                     };
                 }
 
                 const ref = references?.[field.key];
                 if (ref) {
-                    result.targetLocation = ref;
+                    const flattenedRef = Array.isArray(ref) ? ref.flat() : ref;
+                    result.targetLocation = flattenedRef;
                 }
 
                 return result;


### PR DESCRIPTION
For multiSelect metadata fields, the Intelligence API returns per-value confidence scores, confidence levels, and bounding boxes - rather than a single set per field. This doesn't align with the current review/approval (HITL) process or meta-metadata schema, which expect one confidence score and one flat list of bounding boxes per field.
This PR applies the agreed-upon workaround:
- Confidence scores/levels: when multiple scores are returned for a field, we take the lowest score (and its level) so the user sees the most conservative assessment in the UI
- Bounding boxes: when nested arrays of references are returned, we flatten them so all bounding boxes are visible and clickable in Preview
- Reference entries without bounding boxes: filtered out to prevent rendering errors; fields where all references lack bounding boxes correctly trigger deselection
Some per-value granularity is lost (one score/level stored per field instead of per option), but this is acceptable for the HITL process.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selects lowest confidence when per-field scores are arrays; flattens nested reference locations; deselects metadata fields when location entries lack bounding boxes.

* **Tests**
  * Added tests covering metadata field selection with missing bounding boxes and AI suggestion handling for arrayed confidence scores and nested references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->