### PR TITLE
fix(content-sharing): Include direct link logic

### DIFF
--- a/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
+++ b/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
@@ -26,6 +26,7 @@ export const MOCK_ITEM = {
 
 export const MOCK_SHARED_LINK = {
     access: 'open',
+    download_url: 'https://example.com/shared_link=abc123',
     effective_permission: 'can_download',
     is_password_enabled: true,
     unshared_at: 1704067200000,
@@ -112,7 +113,7 @@ export const DEFAULT_ITEM_API_RESPONSE = {
     owned_by: mockOwner,
     permissions: MOCK_PERMISSIONS,
     shared_link: null,
-    shared_link_features: { password: true },
+    shared_link_features: { download_url: true, password: true },
     shared_link_permission_options: ['can_edit', 'can_download', 'can_preview'],
     type: MOCK_ITEM.type,
 };

--- a/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
@@ -79,6 +79,7 @@ describe('convertItemResponse', () => {
             expect(result.sharedLink).toEqual({
                 access: 'open',
                 accessLevels: ['open', 'company', 'collaborators'],
+                downloadUrl: 'https://example.com/shared_link=abc123',
                 expiresAt: 1704067200000,
                 permission: 'can_download',
                 permissionLevels: ['can_edit', 'can_download', 'can_preview'],
@@ -87,6 +88,7 @@ describe('convertItemResponse', () => {
                     canChangeExpiration: true,
                     canChangePassword: true,
                     canChangeVanityName: false,
+                    isDirectLinkAvailable: true,
                     isDownloadAvailable: true,
                     isDownloadEnabled: true,
                     isPasswordAvailable: true,
@@ -135,7 +137,7 @@ describe('convertItemResponse', () => {
                     ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK.shared_link,
                     access: 'collaborators',
                 },
-                shared_link_features: { password: false },
+                shared_link_features: { download_url: false, password: false },
                 permissions: {
                     ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK.permissions,
                 },
@@ -144,6 +146,29 @@ describe('convertItemResponse', () => {
             expect(result.sharedLink.settings.canChangeDownload).toEqual(false);
             expect(result.sharedLink.settings.canChangePassword).toEqual(false);
             expect(result.sharedLink.settings.canChangeExpiration).toEqual(false);
+            expect(result.sharedLink.settings.isDirectLinkAvailable).toEqual(false);
+        });
+    });
+
+    describe('direct link availability', () => {
+        test('should extract downloadUrl from shared_link.download_url', () => {
+            const result = convertItemResponse(MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK);
+            expect(result.sharedLink?.downloadUrl).toEqual('https://example.com/shared_link=abc123');
+            expect(result.sharedLink.settings.isDirectLinkAvailable).toEqual(true);
+        });
+
+        test('should handle when direct link is not available (free users)', () => {
+            const mockItemWithoutDirectLink = {
+                ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK,
+                shared_link: {
+                    ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK.shared_link,
+                    download_url: undefined,
+                },
+                shared_link_features: { download_url: false, password: true },
+            };
+            const result = convertItemResponse(mockItemWithoutDirectLink);
+            expect(result.sharedLink.settings.isDirectLinkAvailable).toEqual(false);
+            expect(result.sharedLink.downloadUrl).toBeUndefined();
         });
     });
 });

--- a/src/elements/content-sharing/utils/convertItemResponse.ts
+++ b/src/elements/content-sharing/utils/convertItemResponse.ts
@@ -23,7 +23,7 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
         type,
     } = itemApiData;
 
-    const { password: isPasswordAvailable } = shared_link_features;
+    const { download_url: isDirectLinkAvailable, password: isPasswordAvailable } = shared_link_features;
 
     const {
         can_download: isDownloadSettingAvailable,
@@ -49,6 +49,7 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
     if (shared_link) {
         const {
             access,
+            download_url: downloadUrl,
             effective_permission: permission,
             is_password_enabled: isPasswordEnabled,
             unshared_at: expirationTimestamp,
@@ -68,6 +69,7 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
                 allowed_shared_link_access_levels,
                 allowed_shared_link_access_levels_disabled_reasons,
             ),
+            downloadUrl,
             expiresAt: expirationTimestamp ? new Date(expirationTimestamp).getTime() : undefined, // convert to milliseconds
             permission,
             permissionLevels:
@@ -78,6 +80,7 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
                 canChangeExpiration,
                 canChangePassword,
                 canChangeVanityName: false, // vanity URLs cannot be set via the API
+                isDirectLinkAvailable,
                 isDownloadAvailable: isDownloadSettingAvailable,
                 isDownloadEnabled: isDownloadAllowed,
                 isPasswordAvailable: isPasswordAvailable ?? false,


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared links now include download URLs and expose direct-link availability in link settings; password-protected links continue to be supported
* **Tests**
  * Extended test coverage to validate direct-link available and unavailable scenarios for shared links
<!-- end of auto-generated comment: release notes by coderabbit.ai -->