### PR TITLE
feat(metadata-editor): merge hydrated and detailed view results

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -21,6 +21,7 @@ import {
     formatMetadataFieldValue,
     handleOnAbort,
     mapDetailedFieldToConfidenceScore,
+    mergeDetailedAndHydratedInstances,
     parseTargetLocation,
 } from './utils';
 import File from './File';
@@ -392,6 +393,35 @@ class Metadata extends File {
     }
 
     /**
+     * Fetches both detailed and hydrated metadata views and merges them so that
+     * the result is in detailed format but with hydrated taxonomy values.
+     *
+     * @param {string} baseUrl - metadata API base URL
+     * @param {string} requestId - typed file id
+     * @return {Array} merged metadata instances
+     */
+    async getDetailedInstancesWithHydratedTaxonomy(
+        baseUrl: string,
+        requestId: string,
+    ): Promise<Array<MetadataInstanceV2>> {
+        try {
+            const [detailedResponse, hydratedResponse] = await Promise.all([
+                this.xhr.get({ url: `${baseUrl}?view=detailed`, id: requestId }),
+                this.xhr.get({ url: `${baseUrl}?view=hydrated`, id: requestId }),
+            ]);
+            const detailedEntries = getProp(detailedResponse, 'data.entries', []);
+            const hydratedEntries = getProp(hydratedResponse, 'data.entries', []);
+            return mergeDetailedAndHydratedInstances(detailedEntries, hydratedEntries);
+        } catch (e) {
+            const { status } = e;
+            if (isUserCorrectableError(status)) {
+                throw e;
+            }
+        }
+        return [];
+    }
+
+    /**
      * Gets metadata instances for a Box file
      *
      * @param {string} id - file id
@@ -407,14 +437,19 @@ class Metadata extends File {
         this.errorCode = ERROR_CODE_FETCH_METADATA;
 
         const baseUrl = this.getMetadataUrl(id);
-        const view = isConfidenceScoreEnabled ? 'detailed' : 'hydrated';
-        const url = isMetadataRedesign ? `${baseUrl}?view=${view}` : baseUrl;
+        const requestId = getTypedFileId(id);
+
+        if (isMetadataRedesign && isConfidenceScoreEnabled) {
+            return this.getDetailedInstancesWithHydratedTaxonomy(baseUrl, requestId);
+        }
+
+        const url = isMetadataRedesign ? `${baseUrl}?view=hydrated` : baseUrl;
 
         let instances = {};
         try {
             instances = await this.xhr.get({
                 url,
-                id: getTypedFileId(id),
+                id: requestId,
             });
         } catch (e) {
             const { status } = e;

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -713,18 +713,52 @@ describe('api/Metadata', () => {
             });
         });
 
-        test('should apply detailed view query string param when isMetadataRedesign and isConfidenceScoreEnabled are true', async () => {
+        test('should make both detailed and hydrated calls when isMetadataRedesign and isConfidenceScoreEnabled are true', async () => {
             metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
-            metadata.xhr.get = jest.fn().mockReturnValueOnce({
-                data: {
-                    entries: [],
-                },
-            });
-            await metadata.getInstances('id', true, true);
+            metadata.xhr.get = jest
+                .fn()
+                .mockResolvedValueOnce({
+                    data: {
+                        entries: [
+                            {
+                                $id: 'inst-1',
+                                region: {
+                                    values: ['uuid-1'],
+                                    details: { updatedAt: 1000, updatedBy: 'user1', updatedAppId: 'app1' },
+                                },
+                            },
+                        ],
+                    },
+                })
+                .mockResolvedValueOnce({
+                    data: {
+                        entries: [
+                            {
+                                $id: 'inst-1',
+                                region: [{ id: 'uuid-1', displayName: 'Japan', level: '1', nodePath: [] }],
+                            },
+                        ],
+                    },
+                });
+            const result = await metadata.getInstances('id', true, true);
+            expect(metadata.xhr.get).toHaveBeenCalledTimes(2);
             expect(metadata.xhr.get).toHaveBeenCalledWith({
                 url: 'metadata_url?view=detailed',
                 id: 'file_id',
             });
+            expect(metadata.xhr.get).toHaveBeenCalledWith({
+                url: 'metadata_url?view=hydrated',
+                id: 'file_id',
+            });
+            expect(result).toEqual([
+                {
+                    $id: 'inst-1',
+                    region: {
+                        values: [{ id: 'uuid-1', displayName: 'Japan', level: '1', nodePath: [] }],
+                        details: { updatedAt: 1000, updatedBy: 'user1', updatedAppId: 'app1' },
+                    },
+                },
+            ]);
         });
 
         test('should not apply view query string param when isMetadataRedesign is false even if isConfidenceScoreEnabled is true', async () => {

--- a/src/api/__tests__/utils.test.js
+++ b/src/api/__tests__/utils.test.js
@@ -7,6 +7,7 @@ import {
     handleOnAbort,
     isDetailedFieldValue,
     mapDetailedFieldToConfidenceScore,
+    mergeDetailedAndHydratedInstances,
     parseTargetLocation,
 } from '../utils';
 import { threadedComments, threadedCommentsFormatted } from '../fixtures';
@@ -249,6 +250,144 @@ describe('api/utils', () => {
             const expectedValue = [{ value: id, displayValue: displayName }];
 
             expect(formatMetadataFieldValue(taxonomyField, [{ id, displayName }])).toEqual(expectedValue);
+        });
+    });
+
+    describe('mergeDetailedAndHydratedInstances()', () => {
+        test('should replace detailed values with hydrated values for taxonomy fields', () => {
+            const detailedEntries = [
+                {
+                    $id: 'inst-1',
+                    $template: 'template1',
+                    $scope: 'enterprise',
+                    region: {
+                        values: ['uuid-1'],
+                        details: { updatedAt: 1000, updatedBy: 'user1', updatedAppId: 'app1' },
+                    },
+                    name: {
+                        values: 'Test Name',
+                        details: { updatedAt: 2000, updatedBy: 'user2', updatedAppId: 'app2' },
+                    },
+                },
+            ];
+            const hydratedEntries = [
+                {
+                    $id: 'inst-1',
+                    $template: 'template1',
+                    $scope: 'enterprise',
+                    region: [{ id: 'uuid-1', displayName: 'Japan', level: '1', nodePath: [] }],
+                    name: 'Test Name',
+                },
+            ];
+
+            const result = mergeDetailedAndHydratedInstances(detailedEntries, hydratedEntries);
+
+            expect(result).toEqual([
+                {
+                    $id: 'inst-1',
+                    $template: 'template1',
+                    $scope: 'enterprise',
+                    region: {
+                        values: [{ id: 'uuid-1', displayName: 'Japan', level: '1', nodePath: [] }],
+                        details: { updatedAt: 1000, updatedBy: 'user1', updatedAppId: 'app1' },
+                    },
+                    name: {
+                        values: 'Test Name',
+                        details: { updatedAt: 2000, updatedBy: 'user2', updatedAppId: 'app2' },
+                    },
+                },
+            ]);
+        });
+
+        test('should return detailed entries unchanged when no matching hydrated entry exists', () => {
+            const detailedEntries = [
+                {
+                    $id: 'inst-1',
+                    region: { values: ['uuid-1'], details: {} },
+                },
+            ];
+            const hydratedEntries = [];
+
+            const result = mergeDetailedAndHydratedInstances(detailedEntries, hydratedEntries);
+
+            expect(result).toEqual(detailedEntries);
+        });
+
+        test('should not modify $-prefixed system fields', () => {
+            const detailedEntries = [
+                {
+                    $id: 'inst-1',
+                    $scope: 'enterprise',
+                    $template: 'tmpl',
+                    field1: { values: 'val1', details: {} },
+                },
+            ];
+            const hydratedEntries = [
+                {
+                    $id: 'inst-1',
+                    $scope: 'enterprise',
+                    $template: 'tmpl',
+                    field1: 'val1',
+                },
+            ];
+
+            const result = mergeDetailedAndHydratedInstances(detailedEntries, hydratedEntries);
+
+            expect(result[0].$id).toBe('inst-1');
+            expect(result[0].$scope).toBe('enterprise');
+            expect(result[0].$template).toBe('tmpl');
+        });
+
+        test('should handle multiple instances', () => {
+            const detailedEntries = [
+                {
+                    $id: 'inst-1',
+                    country: { values: ['id-1'], details: { updatedAt: 100 } },
+                },
+                {
+                    $id: 'inst-2',
+                    city: { values: ['id-2'], details: { updatedAt: 200 } },
+                },
+            ];
+            const hydratedEntries = [
+                {
+                    $id: 'inst-2',
+                    city: [{ id: 'id-2', displayName: 'Tokyo' }],
+                },
+                {
+                    $id: 'inst-1',
+                    country: [{ id: 'id-1', displayName: 'Japan' }],
+                },
+            ];
+
+            const result = mergeDetailedAndHydratedInstances(detailedEntries, hydratedEntries);
+
+            expect(result[0].country.values).toEqual([{ id: 'id-1', displayName: 'Japan' }]);
+            expect(result[0].country.details).toEqual({ updatedAt: 100 });
+            expect(result[1].city.values).toEqual([{ id: 'id-2', displayName: 'Tokyo' }]);
+            expect(result[1].city.details).toEqual({ updatedAt: 200 });
+        });
+
+        test('should skip non-detailed fields during merge', () => {
+            const detailedEntries = [
+                {
+                    $id: 'inst-1',
+                    plainField: 'just a string',
+                    detailedField: { values: 'val', details: {} },
+                },
+            ];
+            const hydratedEntries = [
+                {
+                    $id: 'inst-1',
+                    plainField: 'just a string',
+                    detailedField: 'val',
+                },
+            ];
+
+            const result = mergeDetailedAndHydratedInstances(detailedEntries, hydratedEntries);
+
+            expect(result[0].plainField).toBe('just a string');
+            expect(result[0].detailedField).toEqual({ values: 'val', details: {} });
         });
     });
 });

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -11,6 +11,7 @@ import type {
     MetadataConfidenceScoreData,
     MetadataDetailedFieldValue,
     MetadataFieldValue,
+    MetadataInstanceV2,
     MetadataTargetLocationEntry,
     MetadataTemplateField,
 } from '../common/types/metadata';
@@ -94,6 +95,39 @@ const parseTargetLocation = (fieldValue: any): ?Array<MetadataTargetLocationEntr
     }
 };
 
+const mergeDetailedAndHydratedInstances = (
+    detailedEntries: Array<MetadataInstanceV2>,
+    hydratedEntries: Array<MetadataInstanceV2>,
+): Array<MetadataInstanceV2> => {
+    const hydratedById: { [string]: MetadataInstanceV2 } = {};
+    hydratedEntries.forEach(entry => {
+        hydratedById[entry.$id] = entry;
+    });
+
+    return detailedEntries.map(detailedEntry => {
+        const hydratedEntry = hydratedById[detailedEntry.$id];
+        if (!hydratedEntry) {
+            return detailedEntry;
+        }
+
+        const merged = { ...detailedEntry };
+        Object.keys(merged).forEach(key => {
+            if (key.startsWith('$')) {
+                return;
+            }
+
+            if (isDetailedFieldValue(merged[key]) && key in hydratedEntry) {
+                merged[key] = {
+                    ...merged[key],
+                    values: hydratedEntry[key],
+                };
+            }
+        });
+
+        return merged;
+    });
+};
+
 const handleOnAbort = (xhr: Xhr) => {
     xhr.abort();
 
@@ -107,5 +141,6 @@ export {
     handleOnAbort,
     isDetailedFieldValue,
     mapDetailedFieldToConfidenceScore,
+    mergeDetailedAndHydratedInstances,
     parseTargetLocation,
 };


### PR DESCRIPTION
When both `isMetadataRedesign` and `isConfidenceScoreEnabled` are enabled, the metadata API previously fetched only the detailed view (which contains confidence score details but returns raw taxonomy UUIDs instead of display names). 

This PR changes the approach to fetch both the detailed and hydrated views in parallel, then merge them — preserving the detailed field metadata (e.g. confidenceScore, confidenceLevel, etc.) while replacing raw taxonomy UUID arrays with fully hydrated objects (id, displayName, level, nodePath).

**Before** - a taxonomy field in detailed view:

```ts
{ "values": ["uuid-1"], "details": { "confidenceScore": 1, "confidenceLevel": "HIGH" } }

```

**After** merge - taxonomy values are hydrated while details are retained:

```ts
{ "values": [{ "id": "uuid-1", "displayName": "Japan", "level": "1", "nodePath": [] }], "details":  { "confidenceScore": 1, "confidenceLevel": "HIGH" }}
```

Non-taxonomy fields and $-prefixed system fields are left untouched.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced metadata retrieval that combines detailed and hydrated data views for more complete information when advanced features are enabled.

* **Tests**
  * Added comprehensive test coverage for metadata merging, API calls, and data transformation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->