### PR TITLE
fix(content-sharing): vanity name permission

### DIFF
--- a/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
+++ b/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
@@ -113,7 +113,7 @@ export const DEFAULT_ITEM_API_RESPONSE = {
     owned_by: mockOwner,
     permissions: MOCK_PERMISSIONS,
     shared_link: null,
-    shared_link_features: { download_url: true, password: true },
+    shared_link_features: { download_url: true, password: true, vanity_name: true },
     shared_link_permission_options: ['can_edit', 'can_download', 'can_preview'],
     type: MOCK_ITEM.type,
 };

--- a/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
@@ -166,12 +166,11 @@ describe('convertItemResponse', () => {
                     ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK.shared_link,
                     download_url: undefined,
                 },
-                shared_link_features: { download_url: false, password: true },
+                shared_link_features: { download_url: false, password: true, vanity_name: true },
             };
             const result = convertItemResponse(mockItemWithoutDirectLink);
             expect(result.sharedLink.settings.isDirectLinkAvailable).toEqual(false);
             expect(result.sharedLink.downloadUrl).toBeUndefined();
-            expect(result.sharedLink.settings.isVanityNameAvailable).toEqual(false);
         });
     });
 });

--- a/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
@@ -93,6 +93,7 @@ describe('convertItemResponse', () => {
                     isDownloadEnabled: true,
                     isPasswordAvailable: true,
                     isPasswordEnabled: true,
+                    isVanityNameAvailable: true,
                 },
                 url: 'https://example.com/shared-link',
                 vanityDomain: 'https://example.com/vanity-url',
@@ -137,7 +138,7 @@ describe('convertItemResponse', () => {
                     ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK.shared_link,
                     access: 'collaborators',
                 },
-                shared_link_features: { download_url: false, password: false },
+                shared_link_features: { download_url: false, password: false, vanity_name: false },
                 permissions: {
                     ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK.permissions,
                 },
@@ -147,6 +148,7 @@ describe('convertItemResponse', () => {
             expect(result.sharedLink.settings.canChangePassword).toEqual(false);
             expect(result.sharedLink.settings.canChangeExpiration).toEqual(false);
             expect(result.sharedLink.settings.isDirectLinkAvailable).toEqual(false);
+            expect(result.sharedLink.settings.isVanityNameAvailable).toEqual(false);
         });
     });
 
@@ -169,6 +171,7 @@ describe('convertItemResponse', () => {
             const result = convertItemResponse(mockItemWithoutDirectLink);
             expect(result.sharedLink.settings.isDirectLinkAvailable).toEqual(false);
             expect(result.sharedLink.downloadUrl).toBeUndefined();
+            expect(result.sharedLink.settings.isVanityNameAvailable).toEqual(false);
         });
     });
 });

--- a/src/elements/content-sharing/utils/convertItemResponse.ts
+++ b/src/elements/content-sharing/utils/convertItemResponse.ts
@@ -23,7 +23,7 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
         type,
     } = itemApiData;
 
-    const { download_url: isDirectLinkAvailable, password: isPasswordAvailable } = shared_link_features;
+    const { download_url: isDirectLinkAvailable, password: isPasswordAvailable, vanity_name: isVanityNameAvailable } = shared_link_features;
 
     const {
         can_download: isDownloadSettingAvailable,
@@ -85,6 +85,7 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
                 isDownloadEnabled: isDownloadAllowed,
                 isPasswordAvailable: isPasswordAvailable ?? false,
                 isPasswordEnabled,
+                isVanityNameAvailable: isVanityNameAvailable ?? false,
             },
             url,
             vanityDomain: vanityUrl,

--- a/src/elements/content-sharing/utils/convertItemResponse.ts
+++ b/src/elements/content-sharing/utils/convertItemResponse.ts
@@ -23,7 +23,11 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
         type,
     } = itemApiData;
 
-    const { download_url: isDirectLinkAvailable, password: isPasswordAvailable, vanity_name: isVanityNameAvailable } = shared_link_features;
+    const {
+        download_url: isDirectLinkAvailable,
+        password: isPasswordAvailable,
+        vanity_name: isVanityNameAvailable,
+    } = shared_link_features;
 
     const {
         can_download: isDownloadSettingAvailable,
@@ -79,13 +83,13 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
                 canChangeDownload,
                 canChangeExpiration,
                 canChangePassword,
-                canChangeVanityName: false, // vanity URLs cannot be set via the API
+                canChangeVanityName: false,
                 isDirectLinkAvailable,
                 isDownloadAvailable: isDownloadSettingAvailable,
                 isDownloadEnabled: isDownloadAllowed,
-                isPasswordAvailable: isPasswordAvailable ?? false,
+                isPasswordAvailable,
                 isPasswordEnabled,
-                isVanityNameAvailable: isVanityNameAvailable ?? false,
+                isVanityNameAvailable,
             },
             url,
             vanityDomain: vanityUrl,


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared links now surface vanity-name availability so the UI can indicate whether a shared link’s vanity name can be customized.
* **Behavior Change**
  * Shared-link password availability may now be omitted when the API doesn't provide it, so the UI should handle an unknown/password-availability-empty state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->