### PR TITLE
chore(deps): upgrade uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
         "tabbable": "^1.1.3",
         "ts-loader": "^6.2.1",
         "typescript": "5.2.2",
-        "uuid": "^8.3.2",
+        "uuid": "^14.0.0",
         "wait-on": "^9.0.5",
         "webpack": "^5.105.4",
         "webpack-bundle-analyzer": "^4.10.2",
@@ -349,14 +349,15 @@
         "sass": "1.77.6",
         "scroll-into-view-if-needed": "^2.2.31",
         "tabbable": "^1.1.3",
-        "uuid": "^8.3.2"
+        "uuid": "^14.0.0"
     },
     "resolutions": {
         "draft-js/immutable": "^3.8.3",
         "eslint-plugin-formatjs/**/minimatch": "^9.0.9",
         "qs": "^6.14.1",
         "serialize-javascript": "^7.0.5",
-        "tar": "^7.5.11"
+        "tar": "^7.5.11",
+        "uuid": "^14.0.0"
     },
     "msw": {
         "workerDirectory": [".storybook/public"]

--- a/scripts/jest/jest.config.js
+++ b/scripts/jest/jest.config.js
@@ -28,6 +28,6 @@ module.exports = {
     testMatch: ['**/__tests__/**/*.test.+(js|jsx|ts|tsx)'],
     testPathIgnorePatterns: ['stories.test.js$', 'stories.test.tsx$', 'stories.test.d.ts'],
     transformIgnorePatterns: [
-        'node_modules/(?!(@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers|@box/box-ai-agent-selector|@box/item-icon|@box/combobox-with-api|@box/tree|@box/metadata-filter|@box/metadata-view|@box/content-field|@box/types|@box/box-item-type-selector|@box/unified-share-modal|@box/user-selector|@box/copy-input)/)',
+        'node_modules/(?!(@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers|@box/box-ai-agent-selector|@box/item-icon|@box/combobox-with-api|@box/tree|@box/metadata-filter|@box/metadata-view|@box/content-field|@box/types|@box/box-item-type-selector|@box/unified-share-modal|@box/user-selector|@box/copy-input|uuid)/)',
     ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -19134,10 +19134,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@>=14.0.0, uuid@^14.0.0, uuid@^8.3.2:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
Upgrading UUID, must be >14.0.0

No significant breaking changes between 8 and 14 - most deal with dropping node support.
- [v9.0.0](https://github.com/uuidjs/uuid/releases/tag/v9.0.0) - Sep 2022
- [v10.0.0](https://github.com/uuidjs/uuid/releases/tag/v10.0.0) - Jun 2024
- [v12.0.0](https://github.com/uuidjs/uuid/releases/tag/v12.0.0) - Sep 5, 2025
- [v13.0.0](https://github.com/uuidjs/uuid/releases/tag/v13.0.0) - Sep 8, 2025
- [v14.0.0](https://github.com/uuidjs/uuid/releases/tag/v14.0.0) - Apr 2026

UUID v8 is introduced via direct dependency AND indirect
```
$ yarn why uuid
yarn why v1.22.22
[1/4] 🤔  Why do we have the module "uuid"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "uuid@8.3.2"
info Has been hoisted to "uuid"
info Reasons this module exists
   - Specified in "devDependencies"
   - Hoisted from "cypress#@cypress#request#uuid"
   - Hoisted from "webpack-dev-server#sockjs#uuid"
```

The resolutions is required as cypress/request is used within webpack-dev-server, and no version of cypress/request replaces uuid.
https://github.com/cypress-io/cypress/issues/29775#issuecomment-4302520636

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded development and peer dependency for uuid to ^14.0.0 and added a lock resolution to ensure consistency.

* **Tests**
  * Adjusted test transformer configuration so the uuid package is processed during test runs (improves test compatibility).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->