### PR TITLE
fix(content-sharing): USM Expiration Permission For Individual Users

### DIFF
--- a/src/elements/content-sharing/ContentSharingV2.tsx
+++ b/src/elements/content-sharing/ContentSharingV2.tsx
@@ -183,6 +183,10 @@ function ContentSharingV2({
         if (!api || isEmpty(api) || !item || currentUser) return;
 
         const getUserSuccess = userData => {
+            if (!userData) {
+                return;
+            }
+
             const { enterprise, hostname, id } = userData;
             setCurrentUser({ id });
             setSharingServiceProps(prevSharingServiceProps => ({
@@ -209,13 +213,19 @@ function ContentSharingV2({
             return;
         }
 
-        setSharedLink(prevSharedLink => ({
-            ...prevSharedLink,
-            settings: {
-                ...prevSharedLink.settings,
-                canChangeExpiration: false,
-            },
-        }));
+        setSharedLink(prevSharedLink => {
+            if (!prevSharedLink) {
+                return prevSharedLink;
+            }
+
+            return {
+                ...prevSharedLink,
+                settings: {
+                    ...prevSharedLink.settings,
+                    canChangeExpiration: false,
+                },
+            };
+        });
     }, [isEnterpriseUser, sharedLink]);
 
     // Get collaborators

--- a/src/elements/content-sharing/ContentSharingV2.tsx
+++ b/src/elements/content-sharing/ContentSharingV2.tsx
@@ -73,6 +73,7 @@ function ContentSharingV2({
     const [collaborators, setCollaborators] = React.useState<Collaborator[] | null>(null);
     const [collaboratorsData, setCollaboratorsData] = React.useState<Collaborations | null>(null);
     const [owner, setOwner] = React.useState({ email: '', id: '', name: '' });
+    const [isEnterpriseUser, setIsEnterpriseUser] = React.useState<boolean | null>(null);
 
     const config = React.useMemo(() => {
         return {
@@ -155,6 +156,7 @@ function ContentSharingV2({
         setItem(null);
         setSharedLink(null);
         setCurrentUser(null);
+        setIsEnterpriseUser(null);
         setCollaborationRoles(null);
         setAvatarUrlMap(null);
         setCollaborators(null);
@@ -188,21 +190,7 @@ function ContentSharingV2({
                 serverUrl: hostname ? `${hostname}v/` : '',
             }));
 
-            if (!enterprise?.name) {
-                setSharedLink(prevSharedLink => {
-                    if (!prevSharedLink?.settings) {
-                        return prevSharedLink;
-                    }
-
-                    return {
-                        ...prevSharedLink,
-                        settings: {
-                            ...prevSharedLink.settings,
-                            canChangeExpiration: false,
-                        },
-                    };
-                });
-            }
+            setIsEnterpriseUser(!!enterprise);
         };
 
         (async () => {
@@ -214,6 +202,21 @@ function ContentSharingV2({
             }
         })();
     }, [api, currentUser, item, itemId, itemType, sharedLink, getError]);
+
+    // Set canChangeExpiration to false for non-enterprise (individual) users on every sharedLink update
+    React.useEffect(() => {
+        if (isEnterpriseUser !== false || !sharedLink?.settings?.canChangeExpiration) {
+            return;
+        }
+
+        setSharedLink(prevSharedLink => ({
+            ...prevSharedLink,
+            settings: {
+                ...prevSharedLink.settings,
+                canChangeExpiration: false,
+            },
+        }));
+    }, [isEnterpriseUser, sharedLink]);
 
     // Get collaborators
     React.useEffect(() => {

--- a/src/elements/content-sharing/ContentSharingV2.tsx
+++ b/src/elements/content-sharing/ContentSharingV2.tsx
@@ -181,12 +181,28 @@ function ContentSharingV2({
         if (!api || isEmpty(api) || !item || currentUser) return;
 
         const getUserSuccess = userData => {
-            const { hostname, id } = userData;
+            const { enterprise, hostname, id } = userData;
             setCurrentUser({ id });
             setSharingServiceProps(prevSharingServiceProps => ({
                 ...prevSharingServiceProps,
                 serverUrl: hostname ? `${hostname}v/` : '',
             }));
+
+            if (!enterprise?.name) {
+                setSharedLink(prevSharedLink => {
+                    if (!prevSharedLink?.settings) {
+                        return prevSharedLink;
+                    }
+
+                    return {
+                        ...prevSharedLink,
+                        settings: {
+                            ...prevSharedLink.settings,
+                            canChangeExpiration: false,
+                        },
+                    };
+                });
+            }
         };
 
         (async () => {

--- a/src/elements/content-sharing/__tests__/ContentSharingV2.test.tsx
+++ b/src/elements/content-sharing/__tests__/ContentSharingV2.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, type RenderResult, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, type RenderResult, screen, waitFor } from '@testing-library/react';
 import { Notification, TooltipProvider } from '@box/blueprint-web';
 import { useSharingService } from '../hooks/useSharingService';
 import {
@@ -13,6 +13,11 @@ import {
 } from '../utils/__mocks__/ContentSharingV2Mocks';
 import { CONTENT_SHARING_ITEM_FIELDS } from '../constants';
 import ContentSharingV2 from '../ContentSharingV2';
+
+const FREE_USER_API_RESPONSE = {
+    id: '123',
+    enterprise: null,
+};
 
 const createApiMock = (fileApi, folderApi, usersApi, collaborationsApi) => ({
     getFileAPI: jest.fn().mockReturnValue(fileApi),
@@ -117,6 +122,9 @@ describe('elements/content-sharing/ContentSharingV2', () => {
         expect(await screen.findByRole('button', { name: 'Can view and download' })).toBeVisible();
         expect(screen.getByRole('button', { name: 'Link Settings' })).toBeVisible();
         expect(screen.getByRole('button', { name: 'Copy' })).toBeVisible();
+        // Should have expiration toggle enabled for Business+ users
+        fireEvent.click(screen.getByRole('button', { name: 'Link Settings' }));
+        expect(screen.getByRole('switch', { name: 'Link expiration' })).not.toBeDisabled();
     });
 
     test('should see the classification elements if classification is present', async () => {
@@ -181,6 +189,21 @@ describe('elements/content-sharing/ContentSharingV2', () => {
         renderComponent({ api: apiWithSharedLink, config: { sharedLinkEmail: true } });
         expect(await screen.findByRole('heading', { name: 'Share ‘Box Development Guide.pdf’' })).toBeVisible();
         expect(await screen.findByRole('button', { name: 'Send Shared Link' })).toBeVisible();
+    });
+
+    test('should have disabled expiration toggle for users without enterprise', async () => {
+        const apiFreeUser = {
+            ...defaultApiMock,
+            getFileAPI: jest.fn().mockReturnValue({ getFile: getFileMockWithSharedLink }),
+            getUsersAPI: jest.fn().mockReturnValue({
+                getUser: jest.fn().mockImplementation(createSuccessMock(FREE_USER_API_RESPONSE)),
+                getAvatarUrlWithAccessToken: getAvatarUrlMock,
+            }),
+        };
+
+        renderComponent({ api: apiFreeUser });
+        fireEvent.click(await screen.findByRole('button', { name: 'Link Settings' }));
+        expect(screen.getByRole('switch', { name: 'Link expiration' })).toBeDisabled();
     });
 
     describe('getError function', () => {

--- a/src/elements/content-sharing/__tests__/ContentSharingV2.test.tsx
+++ b/src/elements/content-sharing/__tests__/ContentSharingV2.test.tsx
@@ -5,6 +5,7 @@ import { useSharingService } from '../hooks/useSharingService';
 import {
     DEFAULT_ITEM_API_RESPONSE,
     DEFAULT_USER_API_RESPONSE,
+    FREE_USER_API_RESPONSE,
     MOCK_ITEM,
     MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK,
     MOCK_ITEM_API_RESPONSE_WITH_CLASSIFICATION,
@@ -13,11 +14,6 @@ import {
 } from '../utils/__mocks__/ContentSharingV2Mocks';
 import { CONTENT_SHARING_ITEM_FIELDS } from '../constants';
 import ContentSharingV2 from '../ContentSharingV2';
-
-const FREE_USER_API_RESPONSE = {
-    id: '123',
-    enterprise: null,
-};
 
 const createApiMock = (fileApi, folderApi, usersApi, collaborationsApi) => ({
     getFileAPI: jest.fn().mockReturnValue(fileApi),
@@ -192,7 +188,7 @@ describe('elements/content-sharing/ContentSharingV2', () => {
     });
 
     test('should have disabled expiration toggle for users without enterprise', async () => {
-        const apiFreeUser = {
+        const freeUserApi = {
             ...defaultApiMock,
             getFileAPI: jest.fn().mockReturnValue({ getFile: getFileMockWithSharedLink }),
             getUsersAPI: jest.fn().mockReturnValue({
@@ -201,7 +197,7 @@ describe('elements/content-sharing/ContentSharingV2', () => {
             }),
         };
 
-        renderComponent({ api: apiFreeUser });
+        renderComponent({ api: freeUserApi });
         fireEvent.click(await screen.findByRole('button', { name: 'Link Settings' }));
         expect(screen.getByRole('switch', { name: 'Link expiration' })).toBeDisabled();
     });

--- a/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
+++ b/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
@@ -95,6 +95,11 @@ export const DEFAULT_USER_API_RESPONSE = {
     enterprise: { id: '12345', name: 'Test Enterprise' },
 };
 
+export const FREE_USER_API_RESPONSE = {
+    id: '123',
+    enterprise: null,
+};
+
 export const DEFAULT_ITEM_API_RESPONSE = {
     allowed_invitee_roles: ['editor', 'viewer'],
     allowed_shared_link_access_levels: ['open', 'company', 'collaborators'],

--- a/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
+++ b/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
@@ -92,6 +92,7 @@ export const EMPTY_COLLABORATIONS_RESPONSE = {
 
 export const DEFAULT_USER_API_RESPONSE = {
     id: '789',
+    enterprise: { id: '12345', name: 'Test Enterprise' },
 };
 
 export const DEFAULT_ITEM_API_RESPONSE = {


### PR DESCRIPTION
### What

- In ContentSharingV2.tsx, after fetching the current user, if enterprise is null we set canChangeExpiration: false on the shared link settings state. This prevents free users from seeing an enabled expiration toggle in Link Settings.
- This matches the legacy ContentSharing behavior defined within SharingModal.js
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared link expiration controls now respect enterprise affiliation: enterprise users can enable/change expiration; individual users see the option disabled.

* **Behavior**
  * The Link Settings panel reflects this restriction immediately when opened and stays disabled for non-enterprise users across updates.

* **Tests**
  * Added tests validating UI behavior for enterprise and non-enterprise users and updated test fixtures accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->