### PR TITLE
fix(activity-feed-v2): drop message from PUT when toggling comment status

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
@@ -104,7 +104,7 @@ const FeedItemRow = ({
             };
             const handleStatusChange = (status: FeedItemStatus) => (id: string) => {
                 if (isDisabled) return;
-                onCommentUpdate?.(id, item.originalText, status, false, permissions);
+                onCommentUpdate?.(id, undefined, status, false, permissions);
             };
             const handleEdit = (id: string, content: unknown) => {
                 if (isDisabled) return;

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
@@ -239,13 +239,7 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
 
             lastThreadedAnnotationProps.onResolve?.('comment-1');
 
-            expect(onCommentUpdate).toHaveBeenCalledWith(
-                'comment-1',
-                'Hello world',
-                'resolved',
-                false,
-                commentPermissions,
-            );
+            expect(onCommentUpdate).toHaveBeenCalledWith('comment-1', undefined, 'resolved', false, commentPermissions);
         });
 
         test('should call onCommentUpdate with open status when onUnresolve fires', () => {
@@ -254,7 +248,7 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
 
             lastThreadedAnnotationProps.onUnresolve?.('comment-1');
 
-            expect(onCommentUpdate).toHaveBeenCalledWith('comment-1', 'Hello world', 'open', false, commentPermissions);
+            expect(onCommentUpdate).toHaveBeenCalledWith('comment-1', undefined, 'open', false, commentPermissions);
         });
 
         test('should call onReplyCreate via onPost with serialized text', async () => {


### PR DESCRIPTION
## Summary

When the resolve/unresolve menu item fires in `activity-feed-v2`, `FeedItemRow.handleStatusChange` was passing `item.originalText` alongside `status` to `onCommentUpdate`, which produced a PUT body of `{status, message}` against `/2.0/undoc/comments/{id}`. The server responds with `resolution: null` whenever both fields are sent together, so `resolved_at` and `resolved_by` are dropped and the UI cannot render the "resolved by" line.

The fix: pass `undefined` for the text arg from the comment status handler so the PUT contains only `{status}`. The annotation handler in the same file already does this — this aligns the two paths.

Verified against HAR captures of the broken vs. working flow:

| | Body sent | Response |
|---|---|---|
| Before | `{"status":"resolved","message":"..."}` | `resolution: null` |
| After | `{"status":"resolved"}` | `resolution: { resolved_at, resolved_by: {...} }` |

## Test plan

- [x] Updated `FeedItemRow.test.tsx` — the two assertions for `onResolve`/`onUnresolve` now expect `undefined` for text instead of the existing comment text (the previous assertions were locking in the buggy behavior)
- [x] All 51 tests in the `FeedItemRow` suite pass
- [x] Manual verification: resolve a comment in the activity feed v2 sidebar and confirm the "resolved by <user>" line renders without a refetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where comment text was unnecessarily included when updating comment resolution status (resolve/unresolve).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->