### PR TITLE
style(activity-feed-v2): truncate long author names in sidebar

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1412,7 +1412,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             return (
                 <div
                     aria-labelledby={label}
-                    className="bcs-content"
+                    className="bcs-content bcs-NewActivityFeedContent"
                     data-testid="bcs-content"
                     id={`${label}-content`}
                     role="tabpanel"

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
@@ -63,3 +63,8 @@
         padding: var(--bp-space-030) var(--bp-space-040);
     }
 }
+
+// Lets inner ellipsis truncation resolve against the sidebar width.
+.bcs-NewActivityFeedContent {
+    min-width: 0;
+}


### PR DESCRIPTION
## Summary

When a thread is resolved by a user with a long display name, the resolved-state row (and the author header above it) push the entire activity sidebar wider than its container, clipping the sidebar nav tabs and overflowing to the right.

`.bcs-content` is rendered as a flex item under `.bcs` with the default `min-width: auto`, which sizes it to its content's intrinsic width. A long unbreakable name lets that intrinsic width win over the sidebar's allotted width.

## Fix

Add a `bcs-NewActivityFeedContent` modifier on the V2-only `.bcs-content` wrapper, with `min-width: 0`. This lets the flex item shrink to its allotted size, so the inner ellipsis truncation in threaded-annotations resolves against the sidebar width.

## Test plan
- [ ] Open the Activity sidebar with a resolved thread whose resolver name is long (e.g. "Bartholomew Constantine Maximilian III Of Antarctica").
- [ ] Verify the sidebar stays at its allotted width and the nav tabs are not clipped.
- [ ] Verify the author name in the message header truncates with ellipsis.
- [ ] Verify the "<name> marked as resolved" line truncates with ellipsis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text truncation display in the activity feed sidebar to ensure long content renders correctly and truncates as expected within the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->