### PR TITLE
feat(content-uploader): Implement cancel all confirmation modal

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -386,16 +386,16 @@ be.contentSidebar.editTask.general.title = Modify General Task
 be.contentSidebar.mentionUserSelectorLoading = Loading users
 # Accessibility role description for the mention user selector input
 be.contentSidebar.mentionUserSelectorRoleDescription = Mention a user
-# Aria label for the close button on the cancel all uploads modal
-be.contentUploader.cancelAllUploadsCloseLabel = Close cancel uploads dialog
-# Confirm button for the cancel all uploads modal
-be.contentUploader.cancelAllUploadsConfirmButton = Cancel All
-# Dismiss button for the cancel all uploads modal
-be.contentUploader.cancelAllUploadsKeepButton = Keep Uploading
 # Body content for the cancel all uploads confirmation modal
-be.contentUploader.cancelAllUploadsModalContent = Files that are still uploading will be canceled. Completed uploads will not be affected.
+be.contentUploader.cancelAllUploads.body = Files that are still uploading will be canceled. Completed uploads will not be affected.
+# Aria label for the close button on the cancel all uploads modal
+be.contentUploader.cancelAllUploads.closeLabel = Close cancel uploads dialog
+# Confirm button for the cancel all uploads modal
+be.contentUploader.cancelAllUploads.confirmButton = Cancel All
 # Heading for the cancel all uploads confirmation modal
-be.contentUploader.cancelAllUploadsModalHeading = Cancel all uploads?
+be.contentUploader.cancelAllUploads.heading = Cancel all uploads?
+# Dismiss button for the cancel all uploads modal
+be.contentUploader.cancelAllUploads.keepUploadingButton = Keep Uploading
 # Label for copy action.
 be.copy = Copy
 # Label for create action.

--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -386,6 +386,16 @@ be.contentSidebar.editTask.general.title = Modify General Task
 be.contentSidebar.mentionUserSelectorLoading = Loading users
 # Accessibility role description for the mention user selector input
 be.contentSidebar.mentionUserSelectorRoleDescription = Mention a user
+# Aria label for the close button on the cancel all uploads modal
+be.contentUploader.cancelAllUploadsCloseLabel = Close cancel uploads dialog
+# Confirm button for the cancel all uploads modal
+be.contentUploader.cancelAllUploadsConfirmButton = Cancel All
+# Dismiss button for the cancel all uploads modal
+be.contentUploader.cancelAllUploadsKeepButton = Keep Uploading
+# Body content for the cancel all uploads confirmation modal
+be.contentUploader.cancelAllUploadsModalContent = Files that are still uploading will be canceled. Completed uploads will not be affected.
+# Heading for the cancel all uploads confirmation modal
+be.contentUploader.cancelAllUploadsModalHeading = Cancel all uploads?
 # Label for copy action.
 be.copy = Copy
 # Label for create action.

--- a/src/elements/content-uploader/CancelAllUploadsModal.tsx
+++ b/src/elements/content-uploader/CancelAllUploadsModal.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { useIntl } from 'react-intl';
+import { AlertModal } from '@box/blueprint-web';
+import messages from './messages';
+
+export interface CancelAllUploadsModalProps {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onDismiss: () => void;
+}
+
+export function CancelAllUploadsModal({ isOpen, onConfirm, onDismiss }: CancelAllUploadsModalProps) {
+    const { formatMessage } = useIntl();
+
+    const handleOpenChange = (open: boolean) => {
+        if (!open) {
+            onDismiss();
+        }
+    };
+
+    return (
+        <AlertModal
+            open={isOpen}
+            onOpenChange={handleOpenChange}
+            heading={formatMessage(messages.cancelAllUploadsModalHeading)}
+            textContent={formatMessage(messages.cancelAllUploadsModalContent)}
+            closeButtonAriaLabel={formatMessage(messages.cancelAllUploadsCloseLabel)}
+        >
+            <AlertModal.SecondaryButton onClick={onDismiss}>
+                {formatMessage(messages.cancelAllUploadsKeepButton)}
+            </AlertModal.SecondaryButton>
+            <AlertModal.PrimaryButton variant="destructive" onClick={onConfirm}>
+                {formatMessage(messages.cancelAllUploadsConfirmButton)}
+            </AlertModal.PrimaryButton>
+        </AlertModal>
+    );
+}
+
+export default CancelAllUploadsModal;

--- a/src/elements/content-uploader/CancelAllUploadsModal.tsx
+++ b/src/elements/content-uploader/CancelAllUploadsModal.tsx
@@ -22,15 +22,15 @@ export function CancelAllUploadsModal({ isOpen, onConfirm, onDismiss }: CancelAl
         <AlertModal
             open={isOpen}
             onOpenChange={handleOpenChange}
-            heading={formatMessage(messages.cancelAllUploadsModalHeading)}
-            textContent={formatMessage(messages.cancelAllUploadsModalContent)}
-            closeButtonAriaLabel={formatMessage(messages.cancelAllUploadsCloseLabel)}
+            heading={formatMessage(messages.heading)}
+            textContent={formatMessage(messages.body)}
+            closeButtonAriaLabel={formatMessage(messages.closeLabel)}
         >
             <AlertModal.SecondaryButton onClick={onDismiss}>
-                {formatMessage(messages.cancelAllUploadsKeepButton)}
+                {formatMessage(messages.keepUploadingButton)}
             </AlertModal.SecondaryButton>
             <AlertModal.PrimaryButton variant="destructive" onClick={onConfirm}>
-                {formatMessage(messages.cancelAllUploadsConfirmButton)}
+                {formatMessage(messages.confirmButton)}
             </AlertModal.PrimaryButton>
         </AlertModal>
     );

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -9,11 +9,11 @@ import uniqueid from 'lodash/uniqueId';
 import { UploadsManager as UploadsManagerBP } from '@box/uploads-manager';
 import { TooltipProvider } from '@box/blueprint-web';
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import CancelAllUploadsModal from './CancelAllUploadsModal';
 import DroppableContent from './DroppableContent';
 import Footer from './Footer';
 import UploadsManager from './UploadsManager';
 import { getUploadItemKey, mapToModernizedUploadItems } from './utils/mapToModernizedUploadItem';
-import CancelAllUploadsModal from './CancelAllUploadsModal';
 import API from '../../api';
 import Browser from '../../utils/Browser';
 import Internationalize from '../common/Internationalize';
@@ -1210,24 +1210,6 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     };
 
     /**
-     * Open the Cancel All confirmation modal. Wired as the onCancelAll prop
-     * passed to the modernized uploads manager so the action requires explicit
-     * confirmation before destroying in-progress uploads.
-     */
-    handleCancelAllRequest = () => {
-        this.setState({ isCancelAllModalOpen: true });
-    };
-
-    handleCancelAllDismiss = () => {
-        this.setState({ isCancelAllModalOpen: false });
-    };
-
-    handleCancelAllConfirm = () => {
-        this.setState({ isCancelAllModalOpen: false });
-        this.handleUploadsManagerCancelAll();
-    };
-
-    /**
      * Cancel every pending or in-progress upload at once. Items keep their row
      * in the list with the canceled status. Only used by the modernized flow.
      */
@@ -1239,6 +1221,24 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         cancelable.forEach(item => this.markItemCanceled(item));
         onCancel(cancelable);
         this.updateViewAndCollection([...this.itemsRef.current]);
+    };
+
+    /**
+     * Open the Cancel All confirmation modal. Wired as the onCancelAll prop
+     * passed to the modernized uploads manager so the action requires explicit
+     * confirmation before destroying in-progress uploads.
+     */
+    handleCancelAllClick = () => {
+        this.setState({ isCancelAllModalOpen: true });
+    };
+
+    handleCancelAllDismiss = () => {
+        this.setState({ isCancelAllModalOpen: false });
+    };
+
+    handleCancelAllConfirm = () => {
+        this.setState({ isCancelAllModalOpen: false });
+        this.handleUploadsManagerCancelAll();
     };
 
     /**
@@ -1480,7 +1480,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
                             onItemCancel={this.handleUploadsManagerItemCancel}
                             onItemRetry={this.handleUploadsManagerItemRetry}
                             onItemRemove={this.handleUploadsManagerItemRemove}
-                            onCancelAll={this.handleCancelAllRequest}
+                            onCancelAll={this.handleCancelAllClick}
                             onRetryAll={this.handleUploadsManagerRetryAll}
                         />
                         <CancelAllUploadsModal

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -13,6 +13,7 @@ import DroppableContent from './DroppableContent';
 import Footer from './Footer';
 import UploadsManager from './UploadsManager';
 import { getUploadItemKey, mapToModernizedUploadItems } from './utils/mapToModernizedUploadItem';
+import CancelAllUploadsModal from './CancelAllUploadsModal';
 import API from '../../api';
 import Browser from '../../utils/Browser';
 import Internationalize from '../common/Internationalize';
@@ -113,6 +114,7 @@ export interface ContentUploaderProps {
 
 type State = {
     errorCode?: string;
+    isCancelAllModalOpen: boolean;
     isUploadsManagerExpanded: boolean;
     itemIds: Object;
     items: UploadItem[];
@@ -191,6 +193,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             items: [],
             errorCode: '',
             itemIds: {},
+            isCancelAllModalOpen: false,
             isUploadsManagerExpanded: false,
         };
         this.id = uniqueid('bcu_');
@@ -1207,6 +1210,24 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     };
 
     /**
+     * Open the Cancel All confirmation modal. Wired as the onCancelAll prop
+     * passed to the modernized uploads manager so the action requires explicit
+     * confirmation before destroying in-progress uploads.
+     */
+    handleCancelAllRequest = () => {
+        this.setState({ isCancelAllModalOpen: true });
+    };
+
+    handleCancelAllDismiss = () => {
+        this.setState({ isCancelAllModalOpen: false });
+    };
+
+    handleCancelAllConfirm = () => {
+        this.setState({ isCancelAllModalOpen: false });
+        this.handleUploadsManagerCancelAll();
+    };
+
+    /**
      * Cancel every pending or in-progress upload at once. Items keep their row
      * in the list with the canceled status. Only used by the modernized flow.
      */
@@ -1434,7 +1455,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             theme,
             useUploadsManager,
         }: ContentUploaderProps = this.props;
-        const { view, items, errorCode, isUploadsManagerExpanded }: State = this.state;
+        const { view, items, errorCode, isCancelAllModalOpen, isUploadsManagerExpanded }: State = this.state;
         const isEmpty = items.length === 0;
         const isVisible = !isEmpty || !!isDraggingItemsToUploadsManager;
 
@@ -1459,8 +1480,13 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
                             onItemCancel={this.handleUploadsManagerItemCancel}
                             onItemRetry={this.handleUploadsManagerItemRetry}
                             onItemRemove={this.handleUploadsManagerItemRemove}
-                            onCancelAll={this.handleUploadsManagerCancelAll}
+                            onCancelAll={this.handleCancelAllRequest}
                             onRetryAll={this.handleUploadsManagerRetryAll}
+                        />
+                        <CancelAllUploadsModal
+                            isOpen={isCancelAllModalOpen}
+                            onConfirm={this.handleCancelAllConfirm}
+                            onDismiss={this.handleCancelAllDismiss}
                         />
                     </div>
                 );

--- a/src/elements/content-uploader/__tests__/CancelAllUploadsModal.test.tsx
+++ b/src/elements/content-uploader/__tests__/CancelAllUploadsModal.test.tsx
@@ -18,7 +18,11 @@ describe('elements/content-uploader/CancelAllUploadsModal', () => {
         renderModal();
         expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
         expect(screen.getByText('Cancel all uploads?')).toBeInTheDocument();
-        expect(screen.getByText(/Files that are still uploading will be canceled/)).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Files that are still uploading will be canceled. Completed uploads will not be affected.',
+            ),
+        ).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Cancel All' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Keep Uploading' })).toBeInTheDocument();
     });

--- a/src/elements/content-uploader/__tests__/CancelAllUploadsModal.test.tsx
+++ b/src/elements/content-uploader/__tests__/CancelAllUploadsModal.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { render, screen, userEvent } from '../../../test-utils/testing-library';
+import CancelAllUploadsModal, { type CancelAllUploadsModalProps } from '../CancelAllUploadsModal';
+
+const renderModal = (props: Partial<CancelAllUploadsModalProps> = {}) => {
+    const defaultProps: CancelAllUploadsModalProps = {
+        isOpen: true,
+        onConfirm: jest.fn(),
+        onDismiss: jest.fn(),
+        ...props,
+    };
+    render(<CancelAllUploadsModal {...defaultProps} />);
+    return defaultProps;
+};
+
+describe('elements/content-uploader/CancelAllUploadsModal', () => {
+    test('renders heading, body, and both action buttons when open', async () => {
+        renderModal();
+        expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+        expect(screen.getByText('Cancel all uploads?')).toBeInTheDocument();
+        expect(screen.getByText(/Files that are still uploading will be canceled/)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cancel All' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Keep Uploading' })).toBeInTheDocument();
+    });
+
+    test('calls onConfirm when Cancel All is clicked', async () => {
+        const props = renderModal();
+        const user = userEvent();
+        const button = await screen.findByRole('button', { name: 'Cancel All' });
+        await user.click(button);
+        expect(props.onConfirm).toHaveBeenCalledTimes(1);
+        expect(props.onDismiss).not.toHaveBeenCalled();
+    });
+
+    test('calls onDismiss when Keep Uploading is clicked', async () => {
+        const props = renderModal();
+        const user = userEvent();
+        const button = await screen.findByRole('button', { name: 'Keep Uploading' });
+        await user.click(button);
+        expect(props.onDismiss).toHaveBeenCalledTimes(1);
+        expect(props.onConfirm).not.toHaveBeenCalled();
+    });
+
+    test('does not render dialog when isOpen is false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+});

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -986,7 +986,28 @@ describe('elements/content-uploader/ContentUploader', () => {
                 expect(folderItem.status).toBe(STATUS_CANCELED);
             });
 
-            test('handleUploadsManagerCancelAll should cancel all in-progress and pending items', () => {
+            test('onCancelAll should open the confirmation modal instead of canceling directly', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                const inProgress = {
+                    name: 'a.pdf',
+                    extension: 'pdf',
+                    progress: 25,
+                    status: STATUS_IN_PROGRESS,
+                    file: { name: 'a.pdf' },
+                    api: { cancel: jest.fn() },
+                };
+                wrapper.setState({ items: [inProgress] });
+                const instance = wrapper.instance();
+                instance.itemsRef.current = [inProgress];
+
+                wrapper.find(UploadsManagerBP).prop('onCancelAll')();
+
+                expect(wrapper.state('isCancelAllModalOpen')).toBe(true);
+                expect(inProgress.status).toBe(STATUS_IN_PROGRESS);
+                expect(inProgress.api.cancel).not.toHaveBeenCalled();
+            });
+
+            test('handleCancelAllConfirm should cancel all in-progress and pending items and close modal', () => {
                 const wrapper = getWrapper({ enableModernizedUploads: true });
                 const inProgress = {
                     name: 'a.pdf',
@@ -1012,18 +1033,38 @@ describe('elements/content-uploader/ContentUploader', () => {
                     file: { name: 'c.pdf' },
                     api: { cancel: jest.fn() },
                 };
-                wrapper.setState({ items: [inProgress, pending, complete] });
+                wrapper.setState({ items: [inProgress, pending, complete], isCancelAllModalOpen: true });
                 const instance = wrapper.instance();
                 instance.itemsRef.current = [inProgress, pending, complete];
 
-                wrapper.find(UploadsManagerBP).prop('onCancelAll')();
+                instance.handleCancelAllConfirm();
 
+                expect(wrapper.state('isCancelAllModalOpen')).toBe(false);
                 expect(inProgress.status).toBe(STATUS_CANCELED);
                 expect(pending.status).toBe(STATUS_CANCELED);
                 expect(complete.status).toBe(STATUS_COMPLETE);
                 expect(inProgress.api.cancel).toHaveBeenCalled();
                 expect(pending.api.cancel).toHaveBeenCalled();
                 expect(complete.api.cancel).not.toHaveBeenCalled();
+            });
+
+            test('handleCancelAllDismiss should close the modal without canceling uploads', () => {
+                const wrapper = getWrapper({ enableModernizedUploads: true });
+                const inProgress = {
+                    name: 'a.pdf',
+                    status: STATUS_IN_PROGRESS,
+                    file: { name: 'a.pdf' },
+                    api: { cancel: jest.fn() },
+                };
+                wrapper.setState({ items: [inProgress], isCancelAllModalOpen: true });
+                const instance = wrapper.instance();
+                instance.itemsRef.current = [inProgress];
+
+                instance.handleCancelAllDismiss();
+
+                expect(wrapper.state('isCancelAllModalOpen')).toBe(false);
+                expect(inProgress.status).toBe(STATUS_IN_PROGRESS);
+                expect(inProgress.api.cancel).not.toHaveBeenCalled();
             });
 
             describe('updateViewAndCollection with canceled items', () => {

--- a/src/elements/content-uploader/messages.ts
+++ b/src/elements/content-uploader/messages.ts
@@ -1,28 +1,28 @@
 import { defineMessages } from 'react-intl';
 
 const messages = defineMessages({
-    cancelAllUploadsModalHeading: {
-        id: 'be.contentUploader.cancelAllUploadsModalHeading',
+    heading: {
+        id: 'be.contentUploader.cancelAllUploads.heading',
         defaultMessage: 'Cancel all uploads?',
         description: 'Heading for the cancel all uploads confirmation modal',
     },
-    cancelAllUploadsModalContent: {
-        id: 'be.contentUploader.cancelAllUploadsModalContent',
+    body: {
+        id: 'be.contentUploader.cancelAllUploads.body',
         defaultMessage: 'Files that are still uploading will be canceled. Completed uploads will not be affected.',
         description: 'Body content for the cancel all uploads confirmation modal',
     },
-    cancelAllUploadsConfirmButton: {
-        id: 'be.contentUploader.cancelAllUploadsConfirmButton',
+    confirmButton: {
+        id: 'be.contentUploader.cancelAllUploads.confirmButton',
         defaultMessage: 'Cancel All',
         description: 'Confirm button for the cancel all uploads modal',
     },
-    cancelAllUploadsKeepButton: {
-        id: 'be.contentUploader.cancelAllUploadsKeepButton',
+    keepUploadingButton: {
+        id: 'be.contentUploader.cancelAllUploads.keepUploadingButton',
         defaultMessage: 'Keep Uploading',
         description: 'Dismiss button for the cancel all uploads modal',
     },
-    cancelAllUploadsCloseLabel: {
-        id: 'be.contentUploader.cancelAllUploadsCloseLabel',
+    closeLabel: {
+        id: 'be.contentUploader.cancelAllUploads.closeLabel',
         defaultMessage: 'Close cancel uploads dialog',
         description: 'Aria label for the close button on the cancel all uploads modal',
     },

--- a/src/elements/content-uploader/messages.ts
+++ b/src/elements/content-uploader/messages.ts
@@ -1,0 +1,31 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+    cancelAllUploadsModalHeading: {
+        id: 'be.contentUploader.cancelAllUploadsModalHeading',
+        defaultMessage: 'Cancel all uploads?',
+        description: 'Heading for the cancel all uploads confirmation modal',
+    },
+    cancelAllUploadsModalContent: {
+        id: 'be.contentUploader.cancelAllUploadsModalContent',
+        defaultMessage: 'Files that are still uploading will be canceled. Completed uploads will not be affected.',
+        description: 'Body content for the cancel all uploads confirmation modal',
+    },
+    cancelAllUploadsConfirmButton: {
+        id: 'be.contentUploader.cancelAllUploadsConfirmButton',
+        defaultMessage: 'Cancel All',
+        description: 'Confirm button for the cancel all uploads modal',
+    },
+    cancelAllUploadsKeepButton: {
+        id: 'be.contentUploader.cancelAllUploadsKeepButton',
+        defaultMessage: 'Keep Uploading',
+        description: 'Dismiss button for the cancel all uploads modal',
+    },
+    cancelAllUploadsCloseLabel: {
+        id: 'be.contentUploader.cancelAllUploadsCloseLabel',
+        defaultMessage: 'Close cancel uploads dialog',
+        description: 'Aria label for the close button on the cancel all uploads modal',
+    },
+});
+
+export default messages;


### PR DESCRIPTION
**4/5 PR in the queue:**

1. https://github.com/box/box-ui-elements/pull/4573
2. https://github.com/box/box-ui-elements/pull/4577
3. https://github.com/box/box-ui-elements/pull/4578
4. 👉 https://github.com/box/box-ui-elements/pull/4579
5. https://github.com/box/box-ui-elements/pull/4580

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a confirmation modal when canceling all uploads, allowing users to confirm the action or keep uploading
  * Full internationalization support for the confirmation dialog

* **Tests**
  * Added comprehensive test coverage for the confirmation modal and upload cancellation workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->