### PR TITLE
feat(activity-feed-v2): improve comment posting UX

### DIFF
--- a/src/components/form-elements/draft-js-mention-selector/__tests__/utils.test.js
+++ b/src/components/form-elements/draft-js-mention-selector/__tests__/utils.test.js
@@ -236,5 +236,19 @@ describe('components/form-elements/draft-js-mention-selector/utils', () => {
 
             expect(getFormattedCommentText(dummyEditorState)).toEqual(expected);
         });
+
+        test.each`
+            input                | expected
+            ${'   hello   '}     | ${'hello'}
+            ${'\n\nhello\n\n'}   | ${'hello'}
+            ${'\thello\t'}       | ${'hello'}
+            ${'  \t\nhello\n '}  | ${'hello'}
+            ${'hello world'}     | ${'hello world'}
+            ${'  hello  world '} | ${'hello  world'}
+        `('should trim leading and trailing whitespace from "$input"', ({ input, expected }) => {
+            const dummyEditorState = EditorState.createWithContent(ContentState.createFromText(input));
+
+            expect(getFormattedCommentText(dummyEditorState)).toEqual({ text: expected, hasMention: false });
+        });
     });
 });

--- a/src/components/form-elements/draft-js-mention-selector/utils.js
+++ b/src/components/form-elements/draft-js-mention-selector/utils.js
@@ -163,7 +163,7 @@ function getFormattedCommentText(editorState: EditorState): { hasMention: boolea
 
     // Concatenate the array of block strings with newlines
     // (Each block represents a paragraph)
-    return { text: resultStringArr.join('\n'), hasMention };
+    return { text: resultStringArr.join('\n').trim(), hasMention };
 }
 
 export {

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
@@ -53,4 +53,8 @@
     button svg {
         pointer-events: auto;
     }
+
+    &-mentionEmpty {
+        padding: var(--bp-space-030) var(--bp-space-040);
+    }
 }

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
@@ -20,6 +20,11 @@
         padding-left: var(--bp-space-040);
     }
 
+    &-editor {
+        padding-right: var(--bp-space-040);
+        padding-left: var(--bp-space-040);
+    }
+
     // Forms: BUIE sets width, padding, border, box-shadow, border-radius on
     // contenteditable and inputs via _forms.scss inside .bcs scope.
     div[contenteditable='true'],

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
@@ -20,7 +20,7 @@
         padding-left: var(--bp-space-040);
     }
 
-    &-editor {
+    &-editor > div {
         padding-right: var(--bp-space-040);
         padding-left: var(--bp-space-040);
     }

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -351,11 +351,13 @@ const ActivityFeedV2 = ({
                         </ActivityFeed.List>
                     </div>
                 )}
-                <ActivityFeed.Editor
-                    disableComponent={isDisabled || !currentUser}
-                    onPost={handleCommentPost}
-                    userSelectorProps={userSelectorProps}
-                />
+                <div className="bcs-NewActivityFeed-editor">
+                    <ActivityFeed.Editor
+                        disableComponent={isDisabled || !currentUser}
+                        onPost={handleCommentPost}
+                        userSelectorProps={userSelectorProps}
+                    />
+                </div>
             </ActivityFeed.Root>
             <TaskModal
                 editMode={editingTask ? TASK_EDIT_MODE_EDIT : undefined}

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -260,17 +260,22 @@ const ActivityFeedV2 = ({
         }
     }, [activeFeedEntryId, filteredItems, scrollHandle]);
 
-    // Scroll only to items added since the post snapshot, so a concurrent push from
-    // another user doesn't hijack the viewport.
+    // Scroll only to comments/annotations the current user authored after the post
+    // snapshot, so a concurrent push from another user doesn't hijack the viewport.
     React.useEffect(() => {
         const knownIds = knownIdsBeforePostRef.current;
-        if (!knownIds || !scrollHandle) return;
-        const newItem = filteredItems.find(item => !knownIds.has(item.id));
+        if (!knownIds || !scrollHandle || !currentUserId) return;
+        const newItem = filteredItems.find(item => {
+            if (knownIds.has(item.id)) return false;
+            if (item.type !== 'comment' && item.type !== 'annotation') return false;
+            const author = item.messages[0]?.author;
+            return author ? String(author.id) === currentUserId : false;
+        });
         if (!newItem) return;
         if (scrollHandle.scrollTo(newItem.id)) {
             knownIdsBeforePostRef.current = null;
         }
-    }, [filteredItems, scrollHandle]);
+    }, [currentUserId, filteredItems, scrollHandle]);
 
     const handleCommentPost = React.useCallback(
         async (content: unknown) => {

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -8,14 +8,14 @@
 
 import * as React from 'react';
 import noop from 'lodash/noop';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { ActivityFeed, useActivityFeedScroll } from '@box/activity-feed';
-import { serializeMentionMarkup } from '@box/threaded-annotations';
 
 import TaskModal from '../TaskModal';
 
 import FeedItemRow from './FeedItemRow';
+import { serializeEditorContent } from './helpers';
 import { transformFeedItem } from './transformers';
 
 import type { ActivityFeedV2Props, TransformedFeedItem, UserContact } from './types';
@@ -24,6 +24,7 @@ import type { TaskAssigneeCollection, TaskNew } from '../../../common/types/task
 import { TASK_COMPLETION_RULE_ALL, TASK_EDIT_MODE_EDIT, TASK_TYPE_APPROVAL } from '../../../constants';
 
 import commonMessages from '../../common/messages';
+import draftJsMentionSelectorMessages from '../../../components/form-elements/draft-js-mention-selector/messages';
 import messages from '../messages';
 
 import './ActivityFeedV2.scss';
@@ -68,14 +69,16 @@ const ActivityFeedV2 = ({
 
     const scrolledEntryIdRef = React.useRef<string | null>(null);
     const hasScrolledToEndRef = React.useRef(false);
+    const knownIdsBeforePostRef = React.useRef<Set<string> | null>(null);
 
     const fetchUsers = React.useCallback(
         async (inputValue: string): Promise<UserContact[]> => {
-            if (!getMentionAsync) {
+            const trimmed = inputValue.trim();
+            if (!trimmed || !getMentionAsync) {
                 return [];
             }
             try {
-                const entries = await getMentionAsync(inputValue);
+                const entries = await getMentionAsync(trimmed);
                 return entries.map((c: Record<string, unknown>) => ({
                     email: (c.email as string) ?? (c.login as string) ?? '',
                     id: Number(c.id) || 0,
@@ -114,10 +117,20 @@ const ActivityFeedV2 = ({
 
     const userSelectorProps = React.useMemo(
         () => ({
+            allowEmptyQuery: true,
             ariaRoleDescription: intl.formatMessage(messages.mentionUserSelectorRoleDescription),
             fetchAvatarUrls,
             fetchUsers,
             loadingAriaLabel: intl.formatMessage(messages.mentionUserSelectorLoading),
+            renderEmpty: (value: string) => (
+                <div className="bcs-NewActivityFeed-mentionEmpty">
+                    <FormattedMessage
+                        {...(value.trim()
+                            ? draftJsMentionSelectorMessages.noUsersFound
+                            : draftJsMentionSelectorMessages.startMention)}
+                    />
+                </div>
+            ),
         }),
         [fetchAvatarUrls, fetchUsers, intl],
     );
@@ -247,19 +260,33 @@ const ActivityFeedV2 = ({
         }
     }, [activeFeedEntryId, filteredItems, scrollHandle]);
 
+    // Scroll only to items added since the post snapshot, so a concurrent push from
+    // another user doesn't hijack the viewport.
+    React.useEffect(() => {
+        const knownIds = knownIdsBeforePostRef.current;
+        if (!knownIds || !scrollHandle) return;
+        const newItem = filteredItems.find(item => !knownIds.has(item.id));
+        if (!newItem) return;
+        if (scrollHandle.scrollTo(newItem.id)) {
+            knownIdsBeforePostRef.current = null;
+        }
+    }, [filteredItems, scrollHandle]);
+
     const handleCommentPost = React.useCallback(
         async (content: unknown) => {
             if (!onCommentCreate) return;
-            let serialized;
+            const serialized = serializeEditorContent(content);
+            if (!serialized || !serialized.text) return;
             try {
-                serialized = serializeMentionMarkup(content as Parameters<typeof serializeMentionMarkup>[0]);
-            } catch {
-                return;
+                const snapshot = new Set(filteredItems.map(item => item.id));
+                await onCommentCreate(serialized.text, serialized.hasMention);
+                knownIdsBeforePostRef.current = snapshot;
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error('ActivityFeedV2: failed to post comment', error);
             }
-            if (!serialized.text.trim()) return;
-            onCommentCreate(serialized.text, serialized.hasMention);
         },
-        [onCommentCreate],
+        [filteredItems, onCommentCreate],
     );
 
     return (

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 
+import { ActivityFeed } from '@box/activity-feed';
+
 import { act, render, screen } from '../../../../test-utils/testing-library';
 import ActivityFeedV2 from '..';
 import type { ActivityFeedV2Props } from '../ActivityFeedV2';
+
+type EditorProps = React.ComponentProps<typeof ActivityFeed.Editor>;
+
+const mockSerializeMentionMarkup = jest.fn((doc: unknown) => ({ hasMention: false, text: JSON.stringify(doc) }));
 
 jest.mock('@box/threaded-annotations', () => ({
     AnnotationBadgeType: {
@@ -12,7 +18,7 @@ jest.mock('@box/threaded-annotations', () => ({
         Point: 'point',
         Region: 'region',
     },
-    serializeMentionMarkup: (doc: unknown) => ({ hasMention: false, text: JSON.stringify(doc) }),
+    serializeMentionMarkup: (doc: unknown) => mockSerializeMentionMarkup(doc),
 }));
 
 const mockScrollTo = jest.fn<boolean, [string]>(() => true);
@@ -20,6 +26,7 @@ const mockScrollTo = jest.fn<boolean, [string]>(() => true);
 type FilterOptionProps = { checked?: boolean; onCheckedChange?: (checked: boolean) => void };
 let lastShowResolvedOptionProps: FilterOptionProps = {};
 let lastMentionMeOptionProps: FilterOptionProps = {};
+let lastEditorProps: Partial<EditorProps> = {};
 
 jest.mock('@box/activity-feed', () => {
     const actual = jest.requireActual('@box/activity-feed');
@@ -37,7 +44,10 @@ jest.mock('@box/activity-feed', () => {
         <div data-testid={`threaded-annotation-${props.messages?.[0]?.id}`}>ThreadedAnnotation</div>
     );
     ActivityFeedList.Version = (props: { id: string }) => <div data-testid={`version-${props.id}`}>Version</div>;
-    const ActivityFeedEditor = () => <div data-testid="activity-feed-editor">Editor</div>;
+    const ActivityFeedEditor = (props: Partial<EditorProps>) => {
+        lastEditorProps = props;
+        return <div data-testid="activity-feed-editor">Editor</div>;
+    };
     const ActivityFeedHeader = ({ children }: { children: React.ReactNode }) => (
         <div data-testid="activity-feed-header">{children}</div>
     );
@@ -153,6 +163,11 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         mockScrollTo.mockReturnValue(true);
         lastShowResolvedOptionProps = {};
         lastMentionMeOptionProps = {};
+        lastEditorProps = {};
+        mockSerializeMentionMarkup.mockImplementation((doc: unknown) => ({
+            hasMention: false,
+            text: JSON.stringify(doc),
+        }));
     });
 
     afterEach(() => {
@@ -321,6 +336,129 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             />,
         );
         expect(screen.getByTestId('activity-feed-root')).toBeVisible();
+    });
+
+    describe('mention popover behavior', () => {
+        test('should pass allowEmptyQuery=true so the popover opens on @ before any character is typed', () => {
+            render(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[] as ActivityFeedV2Props['feedItems']} />);
+
+            expect(lastEditorProps.userSelectorProps?.allowEmptyQuery).toBe(true);
+        });
+
+        test('should skip the API call when fetchUsers is invoked with an empty query', async () => {
+            const getMentionAsync = jest.fn().mockResolvedValue([{ id: '1', name: 'foo' }]);
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[] as ActivityFeedV2Props['feedItems']}
+                    getMentionAsync={getMentionAsync}
+                />,
+            );
+
+            const result = await lastEditorProps.userSelectorProps?.fetchUsers?.('');
+
+            expect(getMentionAsync).not.toHaveBeenCalled();
+            expect(result).toEqual([]);
+        });
+
+        test('should skip the API call when fetchUsers is invoked with a whitespace-only query', async () => {
+            const getMentionAsync = jest.fn().mockResolvedValue([{ id: '1', name: 'foo' }]);
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[] as ActivityFeedV2Props['feedItems']}
+                    getMentionAsync={getMentionAsync}
+                />,
+            );
+
+            const result = await lastEditorProps.userSelectorProps?.fetchUsers?.('   ');
+
+            expect(getMentionAsync).not.toHaveBeenCalled();
+            expect(result).toEqual([]);
+        });
+
+        test('should call getMentionAsync with the trimmed value and shape results for a non-empty query', async () => {
+            const getMentionAsync = jest.fn().mockResolvedValue([
+                { email: 'a@b.com', id: '7', name: 'Alice' },
+                { id: '8', login: 'bob@b.com', name: 'Bob' },
+            ]);
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[] as ActivityFeedV2Props['feedItems']}
+                    getMentionAsync={getMentionAsync}
+                />,
+            );
+
+            const result = await lastEditorProps.userSelectorProps?.fetchUsers?.('  al  ');
+
+            expect(getMentionAsync).toHaveBeenCalledWith('al');
+            expect(result).toEqual([
+                { email: 'a@b.com', id: 7, name: 'Alice', value: '7' },
+                { email: 'bob@b.com', id: 8, name: 'Bob', value: '8' },
+            ]);
+        });
+
+        test('should render the V1-style start prompt via renderEmpty when value is empty', () => {
+            render(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[] as ActivityFeedV2Props['feedItems']} />);
+
+            const empty = lastEditorProps.userSelectorProps?.renderEmpty?.('');
+            render(<>{empty}</>);
+
+            expect(screen.getByText('Mention someone to notify them')).toBeVisible();
+        });
+
+        test('should render the V1-style start prompt via renderEmpty when value is whitespace-only', () => {
+            render(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[] as ActivityFeedV2Props['feedItems']} />);
+
+            const empty = lastEditorProps.userSelectorProps?.renderEmpty?.('   ');
+            render(<>{empty}</>);
+
+            expect(screen.getByText('Mention someone to notify them')).toBeVisible();
+        });
+
+        test('should render the no-users-found message via renderEmpty when value is non-empty', () => {
+            render(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[] as ActivityFeedV2Props['feedItems']} />);
+
+            const empty = lastEditorProps.userSelectorProps?.renderEmpty?.('xyz');
+            render(<>{empty}</>);
+
+            expect(screen.getByText('No users found')).toBeVisible();
+        });
+    });
+
+    describe('comment posting', () => {
+        test('should call onCommentCreate with trimmed text when the editor posts content', async () => {
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: true, text: '   hello world   ' });
+            const onCommentCreate = jest.fn();
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+
+            expect(onCommentCreate).toHaveBeenCalledWith('hello world', true);
+        });
+
+        test('should skip onCommentCreate when the trimmed text is empty', async () => {
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: '   \n\t   ' });
+            const onCommentCreate = jest.fn();
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+
+            expect(onCommentCreate).not.toHaveBeenCalled();
+        });
     });
 
     describe('filter controls', () => {
@@ -520,6 +658,167 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             expect(mockScrollTo).toHaveBeenCalledTimes(1);
             rerender(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[mockComment]} />);
             expect(mockScrollTo).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('scroll to user post', () => {
+        const newComment = { ...mockComment, id: 'new-comment', tagged_message: 'fresh post' };
+        const strangerComment = { ...mockComment, id: 'stranger-comment', tagged_message: 'unrelated' };
+
+        test('should scroll to the new item once feedItems updates after a post', async () => {
+            const onCommentCreate = jest.fn();
+            const { rerender } = render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+            mockScrollTo.mockClear();
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+            expect(onCommentCreate).toHaveBeenCalled();
+            expect(mockScrollTo).not.toHaveBeenCalled();
+
+            rerender(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            expect(mockScrollTo).toHaveBeenLastCalledWith('new-comment');
+        });
+
+        test('should not scroll when onCommentCreate rejects (post failed)', async () => {
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+            const onCommentCreate = jest.fn().mockRejectedValue(new Error('network error'));
+            const { rerender } = render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+            mockScrollTo.mockClear();
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+            rerender(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            expect(consoleError).toHaveBeenCalledWith('ActivityFeedV2: failed to post comment', expect.any(Error));
+            expect(mockScrollTo).not.toHaveBeenCalled();
+            consoleError.mockRestore();
+        });
+
+        test('should not scroll to a concurrent push that arrives without a user post', async () => {
+            const { rerender } = render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
+                />,
+            );
+            mockScrollTo.mockClear();
+
+            rerender(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment, strangerComment] as ActivityFeedV2Props['feedItems']}
+                />,
+            );
+
+            expect(mockScrollTo).not.toHaveBeenCalled();
+        });
+
+        test('should scroll to the user post even when a stranger post lands in the same render', async () => {
+            const onCommentCreate = jest.fn();
+            const { rerender } = render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+            mockScrollTo.mockClear();
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+            rerender(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment, newComment, strangerComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            expect(mockScrollTo).toHaveBeenCalledWith('new-comment');
+            expect(mockScrollTo).not.toHaveBeenCalledWith('stranger-comment');
+        });
+
+        test('should not scroll when serializeEditorContent yields no text', async () => {
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: '   ' });
+            const onCommentCreate = jest.fn();
+            const { rerender } = render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+            mockScrollTo.mockClear();
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+            rerender(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            expect(onCommentCreate).not.toHaveBeenCalled();
+            expect(mockScrollTo).not.toHaveBeenCalled();
+        });
+
+        test('should retry the scroll on the next feedItems change when scrollTo returns false', async () => {
+            mockScrollTo.mockReturnValue(false);
+            const onCommentCreate = jest.fn();
+            const { rerender } = render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+            mockScrollTo.mockClear();
+            mockScrollTo.mockReturnValue(false);
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+            rerender(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+            expect(mockScrollTo).toHaveBeenLastCalledWith('new-comment');
+
+            mockScrollTo.mockClear();
+            mockScrollTo.mockReturnValue(true);
+            rerender(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[mockComment, newComment, strangerComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            expect(mockScrollTo).toHaveBeenLastCalledWith('new-comment');
         });
     });
 });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -662,14 +662,25 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
     });
 
     describe('scroll to user post', () => {
-        const newComment = { ...mockComment, id: 'new-comment', tagged_message: 'fresh post' };
-        const strangerComment = { ...mockComment, id: 'stranger-comment', tagged_message: 'unrelated' };
+        const numericCurrentUser: ActivityFeedV2Props['currentUser'] = { id: '10', name: 'Current User', type: 'user' };
+        const userComment = {
+            ...mockComment,
+            created_by: { id: '10', name: 'Current User', type: 'user' },
+            id: 'new-comment',
+            tagged_message: 'fresh post',
+        };
+        const strangerComment = {
+            ...mockComment,
+            created_by: { id: '99', name: 'Stranger', type: 'user' },
+            id: 'stranger-comment',
+            tagged_message: 'unrelated',
+        };
 
-        test('should scroll to the new item once feedItems updates after a post', async () => {
+        test('should scroll to the new user item once feedItems updates after a post', async () => {
             const onCommentCreate = jest.fn();
             const { rerender } = render(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
+                    currentUser={numericCurrentUser}
                     feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
@@ -682,8 +693,8 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
 
             rerender(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
-                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment, userComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
             );
@@ -696,7 +707,7 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             const onCommentCreate = jest.fn().mockRejectedValue(new Error('network error'));
             const { rerender } = render(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
+                    currentUser={numericCurrentUser}
                     feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
@@ -706,8 +717,8 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             await lastEditorProps.onPost?.({ type: 'doc', content: [] });
             rerender(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
-                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment, userComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
             );
@@ -720,7 +731,7 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         test('should not scroll to a concurrent push that arrives without a user post', async () => {
             const { rerender } = render(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
+                    currentUser={numericCurrentUser}
                     feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
                 />,
             );
@@ -728,7 +739,7 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
 
             rerender(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
+                    currentUser={numericCurrentUser}
                     feedItems={[mockComment, strangerComment] as ActivityFeedV2Props['feedItems']}
                 />,
             );
@@ -736,11 +747,11 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             expect(mockScrollTo).not.toHaveBeenCalled();
         });
 
-        test('should scroll to the user post even when a stranger post lands in the same render', async () => {
+        test('should scroll past a stranger insert and target the user-authored item only', async () => {
             const onCommentCreate = jest.fn();
             const { rerender } = render(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
+                    currentUser={numericCurrentUser}
                     feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
@@ -750,8 +761,8 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             await lastEditorProps.onPost?.({ type: 'doc', content: [] });
             rerender(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
-                    feedItems={[mockComment, newComment, strangerComment] as ActivityFeedV2Props['feedItems']}
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment, strangerComment, userComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
             );
@@ -760,12 +771,11 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             expect(mockScrollTo).not.toHaveBeenCalledWith('stranger-comment');
         });
 
-        test('should not scroll when serializeEditorContent yields no text', async () => {
-            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: '   ' });
+        test('should not scroll when only a stranger insert lands after a user post', async () => {
             const onCommentCreate = jest.fn();
             const { rerender } = render(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
+                    currentUser={numericCurrentUser}
                     feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
@@ -775,8 +785,32 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             await lastEditorProps.onPost?.({ type: 'doc', content: [] });
             rerender(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
-                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment, strangerComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+
+            expect(mockScrollTo).not.toHaveBeenCalled();
+        });
+
+        test('should not scroll when serializeEditorContent yields no text', async () => {
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: '   ' });
+            const onCommentCreate = jest.fn();
+            const { rerender } = render(
+                <ActivityFeedV2
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
+                    onCommentCreate={onCommentCreate}
+                />,
+            );
+            mockScrollTo.mockClear();
+
+            await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+            rerender(
+                <ActivityFeedV2
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment, userComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
             );
@@ -790,7 +824,7 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             const onCommentCreate = jest.fn();
             const { rerender } = render(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
+                    currentUser={numericCurrentUser}
                     feedItems={[mockComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
@@ -801,8 +835,8 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             await lastEditorProps.onPost?.({ type: 'doc', content: [] });
             rerender(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
-                    feedItems={[mockComment, newComment] as ActivityFeedV2Props['feedItems']}
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment, userComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
             );
@@ -812,8 +846,8 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             mockScrollTo.mockReturnValue(true);
             rerender(
                 <ActivityFeedV2
-                    currentUser={mockCurrentUser}
-                    feedItems={[mockComment, newComment, strangerComment] as ActivityFeedV2Props['feedItems']}
+                    currentUser={numericCurrentUser}
+                    feedItems={[mockComment, userComment, strangerComment] as ActivityFeedV2Props['feedItems']}
                     onCommentCreate={onCommentCreate}
                 />,
             );

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/helpers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/helpers.test.ts
@@ -43,6 +43,19 @@ describe('elements/content-sidebar/activity-feed-v2/helpers', () => {
             expect(mockedSerialize).toHaveBeenCalledWith(content);
         });
 
+        test.each`
+            input                       | expected
+            ${'   hello   '}            | ${'hello'}
+            ${'\n\nhello world\n\n'}    | ${'hello world'}
+            ${'\thello\t'}              | ${'hello'}
+            ${'  \t\nhello\n '}         | ${'hello'}
+            ${'   leading and inner  '} | ${'leading and inner'}
+        `('should trim leading and trailing whitespace from "$input"', ({ input, expected }) => {
+            mockedSerialize.mockReturnValue({ hasMention: true, text: input });
+
+            expect(serializeEditorContent({})).toEqual({ hasMention: true, text: expected });
+        });
+
         test('should log via console.error and return null when serialize throws', () => {
             const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
             mockedSerialize.mockImplementation(() => {

--- a/src/elements/content-sidebar/activity-feed-v2/helpers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/helpers.ts
@@ -13,7 +13,8 @@ type EditorContent = Parameters<typeof serializeMentionMarkup>[0];
 
 export const serializeEditorContent = (content: unknown): ReturnType<typeof serializeMentionMarkup> | null => {
     try {
-        return serializeMentionMarkup(content as EditorContent);
+        const serialized = serializeMentionMarkup(content as EditorContent);
+        return { ...serialized, text: serialized.text.trim() };
     } catch (error) {
         // eslint-disable-next-line no-console
         console.error('ActivityFeedV2: failed to serialize editor content', error);

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -147,6 +147,7 @@ class CommentForm extends React.Component<CommentFormProps, State> {
         const allowVideoTimestamps = isVideo && istimestampedCommentsEnabled;
         const timestampLabel = allowVideoTimestamps ? formatMessage(messages.commentTimestampLabel) : undefined;
         const { commentEditorState } = this.state;
+        const isPostDisabled = !commentEditorState?.getCurrentContent().getPlainText().trim();
         const inputContainerClassNames = classNames('bcs-CommentForm', className, {
             'bcs-is-open': isOpen,
         });
@@ -186,7 +187,7 @@ class CommentForm extends React.Component<CommentFormProps, State> {
                             </div>
                         )}
 
-                        {isOpen && <CommentFormControls onCancel={onCancel} />}
+                        {isOpen && <CommentFormControls isDisabled={isPostDisabled} onCancel={onCancel} />}
                     </Form>
                 </Media.Body>
             </Media>

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentForm.js
@@ -147,7 +147,7 @@ class CommentForm extends React.Component<CommentFormProps, State> {
         const allowVideoTimestamps = isVideo && istimestampedCommentsEnabled;
         const timestampLabel = allowVideoTimestamps ? formatMessage(messages.commentTimestampLabel) : undefined;
         const { commentEditorState } = this.state;
-        const isPostDisabled = !commentEditorState?.getCurrentContent().getPlainText().trim();
+        const isPostDisabled = !commentEditorState.getCurrentContent().getPlainText().trim();
         const inputContainerClassNames = classNames('bcs-CommentForm', className, {
             'bcs-is-open': isOpen,
         });

--- a/src/elements/content-sidebar/activity-feed/comment-form/CommentFormControls.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/CommentFormControls.js
@@ -13,15 +13,16 @@ import messages from './messages';
 import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
 
 type Props = {
+    isDisabled?: boolean,
     onCancel: Function,
 };
 
-const CommentInputControls = ({ onCancel }: Props): React.Node => (
+const CommentInputControls = ({ isDisabled, onCancel }: Props): React.Node => (
     <div className="bcs-CommentFormControls">
         <Button data-resin-target={ACTIVITY_TARGETS.APPROVAL_FORM_CANCEL} onClick={onCancel} type="button">
             <FormattedMessage {...messages.commentCancel} />
         </Button>
-        <PrimaryButton data-resin-target={ACTIVITY_TARGETS.APPROVAL_FORM_POST}>
+        <PrimaryButton data-resin-target={ACTIVITY_TARGETS.APPROVAL_FORM_POST} isDisabled={isDisabled}>
             <FormattedMessage {...messages.commentPost} />
         </PrimaryButton>
     </div>

--- a/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
@@ -191,6 +191,12 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
             expect(findControls(wrapper).prop('isDisabled')).toBe(true);
         });
 
+        test('should pass isDisabled=true to the controls when the editor has only whitespace', () => {
+            const wrapper = getWrapper({ isOpen: true, tagged_message: '   \n\t   ' });
+
+            expect(findControls(wrapper).prop('isDisabled')).toBe(true);
+        });
+
         test('should pass isDisabled=false to the controls when the editor has non-whitespace content', () => {
             const wrapper = getWrapper({ isOpen: true, tagged_message: 'hello' });
 

--- a/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
@@ -130,20 +130,32 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
         expect(wrapper.find('DraftJSMentionSelector').at(0).prop('placeholder')).toEqual('Your comment goes here');
     });
 
-    test('should not focus on textbox when shouldFocusOnOpen is false', () => {
-        const mockFocusFunc = jest.fn();
-        EditorState.moveFocusToEnd = mockFocusFunc;
+    describe('moveFocusToEnd', () => {
+        let originalMoveFocusToEnd;
 
-        getWrapperRTL();
-        expect(mockFocusFunc).not.toHaveBeenCalled();
-    });
+        beforeEach(() => {
+            originalMoveFocusToEnd = EditorState.moveFocusToEnd;
+        });
 
-    test('should focus on textbox when shouldFocusOnOpen is true', () => {
-        const mockFocusFunc = jest.fn();
-        EditorState.moveFocusToEnd = mockFocusFunc;
+        afterEach(() => {
+            EditorState.moveFocusToEnd = originalMoveFocusToEnd;
+        });
 
-        getWrapperRTL({ shouldFocusOnOpen: true });
-        expect(mockFocusFunc).toHaveBeenCalled();
+        test('should not focus on textbox when shouldFocusOnOpen is false', () => {
+            const mockFocusFunc = jest.fn();
+            EditorState.moveFocusToEnd = mockFocusFunc;
+
+            getWrapperRTL();
+            expect(mockFocusFunc).not.toHaveBeenCalled();
+        });
+
+        test('should focus on textbox when shouldFocusOnOpen is true', () => {
+            const mockFocusFunc = jest.fn(state => state);
+            EditorState.moveFocusToEnd = mockFocusFunc;
+
+            getWrapperRTL({ shouldFocusOnOpen: true });
+            expect(mockFocusFunc).toHaveBeenCalled();
+        });
     });
 
     test('should enable timestamp when file is a video and timestampedComments is enabled', () => {

--- a/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentForm.test.js
@@ -169,4 +169,20 @@ describe('elements/content-sidebar/ActivityFeed/comment-form/CommentForm', () =>
         });
         expect(wrapper.find('DraftJSMentionSelector').at(0).prop('timestampLabel')).toBeUndefined();
     });
+
+    describe('post button disabled state', () => {
+        const findControls = wrapper => wrapper.find('CommentInputControls');
+
+        test('should pass isDisabled=true to the controls when the editor is empty', () => {
+            const wrapper = getWrapper({ isOpen: true });
+
+            expect(findControls(wrapper).prop('isDisabled')).toBe(true);
+        });
+
+        test('should pass isDisabled=false to the controls when the editor has non-whitespace content', () => {
+            const wrapper = getWrapper({ isOpen: true, tagged_message: 'hello' });
+
+            expect(findControls(wrapper).prop('isDisabled')).toBe(false);
+        });
+    });
 });

--- a/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentFormControls.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment-form/__tests__/CommentFormControls.test.js
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import CommentFormControls from '../CommentFormControls';
+
+jest.mock('react-intl', () => ({
+    ...jest.requireActual('react-intl'),
+    FormattedMessage: ({ defaultMessage }) => <span>{defaultMessage}</span>,
+}));
+
+const renderControls = (props = {}) =>
+    render(
+        <IntlProvider locale="en">
+            <CommentFormControls onCancel={() => {}} {...props} />
+        </IntlProvider>,
+    );
+
+describe('elements/content-sidebar/ActivityFeed/comment-form/CommentFormControls', () => {
+    test('should render Post button enabled by default', () => {
+        renderControls();
+        const post = screen.getByRole('button', { name: 'Post' });
+        expect(post).not.toHaveAttribute('aria-disabled');
+        expect(post).not.toHaveClass('is-disabled');
+    });
+
+    test('should disable Post button when isDisabled is true', () => {
+        renderControls({ isDisabled: true });
+        const post = screen.getByRole('button', { name: 'Post' });
+        expect(post).toHaveAttribute('aria-disabled', 'true');
+        expect(post).toHaveClass('is-disabled');
+    });
+
+    test('should leave Cancel button enabled even when Post is disabled', () => {
+        renderControls({ isDisabled: true });
+        const cancel = screen.getByRole('button', { name: 'Cancel' });
+        expect(cancel).not.toHaveAttribute('aria-disabled');
+    });
+});

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/BaseComment.test.js
@@ -405,7 +405,7 @@ describe('elements/content-sidebar/ActivityFeed/comment/BaseComment', () => {
     });
 
     test('should focus on the edit CommentForm when it is opened', () => {
-        const mockFocusFunc = jest.fn();
+        const mockFocusFunc = jest.fn(editor => editor);
         EditorState.moveFocusToEnd = mockFocusFunc;
 
         getWrapper({ canEdit: true });

--- a/src/elements/content-sidebar/activity-feed/comment/__tests__/CreateReply.test.js
+++ b/src/elements/content-sidebar/activity-feed/comment/__tests__/CreateReply.test.js
@@ -130,7 +130,7 @@ describe('elements/content-sidebar/ActivityFeed/comment/CreateReply', () => {
     });
 
     test('reply form should be focused when opened', () => {
-        const mockFocusFunc = jest.fn();
+        const mockFocusFunc = jest.fn(editor => editor);
         EditorState.moveFocusToEnd = mockFocusFunc;
 
         getWrapper({ showReplyForm: true });


### PR DESCRIPTION
## Summary

Improves comment posting UX in the activity feed across V1 and V2.

**V2 mention popover** - Open the popover immediately on `@` (parity with box-annotations and V1) and show V1-style copy:
- "Mention someone to notify them" while the input is empty
- "No users found" once the user types
- No API round-trip on empty or whitespace-only queries

**V1 + V2 trim** - Strip leading and trailing whitespace from comment text before sending to the API. Inner whitespace is preserved.

**V1 disable post button** - The post button is now disabled when the editor is empty or whitespace-only, matching the form validation that already blocks submit. Visible feedback instead of a clickable button that does nothing.

**V2 auto-scroll on post** - After a successful post, scroll to the new item using a snapshot of feed item ids taken at post time, so a concurrent push from another user does not hijack the viewport. `onCommentCreate` is awaited so rejections are logged and do not arm the scroll for an unrelated update.

V1 mention selector is otherwise unchanged. The trim change to `getFormattedCommentText` is intentional and applies to all V1 comment surfaces.

## Test plan

- [ ] V2 sidebar: type `@`, popover opens with "Mention someone to notify them"; type a letter, popover shows matches or "No users found"
- [ ] V2 sidebar: post a comment with surrounding whitespace, confirm the saved comment is trimmed
- [ ] V2 sidebar: post a comment, confirm the feed scrolls to the new comment
- [ ] V2 sidebar: with another tab posting, confirm the local user is scrolled only to their own post (not the stranger post)
- [ ] V1 sidebar: open the comment form with an empty editor, confirm the Post button is visibly disabled
- [ ] V1 sidebar: type only spaces, confirm Post stays disabled; type a real character, confirm it enables
- [ ] V1 sidebar: post with surrounding whitespace, confirm the saved comment is trimmed
- [ ] Unit tests: `yarn test --watchAll=false --testPathPattern="(activity-feed-v2|comment-form|draft-js-mention-selector)"` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post button disables when comment input is empty.
  * Mention selector trims queries, supports empty queries, and shows improved empty-state messaging.
  * Editor container wrapped to apply editor-specific spacing.

* **Bug Fixes**
  * Serialized comment text is trimmed to remove leading/trailing whitespace before posting.

* **Style**
  * Added padding for editor and mention-empty activity feed states.

* **Tests**
  * Expanded coverage for mentions, trimming, disabled post state, posting, and scroll-to-new-post behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->