### PR TITLE
feat(uploads-manager): add enableModernizedUploads feature flag to ContentUploader

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -386,16 +386,6 @@ be.contentSidebar.editTask.general.title = Modify General Task
 be.contentSidebar.mentionUserSelectorLoading = Loading users
 # Accessibility role description for the mention user selector input
 be.contentSidebar.mentionUserSelectorRoleDescription = Mention a user
-# Aria label for the close button on the cancel all uploads modal
-be.contentUploader.cancelAllUploadsCloseLabel = Close cancel uploads dialog
-# Confirm button for the cancel all uploads modal
-be.contentUploader.cancelAllUploadsConfirmButton = Cancel All
-# Dismiss button for the cancel all uploads modal
-be.contentUploader.cancelAllUploadsKeepButton = Keep Uploading
-# Body content for the cancel all uploads confirmation modal
-be.contentUploader.cancelAllUploadsModalContent = Files that are still uploading will be canceled. Completed uploads will not be affected.
-# Heading for the cancel all uploads confirmation modal
-be.contentUploader.cancelAllUploadsModalHeading = Cancel all uploads?
 # Label for copy action.
 be.copy = Copy
 # Label for create action.

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -386,6 +386,16 @@ be.contentSidebar.editTask.general.title = Modify General Task
 be.contentSidebar.mentionUserSelectorLoading = Loading users
 # Accessibility role description for the mention user selector input
 be.contentSidebar.mentionUserSelectorRoleDescription = Mention a user
+# Aria label for the close button on the cancel all uploads modal
+be.contentUploader.cancelAllUploadsCloseLabel = Close cancel uploads dialog
+# Confirm button for the cancel all uploads modal
+be.contentUploader.cancelAllUploadsConfirmButton = Cancel All
+# Dismiss button for the cancel all uploads modal
+be.contentUploader.cancelAllUploadsKeepButton = Keep Uploading
+# Body content for the cancel all uploads confirmation modal
+be.contentUploader.cancelAllUploadsModalContent = Files that are still uploading will be canceled. Completed uploads will not be affected.
+# Heading for the cancel all uploads confirmation modal
+be.contentUploader.cancelAllUploadsModalHeading = Cancel all uploads?
 # Label for copy action.
 be.copy = Copy
 # Label for create action.

--- a/scripts/jest/jest.config.js
+++ b/scripts/jest/jest.config.js
@@ -28,6 +28,6 @@ module.exports = {
     testMatch: ['**/__tests__/**/*.test.+(js|jsx|ts|tsx)'],
     testPathIgnorePatterns: ['stories.test.js$', 'stories.test.tsx$', 'stories.test.d.ts'],
     transformIgnorePatterns: [
-        'node_modules/(?!(@box/activity-feed|@box/collaboration-popover|@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers|@box/box-ai-agent-selector|@box/item-icon|@box/combobox-with-api|@box/tree|@box/metadata-filter|@box/metadata-view|@box/content-field|@box/types|@box/box-item-type-selector|@box/unified-share-modal|@box/user-selector|@box/copy-input|@box/readable-time|@box/threaded-annotations)/)',
+        'node_modules/(?!(@box/activity-feed|@box/collaboration-popover|@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers|@box/box-ai-agent-selector|@box/item-icon|@box/combobox-with-api|@box/tree|@box/metadata-filter|@box/metadata-view|@box/content-field|@box/types|@box/box-item-type-selector|@box/unified-share-modal|@box/user-selector|@box/copy-input|@box/readable-time|@box/threaded-annotations|@box/uploads-manager)/)',
     ],
 };

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -6,6 +6,7 @@ import flow from 'lodash/flow';
 import getProp from 'lodash/get';
 import noop from 'lodash/noop';
 import uniqueid from 'lodash/uniqueId';
+import { UploadsManager as UploadsManagerBP } from '@box/uploads-manager';
 import { TooltipProvider } from '@box/blueprint-web';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import DroppableContent from './DroppableContent';
@@ -1297,55 +1298,68 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             be: !useUploadsManager,
         });
 
+        const renderUploader = () => {
+            if (enableModernizedUploads) {
+                return (
+                    <div ref={measureRef} className={styleClassName} id={this.id}>
+                        <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                        <UploadsManagerBP items={[]} />
+                    </div>
+                );
+            }
+
+            if (useUploadsManager) {
+                return (
+                    <div ref={measureRef} className={styleClassName} id={this.id}>
+                        <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                        <UploadsManager
+                            isDragging={isDraggingItemsToUploadsManager}
+                            isExpanded={isUploadsManagerExpanded}
+                            isResumableUploadsEnabled={isResumableUploadsEnabled}
+                            isVisible={isVisible}
+                            items={items}
+                            onItemActionClick={this.onClick}
+                            onRemoveActionClick={this.removeFileFromUploadQueue}
+                            onUpgradeCTAClick={onUpgradeCTAClick}
+                            onUploadsManagerActionClick={this.clickAllWithStatus}
+                            toggleUploadsManager={this.toggleUploadsManager}
+                            view={view}
+                        />
+                    </div>
+                )
+            }
+ 
+            return (
+                <div ref={measureRef} className={styleClassName} id={this.id}>
+                    <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                    <DroppableContent
+                        addDataTransferItemsToUploadQueue={this.addDroppedItemsToUploadQueue}
+                        addFiles={this.addFilesToUploadQueue}
+                        allowedTypes={['Files']}
+                        isFolderUploadEnabled={isFolderUploadEnabled}
+                        isTouch={isTouch}
+                        items={items}
+                        onClick={this.onClick}
+                        view={view}
+                    />
+                    <Footer
+                        errorCode={errorCode}
+                        fileLimit={fileLimit}
+                        hasFiles={hasFiles}
+                        isLoading={isLoading}
+                        onCancel={this.cancel}
+                        onClose={onClose}
+                        onUpload={this.upload}
+                        isDone={isDone}
+                    />
+                </div>
+            )
+        }
+
         return (
             <Internationalize language={language} messages={messages}>
                 <TooltipProvider>
-                    {enableModernizedUploads ? (
-                        <div ref={measureRef} className={styleClassName} id={this.id}>
-                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
-                        </div>
-                    ) : useUploadsManager ? (
-                        <div ref={measureRef} className={styleClassName} id={this.id}>
-                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
-                            <UploadsManager
-                                isDragging={isDraggingItemsToUploadsManager}
-                                isExpanded={isUploadsManagerExpanded}
-                                isResumableUploadsEnabled={isResumableUploadsEnabled}
-                                isVisible={isVisible}
-                                items={items}
-                                onItemActionClick={this.onClick}
-                                onRemoveActionClick={this.removeFileFromUploadQueue}
-                                onUpgradeCTAClick={onUpgradeCTAClick}
-                                onUploadsManagerActionClick={this.clickAllWithStatus}
-                                toggleUploadsManager={this.toggleUploadsManager}
-                                view={view}
-                            />
-                        </div>
-                    ) : (
-                        <div ref={measureRef} className={styleClassName} id={this.id}>
-                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
-                            <DroppableContent
-                                addDataTransferItemsToUploadQueue={this.addDroppedItemsToUploadQueue}
-                                addFiles={this.addFilesToUploadQueue}
-                                allowedTypes={['Files']}
-                                isFolderUploadEnabled={isFolderUploadEnabled}
-                                isTouch={isTouch}
-                                items={items}
-                                onClick={this.onClick}
-                                view={view}
-                            />
-                            <Footer
-                                errorCode={errorCode}
-                                fileLimit={fileLimit}
-                                hasFiles={hasFiles}
-                                isLoading={isLoading}
-                                onCancel={this.cancel}
-                                onClose={onClose}
-                                onUpload={this.upload}
-                                isDone={isDone}
-                            />
-                        </div>
-                    )}
+                    {renderUploader()}
                 </TooltipProvider>
             </Internationalize>
         );

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -104,6 +104,7 @@ export interface ContentUploaderProps {
     token?: Token;
     uploadHost: string;
     useUploadsManager?: boolean;
+    enableModernizedUploads?: boolean;
 }
 
 type State = {
@@ -169,6 +170,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         rootFolderId: DEFAULT_ROOT,
         uploadHost: DEFAULT_HOSTNAME_UPLOAD,
         useUploadsManager: false,
+        enableModernizedUploads: false,
     };
 
     /**
@@ -1268,6 +1270,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     render() {
         const {
             className,
+            enableModernizedUploads,
             fileLimit,
             isDraggingItemsToUploadsManager = false,
             isFolderUploadEnabled,
@@ -1297,7 +1300,11 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         return (
             <Internationalize language={language} messages={messages}>
                 <TooltipProvider>
-                    {useUploadsManager ? (
+                    {enableModernizedUploads ? (
+                        <div ref={measureRef} className={styleClassName} id={this.id}>
+                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                        </div>
+                    ) : useUploadsManager ? (
                         <div ref={measureRef} className={styleClassName} id={this.id}>
                             <ThemingStyles selector={`#${this.id}`} theme={theme} />
                             <UploadsManager

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -4,6 +4,8 @@ import * as UploaderUtils from '../../../utils/uploads';
 import Browser from '../../../utils/Browser';
 import { ContentUploaderComponent, CHUNKED_UPLOAD_MIN_SIZE_BYTES } from '../ContentUploader';
 import Footer from '../Footer';
+import UploadsManager from '../UploadsManager';
+import DroppableContent from '../DroppableContent';
 import {
     STATUS_PENDING,
     STATUS_IN_PROGRESS,
@@ -753,6 +755,34 @@ describe('elements/content-uploader/ContentUploader', () => {
             await instance.addFolderDataTransferItemsToUploadQueue(mockFoldersList, jest.fn());
             expect(instance.addToQueue).toBeCalledTimes(1);
             expect(instance.addToQueue.mock.calls[0][0].length).toBe(mockFoldersList.length);
+        });
+    });
+
+    describe('render()', () => {
+        describe('enableModernizedUploads', () => {
+            test('should render legacy UploadsManager when enableModernizedUploads is false and useUploadsManager is true', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: false, useUploadsManager: true });
+                expect(wrapper.find(UploadsManager)).toHaveLength(1);
+                expect(wrapper.find(DroppableContent)).toHaveLength(0);
+            });
+
+            test('should render DroppableContent when enableModernizedUploads is false and useUploadsManager is false', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: false, useUploadsManager: false });
+                expect(wrapper.find(DroppableContent)).toHaveLength(1);
+                expect(wrapper.find(UploadsManager)).toHaveLength(0);
+            });
+
+            test('should render modernized uploads placeholder when enableModernizedUploads is true', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                expect(wrapper.find(UploadsManager)).toHaveLength(0);
+                expect(wrapper.find(DroppableContent)).toHaveLength(0);
+            });
+
+            test('should render modernized uploads placeholder even when useUploadsManager is true', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true, useUploadsManager: true });
+                expect(wrapper.find(UploadsManager)).toHaveLength(0);
+                expect(wrapper.find(DroppableContent)).toHaveLength(0);
+            });
         });
     });
 });

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { UploadsManager as UploadsManagerBP } from '@box/uploads-manager';
 import * as UploaderUtils from '../../../utils/uploads';
 import Browser from '../../../utils/Browser';
 import { ContentUploaderComponent, CHUNKED_UPLOAD_MIN_SIZE_BYTES } from '../ContentUploader';
@@ -763,6 +764,7 @@ describe('elements/content-uploader/ContentUploader', () => {
             test('should render legacy UploadsManager when enableModernizedUploads is false and useUploadsManager is true', () => {
                 const wrapper = getWrapper({ enableModernizedUploads: false, useUploadsManager: true });
                 expect(wrapper.find(UploadsManager)).toHaveLength(1);
+                expect(wrapper.find(UploadsManagerBP)).toHaveLength(0);
                 expect(wrapper.find(DroppableContent)).toHaveLength(0);
             });
 
@@ -770,16 +772,19 @@ describe('elements/content-uploader/ContentUploader', () => {
                 const wrapper = getWrapper({ enableModernizedUploads: false, useUploadsManager: false });
                 expect(wrapper.find(DroppableContent)).toHaveLength(1);
                 expect(wrapper.find(UploadsManager)).toHaveLength(0);
+                expect(wrapper.find(UploadsManagerBP)).toHaveLength(0);
             });
 
-            test('should render modernized uploads placeholder when enableModernizedUploads is true', () => {
+            test('should render modernized UploadsManager when enableModernizedUploads is true', () => {
                 const wrapper = getWrapper({ enableModernizedUploads: true });
+                expect(wrapper.find(UploadsManagerBP)).toHaveLength(1);
                 expect(wrapper.find(UploadsManager)).toHaveLength(0);
                 expect(wrapper.find(DroppableContent)).toHaveLength(0);
             });
 
-            test('should render modernized uploads placeholder even when useUploadsManager is true', () => {
+            test('should render modernized UploadsManager when enableModernizedUploads is true and useUploadsManager is true', () => {
                 const wrapper = getWrapper({ enableModernizedUploads: true, useUploadsManager: true });
+                expect(wrapper.find(UploadsManagerBP)).toHaveLength(1);
                 expect(wrapper.find(UploadsManager)).toHaveLength(0);
                 expect(wrapper.find(DroppableContent)).toHaveLength(0);
             });

--- a/src/elements/content-uploader/stories/ContentUploader.stories.js
+++ b/src/elements/content-uploader/stories/ContentUploader.stories.js
@@ -10,6 +10,12 @@ export const withTheming = {
     },
 };
 
+export const withModernizedUploads = {
+    args: {
+        enableModernizedUploads: true,
+    },
+};
+
 export default {
     title: 'Elements/ContentUploader',
     component: ContentUploader,


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

## Summary
- Add a new `enableModernizedUploads` feature flag prop to `ContentUploader` (default `false`).
- Gate rendering so:
  - `enableModernizedUploads=true` renders the modernized uploads placeholder (`@box/uploads-manager`).
  - Otherwise behavior stays the same (`UploadsManager` when `useUploadsManager=true`, `DroppableContent` flow when false).
- Update Jest config to transform `@box/uploads-manager` in tests.
- Add/extend tests for the three render paths and add a Storybook variant (`withModernizedUploads`).
## Test plan
- [ ] Run: `yarn test src/elements/content-uploader/__tests__/ContentUploader.test.js`
- [ ] In Storybook, verify `withModernizedUploads` renders the modernized placeholder path.
- [ ] Regression check:
  - [ ] `enableModernizedUploads=false` + `useUploadsManager=true` still renders legacy `UploadsManager`.
  - [ ] `enableModernizedUploads=false` + `useUploadsManager=false` still renders `DroppableContent`.
## Notes
- This PR is intended as a feature-flagged, non-breaking integration path for modernized uploads.
- After approvals, follow repo guidance by adding the `ready-to-merge` label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modernized uploads UI added to the content uploader, toggleable via a new enableModernizedUploads flag (off by default); Storybook story added showcasing the modernized UI.

* **Tests**
  * Added tests verifying the uploader renders legacy, non-manager, or modernized UI based on configuration.

* **Chores**
  * Jest transformer configuration updated to transform one additional dependency inside node_modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->