### PR TITLE
chore: patch wait-on/axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,8 +364,7 @@
         "eslint-plugin-formatjs/**/minimatch": "^9.0.9",
         "qs": "^6.14.1",
         "serialize-javascript": "^7.0.5",
-        "tar": "^7.5.11",
-        "wait-on/axios": "^1.15.2"
+        "tar": "^7.5.11"
     },
     "msw": {
         "workerDirectory": [".storybook/public"]

--- a/package.json
+++ b/package.json
@@ -364,7 +364,8 @@
         "eslint-plugin-formatjs/**/minimatch": "^9.0.9",
         "qs": "^6.14.1",
         "serialize-javascript": "^7.0.5",
-        "tar": "^7.5.11"
+        "tar": "^7.5.11",
+        "wait-on/axios": "^1.15.2"
     },
     "msw": {
         "workerDirectory": [".storybook/public"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7092,7 +7092,7 @@ axios@^0.31.1:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-axios@^1.15.0, axios@^1.15.2:
+axios@^1.15.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
   integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7092,12 +7092,12 @@ axios@^0.31.1:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-axios@^1.15.0:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.1.tgz#075420b785da8adbdf545785b69f90c926b28542"
-  integrity sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==
+axios@^1.15.0, axios@^1.15.2:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
@@ -10590,7 +10590,7 @@ flowgen@^1.10.0:
     typescript "~4.4.4"
     typescript-compiler "^1.4.1-2"
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.11, follow-redirects@^1.15.4:
+follow-redirects@^1.0.0, follow-redirects@^1.15.4, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==


### PR DESCRIPTION
Resolve issue: 

- https://github.com/box/box-ui-elements/security/dependabot/417
- https://github.com/box/box-ui-elements/security/dependabot/418

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configurations to enhance package compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->