### PR TITLE
feat(content-uploader): Implement cancelled state uploads manager

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -386,16 +386,6 @@ be.contentSidebar.editTask.general.title = Modify General Task
 be.contentSidebar.mentionUserSelectorLoading = Loading users
 # Accessibility role description for the mention user selector input
 be.contentSidebar.mentionUserSelectorRoleDescription = Mention a user
-# Aria label for the close button on the cancel all uploads modal
-be.contentUploader.cancelAllUploadsCloseLabel = Close cancel uploads dialog
-# Confirm button for the cancel all uploads modal
-be.contentUploader.cancelAllUploadsConfirmButton = Cancel All
-# Dismiss button for the cancel all uploads modal
-be.contentUploader.cancelAllUploadsKeepButton = Keep Uploading
-# Body content for the cancel all uploads confirmation modal
-be.contentUploader.cancelAllUploadsModalContent = Files that are still uploading will be canceled. Completed uploads will not be affected.
-# Heading for the cancel all uploads confirmation modal
-be.contentUploader.cancelAllUploadsModalHeading = Cancel all uploads?
 # Label for copy action.
 be.copy = Copy
 # Label for create action.

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -386,6 +386,16 @@ be.contentSidebar.editTask.general.title = Modify General Task
 be.contentSidebar.mentionUserSelectorLoading = Loading users
 # Accessibility role description for the mention user selector input
 be.contentSidebar.mentionUserSelectorRoleDescription = Mention a user
+# Aria label for the close button on the cancel all uploads modal
+be.contentUploader.cancelAllUploadsCloseLabel = Close cancel uploads dialog
+# Confirm button for the cancel all uploads modal
+be.contentUploader.cancelAllUploadsConfirmButton = Cancel All
+# Dismiss button for the cancel all uploads modal
+be.contentUploader.cancelAllUploadsKeepButton = Keep Uploading
+# Body content for the cancel all uploads confirmation modal
+be.contentUploader.cancelAllUploadsModalContent = Files that are still uploading will be canceled. Completed uploads will not be affected.
+# Heading for the cancel all uploads confirmation modal
+be.contentUploader.cancelAllUploadsModalHeading = Cancel all uploads?
 # Label for copy action.
 be.copy = Copy
 # Label for create action.

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -1005,6 +1005,13 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         );
         const uploadItemsStatus = isResumableUploadsEnabled ? areAllItemsFinished : noFileIsPendingOrInProgress;
 
+        // In the modernized flow, suppress the completion notification when
+        // no item actually finished successfully (e.g. user canceled every
+        // upload). This prevents a misleading "upload complete" toast/callback
+        // from any of the onComplete call sites below.
+        const hasCompletedItem = items.some(uploadItem => uploadItem.status === STATUS_COMPLETE);
+        const shouldFireOnComplete = !enableModernizedUploads || hasCompletedItem;
+
         let view = '';
         if ((items && items.length === 0) || allItemsArePending) {
             view = VIEW_UPLOAD_EMPTY;
@@ -1013,7 +1020,9 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             view = VIEW_UPLOAD_SUCCESS;
 
             if (!useUploadsManager) {
-                onComplete(cloneDeep(filesToBeUploaded.map(item => item.boxFile)));
+                if (shouldFireOnComplete) {
+                    onComplete(cloneDeep(filesToBeUploaded.map(item => item.boxFile)));
+                }
                 // Reset item collection after successful upload
                 items = [];
             }
@@ -1025,7 +1034,9 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             view = VIEW_UPLOAD_SUCCESS;
 
             if (!useUploadsManager) {
-                onComplete(cloneDeep(items.map(item => item.boxFile)));
+                if (shouldFireOnComplete) {
+                    onComplete(cloneDeep(items.map(item => item.boxFile)));
+                }
                 // Reset item collection after successful upload
                 items = [];
             }
@@ -1035,11 +1046,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             if (this.isAutoExpanded) {
                 this.resetUploadManagerExpandState();
             } // Else manually expanded so don't close
-            // In the modernized flow, suppress the completion notification
-            // when no item actually finished successfully (e.g. user canceled
-            // every upload). This prevents a misleading "upload complete" toast.
-            const hasCompletedItem = items.some(uploadItem => uploadItem.status === STATUS_COMPLETE);
-            if (!enableModernizedUploads || hasCompletedItem) {
+            if (shouldFireOnComplete) {
                 onComplete(items);
             }
         }

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -977,19 +977,31 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      */
     updateViewAndCollection(items: UploadItem[], callback?: () => void) {
         const {
+            enableModernizedUploads,
             isPartialUploadEnabled,
             isResumableUploadsEnabled,
             onComplete,
             useUploadsManager,
         }: ContentUploaderProps = this.props;
-        const someUploadIsInProgress = items.some(uploadItem => uploadItem.status !== STATUS_COMPLETE);
+        // When the modernized flow is on, canceled items are kept in the list
+        // but treated as terminal so they do not block completion logic. The
+        // legacy view/state machine sees canceled items as non-COMPLETE which
+        // would otherwise stall progress and emit a stale success notification.
+        const isTerminalForModernized = (uploadItem: UploadItem) =>
+            enableModernizedUploads && uploadItem.status === STATUS_CANCELED;
+        const someUploadIsInProgress = items.some(
+            uploadItem => uploadItem.status !== STATUS_COMPLETE && !isTerminalForModernized(uploadItem),
+        );
         const someUploadHasFailed = items.some(uploadItem => uploadItem.status === STATUS_ERROR);
         const allItemsArePending = !items.some(uploadItem => uploadItem.status !== STATUS_PENDING);
         const noFileIsPendingOrInProgress = items.every(
             uploadItem => uploadItem.status !== STATUS_PENDING && uploadItem.status !== STATUS_IN_PROGRESS,
         );
         const areAllItemsFinished = items.every(
-            uploadItem => uploadItem.status === STATUS_COMPLETE || uploadItem.status === STATUS_ERROR,
+            uploadItem =>
+                uploadItem.status === STATUS_COMPLETE ||
+                uploadItem.status === STATUS_ERROR ||
+                isTerminalForModernized(uploadItem),
         );
         const uploadItemsStatus = isResumableUploadsEnabled ? areAllItemsFinished : noFileIsPendingOrInProgress;
 
@@ -1023,7 +1035,13 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             if (this.isAutoExpanded) {
                 this.resetUploadManagerExpandState();
             } // Else manually expanded so don't close
-            onComplete(items);
+            // In the modernized flow, suppress the completion notification
+            // when no item actually finished successfully (e.g. user canceled
+            // every upload). This prevents a misleading "upload complete" toast.
+            const hasCompletedItem = items.some(uploadItem => uploadItem.status === STATUS_COMPLETE);
+            if (!enableModernizedUploads || hasCompletedItem) {
+                onComplete(items);
+            }
         }
 
         const state: Partial<State> = {

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -1026,6 +1026,62 @@ describe('elements/content-uploader/ContentUploader', () => {
                 expect(complete.api.cancel).not.toHaveBeenCalled();
             });
 
+            test('updateViewAndCollection should not fire onComplete when all items are canceled (modernized)', () => {
+                const onComplete = jest.fn();
+                const wrapper = getWrapper({
+                    enableModernizedUploads: true,
+                    useUploadsManager: true,
+                    onComplete,
+                });
+                const instance = wrapper.instance();
+                const canceled = { status: 'canceled' };
+                instance.updateViewAndCollection([
+                    { ...canceled, file: { name: 'a' } },
+                    { ...canceled, file: { name: 'b' } },
+                ]);
+                expect(onComplete).not.toHaveBeenCalled();
+            });
+
+            test('updateViewAndCollection should fire onComplete when at least one item completes (modernized)', () => {
+                const onComplete = jest.fn();
+                const wrapper = getWrapper({
+                    enableModernizedUploads: true,
+                    useUploadsManager: true,
+                    onComplete,
+                });
+                const instance = wrapper.instance();
+                instance.updateViewAndCollection([
+                    { status: STATUS_COMPLETE, file: { name: 'a' } },
+                    { status: 'canceled', file: { name: 'b' } },
+                ]);
+                expect(onComplete).toHaveBeenCalled();
+            });
+
+            test('updateViewAndCollection should treat canceled items as terminal (modernized)', () => {
+                const wrapper = getWrapper({
+                    enableModernizedUploads: true,
+                    useUploadsManager: true,
+                });
+                const instance = wrapper.instance();
+                instance.updateViewAndCollection([
+                    { status: STATUS_COMPLETE, file: { name: 'a' } },
+                    { status: 'canceled', file: { name: 'b' } },
+                ]);
+                expect(wrapper.state('view')).not.toBe(VIEW_UPLOAD_IN_PROGRESS);
+            });
+
+            test('updateViewAndCollection should preserve legacy behavior when modernized flag is off', () => {
+                const onComplete = jest.fn();
+                const wrapper = getWrapper({
+                    enableModernizedUploads: false,
+                    useUploadsManager: true,
+                    onComplete,
+                });
+                const instance = wrapper.instance();
+                instance.updateViewAndCollection([{ status: STATUS_COMPLETE, file: { name: 'a' } }]);
+                expect(onComplete).toHaveBeenCalled();
+            });
+
             test('handleUploadsManagerRetryAll should restart errored and canceled items', () => {
                 const onClickRetry = jest.fn();
                 const wrapper = getWrapper({ enableModernizedUploads: true, onClickRetry });

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -1026,60 +1026,70 @@ describe('elements/content-uploader/ContentUploader', () => {
                 expect(complete.api.cancel).not.toHaveBeenCalled();
             });
 
-            test('updateViewAndCollection should not fire onComplete when all items are canceled (modernized)', () => {
-                const onComplete = jest.fn();
-                const wrapper = getWrapper({
-                    enableModernizedUploads: true,
-                    useUploadsManager: true,
-                    onComplete,
-                });
-                const instance = wrapper.instance();
-                const canceled = { status: 'canceled' };
-                instance.updateViewAndCollection([
-                    { ...canceled, file: { name: 'a' } },
-                    { ...canceled, file: { name: 'b' } },
-                ]);
-                expect(onComplete).not.toHaveBeenCalled();
-            });
+            describe('updateViewAndCollection with canceled items', () => {
+                let onComplete;
+                let wrapper;
+                let instance;
 
-            test('updateViewAndCollection should fire onComplete when at least one item completes (modernized)', () => {
-                const onComplete = jest.fn();
-                const wrapper = getWrapper({
-                    enableModernizedUploads: true,
-                    useUploadsManager: true,
-                    onComplete,
+                beforeEach(() => {
+                    onComplete = jest.fn();
+                    wrapper = getWrapper({
+                        enableModernizedUploads: true,
+                        useUploadsManager: true,
+                        onComplete,
+                    });
+                    instance = wrapper.instance();
                 });
-                const instance = wrapper.instance();
-                instance.updateViewAndCollection([
-                    { status: STATUS_COMPLETE, file: { name: 'a' } },
-                    { status: 'canceled', file: { name: 'b' } },
-                ]);
-                expect(onComplete).toHaveBeenCalled();
-            });
 
-            test('updateViewAndCollection should treat canceled items as terminal (modernized)', () => {
-                const wrapper = getWrapper({
-                    enableModernizedUploads: true,
-                    useUploadsManager: true,
+                test('should not fire onComplete when all items are canceled (modernized)', () => {
+                    instance.updateViewAndCollection([
+                        { status: STATUS_CANCELED, file: { name: 'a' } },
+                        { status: STATUS_CANCELED, file: { name: 'b' } },
+                    ]);
+                    expect(onComplete).not.toHaveBeenCalled();
                 });
-                const instance = wrapper.instance();
-                instance.updateViewAndCollection([
-                    { status: STATUS_COMPLETE, file: { name: 'a' } },
-                    { status: 'canceled', file: { name: 'b' } },
-                ]);
-                expect(wrapper.state('view')).not.toBe(VIEW_UPLOAD_IN_PROGRESS);
-            });
 
-            test('updateViewAndCollection should preserve legacy behavior when modernized flag is off', () => {
-                const onComplete = jest.fn();
-                const wrapper = getWrapper({
-                    enableModernizedUploads: false,
-                    useUploadsManager: true,
-                    onComplete,
+                test('should fire onComplete when at least one item completes (modernized)', () => {
+                    instance.updateViewAndCollection([
+                        { status: STATUS_COMPLETE, file: { name: 'a' } },
+                        { status: STATUS_CANCELED, file: { name: 'b' } },
+                    ]);
+                    expect(onComplete).toHaveBeenCalled();
                 });
-                const instance = wrapper.instance();
-                instance.updateViewAndCollection([{ status: STATUS_COMPLETE, file: { name: 'a' } }]);
-                expect(onComplete).toHaveBeenCalled();
+
+                test('should treat canceled items as terminal and resolve to VIEW_UPLOAD_SUCCESS (modernized)', () => {
+                    instance.updateViewAndCollection([
+                        { status: STATUS_COMPLETE, file: { name: 'a' } },
+                        { status: STATUS_CANCELED, file: { name: 'b' } },
+                    ]);
+                    expect(wrapper.state('view')).toBe(VIEW_UPLOAD_SUCCESS);
+                });
+
+                test('should not fire onComplete on the partial-upload path when all items are canceled (modernized, no manager)', () => {
+                    onComplete = jest.fn();
+                    wrapper = getWrapper({
+                        enableModernizedUploads: true,
+                        isPartialUploadEnabled: true,
+                        useUploadsManager: false,
+                        onComplete,
+                    });
+                    wrapper.instance().updateViewAndCollection([
+                        { status: STATUS_CANCELED, file: { name: 'a' } },
+                        { status: STATUS_CANCELED, file: { name: 'b' } },
+                    ]);
+                    expect(onComplete).not.toHaveBeenCalled();
+                });
+
+                test('should preserve legacy behavior when modernized flag is off', () => {
+                    onComplete = jest.fn();
+                    wrapper = getWrapper({
+                        enableModernizedUploads: false,
+                        useUploadsManager: true,
+                        onComplete,
+                    });
+                    wrapper.instance().updateViewAndCollection([{ status: STATUS_COMPLETE, file: { name: 'a' } }]);
+                    expect(onComplete).toHaveBeenCalled();
+                });
             });
 
             test('handleUploadsManagerRetryAll should restart errored and canceled items', () => {


### PR DESCRIPTION
Make `STATUS_CANCELED` a terminal state inside `ContentUploader.updateViewAndCollection` when the modernized flow is on. Without this, canceled items keep the view stuck in `VIEW_UPLOAD_IN_PROGRESS` and `onComplete` never fires for batches where every item was canceled
  
  **3/5 PR in the queue:**

1. https://github.com/box/box-ui-elements/pull/4573
2. https://github.com/box/box-ui-elements/pull/4577
3. 👉 https://github.com/box/box-ui-elements/pull/4578
4. https://github.com/box/box-ui-elements/pull/4579
5. https://github.com/box/box-ui-elements/pull/4580

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canceled uploads are now treated as finished so the uploader no longer appears to keep processing after cancellation.
  * Completion notifications only fire when at least one upload successfully completes, preventing false completion callbacks when all items were canceled.
* **Tests**
  * Added tests verifying cancellation and completion behaviors across modernized and legacy flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->