### PR TITLE
test: add unused message to verify ci i18n drift check (without fix)

### DIFF
--- a/src/elements/content-sidebar/DocGenSidebar/messages.tsx
+++ b/src/elements/content-sidebar/DocGenSidebar/messages.tsx
@@ -26,6 +26,11 @@ const messages = defineMessages({
         description: 'Dropdown tags section header',
         defaultMessage: 'Dropdown tags',
     },
+    ciTest: {
+        id: 'be.docGenSidebar.ciTest',
+        description: 'Throwaway message used to verify the CI i18n drift check fires (do not merge)',
+        defaultMessage: 'ci test',
+    },
     docGenTags: {
         id: 'be.docGenSidebar.docGenTags',
         description: 'DocGen sidebar header',


### PR DESCRIPTION
Control PR for #4523 / #4524. Same unused `defineMessages` change as #4524, but branched directly from `master` so it does **not** include the fix.

Expected: CI passes silently — proving the safety check in `scripts/check_generated_files.sh` is currently a no-op and that #4523 is needed.

Do not merge — close once CI confirms it passes.