### PR TITLE
feat(content-sharing): Get correct pending collab response

### DIFF
--- a/src/elements/content-sharing/utils/convertCollaborators.ts
+++ b/src/elements/content-sharing/utils/convertCollaborators.ts
@@ -36,7 +36,7 @@ export const convertCollab = ({
     let collabEmail = inviteEmail;
     let collabName = inviteEmail;
 
-    if (accessibleBy?.name) {
+    if (accessibleBy?.id) {
         const { id: userId, login, name } = accessibleBy;
 
         collabId = userId;
@@ -44,7 +44,7 @@ export const convertCollab = ({
         collabName = name;
     }
 
-    if (!collabName) {
+    if (!collabName && !collabEmail) {
         return null;
     }
 
@@ -61,7 +61,7 @@ export const convertCollab = ({
         isCurrentUser: collabId != null && collabId === currentUserId,
         isExternal,
         isPending: status === STATUS_PENDING,
-        name: collabName,
+        name: collabName || collabEmail,
         role: API_TO_USM_COLLAB_ROLE_MAP[role],
         ...(collabId != null ? { userId: `${collabId}` } : {}),
     };


### PR DESCRIPTION
After the backend public API response changed for registered pending collaborators, we need this PR to get the updated response to return the correct collabs.
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collaborator information display to better handle missing names by using email addresses as fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->