### PR TITLE
feat(activity-feed-v2): request enhanced UAA activity types

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -37,6 +37,8 @@ import {
     FILE_ACTIVITY_TYPE_ANNOTATION,
     FILE_ACTIVITY_TYPE_APP_ACTIVITY,
     FILE_ACTIVITY_TYPE_COMMENT,
+    FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
+    FILE_ACTIVITY_TYPE_ENHANCED_COMMENT,
     FILE_ACTIVITY_TYPE_TASK,
     FILE_ACTIVITY_TYPE_VERSION,
     HTTP_STATUS_CODE_CONFLICT,
@@ -162,13 +164,17 @@ export const getParsedFileActivitiesResponse = (
                     if (taskItem.task_type) {
                         taskItem.task_type = taskItem.task_type.toUpperCase();
                     }
-                    // $FlowFixMe File Activities only returns a created_by user, Flow type fix is needed
                     taskItem.created_by = { target: taskItem.created_by };
 
                     return taskItem;
                 }
-                case FILE_ACTIVITY_TYPE_COMMENT: {
-                    const commentItem = { ...source[FILE_ACTIVITY_TYPE_COMMENT] };
+                case FILE_ACTIVITY_TYPE_COMMENT:
+                case FILE_ACTIVITY_TYPE_ENHANCED_COMMENT: {
+                    const rawCommentItem =
+                        item.activity_type === FILE_ACTIVITY_TYPE_ENHANCED_COMMENT
+                            ? source[FILE_ACTIVITY_TYPE_ENHANCED_COMMENT]
+                            : source[FILE_ACTIVITY_TYPE_COMMENT];
+                    const commentItem = { ...rawCommentItem };
 
                     if (commentItem.replies && commentItem.replies.length) {
                         const replies = parseReplies(commentItem.replies);
@@ -177,17 +183,25 @@ export const getParsedFileActivitiesResponse = (
                     }
 
                     commentItem.tagged_message = commentItem.tagged_message || commentItem.message || '';
+                    commentItem.type = FILE_ACTIVITY_TYPE_COMMENT;
 
                     return commentItem;
                 }
-                case FILE_ACTIVITY_TYPE_ANNOTATION: {
-                    const annotationItem = { ...source[FILE_ACTIVITY_TYPE_ANNOTATION] };
+                case FILE_ACTIVITY_TYPE_ANNOTATION:
+                case FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION: {
+                    const rawAnnotationItem =
+                        item.activity_type === FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION
+                            ? source[FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION]
+                            : source[FILE_ACTIVITY_TYPE_ANNOTATION];
+                    const annotationItem = { ...rawAnnotationItem };
 
                     if (annotationItem.replies && annotationItem.replies.length) {
                         const replies = parseReplies(annotationItem.replies);
 
                         annotationItem.replies = replies;
                     }
+
+                    annotationItem.type = FILE_ACTIVITY_TYPE_ANNOTATION;
 
                     return annotationItem;
                 }
@@ -554,6 +568,7 @@ class Feed extends Base {
             shouldShowTasks = true,
             shouldShowVersions = true,
             shouldUseUAA = false,
+            useEnhancedActivities = false,
         }: {
             shouldShowAnnotations?: boolean,
             shouldShowAppActivity?: boolean,
@@ -561,6 +576,7 @@ class Feed extends Base {
             shouldShowTasks?: boolean,
             shouldShowVersions?: boolean,
             shouldUseUAA?: boolean,
+            useEnhancedActivities?: boolean,
         } = {},
         logAPIParity?: Function,
     ): void {
@@ -597,12 +613,14 @@ class Feed extends Base {
 
         const annotationActivityType =
             shouldShowAnnotations && permissions[PERMISSION_CAN_VIEW_ANNOTATIONS]
-                ? [FILE_ACTIVITY_TYPE_ANNOTATION]
+                ? [useEnhancedActivities ? FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION : FILE_ACTIVITY_TYPE_ANNOTATION]
                 : [];
         const appActivityActivityType = shouldShowAppActivity ? [FILE_ACTIVITY_TYPE_APP_ACTIVITY] : [];
         const taskActivityType = shouldShowTasks ? [FILE_ACTIVITY_TYPE_TASK] : [];
         const versionsActivityType = shouldShowVersions ? [FILE_ACTIVITY_TYPE_VERSION] : [];
-        const commentActivityType = permissions[PERMISSION_CAN_COMMENT] ? [FILE_ACTIVITY_TYPE_COMMENT] : [];
+        const commentActivityType = permissions[PERMISSION_CAN_COMMENT]
+            ? [useEnhancedActivities ? FILE_ACTIVITY_TYPE_ENHANCED_COMMENT : FILE_ACTIVITY_TYPE_COMMENT]
+            : [];
         const filteredActivityTypes = [
             ...annotationActivityType,
             ...appActivityActivityType,

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -164,6 +164,7 @@ export const getParsedFileActivitiesResponse = (
                     if (taskItem.task_type) {
                         taskItem.task_type = taskItem.task_type.toUpperCase();
                     }
+                    // $FlowFixMe File Activities only returns a created_by user, Flow type fix is needed
                     taskItem.created_by = { target: taskItem.created_by };
 
                     return taskItem;
@@ -174,6 +175,9 @@ export const getParsedFileActivitiesResponse = (
                         item.activity_type === FILE_ACTIVITY_TYPE_ENHANCED_COMMENT
                             ? source[FILE_ACTIVITY_TYPE_ENHANCED_COMMENT]
                             : source[FILE_ACTIVITY_TYPE_COMMENT];
+                    if (!rawCommentItem) {
+                        return null;
+                    }
                     const commentItem = { ...rawCommentItem };
 
                     if (commentItem.replies && commentItem.replies.length) {
@@ -183,7 +187,8 @@ export const getParsedFileActivitiesResponse = (
                     }
 
                     commentItem.tagged_message = commentItem.tagged_message || commentItem.message || '';
-                    commentItem.type = FILE_ACTIVITY_TYPE_COMMENT;
+                    // enhanced_comment is a wire-only variant; downstream consumers see the legacy type
+                    commentItem.type = FEED_ITEM_TYPE_COMMENT;
 
                     return commentItem;
                 }
@@ -193,6 +198,9 @@ export const getParsedFileActivitiesResponse = (
                         item.activity_type === FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION
                             ? source[FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION]
                             : source[FILE_ACTIVITY_TYPE_ANNOTATION];
+                    if (!rawAnnotationItem) {
+                        return null;
+                    }
                     const annotationItem = { ...rawAnnotationItem };
 
                     if (annotationItem.replies && annotationItem.replies.length) {
@@ -201,7 +209,8 @@ export const getParsedFileActivitiesResponse = (
                         annotationItem.replies = replies;
                     }
 
-                    annotationItem.type = FILE_ACTIVITY_TYPE_ANNOTATION;
+                    // enhanced_annotation is a wire-only variant; downstream consumers see the legacy type
+                    annotationItem.type = FEED_ITEM_TYPE_ANNOTATION;
 
                     return annotationItem;
                 }

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -633,6 +633,32 @@ describe('api/Feed', () => {
                 done();
             });
         });
+
+        test('should request enhanced_annotation and enhanced_comment when useEnhancedActivities is true', done => {
+            feed.feedItems(file, false, successCb, errorCb, errorCb, {
+                shouldUseUAA: true,
+                shouldShowAnnotations: true,
+                shouldShowAppActivity: true,
+                shouldShowTasks: true,
+                shouldShowReplies: true,
+                shouldShowVersions: true,
+                useEnhancedActivities: true,
+            });
+            setImmediate(() => {
+                expect(feed.fetchFileActivities).toBeCalledWith(
+                    file.permissions,
+                    [
+                        'enhanced_annotation',
+                        FILE_ACTIVITY_TYPE_APP_ACTIVITY,
+                        'enhanced_comment',
+                        FILE_ACTIVITY_TYPE_TASK,
+                        FILE_ACTIVITY_TYPE_VERSION,
+                    ],
+                    true,
+                );
+                done();
+            });
+        });
     });
 
     describe('fetchAnnotations()', () => {
@@ -2352,6 +2378,22 @@ describe('api/Feed', () => {
                     collaborators: { 42: mockUser },
                 },
             ]);
+        });
+
+        test('should parse enhanced_comment and enhanced_annotation activity types like their legacy counterparts', () => {
+            const enhancedComment = { ...threadedCommentsFormatted[0], id: 'enh-comment-1', message: 'enh' };
+            const enhancedAnnotation = { ...mockFormattedAnnotations[0], id: 'enh-annotation-1' };
+            const enhancedActivities = {
+                entries: [
+                    { activity_type: 'enhanced_comment', source: { enhanced_comment: enhancedComment } },
+                    { activity_type: 'enhanced_annotation', source: { enhanced_annotation: enhancedAnnotation } },
+                ],
+            };
+            const parsed = getParsedFileActivitiesResponse(enhancedActivities);
+            expect(parsed).toHaveLength(2);
+            const byId = Object.fromEntries(parsed.map(item => [item.id, item]));
+            expect(byId['enh-comment-1'].type).toBe(FILE_ACTIVITY_TYPE_COMMENT);
+            expect(byId['enh-annotation-1'].type).toBe(FILE_ACTIVITY_TYPE_ANNOTATION);
         });
 
         test('should return a parsed entries array when response is valid', () => {

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -12,6 +12,8 @@ import {
     FILE_ACTIVITY_TYPE_ANNOTATION,
     FILE_ACTIVITY_TYPE_APP_ACTIVITY,
     FILE_ACTIVITY_TYPE_COMMENT,
+    FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
+    FILE_ACTIVITY_TYPE_ENHANCED_COMMENT,
     FILE_ACTIVITY_TYPE_TASK,
     FILE_ACTIVITY_TYPE_VERSION,
     IS_ERROR_DISPLAYED,
@@ -636,21 +638,21 @@ describe('api/Feed', () => {
 
         test('should request enhanced_annotation and enhanced_comment when useEnhancedActivities is true', done => {
             feed.feedItems(file, false, successCb, errorCb, errorCb, {
-                shouldUseUAA: true,
                 shouldShowAnnotations: true,
                 shouldShowAppActivity: true,
-                shouldShowTasks: true,
                 shouldShowReplies: true,
+                shouldShowTasks: true,
                 shouldShowVersions: true,
+                shouldUseUAA: true,
                 useEnhancedActivities: true,
             });
             setImmediate(() => {
                 expect(feed.fetchFileActivities).toBeCalledWith(
                     file.permissions,
                     [
-                        'enhanced_annotation',
+                        FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
                         FILE_ACTIVITY_TYPE_APP_ACTIVITY,
-                        'enhanced_comment',
+                        FILE_ACTIVITY_TYPE_ENHANCED_COMMENT,
                         FILE_ACTIVITY_TYPE_TASK,
                         FILE_ACTIVITY_TYPE_VERSION,
                     ],
@@ -2380,20 +2382,51 @@ describe('api/Feed', () => {
             ]);
         });
 
-        test('should parse enhanced_comment and enhanced_annotation activity types like their legacy counterparts', () => {
-            const enhancedComment = { ...threadedCommentsFormatted[0], id: 'enh-comment-1', message: 'enh' };
-            const enhancedAnnotation = { ...mockFormattedAnnotations[0], id: 'enh-annotation-1' };
+        test('should remap enhanced_comment and enhanced_annotation activity types to the legacy type', () => {
+            const enhancedComment = {
+                ...threadedCommentsFormatted[0],
+                id: 'enh-comment-1',
+                message: 'enh',
+                type: FILE_ACTIVITY_TYPE_ENHANCED_COMMENT,
+            };
+            const enhancedAnnotation = {
+                ...mockFormattedAnnotations[0],
+                id: 'enh-annotation-1',
+                type: FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
+            };
             const enhancedActivities = {
                 entries: [
-                    { activity_type: 'enhanced_comment', source: { enhanced_comment: enhancedComment } },
-                    { activity_type: 'enhanced_annotation', source: { enhanced_annotation: enhancedAnnotation } },
+                    {
+                        activity_type: FILE_ACTIVITY_TYPE_ENHANCED_COMMENT,
+                        source: { [FILE_ACTIVITY_TYPE_ENHANCED_COMMENT]: enhancedComment },
+                    },
+                    {
+                        activity_type: FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
+                        source: { [FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION]: enhancedAnnotation },
+                    },
                 ],
             };
             const parsed = getParsedFileActivitiesResponse(enhancedActivities);
             expect(parsed).toHaveLength(2);
             const byId = Object.fromEntries(parsed.map(item => [item.id, item]));
-            expect(byId['enh-comment-1'].type).toBe(FILE_ACTIVITY_TYPE_COMMENT);
-            expect(byId['enh-annotation-1'].type).toBe(FILE_ACTIVITY_TYPE_ANNOTATION);
+            expect(byId['enh-comment-1'].type).toBe(FEED_ITEM_TYPE_COMMENT);
+            expect(byId['enh-annotation-1'].type).toBe(FEED_ITEM_TYPE_ANNOTATION);
+        });
+
+        test('should drop entries whose activity_type does not match a populated source key', () => {
+            const response = {
+                entries: [
+                    {
+                        activity_type: FILE_ACTIVITY_TYPE_ENHANCED_COMMENT,
+                        source: { [FILE_ACTIVITY_TYPE_COMMENT]: { ...threadedCommentsFormatted[0], id: 'mismatch-1' } },
+                    },
+                    {
+                        activity_type: FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
+                        source: {},
+                    },
+                ],
+            };
+            expect(getParsedFileActivitiesResponse(response)).toEqual([]);
         });
 
         test('should return a parsed entries array when response is valid', () => {

--- a/src/common/types/feed.js
+++ b/src/common/types/feed.js
@@ -15,6 +15,8 @@ import {
     FILE_ACTIVITY_TYPE_ANNOTATION,
     FILE_ACTIVITY_TYPE_APP_ACTIVITY,
     FILE_ACTIVITY_TYPE_COMMENT,
+    FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
+    FILE_ACTIVITY_TYPE_ENHANCED_COMMENT,
     FILE_ACTIVITY_TYPE_TASK,
     FILE_ACTIVITY_TYPE_VERSION,
 } from '../../constants';
@@ -178,6 +180,8 @@ type FileActivityTypes =
     | typeof FILE_ACTIVITY_TYPE_ANNOTATION
     | typeof FILE_ACTIVITY_TYPE_APP_ACTIVITY
     | typeof FILE_ACTIVITY_TYPE_COMMENT
+    | typeof FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION
+    | typeof FILE_ACTIVITY_TYPE_ENHANCED_COMMENT
     | typeof FILE_ACTIVITY_TYPE_TASK
     | typeof FILE_ACTIVITY_TYPE_VERSION;
 
@@ -190,6 +194,12 @@ type FileActivitySource =
       }
     | {
           comment: Comment,
+      }
+    | {
+          enhanced_annotation: Annotation,
+      }
+    | {
+          enhanced_comment: Comment,
       }
     | {
           task: TaskNew,

--- a/src/common/types/feed.js
+++ b/src/common/types/feed.js
@@ -176,6 +176,7 @@ type ActivityFilterItemType =
     | typeof COMMENT_STATUS_RESOLVED
     | typeof FEED_ITEM_TYPE_TASK;
 
+// FILE_ACTIVITY_TYPE_ENHANCED_* are wire-only; the parser remaps them to the legacy variants
 type FileActivityTypes =
     | typeof FILE_ACTIVITY_TYPE_ANNOTATION
     | typeof FILE_ACTIVITY_TYPE_APP_ACTIVITY

--- a/src/constants.js
+++ b/src/constants.js
@@ -537,6 +537,8 @@ export const ACTION_TYPE_TRASHED: 'trashed' = 'trashed';
 export const FILE_ACTIVITY_TYPE_ANNOTATION: 'annotation' = 'annotation';
 export const FILE_ACTIVITY_TYPE_APP_ACTIVITY: 'app_activity' = 'app_activity';
 export const FILE_ACTIVITY_TYPE_COMMENT: 'comment' = 'comment';
+export const FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION: 'enhanced_annotation' = 'enhanced_annotation';
+export const FILE_ACTIVITY_TYPE_ENHANCED_COMMENT: 'enhanced_comment' = 'enhanced_comment';
 export const FILE_ACTIVITY_TYPE_TASK: 'task' = 'task';
 export const FILE_ACTIVITY_TYPE_VERSION: 'versions' = 'versions';
 

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -805,6 +805,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                 shouldShowTasks,
                 shouldShowVersions,
                 shouldUseUAA,
+                useEnhancedActivities: isThreadedRepliesV2Enabled,
             },
             shouldUseUAA ? this.logAPIParity : undefined,
         );

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -846,7 +846,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
             );
         });
 
-        test('should set shouldShowReplies to true when threadedRepliesV2 is enabled even if hasReplies is false', () => {
+        test('should set shouldShowReplies and useEnhancedActivities to true when threadedRepliesV2 is enabled even if hasReplies is false', () => {
             wrapper = getWrapper({
                 features: {
                     activityFeed: {
@@ -868,12 +868,12 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsSuccessCallback,
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
-                expect.objectContaining({ shouldShowReplies: true }),
+                expect.objectContaining({ shouldShowReplies: true, useEnhancedActivities: true }),
                 undefined,
             );
         });
 
-        test('should set shouldShowReplies to true when both hasReplies and threadedRepliesV2 are enabled', () => {
+        test('should set shouldShowReplies and useEnhancedActivities to true when both hasReplies and threadedRepliesV2 are enabled', () => {
             wrapper = getWrapper({
                 features: {
                     activityFeed: {
@@ -895,7 +895,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsSuccessCallback,
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
-                expect.objectContaining({ shouldShowReplies: true }),
+                expect.objectContaining({ shouldShowReplies: true, useEnhancedActivities: true }),
                 undefined,
             );
         });

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -805,6 +805,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                         shouldShowTasks: expectedTasks,
                         shouldShowVersions: expectedVersions,
                         shouldUseUAA: expectedUseUAA,
+                        useEnhancedActivities: false,
                     },
                     expectedUseUAA ? instance.logAPIParity : undefined,
                 );
@@ -839,6 +840,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                     shouldShowTasks: true,
                     shouldShowVersions: true,
                     shouldUseUAA: false,
+                    useEnhancedActivities: false,
                 },
                 undefined,
             );


### PR DESCRIPTION
## Summary

- Send `enhanced_annotation` and `enhanced_comment` to the UAA `file_activities` endpoint when the threaded-replies v2 surface is active. The legacy `annotation` and `comment` types are filtered by the BFF, dropping frame/timestamp annotations and timestamped comments; the enhanced variants do not.
- Remap the enhanced source key in the response parser back to the legacy `FEED_ITEM_TYPE_ANNOTATION` / `FEED_ITEM_TYPE_COMMENT` shape so downstream consumers are unaware of the wire-only swap. Documented as an invariant on `FileActivityTypes` and at the two remap sites.
- Guard the parser against an entry whose `source` key does not match its `activity_type` (drop the entry instead of producing a phantom feed item from spreading undefined).

## Test plan

- [ ] Unit tests pass: `yarn test --watchAll=false --testPathPattern="(api/__tests__/Feed|content-sidebar/__tests__/ActivitySidebar)"`
- [ ] Flow: `yarn flow` reports no errors
- [ ] With threaded-replies v2 enabled and UAA enabled, the activity feed loads frame-target annotations and timestamped comments for a video file
- [ ] With threaded-replies v2 disabled, the activity feed continues to request the legacy `annotation` / `comment` activity types and renders identically to master
- [ ] A malformed UAA response (mismatched `activity_type` / `source` key, or missing `source`) does not produce blank rows in the feed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added support for enhanced file activity variants in the feed API for comments and annotations, automatically enabled via feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->