### PR TITLE
test: add unused message to verify ci i18n drift check

### DIFF
--- a/scripts/check_generated_files.sh
+++ b/scripts/check_generated_files.sh
@@ -16,9 +16,14 @@ check_generated_files() {
     printf "${blue}-------------------------------------------------------------${end}"
     yarn --cwd /buie build:i18n || return 1
 
-    if [[ $(git status --porcelain 2>/dev/null | egrep "^(M| M)") != "" ]]; then
+    # `yarn --cwd /buie ...` runs the build at /buie, but the executor's shell
+    # working directory is ~/buie. Without `-C /buie`, git status would inspect
+    # the wrong tree and silently miss generated changes (e.g. en-US.properties
+    # drift when a PR adds defineMessages but forgets to commit the rebuilt
+    # properties file).
+    if [[ $(git -C /buie status --porcelain 2>/dev/null | egrep "^(M| M)") != "" ]]; then
         printf "${red}Your PR has uncommitted files!${end}"
-        git status --porcelain
+        git -C /buie status --porcelain
         return 1
     fi
 }

--- a/src/elements/content-sidebar/DocGenSidebar/messages.tsx
+++ b/src/elements/content-sidebar/DocGenSidebar/messages.tsx
@@ -26,6 +26,11 @@ const messages = defineMessages({
         description: 'Dropdown tags section header',
         defaultMessage: 'Dropdown tags',
     },
+    ciTest: {
+        id: 'be.docGenSidebar.ciTest',
+        description: 'Throwaway message used to verify the CI i18n drift check fires (do not merge)',
+        defaultMessage: 'ci test',
+    },
     docGenTags: {
         id: 'be.docGenSidebar.docGenTags',
         description: 'DocGen sidebar header',


### PR DESCRIPTION
Companion to #4523. Adds an unused `defineMessages` entry without updating `i18n/en-US.properties`, simulating a developer who pushed with `--no-verify` and skipped the local prepush hook.

Expected: with #4523's fix, CI should fail at the `build-unit-tests` job's "Checking locales and styles" step. Without the fix it passes silently.

Do not merge — close once CI confirms the failure.