### PR TITLE
chore(i18n): sync en-US.properties with source messages

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1408,6 +1408,46 @@ boxui.presence.timeSinceLastModified = Edited {timeAgo}
 boxui.presence.timeSinceLastPreviewed = Previewed {timeAgo}
 # Description of the button to toggle the presence overlay with recent activity
 boxui.presence.toggleButtonLabel = Recent Activity
+# Text on the add filter button, on click generates another filter row
+boxui.queryBar.addFilterButtonText = + Add Filter
+# Text on the apply filter button, on click applies the filters
+boxui.queryBar.applyFiltersButtonText = Apply
+# Text on the columns button, on click opens a menu which allows users to choose which columns to render
+boxui.queryBar.columnsButtonText = Columns
+# Text on the columns button, if one or more columns have been hidden then it will display this text
+boxui.queryBar.columnsHiddenButtonText = {count, plural, one {1 Column Hidden} other {{count} Columns Hidden}}
+# Text on the connector dropdown, on click should open a dropdown showing either AND or OR
+boxui.queryBar.connectorAndText = AND
+# Text on the connector dropdown, on click should open a dropdown showing either AND or OR
+boxui.queryBar.connectorOrText = OR
+# Text on the label, the first condition will show WHERE
+boxui.queryBar.connectorWhereText = WHERE
+# Text on the filters button, on click opens a menu which allows users to filter through the files
+boxui.queryBar.filtersButtonText = Modify Filters
+# Header text shown in template dropdown
+boxui.queryBar.metadataViewTemplateListHeaderTitle = METADATA TEMPLATES
+# Text on the filters button, will display a number in front of the filters text indicating how many filters are applied
+boxui.queryBar.multipleFiltersButtonText = {number} Filters
+# Text on the filters dropdown that is displayed when no filters have been inserted
+boxui.queryBar.noFiltersAppliedText = No Filters Applied
+# Text on the templates button when templates have been loaded and there are no templates in the enterprise
+boxui.queryBar.noTemplatesText = No Templates Available
+# Placeholder text on the value button, on click should open a dropdown
+boxui.queryBar.selectValuePlaceholderText = Select value
+# Text on the templates button, on click opens a menu which allows users to select a metadata templates
+boxui.queryBar.templatesButtonText = Select Metadata
+# Text on the templates button when templates are still being loaded
+boxui.queryBar.templatesLoadingButtonText = Template Name
+# Text displayed on the Tooltip for an input field
+boxui.queryBar.tooltipEnterValueError = Please Enter a Value
+# Text displayed on the Tooltip for an input field of type float
+boxui.queryBar.tooltipInvalidFloatError = Please Enter a Decimal Number
+# Text displayed on the Tooltip for an input field of type number
+boxui.queryBar.tooltipInvalidNumberError = Please Enter an Integer
+# Text displayed on the Tooltip for a date field
+boxui.queryBar.tooltipSelectDateError = Please Select a Date
+# Text displayed on the Tooltip for a value field
+boxui.queryBar.tooltipSelectValueError = Please Select a Value
 # Icon title for a Box item of type bookmark or web-link
 boxui.quickSearch.bookmark = Bookmark
 # Icon title for a Box item of type folder that has collaborators
@@ -1658,6 +1698,12 @@ boxui.selectField.clearAll = Clear All
 boxui.selectField.noResults = No Results
 # Placeholder text shown in the search input
 boxui.selectField.searchPlaceholder = Search
+# Title for "Access Type" menu, in all capital letters
+boxui.share.accessType = ACCESS TYPE
+# Label for a shared link permission level
+boxui.share.canEdit = Can edit
+# Label for a shared link permission level
+boxui.share.canView = Can view
 # Text for Co-owner permission level in permissions table
 boxui.share.coownerLevelText = Co-owner
 # Text for permissions table Delete column
@@ -1668,6 +1714,10 @@ boxui.share.downloadTableHeaderText = Download
 boxui.share.editTableHeaderText = Edit
 # Text for Editor permission level in permissions table
 boxui.share.editorLevelText = Editor
+# Field label for shared link recipient list (title-case)
+boxui.share.emailSharedLink = Email Shared Link
+# Error message when user tries to send shared link as email without entering any recipients
+boxui.share.enterAtLeastOneEmail = Enter at least one valid email
 # Text for permissions table Get Link column
 boxui.share.getLinkTableHeaderText = Get Link
 # Label for a Group contact type
@@ -1686,10 +1736,70 @@ boxui.share.inviteFileEditorsLabel = Invite people to become editors of this fil
 boxui.share.inviteePermissionsFieldLabel = Invitee Permissions
 # Tooltip text a user can use to learn more about collaborator permission options
 boxui.share.inviteePermissionsLearnMore = Learn More
+# Label for "Message" text box to email the shared link (title-case)
+boxui.share.message = Message
 # Placeholder text for message section
 boxui.share.messageSelectorPlaceholder = Add a message
 # Text for permissions table Owner column
 boxui.share.ownerTableHeaderText = Owner
+# Description of a company shared link for a file with view and download permissions
+boxui.share.peopleInCompanyCanDownloadFile = Anyone in your company with the link can view and download this file.
+# Description of a company shared link for a folder with view and download permissions
+boxui.share.peopleInCompanyCanDownloadFolder = Anyone in your company with the link can view this folder and download its contents.
+# Description of a company shared link for a file with edit permissions (implies view and download permissions as well)
+boxui.share.peopleInCompanyCanEditFile = Anyone in your company with the link can edit and download this file.
+# Description of a company shared link for a file with view permissions
+boxui.share.peopleInCompanyCanViewFile = Anyone in your company with the link can view this file.
+# Description of a company shared link for a folder with view permissions
+boxui.share.peopleInCompanyCanViewFolder = Anyone in your company with the link can view this folder.
+# This string describes the access level of a file or folder, or who can see the item. {enterpriseName} is the company name
+boxui.share.peopleInEnterprise = People in {enterpriseName}
+# Description of a collaborator-only shared link for a file with no permissions
+boxui.share.peopleInItemCanAccessFile = Any collaborator on the file with the link can access this file.
+# Description of a collaborator-only shared link for a folder with no permissions
+boxui.share.peopleInItemCanAccessFolder = Any collaborator on the folder with the link can access this folder.
+# Description of a collaborator-only shared link for a file with download permissions
+boxui.share.peopleInItemCanDownloadFile = Any collaborator on this file with the link can download this file.
+# Description of a collaborator-only shared link for a folder with download permissions
+boxui.share.peopleInItemCanDownloadFolder = Any collaborator on this folder with the link can download this folder.
+# Description of a collaborator-only shared link for a file with edit permissions (implies view and download permissions as well)
+boxui.share.peopleInItemCanEditFile = Any collaborator on this file with the link can edit this file and download its contents.
+# Description of a collaborator-only shared link for a file with view and download permissions
+boxui.share.peopleInItemCanPreviewAndDownloadFile = Any collaborator on this file with the link can view this file and download its contents.
+# Description of a collaborator-only shared link for a folder with view and download permissions
+boxui.share.peopleInItemCanPreviewAndDownloadFolder = Any collaborator on this folder with the link can view this folder and download its contents.
+# Description of a collaborator-only shared link for a file with view permissions
+boxui.share.peopleInItemCanPreviewFile = Any collaborator on this file with the link can view this file.
+# Description of a collaborator-only shared link for a folder with view permissions
+boxui.share.peopleInItemCanPreviewFolder = Any collaborator on this folder with the link can view this folder.
+# Description of a specific company shared link for a file with view and download permissions. {company} is the company name
+boxui.share.peopleInSpecifiedCompanyCanDownloadFile = Anyone in {company} with the link can view and download this file.
+# Description of a specific company shared link for a folder with view and download permissions. {company} is the company name
+boxui.share.peopleInSpecifiedCompanyCanDownloadFolder = Anyone in {company} with the link can view this folder and download its contents.
+# Description of a specific company shared link for a file with edit permissions (implies view and download permissions as well). {company} is the company name
+boxui.share.peopleInSpecifiedCompanyCanEditFile = Anyone in {company} with the link can edit and download this file.
+# Description of an specific company shared link for a file with view permissions. {company} is the company name
+boxui.share.peopleInSpecifiedCompanyCanViewFile = Anyone in {company} with the link can view this file.
+# Description of an specific company shared link for a folder with view permissions. {company} is the company name
+boxui.share.peopleInSpecifiedCompanyCanViewFolder = Anyone in {company} with the link can view this folder.
+# Label for "People in this file" option
+boxui.share.peopleInThisFile = People in this file
+# Label for "People in this folder" option
+boxui.share.peopleInThisFolder = People in this folder
+# Label for "People in your company" option
+boxui.share.peopleInYourCompany = People in your company
+# Description of an open shared link for a file with view and download permissions
+boxui.share.peopleWithLinkCanDownloadFile = Anyone with the link can view and download this file.
+# Description of an open shared link for a folder with view and download permissions
+boxui.share.peopleWithLinkCanDownloadFolder = Anyone with the link can view this folder and download its contents.
+# Description of an open shared link for a file with edit permissions (implies view and download permissions as well)
+boxui.share.peopleWithLinkCanEditFile = Anyone with the link can edit and download this file.
+# Description of an open shared link for a file with view permissions
+boxui.share.peopleWithLinkCanViewFile = Anyone with the link can view this file.
+# Description of an open shared link for a folder with view permissions
+boxui.share.peopleWithLinkCanViewFolder = Anyone with the link can view this folder.
+# Label for "People with the link" option
+boxui.share.peopleWithTheLink = People with the link
 # Text for permissions table Permission Levels column
 boxui.share.permissionLevelsTableHeaderText = Permission Levels
 # Label for optional personal message to include when inviting collaborators to an item
@@ -1708,6 +1818,20 @@ boxui.share.referAFriendBadgeText = REFER
 boxui.share.referAFriendRewardCenterLinkText = Click Here
 # Text encouraging users to refer a friend to sign up for Box
 boxui.share.referAFriendText = Want a free month of Box? Refer your friend!
+# Label for option to remove shared link
+boxui.share.removeLink = Remove Link
+# Description for confirmation modal to remove a shared link
+boxui.share.removeLinkConfirmationDescription = This will permanently remove the shared link. If this item is embedded on other sites it will also become inaccessible. Any custom properties, settings and expirations will be removed as well. Do you want to continue?
+# Label for confirmation modal to remove a shared link (title-case)
+boxui.share.removeLinkConfirmationTitle = Remove Shared Link
+# Accessible label for button that loads share settings popup
+boxui.share.settingsButtonLabel = Open shared link settings popup
+# Tooltip describing when this shared link will expire. {expiration, date, long} is the formatted date
+boxui.share.sharedLinkExpirationTooltip = This link will expire on {expiration, date, long}
+# Label for field to copy shared link URL (title-case)
+boxui.share.sharedLinkLabel = Shared Link
+# Title for shared link modal (title-case)
+boxui.share.sharedLinkModalTitle = Shared Link for {itemName}
 # Text to show when the access level of people in company and user can view only
 boxui.share.sharedLinkSettings.accessLevel.inCompanyView = This content is available to anyone within your company with the link, and can be viewed.
 # Text to show when the access level of people in company and user can view and download
@@ -1770,6 +1894,26 @@ boxui.share.vanityURLEnableText = Publish content broadly with a custom, non-pri
 boxui.share.viewerLevelText = Viewer
 # Text for Viewer Uploader permission level in permissions table
 boxui.share.viewerUploaderLevelText = Viewer Uploader
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.downloadOnly = Download Only
+# Description of permissions granted when inviting a collab to this item
+boxui.shareMenu.editAndComment = Edit and Comment
+# Label for menu option to get shared link for item (title-case)
+boxui.shareMenu.getSharedLink = Get Shared Link
+# Label for disabled menu option when user does not have permission to get shared link for item
+boxui.shareMenu.insufficientPermissionsMenuOption = Insufficient sharing permissions. Please contact the folder owner.
+# Tooltip to show when user does not have permission to invite collaborators to item
+boxui.shareMenu.insufficientPermissionsTooltip = You have insufficient permissions to invite collaborators.
+# Label for menu option to invite collaborators to item
+boxui.shareMenu.inviteCollabs = Invite Collaborators
+# Tooltip to show when only owners and co-owners are allowed to invite collaborators to item
+boxui.shareMenu.ownerCoownerOnlyTooltip = You have insufficient permissions to invite collaborators. Only the owner and co-owners can invite collaborators.
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.shortcutOnly = Shortcut Only
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.viewAndDownload = View and Download
+# Description of permissions granted to users who have access to the shared link
+boxui.shareMenu.viewOnly = View Only
 # Aria-label for the dropdown menu that shows actions for selected items
 boxui.subHeader.bulkItemActionMenuAriaLabel = Bulk actions
 # Text for metadata button that will open the metadata side panel


### PR DESCRIPTION
Rebuild `i18n/en-US.properties` to pick up message keys that drifted out of sync with source `defineMessages` calls.

Affected namespaces: `queryBar`, `share`, `shareMenu` — introduced by the deprecation PRs (#4549, #4550, #4551) which moved message definitions but didn't regenerate the properties file.

## Steps taken

1. Ran `yarn build:i18n` on latest master
2. Committed the resulting diff (144 new lines in `en-US.properties`)