### PR TITLE
fix(activity-feed-v2): use newest version number for multi-version activities

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
@@ -467,6 +467,12 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = transformVersionToProps(version as unknown as BoxItemVersion);
             expect(result.actionType).toBe('upload');
         });
+
+        test('should fall back to version_end when version_number is missing', () => {
+            const version = { ...mockVersion, version_end: 7, version_number: undefined, version_start: 1 };
+            const result = transformVersionToProps(version as unknown as BoxItemVersion);
+            expect(result.versionNumber).toBe(7);
+        });
     });
 
     describe('transformAppActivityToProps()', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -250,7 +250,7 @@ export const transformVersionToProps = (version: BoxItemVersion): VersionItemPro
         avatarUrl: user?.avatar_url,
         createdAt: toUnixMs(version.created_at),
         id: version.id,
-        versionNumber: parseInt(version.version_number, 10) || 0,
+        versionNumber: parseInt(version.version_number, 10) || version.version_end || 0,
     };
 };
 


### PR DESCRIPTION
## Summary
- When `/file_activities` returns a single `versions` activity spanning multiple versions, `Feed.js` only assigns `version_number` if `start === end`. For ranges, only `version_end` and `version_start` are populated.
- `transformVersionToProps` was producing `versionNumber: 0` in that case, causing `onVersionHistoryClick` to receive 0.
- Fall back to `version_end` (the newest version number in the range) when `version_number` is unset.

## Test plan
- [x] Added unit test covering the multi-version fallback in `transformers.test.ts`
- [x] `yarn test --watchAll=false --testPathPattern="activity-feed-v2/__tests__/transformers"` (62 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version number handling with enhanced fallback logic to ensure proper version identification when primary version data is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/box/box-ui-elements/pull/4600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->