### PR TITLE
fix(ci): update directory for generated files

### DIFF
--- a/scripts/check_generated_files.sh
+++ b/scripts/check_generated_files.sh
@@ -16,9 +16,14 @@ check_generated_files() {
     printf "${blue}-------------------------------------------------------------${end}"
     yarn --cwd /buie build:i18n || return 1
 
-    if [[ $(git status --porcelain 2>/dev/null | egrep "^(M| M)") != "" ]]; then
+    # `yarn --cwd /buie ...` runs the build at /buie, but the executor's shell
+    # working directory is ~/buie. Without `-C /buie`, git status would inspect
+    # the wrong tree and silently miss generated changes (e.g. en-US.properties
+    # drift when a PR adds defineMessages but forgets to commit the rebuilt
+    # properties file).
+    if [[ $(git -C /buie status --porcelain 2>/dev/null | egrep "^(M| M)") != "" ]]; then
         printf "${red}Your PR has uncommitted files!${end}"
-        git status --porcelain
+        git -C /buie status --porcelain
         return 1
     fi
 }


### PR DESCRIPTION
## Summary

The PR safety check that's supposed to flag drift between `defineMessages` and `i18n/en-US.properties` has been silently failing since #3771. That's how #4521 slipped through — the missing `docGenSidebar` translations only got caught at release time.

The reason it's silently failing: #3771 started running `yarn` with `--cwd /buie`, but the executor's shell `working_directory` is still `~/buie`. So `yarn build:i18n` regenerates `/buie/i18n/en-US.properties`, then `git status --porcelain` runs in `~/buie` (which only has the unmodified post-`checkout` tree) and always reports clean.

Fix is to point `git status` at the same tree the build wrote to via `git -C /buie`.

A companion test branch (`test-i18n-should-fail`) intentionally introduces `en-US.properties` drift to verify this fix actually trips CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved consistency in build artifact verification by aligning script operations with the build system's working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->