### PR TITLE
Integrate shared feature into content uploader

### DIFF
--- a/scripts/jest/jest.config.js
+++ b/scripts/jest/jest.config.js
@@ -28,6 +28,6 @@ module.exports = {
     testMatch: ['**/__tests__/**/*.test.+(js|jsx|ts|tsx)'],
     testPathIgnorePatterns: ['stories.test.js$', 'stories.test.tsx$', 'stories.test.d.ts'],
     transformIgnorePatterns: [
-        'node_modules/(?!(@box/activity-feed|@box/collaboration-popover|@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers|@box/box-ai-agent-selector|@box/item-icon|@box/combobox-with-api|@box/tree|@box/metadata-filter|@box/metadata-view|@box/content-field|@box/types|@box/box-item-type-selector|@box/unified-share-modal|@box/user-selector|@box/copy-input|@box/readable-time|@box/threaded-annotations)/)',
+        'node_modules/(?!(@box/activity-feed|@box/collaboration-popover|@box/react-virtualized/dist/es|@box/cldr-data|@box/blueprint-web|@box/blueprint-web-assets|@box/metadata-editor|@box/box-ai-content-answers|@box/box-ai-agent-selector|@box/item-icon|@box/combobox-with-api|@box/tree|@box/metadata-filter|@box/metadata-view|@box/content-field|@box/types|@box/box-item-type-selector|@box/unified-share-modal|@box/user-selector|@box/copy-input|@box/readable-time|@box/threaded-annotations|@box/uploads-manager)/)',
     ],
 };

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -6,6 +6,7 @@ import flow from 'lodash/flow';
 import getProp from 'lodash/get';
 import noop from 'lodash/noop';
 import uniqueid from 'lodash/uniqueId';
+import { UploadsManager as UploadsManagerBP } from '@box/uploads-manager';
 import { TooltipProvider } from '@box/blueprint-web';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import DroppableContent from './DroppableContent';
@@ -1297,55 +1298,68 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             be: !useUploadsManager,
         });
 
+        const renderUploader = () => {
+            if (enableModernizedUploads) {
+                return (
+                    <div ref={measureRef} className={styleClassName} id={this.id}>
+                        <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                        <UploadsManagerBP items={[]} />
+                    </div>
+                );
+            }
+
+            if (useUploadsManager) {
+                return (
+                    <div ref={measureRef} className={styleClassName} id={this.id}>
+                        <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                        <UploadsManager
+                            isDragging={isDraggingItemsToUploadsManager}
+                            isExpanded={isUploadsManagerExpanded}
+                            isResumableUploadsEnabled={isResumableUploadsEnabled}
+                            isVisible={isVisible}
+                            items={items}
+                            onItemActionClick={this.onClick}
+                            onRemoveActionClick={this.removeFileFromUploadQueue}
+                            onUpgradeCTAClick={onUpgradeCTAClick}
+                            onUploadsManagerActionClick={this.clickAllWithStatus}
+                            toggleUploadsManager={this.toggleUploadsManager}
+                            view={view}
+                        />
+                    </div>
+                )
+            }
+ 
+            return (
+                <div ref={measureRef} className={styleClassName} id={this.id}>
+                    <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                    <DroppableContent
+                        addDataTransferItemsToUploadQueue={this.addDroppedItemsToUploadQueue}
+                        addFiles={this.addFilesToUploadQueue}
+                        allowedTypes={['Files']}
+                        isFolderUploadEnabled={isFolderUploadEnabled}
+                        isTouch={isTouch}
+                        items={items}
+                        onClick={this.onClick}
+                        view={view}
+                    />
+                    <Footer
+                        errorCode={errorCode}
+                        fileLimit={fileLimit}
+                        hasFiles={hasFiles}
+                        isLoading={isLoading}
+                        onCancel={this.cancel}
+                        onClose={onClose}
+                        onUpload={this.upload}
+                        isDone={isDone}
+                    />
+                </div>
+            )
+        }
+
         return (
             <Internationalize language={language} messages={messages}>
                 <TooltipProvider>
-                    {enableModernizedUploads ? (
-                        <div ref={measureRef} className={styleClassName} id={this.id}>
-                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
-                        </div>
-                    ) : useUploadsManager ? (
-                        <div ref={measureRef} className={styleClassName} id={this.id}>
-                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
-                            <UploadsManager
-                                isDragging={isDraggingItemsToUploadsManager}
-                                isExpanded={isUploadsManagerExpanded}
-                                isResumableUploadsEnabled={isResumableUploadsEnabled}
-                                isVisible={isVisible}
-                                items={items}
-                                onItemActionClick={this.onClick}
-                                onRemoveActionClick={this.removeFileFromUploadQueue}
-                                onUpgradeCTAClick={onUpgradeCTAClick}
-                                onUploadsManagerActionClick={this.clickAllWithStatus}
-                                toggleUploadsManager={this.toggleUploadsManager}
-                                view={view}
-                            />
-                        </div>
-                    ) : (
-                        <div ref={measureRef} className={styleClassName} id={this.id}>
-                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
-                            <DroppableContent
-                                addDataTransferItemsToUploadQueue={this.addDroppedItemsToUploadQueue}
-                                addFiles={this.addFilesToUploadQueue}
-                                allowedTypes={['Files']}
-                                isFolderUploadEnabled={isFolderUploadEnabled}
-                                isTouch={isTouch}
-                                items={items}
-                                onClick={this.onClick}
-                                view={view}
-                            />
-                            <Footer
-                                errorCode={errorCode}
-                                fileLimit={fileLimit}
-                                hasFiles={hasFiles}
-                                isLoading={isLoading}
-                                onCancel={this.cancel}
-                                onClose={onClose}
-                                onUpload={this.upload}
-                                isDone={isDone}
-                            />
-                        </div>
-                    )}
+                    {renderUploader()}
                 </TooltipProvider>
             </Internationalize>
         );

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -12,6 +12,7 @@ import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import DroppableContent from './DroppableContent';
 import Footer from './Footer';
 import UploadsManager from './UploadsManager';
+import { mapToModernizedUploadItems } from './utils/mapToModernizedUploadItem';
 import API from '../../api';
 import Browser from '../../utils/Browser';
 import Internationalize from '../common/Internationalize';
@@ -1220,6 +1221,28 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     };
 
     /**
+     * Find legacy UploadItem by the id used by the modernized uploads manager.
+     */
+    findItemByModernizedId = (id: string): UploadItem | undefined => {
+        const { rootFolderId } = this.props;
+        return this.state.items.find(item => getFileId(item.file, rootFolderId) === id);
+    };
+
+    handleModernizedItemAction = (id: string) => {
+        const item = this.findItemByModernizedId(id);
+        if (item) {
+            this.onClick(item);
+        }
+    };
+
+    handleModernizedItemRemove = (id: string) => {
+        const item = this.findItemByModernizedId(id);
+        if (item) {
+            this.removeFileFromUploadQueue(item);
+        }
+    };
+
+    /**
      * Empties the items queue
      *
      * @return {void}
@@ -1282,6 +1305,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             messages,
             onClose,
             onUpgradeCTAClick,
+            rootFolderId,
             theme,
             useUploadsManager,
         }: ContentUploaderProps = this.props;
@@ -1303,7 +1327,14 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
                 return (
                     <div ref={measureRef} className={styleClassName} id={this.id}>
                         <ThemingStyles selector={`#${this.id}`} theme={theme} />
-                        <UploadsManagerBP items={[]} />
+                        <UploadsManagerBP
+                            items={mapToModernizedUploadItems(items, rootFolderId)}
+                            isExpanded={isUploadsManagerExpanded}
+                            onToggle={this.toggleUploadsManager}
+                            onItemCancel={this.handleModernizedItemAction}
+                            onItemRetry={this.handleModernizedItemAction}
+                            onItemRemove={this.handleModernizedItemRemove}
+                        />
                     </div>
                 );
             }

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -104,6 +104,7 @@ export interface ContentUploaderProps {
     token?: Token;
     uploadHost: string;
     useUploadsManager?: boolean;
+    enableModernizedUploads?: boolean;
 }
 
 type State = {
@@ -169,6 +170,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         rootFolderId: DEFAULT_ROOT,
         uploadHost: DEFAULT_HOSTNAME_UPLOAD,
         useUploadsManager: false,
+        enableModernizedUploads: false,
     };
 
     /**
@@ -1268,6 +1270,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     render() {
         const {
             className,
+            enableModernizedUploads,
             fileLimit,
             isDraggingItemsToUploadsManager = false,
             isFolderUploadEnabled,
@@ -1297,7 +1300,11 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         return (
             <Internationalize language={language} messages={messages}>
                 <TooltipProvider>
-                    {useUploadsManager ? (
+                    {enableModernizedUploads ? (
+                        <div ref={measureRef} className={styleClassName} id={this.id}>
+                            <ThemingStyles selector={`#${this.id}`} theme={theme} />
+                        </div>
+                    ) : useUploadsManager ? (
                         <div ref={measureRef} className={styleClassName} id={this.id}>
                             <ThemingStyles selector={`#${this.id}`} theme={theme} />
                             <UploadsManager

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -4,6 +4,8 @@ import * as UploaderUtils from '../../../utils/uploads';
 import Browser from '../../../utils/Browser';
 import { ContentUploaderComponent, CHUNKED_UPLOAD_MIN_SIZE_BYTES } from '../ContentUploader';
 import Footer from '../Footer';
+import UploadsManager from '../UploadsManager';
+import DroppableContent from '../DroppableContent';
 import {
     STATUS_PENDING,
     STATUS_IN_PROGRESS,
@@ -753,6 +755,34 @@ describe('elements/content-uploader/ContentUploader', () => {
             await instance.addFolderDataTransferItemsToUploadQueue(mockFoldersList, jest.fn());
             expect(instance.addToQueue).toBeCalledTimes(1);
             expect(instance.addToQueue.mock.calls[0][0].length).toBe(mockFoldersList.length);
+        });
+    });
+
+    describe('render()', () => {
+        describe('enableModernizedUploads', () => {
+            test('should render legacy UploadsManager when enableModernizedUploads is false and useUploadsManager is true', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: false, useUploadsManager: true });
+                expect(wrapper.find(UploadsManager)).toHaveLength(1);
+                expect(wrapper.find(DroppableContent)).toHaveLength(0);
+            });
+
+            test('should render DroppableContent when enableModernizedUploads is false and useUploadsManager is false', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: false, useUploadsManager: false });
+                expect(wrapper.find(DroppableContent)).toHaveLength(1);
+                expect(wrapper.find(UploadsManager)).toHaveLength(0);
+            });
+
+            test('should render modernized uploads placeholder when enableModernizedUploads is true', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                expect(wrapper.find(UploadsManager)).toHaveLength(0);
+                expect(wrapper.find(DroppableContent)).toHaveLength(0);
+            });
+
+            test('should render modernized uploads placeholder even when useUploadsManager is true', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true, useUploadsManager: true });
+                expect(wrapper.find(UploadsManager)).toHaveLength(0);
+                expect(wrapper.find(DroppableContent)).toHaveLength(0);
+            });
         });
     });
 });

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -6,6 +6,7 @@ import { ContentUploaderComponent, CHUNKED_UPLOAD_MIN_SIZE_BYTES } from '../Cont
 import Footer from '../Footer';
 import UploadsManager from '../UploadsManager';
 import DroppableContent from '../DroppableContent';
+import { UploadsManager as UploadsManagerBP } from '@box/uploads-manager';
 import {
     STATUS_PENDING,
     STATUS_IN_PROGRESS,
@@ -772,16 +773,93 @@ describe('elements/content-uploader/ContentUploader', () => {
                 expect(wrapper.find(UploadsManager)).toHaveLength(0);
             });
 
-            test('should render modernized uploads placeholder when enableModernizedUploads is true', () => {
+            test('should render modernized UploadsManagerBP when enableModernizedUploads is true', () => {
                 const wrapper = getWrapper({ enableModernizedUploads: true });
+                expect(wrapper.find(UploadsManagerBP)).toHaveLength(1);
                 expect(wrapper.find(UploadsManager)).toHaveLength(0);
                 expect(wrapper.find(DroppableContent)).toHaveLength(0);
             });
 
-            test('should render modernized uploads placeholder even when useUploadsManager is true', () => {
+            test('should render modernized UploadsManagerBP even when useUploadsManager is true', () => {
                 const wrapper = getWrapper({ enableModernizedUploads: true, useUploadsManager: true });
+                expect(wrapper.find(UploadsManagerBP)).toHaveLength(1);
                 expect(wrapper.find(UploadsManager)).toHaveLength(0);
-                expect(wrapper.find(DroppableContent)).toHaveLength(0);
+            });
+
+            test('should map state.items to modernized item shape', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                wrapper.setState({
+                    items: [
+                        {
+                            name: 'foo.pdf',
+                            extension: 'pdf',
+                            progress: 42,
+                            status: STATUS_IN_PROGRESS,
+                            file: { name: 'foo.pdf' },
+                        },
+                    ],
+                });
+                const items = wrapper.find(UploadsManagerBP).prop('items');
+                expect(items).toHaveLength(1);
+                expect(items[0]).toMatchObject({
+                    name: 'foo.pdf',
+                    extension: 'pdf',
+                    progress: 42,
+                    status: 'uploading',
+                });
+            });
+
+            test('should pass isExpanded from state', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                wrapper.setState({ isUploadsManagerExpanded: true });
+                expect(wrapper.find(UploadsManagerBP).prop('isExpanded')).toBe(true);
+            });
+
+            test('should call onClick when onItemCancel is invoked', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                const item = {
+                    name: 'foo.pdf',
+                    extension: 'pdf',
+                    progress: 0,
+                    status: STATUS_PENDING,
+                    file: { name: 'foo.pdf' },
+                };
+                wrapper.setState({ items: [item] });
+                const instance = wrapper.instance();
+                const onClickSpy = jest.spyOn(instance, 'onClick').mockImplementation(() => {});
+
+                wrapper.find(UploadsManagerBP).prop('onItemCancel')('foo.pdf');
+
+                expect(onClickSpy).toHaveBeenCalledWith(item);
+            });
+
+            test('should call removeFileFromUploadQueue when onItemRemove is invoked', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                const item = {
+                    name: 'foo.pdf',
+                    extension: 'pdf',
+                    progress: 0,
+                    status: STATUS_COMPLETE,
+                    file: { name: 'foo.pdf' },
+                };
+                wrapper.setState({ items: [item] });
+                const instance = wrapper.instance();
+                const removeSpy = jest.spyOn(instance, 'removeFileFromUploadQueue').mockImplementation(() => {});
+
+                wrapper.find(UploadsManagerBP).prop('onItemRemove')('foo.pdf');
+
+                expect(removeSpy).toHaveBeenCalledWith(item);
+            });
+
+            test('should no-op when modernized id does not match any item', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                wrapper.setState({ items: [] });
+                const instance = wrapper.instance();
+                const onClickSpy = jest.spyOn(instance, 'onClick').mockImplementation(() => {});
+
+                wrapper.find(UploadsManagerBP).prop('onItemCancel')('missing-id');
+
+                expect(onClickSpy).not.toHaveBeenCalled();
             });
         });
     });

--- a/src/elements/content-uploader/stories/ContentUploader.stories.js
+++ b/src/elements/content-uploader/stories/ContentUploader.stories.js
@@ -10,6 +10,12 @@ export const withTheming = {
     },
 };
 
+export const withModernizedUploads = {
+    args: {
+        enableModernizedUploads: true,
+    },
+};
+
 export default {
     title: 'Elements/ContentUploader',
     component: ContentUploader,

--- a/src/elements/content-uploader/utils/__tests__/mapToModernizedUploadItem.test.ts
+++ b/src/elements/content-uploader/utils/__tests__/mapToModernizedUploadItem.test.ts
@@ -1,0 +1,79 @@
+import {
+    STATUS_PENDING,
+    STATUS_IN_PROGRESS,
+    STATUS_STAGED,
+    STATUS_COMPLETE,
+    STATUS_ERROR,
+} from '../../../../constants';
+import { mapToModernizedUploadItem, mapToModernizedUploadItems } from '../mapToModernizedUploadItem';
+
+const buildLegacyItem = (overrides = {}) => ({
+    name: 'foo.pdf',
+    extension: 'pdf',
+    progress: 50,
+    status: STATUS_IN_PROGRESS,
+    size: 100,
+    file: { name: 'foo.pdf' } as File,
+    api: {} as never,
+    ...overrides,
+});
+
+describe('mapToModernizedUploadItem()', () => {
+    test('maps core fields', () => {
+        const result = mapToModernizedUploadItem(buildLegacyItem(), '0');
+        expect(result).toEqual({
+            id: 'foo.pdf',
+            name: 'foo.pdf',
+            extension: 'pdf',
+            progress: 50,
+            status: 'uploading',
+            isFolder: undefined,
+            errorMessage: undefined,
+        });
+    });
+
+    test.each([
+        [STATUS_PENDING, 'pending'],
+        [STATUS_IN_PROGRESS, 'uploading'],
+        [STATUS_STAGED, 'staged'],
+        [STATUS_COMPLETE, 'complete'],
+        [STATUS_ERROR, 'error'],
+    ])('maps legacy status %s to modernized %s', (legacy, modernized) => {
+        const result = mapToModernizedUploadItem(buildLegacyItem({ status: legacy }), '0');
+        expect(result.status).toBe(modernized);
+    });
+
+    test('extracts errorMessage from item.error', () => {
+        const result = mapToModernizedUploadItem(
+            buildLegacyItem({ status: STATUS_ERROR, error: { message: 'Boom' } }),
+            '0',
+        );
+        expect(result.errorMessage).toBe('Boom');
+    });
+
+    test('forwards isFolder', () => {
+        const result = mapToModernizedUploadItem(buildLegacyItem({ isFolder: true }), '0');
+        expect(result.isFolder).toBe(true);
+    });
+
+    test('defaults missing extension and progress', () => {
+        const result = mapToModernizedUploadItem(
+            buildLegacyItem({ extension: undefined, progress: undefined }),
+            '0',
+        );
+        expect(result.extension).toBe('');
+        expect(result.progress).toBe(0);
+    });
+});
+
+describe('mapToModernizedUploadItems()', () => {
+    test('maps a list', () => {
+        const result = mapToModernizedUploadItems(
+            [buildLegacyItem({ name: 'a.pdf', file: { name: 'a.pdf' } as File }), buildLegacyItem({ name: 'b.pdf', file: { name: 'b.pdf' } as File })],
+            '0',
+        );
+        expect(result).toHaveLength(2);
+        expect(result[0].id).toBe('a.pdf');
+        expect(result[1].id).toBe('b.pdf');
+    });
+});

--- a/src/elements/content-uploader/utils/mapToModernizedUploadItem.ts
+++ b/src/elements/content-uploader/utils/mapToModernizedUploadItem.ts
@@ -1,0 +1,47 @@
+import {
+    STATUS_PENDING,
+    STATUS_IN_PROGRESS,
+    STATUS_STAGED,
+    STATUS_COMPLETE,
+    STATUS_ERROR,
+} from '../../../constants';
+import { getFileId } from '../../../utils/uploads';
+import { UploadItem as LegacyUploadItem } from '../../../common/types/upload';
+
+type ModernizedStatus = 'pending' | 'uploading' | 'staged' | 'complete' | 'error' | 'canceled';
+
+export interface ModernizedUploadItem {
+    id: string;
+    name: string;
+    extension: string;
+    progress: number;
+    status: ModernizedStatus;
+    isFolder?: boolean;
+    errorMessage?: string;
+}
+
+const STATUS_MAP: Record<string, ModernizedStatus> = {
+    [STATUS_PENDING]: 'pending',
+    [STATUS_IN_PROGRESS]: 'uploading',
+    [STATUS_STAGED]: 'staged',
+    [STATUS_COMPLETE]: 'complete',
+    [STATUS_ERROR]: 'error',
+};
+
+export function mapToModernizedUploadItem(item: LegacyUploadItem, rootFolderId: string): ModernizedUploadItem {
+    const errorMessage = item.error ? (item.error as { message?: string }).message : undefined;
+
+    return {
+        id: getFileId(item.file, rootFolderId),
+        name: item.name,
+        extension: item.extension ?? '',
+        progress: item.progress ?? 0,
+        status: STATUS_MAP[item.status] ?? 'pending',
+        isFolder: item.isFolder,
+        errorMessage,
+    };
+}
+
+export function mapToModernizedUploadItems(items: LegacyUploadItem[], rootFolderId: string): ModernizedUploadItem[] {
+    return items.map(item => mapToModernizedUploadItem(item, rootFolderId));
+}


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ContentUploader component now supports a modernized uploads manager implementation via an optional prop, with automatic item mapping and callback handling
  * Added Storybook story demonstrating the modernized uploads functionality

* **Tests**
  * Added comprehensive test coverage for modernized uploads rendering, callback routing, and item status mapping

* **Chores**
  * Updated Jest configuration for additional package support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->