### PR TITLE
fix(content-sharing): address access level bug

### DIFF
--- a/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
+++ b/src/elements/content-sharing/utils/__mocks__/ContentSharingV2Mocks.js
@@ -25,7 +25,7 @@ export const MOCK_ITEM = {
 };
 
 export const MOCK_SHARED_LINK = {
-    access: 'open',
+    effective_access: 'open',
     download_url: 'https://example.com/shared_link=abc123',
     effective_permission: 'can_download',
     is_password_enabled: true,

--- a/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
+++ b/src/elements/content-sharing/utils/__tests__/convertItemResponse.test.ts
@@ -136,7 +136,7 @@ describe('convertItemResponse', () => {
                 allowed_invitee_roles: ['viewer'],
                 shared_link: {
                     ...MOCK_ITEM_API_RESPONSE_WITH_SHARED_LINK.shared_link,
-                    access: 'collaborators',
+                    effective_access: 'collaborators',
                 },
                 shared_link_features: { download_url: false, password: false, vanity_name: false },
                 permissions: {

--- a/src/elements/content-sharing/utils/convertItemResponse.ts
+++ b/src/elements/content-sharing/utils/convertItemResponse.ts
@@ -52,8 +52,8 @@ export const convertItemResponse = (itemApiData: ContentSharingItemAPIResponse):
     let sharedLink;
     if (shared_link) {
         const {
-            access,
             download_url: downloadUrl,
+            effective_access: access,
             effective_permission: permission,
             is_password_enabled: isPasswordEnabled,
             unshared_at: expirationTimestamp,


### PR DESCRIPTION
## What
The sharedLink.access is returning the previously selected access level, which in the case when the allowed access level is set, it may mismatch. The bug is introduced due to the returned sharedLink.access and the returned allowed_shared_link_access_levels mismatch.

## Fix
Leveraging the correctly returned sharedLink.effective_access to avoid the mismatch.


<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data for shared link access scenarios.

* **Refactor**
  * Improved internal handling of shared link access information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->