### PR TITLE
fix(activity-feed-v2): forward hasActiveFilters and harden UAA parser

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,6 +12,7 @@
 /src/api/                                   @box/ui-elements
 /src/api/box-edit/                          @box/ui-elements @box/partners
 /src/api/Feed.js                            @box/ui-elements @box/preview
+/src/api/__tests__/Feed.test.js             @box/ui-elements @box/preview
 /src/api/uploads/                           @box/ui-elements @box/create-communicate
 /src/components/                            @box/ui-elements
 /src/elements/                              @box/ui-elements

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -141,7 +141,11 @@ export const getParsedFileActivitiesResponse = (
 
             switch (item.activity_type) {
                 case FILE_ACTIVITY_TYPE_TASK: {
-                    const taskItem = { ...source[FILE_ACTIVITY_TYPE_TASK] };
+                    const rawTaskItem = source[FILE_ACTIVITY_TYPE_TASK];
+                    if (!rawTaskItem) {
+                        return null;
+                    }
+                    const taskItem = { ...rawTaskItem };
                     // UAA follows a lowercased enum naming convention, convert to uppercase to align with task api
                     if (taskItem.assigned_to?.entries) {
                         const assignedToEntries = taskItem.assigned_to.entries.map(entry => {
@@ -576,16 +580,16 @@ class Feed extends Base {
             shouldShowReplies = false,
             shouldShowTasks = true,
             shouldShowVersions = true,
+            shouldUseEnhancedActivities = false,
             shouldUseUAA = false,
-            useEnhancedActivities = false,
         }: {
             shouldShowAnnotations?: boolean,
             shouldShowAppActivity?: boolean,
             shouldShowReplies?: boolean,
             shouldShowTasks?: boolean,
             shouldShowVersions?: boolean,
+            shouldUseEnhancedActivities?: boolean,
             shouldUseUAA?: boolean,
-            useEnhancedActivities?: boolean,
         } = {},
         logAPIParity?: Function,
     ): void {
@@ -622,13 +626,13 @@ class Feed extends Base {
 
         const annotationActivityType =
             shouldShowAnnotations && permissions[PERMISSION_CAN_VIEW_ANNOTATIONS]
-                ? [useEnhancedActivities ? FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION : FILE_ACTIVITY_TYPE_ANNOTATION]
+                ? [shouldUseEnhancedActivities ? FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION : FILE_ACTIVITY_TYPE_ANNOTATION]
                 : [];
         const appActivityActivityType = shouldShowAppActivity ? [FILE_ACTIVITY_TYPE_APP_ACTIVITY] : [];
         const taskActivityType = shouldShowTasks ? [FILE_ACTIVITY_TYPE_TASK] : [];
         const versionsActivityType = shouldShowVersions ? [FILE_ACTIVITY_TYPE_VERSION] : [];
         const commentActivityType = permissions[PERMISSION_CAN_COMMENT]
-            ? [useEnhancedActivities ? FILE_ACTIVITY_TYPE_ENHANCED_COMMENT : FILE_ACTIVITY_TYPE_COMMENT]
+            ? [shouldUseEnhancedActivities ? FILE_ACTIVITY_TYPE_ENHANCED_COMMENT : FILE_ACTIVITY_TYPE_COMMENT]
             : [];
         const filteredActivityTypes = [
             ...annotationActivityType,

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -636,15 +636,15 @@ describe('api/Feed', () => {
             });
         });
 
-        test('should request enhanced_annotation and enhanced_comment when useEnhancedActivities is true', done => {
+        test('should request enhanced_annotation and enhanced_comment when shouldUseEnhancedActivities is true', done => {
             feed.feedItems(file, false, successCb, errorCb, errorCb, {
                 shouldShowAnnotations: true,
                 shouldShowAppActivity: true,
                 shouldShowReplies: true,
                 shouldShowTasks: true,
                 shouldShowVersions: true,
+                shouldUseEnhancedActivities: true,
                 shouldUseUAA: true,
-                useEnhancedActivities: true,
             });
             setImmediate(() => {
                 expect(feed.fetchFileActivities).toBeCalledWith(
@@ -2422,6 +2422,10 @@ describe('api/Feed', () => {
                     },
                     {
                         activity_type: FILE_ACTIVITY_TYPE_ENHANCED_ANNOTATION,
+                        source: {},
+                    },
+                    {
+                        activity_type: FILE_ACTIVITY_TYPE_TASK,
                         source: {},
                     },
                 ],

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -804,8 +804,8 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                 shouldShowReplies,
                 shouldShowTasks,
                 shouldShowVersions,
+                shouldUseEnhancedActivities: isThreadedRepliesV2Enabled,
                 shouldUseUAA,
-                useEnhancedActivities: isThreadedRepliesV2Enabled,
             },
             shouldUseUAA ? this.logAPIParity : undefined,
         );

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -804,8 +804,8 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                         shouldShowReplies: expectedReplies,
                         shouldShowTasks: expectedTasks,
                         shouldShowVersions: expectedVersions,
+                        shouldUseEnhancedActivities: false,
                         shouldUseUAA: expectedUseUAA,
-                        useEnhancedActivities: false,
                     },
                     expectedUseUAA ? instance.logAPIParity : undefined,
                 );
@@ -839,14 +839,14 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                     shouldShowReplies: true,
                     shouldShowTasks: true,
                     shouldShowVersions: true,
+                    shouldUseEnhancedActivities: false,
                     shouldUseUAA: false,
-                    useEnhancedActivities: false,
                 },
                 undefined,
             );
         });
 
-        test('should set shouldShowReplies and useEnhancedActivities to true when threadedRepliesV2 is enabled even if hasReplies is false', () => {
+        test('should set shouldShowReplies and shouldUseEnhancedActivities to true when threadedRepliesV2 is enabled even if hasReplies is false', () => {
             wrapper = getWrapper({
                 features: {
                     activityFeed: {
@@ -868,12 +868,12 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsSuccessCallback,
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
-                expect.objectContaining({ shouldShowReplies: true, useEnhancedActivities: true }),
+                expect.objectContaining({ shouldShowReplies: true, shouldUseEnhancedActivities: true }),
                 undefined,
             );
         });
 
-        test('should set shouldShowReplies and useEnhancedActivities to true when both hasReplies and threadedRepliesV2 are enabled', () => {
+        test('should set shouldShowReplies and shouldUseEnhancedActivities to true when both hasReplies and threadedRepliesV2 are enabled', () => {
             wrapper = getWrapper({
                 features: {
                     activityFeed: {
@@ -895,7 +895,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsSuccessCallback,
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
-                expect.objectContaining({ shouldShowReplies: true, useEnhancedActivities: true }),
+                expect.objectContaining({ shouldShowReplies: true, shouldUseEnhancedActivities: true }),
                 undefined,
             );
         });

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -300,7 +300,7 @@ const ActivityFeedV2 = ({
             <ActivityFeed.Root mentionContext={mentionContext} scrollTo={scrollHandle}>
                 <ActivityFeed.Header title={headerTitle}>
                     <ActivityFeed.Header.Actions>
-                        <ActivityFeed.Header.FilterMenu>
+                        <ActivityFeed.Header.FilterMenu hasActiveFilters={showOnlyMentionsMe || showResolved}>
                             <ActivityFeed.Header.ShowResolvedOption
                                 checked={showResolved}
                                 onCheckedChange={handleShowResolvedChange}

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -23,7 +23,9 @@ jest.mock('@box/threaded-annotations', () => ({
 
 const mockScrollTo = jest.fn<boolean, [string]>(() => true);
 
+type FilterMenuProps = { children?: React.ReactNode; hasActiveFilters?: boolean };
 type FilterOptionProps = { checked?: boolean; onCheckedChange?: (checked: boolean) => void };
+let lastFilterMenuProps: FilterMenuProps = {};
 let lastShowResolvedOptionProps: FilterOptionProps = {};
 let lastMentionMeOptionProps: FilterOptionProps = {};
 let lastEditorProps: Partial<EditorProps> = {};
@@ -52,7 +54,10 @@ jest.mock('@box/activity-feed', () => {
         <div data-testid="activity-feed-header">{children}</div>
     );
     ActivityFeedHeader.Actions = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
-    ActivityFeedHeader.FilterMenu = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+    ActivityFeedHeader.FilterMenu = (props: FilterMenuProps) => {
+        lastFilterMenuProps = props;
+        return <div data-testid="filter-menu">{props.children}</div>;
+    };
     ActivityFeedHeader.ShowResolvedOption = (props: FilterOptionProps) => {
         lastShowResolvedOptionProps = props;
         return <div data-testid="show-resolved-option">{String(props.checked)}</div>;
@@ -161,6 +166,7 @@ const feedItems = [
 describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
     beforeEach(() => {
         mockScrollTo.mockReturnValue(true);
+        lastFilterMenuProps = {};
         lastShowResolvedOptionProps = {};
         lastMentionMeOptionProps = {};
         lastEditorProps = {};
@@ -466,7 +472,28 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             render(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[] as ActivityFeedV2Props['feedItems']} />);
             expect(lastShowResolvedOptionProps.checked).toBe(false);
             expect(lastMentionMeOptionProps.checked).toBe(false);
+            expect(lastFilterMenuProps.hasActiveFilters).toBe(false);
         });
+
+        test.each`
+            showOnlyMentionsMe | showResolved | expected
+            ${true}            | ${false}     | ${true}
+            ${false}           | ${true}      | ${true}
+            ${true}            | ${true}      | ${true}
+        `(
+            'should set hasActiveFilters=$expected when showOnlyMentionsMe=$showOnlyMentionsMe and showResolved=$showResolved',
+            ({ showOnlyMentionsMe, showResolved, expected }) => {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        showOnlyMentionsMe={showOnlyMentionsMe}
+                        showResolved={showResolved}
+                    />,
+                );
+                expect(lastFilterMenuProps.hasActiveFilters).toBe(expected);
+            },
+        );
 
         test('should reflect the controlled showResolved prop in the filter menu', () => {
             render(


### PR DESCRIPTION
## Summary

- Forward `hasActiveFilters` to `ActivityFeed.Header.FilterMenu`,
  derived from `showOnlyMentionsMe || showResolved`, so the activity
  feed filter trigger renders its pressed state when a filter is
  applied.
- Rename `useEnhancedActivities` to `shouldUseEnhancedActivities` for
  naming consistency with `shouldUseUAA` and the `shouldShow*` options
  in the same `feedItems` options bag.
- Add a missing-source guard to the `FILE_ACTIVITY_TYPE_TASK` parser
  case so an entry whose source key is absent is dropped rather than
  producing a phantom feed item by spreading `undefined`. Matches the
  existing comment and annotation guards.
- Add `Feed.test.js` to `CODEOWNERS` so it is co-owned alongside
  `Feed.js`.

## Test plan

- [ ] Unit tests pass: `yarn test --watchAll=false --testPathPattern="(activity-feed-v2|api/__tests__/Feed|content-sidebar/__tests__/ActivitySidebar)"`
- [ ] Flow: `yarn flow` reports no errors
- [ ] With threaded-replies v2 enabled, applying "Mentions me" or
      "Show resolved" renders the filter trigger in its pressed state
- [ ] With threaded-replies v2 disabled, the filter trigger renders in
      the unpressed state regardless of filter selections
- [ ] A malformed UAA response missing the task source key drops the
      entry instead of producing a blank row in the feed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity feed parsing to handle missing task data gracefully

* **New Features**
  * Filter menu now displays a visual indicator when filters are actively applied (e.g., mentions or resolved items)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->