### PR TITLE
fix(content-preview): forward annotator token; wire reply delete

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -1003,6 +1003,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
         this.preview.show(file.id, token, {
             ...previewOptions,
             ...omit(rest, Object.keys(previewOptions)),
+            annotatorToken: tokenOrTokenFunction,
         });
         if (advancedContentInsights) {
             this.preview.addListener('advanced_insights_report', onContentInsightsEventReport);

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1438,6 +1438,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                         onCommentDelete={this.deleteComment}
                         onCommentUpdate={this.updateComment}
                         onReplyCreate={this.createReply}
+                        onReplyDelete={this.deleteReply}
                         onReplyUpdate={({ id, onError, onSuccess, parentId, permissions, text }) =>
                             this.updateReply(id, parentId, text, permissions, onSuccess, onError)
                         }

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -51,6 +51,7 @@ const ActivityFeedV2 = ({
     onCommentDelete,
     onCommentUpdate,
     onReplyCreate,
+    onReplyDelete,
     onReplyUpdate,
     onShowOnlyMentionsMeChange,
     onShowResolvedChange,
@@ -339,6 +340,7 @@ const ActivityFeedV2 = ({
                                     onCommentDelete={onCommentDelete}
                                     onCommentUpdate={onCommentUpdate}
                                     onReplyCreate={onReplyCreate}
+                                    onReplyDelete={onReplyDelete}
                                     onReplyUpdate={onReplyUpdate}
                                     onTaskAssignmentUpdate={onTaskAssignmentUpdate}
                                     onTaskDelete={onTaskDelete}

--- a/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
@@ -12,10 +12,10 @@ import type { Annotation, AnnotationPermission } from '../../../common/types/ann
 import type { BoxCommentPermission, CommentFeedItemType, FeedItemStatus } from '../../../common/types/feed';
 import type { TaskCollabStatus, TaskNew } from '../../../common/types/tasks';
 
-import { dispatchReplyEdit, logEditError, serializeEditorContent } from './helpers';
+import { dispatchReplyDelete, dispatchReplyEdit, logEditError, serializeEditorContent } from './helpers';
 import { annotationTargetToBadge } from './transformers';
 
-import type { OnReplyUpdate, TransformedFeedItem, UserSelectorProps } from './types';
+import type { OnReplyDelete, OnReplyUpdate, TransformedFeedItem, UserSelectorProps } from './types';
 
 import {
     FEED_ITEM_TYPE_ANNOTATION,
@@ -51,6 +51,7 @@ type FeedItemRowProps = {
         onError?: (() => void) | null,
     ) => void;
     onReplyCreate?: (parentId: string, parentType: CommentFeedItemType, text: string) => void;
+    onReplyDelete?: OnReplyDelete;
     onReplyUpdate?: OnReplyUpdate;
     onTaskAssignmentUpdate?: (taskId: string, taskAssignmentId: string, status: TaskCollabStatus) => void;
     onTaskDelete?: (task: TaskNew) => void;
@@ -87,6 +88,7 @@ const FeedItemRow = ({
     onCommentDelete,
     onCommentUpdate,
     onReplyCreate,
+    onReplyDelete,
     onReplyUpdate,
     onTaskAssignmentUpdate,
     onTaskDelete,
@@ -100,7 +102,11 @@ const FeedItemRow = ({
             const { permissions } = item;
             const handleDelete = (id: string) => {
                 if (isDisabled) return;
-                onCommentDelete?.({ id, permissions });
+                if (id === item.id) {
+                    onCommentDelete?.({ id, permissions });
+                    return;
+                }
+                dispatchReplyDelete({ id, messages: item.messages, onReplyDelete, parentId: item.id });
             };
             const handleStatusChange = (status: FeedItemStatus) => (id: string) => {
                 if (isDisabled) return;
@@ -150,7 +156,11 @@ const FeedItemRow = ({
             const fileVersionId = item.annotation.file_version?.id;
             const handleDelete = (id: string) => {
                 if (isDisabled) return;
-                onAnnotationDelete?.({ id, permissions });
+                if (id === item.id) {
+                    onAnnotationDelete?.({ id, permissions });
+                    return;
+                }
+                dispatchReplyDelete({ id, messages: item.messages, onReplyDelete, parentId: item.id });
             };
             const handleStatusChange = (status: FeedItemStatus) => (id: string) => {
                 if (isDisabled) return;

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
@@ -5,7 +5,7 @@ import type { AnnotationBadgeTargetType, ThreadedAnnotationsPropsV2 } from '@box
 
 import { render, screen } from '../../../../test-utils/testing-library';
 import FeedItemRow from '../FeedItemRow';
-import { dispatchReplyEdit, logEditError, serializeEditorContent } from '../helpers';
+import { dispatchReplyDelete, dispatchReplyEdit, logEditError, serializeEditorContent } from '../helpers';
 import { annotationTargetToBadge } from '../transformers';
 
 import type { TaskNew } from '../../../../common/types/tasks';
@@ -41,6 +41,7 @@ jest.mock('@box/activity-feed', () => {
 });
 
 jest.mock('../helpers', () => ({
+    dispatchReplyDelete: jest.fn(),
     dispatchReplyEdit: jest.fn(),
     logEditError: jest.fn(),
     serializeEditorContent: jest.fn(),
@@ -52,6 +53,7 @@ jest.mock('../transformers', () => ({
 }));
 
 const mockedSerializeEditorContent = jest.mocked(serializeEditorContent);
+const mockedDispatchReplyDelete = jest.mocked(dispatchReplyDelete);
 const mockedDispatchReplyEdit = jest.mocked(dispatchReplyEdit);
 const mockedAnnotationTargetToBadge = jest.mocked(annotationTargetToBadge);
 
@@ -233,6 +235,29 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
             expect(onCommentDelete).toHaveBeenCalledWith({ id: 'comment-1', permissions: commentPermissions });
         });
 
+        test('should delegate onDelete of a reply id to dispatchReplyDelete with messages and parent id', () => {
+            const onCommentDelete = jest.fn();
+            const onReplyDelete = jest.fn();
+            render(
+                <FeedItemRow
+                    {...defaultProps}
+                    item={mockComment}
+                    onCommentDelete={onCommentDelete}
+                    onReplyDelete={onReplyDelete}
+                />,
+            );
+
+            lastThreadedAnnotationProps.onDelete?.('reply-1');
+
+            expect(mockedDispatchReplyDelete).toHaveBeenCalledWith({
+                id: 'reply-1',
+                messages: mockComment.messages,
+                onReplyDelete,
+                parentId: 'comment-1',
+            });
+            expect(onCommentDelete).not.toHaveBeenCalled();
+        });
+
         test('should call onCommentUpdate with resolved status when onResolve fires', () => {
             const onCommentUpdate = jest.fn();
             render(<FeedItemRow {...defaultProps} item={mockComment} onCommentUpdate={onCommentUpdate} />);
@@ -401,6 +426,29 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
             lastThreadedAnnotationProps.onThreadDelete?.();
 
             expect(onAnnotationDelete).toHaveBeenCalledWith({ id: 'annotation-1', permissions: annotationPermissions });
+        });
+
+        test('should delegate onDelete of a reply id to dispatchReplyDelete with messages and parent id', () => {
+            const onAnnotationDelete = jest.fn();
+            const onReplyDelete = jest.fn();
+            render(
+                <FeedItemRow
+                    {...defaultProps}
+                    item={mockAnnotation}
+                    onAnnotationDelete={onAnnotationDelete}
+                    onReplyDelete={onReplyDelete}
+                />,
+            );
+
+            lastThreadedAnnotationProps.onDelete?.('annotation-reply-1');
+
+            expect(mockedDispatchReplyDelete).toHaveBeenCalledWith({
+                id: 'annotation-reply-1',
+                messages: mockAnnotation.messages,
+                onReplyDelete,
+                parentId: 'annotation-1',
+            });
+            expect(onAnnotationDelete).not.toHaveBeenCalled();
         });
 
         test('should call onAnnotationStatusChange with resolved when onResolve fires', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/helpers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/helpers.test.ts
@@ -1,6 +1,12 @@
 import { serializeMentionMarkup } from '@box/threaded-annotations';
 
-import { dispatchReplyEdit, findMessagePermissions, logEditError, serializeEditorContent } from '../helpers';
+import {
+    dispatchReplyDelete,
+    dispatchReplyEdit,
+    findMessagePermissions,
+    logEditError,
+    serializeEditorContent,
+} from '../helpers';
 
 import type { TransformedCommentItem } from '../types';
 
@@ -127,6 +133,36 @@ describe('elements/content-sidebar/activity-feed-v2/helpers', () => {
             expect(() =>
                 dispatchReplyEdit({ id: 'reply-1', messages, parentId: 'root', text: 'edited' }),
             ).not.toThrow();
+        });
+    });
+
+    describe('dispatchReplyDelete()', () => {
+        test('should call onReplyDelete with parentId and snake_case reply permissions', () => {
+            const onReplyDelete = jest.fn();
+            dispatchReplyDelete({ id: 'reply-1', messages, onReplyDelete, parentId: 'root' });
+
+            expect(onReplyDelete).toHaveBeenCalledWith({
+                id: 'reply-1',
+                parentId: 'root',
+                permissions: { can_delete: true, can_edit: true, can_reply: false, can_resolve: false },
+            });
+        });
+
+        test('should log and skip the dispatch when reply permissions cannot be resolved', () => {
+            const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+            const onReplyDelete = jest.fn();
+
+            dispatchReplyDelete({ id: 'orphan-id', messages, onReplyDelete, parentId: 'root' });
+
+            expect(onReplyDelete).not.toHaveBeenCalled();
+            expect(consoleError).toHaveBeenCalledWith(
+                'ActivityFeedV2: no permissions found for reply "orphan-id" in thread "root"',
+            );
+            consoleError.mockRestore();
+        });
+
+        test('should not throw when onReplyDelete is not provided', () => {
+            expect(() => dispatchReplyDelete({ id: 'reply-1', messages, parentId: 'root' })).not.toThrow();
         });
     });
 });

--- a/src/elements/content-sidebar/activity-feed-v2/helpers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/helpers.ts
@@ -7,7 +7,7 @@ import { serializeMentionMarkup } from '@box/threaded-annotations';
 
 import type { BoxCommentPermission } from '../../../common/types/feed';
 
-import type { OnReplyUpdate, TransformedCommentItem } from './types';
+import type { OnReplyDelete, OnReplyUpdate, TransformedCommentItem } from './types';
 
 type EditorContent = Parameters<typeof serializeMentionMarkup>[0];
 
@@ -63,4 +63,24 @@ export const dispatchReplyEdit = ({
         return;
     }
     onReplyUpdate?.({ id, parentId, permissions, text });
+};
+
+export const dispatchReplyDelete = ({
+    id,
+    messages,
+    onReplyDelete,
+    parentId,
+}: {
+    id: string;
+    messages: TransformedCommentItem['messages'];
+    onReplyDelete?: OnReplyDelete;
+    parentId: string;
+}) => {
+    const permissions = findMessagePermissions(messages, id);
+    if (!permissions) {
+        // eslint-disable-next-line no-console
+        console.error(`ActivityFeedV2: no permissions found for reply "${id}" in thread "${parentId}"`);
+        return;
+    }
+    onReplyDelete?.({ id, parentId, permissions });
 };

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -28,6 +28,8 @@ export type UserSelectorProps = {
     loadingAriaLabel: string;
 };
 
+export type OnReplyDelete = (params: { id: string; parentId: string; permissions: BoxCommentPermission }) => void;
+
 export type OnReplyUpdate = (params: {
     id: string;
     onError?: () => void;
@@ -102,6 +104,7 @@ export type ActivityFeedV2Props = {
         onError?: (() => void) | null,
     ) => void;
     onReplyCreate?: (parentId: string, parentType: CommentFeedItemType, text: string) => void;
+    onReplyDelete?: OnReplyDelete;
     onReplyUpdate?: OnReplyUpdate;
     onShowOnlyMentionsMeChange?: (checked: boolean) => void;
     onShowResolvedChange?: (checked: boolean) => void;


### PR DESCRIPTION
## Summary

Two changes:

- **`fix(content-preview)`** - Forward `tokenOrTokenFunction` as `annotatorToken` in the options passed to `Preview.show()` so the annotator can authenticate. The assignment is placed after the rest spread so a caller-supplied `annotatorToken` in `rest` cannot override it.
- **`feat(activity-feed-v2)`** - Add an `OnReplyDelete` callback wired from `ActivitySidebar.deleteReply` through `ActivityFeedV2` to `FeedItemRow`. When the threaded `onDelete` callback fires for a reply id (anything other than the parent comment or annotation id), `FeedItemRow` routes to `onReplyDelete` instead of `onCommentDelete`/`onAnnotationDelete`. Reply permissions are resolved from `item.messages` via a new `dispatchReplyDelete` helper that mirrors the existing `dispatchReplyEdit`.

## Test plan

- [x] `yarn test --watchAll=false --testPathPattern="activity-feed-v2/__tests__"` (178 passed)
- [x] `yarn test --watchAll=false --testPathPattern="content-preview/__tests__/ContentPreview"` (149 passed)
- [x] Pre-push full test suite on changed files (758 passed across 20 suites)
- [ ] Manual: delete a reply on a comment thread and confirm the API call uses the reply id
- [ ] Manual: delete a reply on an annotation thread and confirm the API call uses the reply id
- [ ] Manual: open a preview with annotations enabled and confirm the annotator authenticates with the forwarded token


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reply deletion capability for threaded comments and annotations in the activity feed.
  * Enhanced content preview with improved authenticator token support for the Box Preview SDK integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->