### PR TITLE
fix(activity-feed-v2): bump UAA reply_limit to 1000 for V2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,8 @@
 /src/api/box-edit/                          @box/ui-elements @box/partners
 /src/api/Feed.js                            @box/ui-elements @box/preview
 /src/api/__tests__/Feed.test.js             @box/ui-elements @box/preview
+/src/api/FileActivities.js                  @box/ui-elements @box/preview
+/src/api/__tests__/FileActivities.test.js   @box/ui-elements @box/preview
 /src/api/uploads/                           @box/ui-elements @box/create-communicate
 /src/components/                            @box/ui-elements
 /src/elements/                              @box/ui-elements

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -645,7 +645,12 @@ class Feed extends Base {
         const fileActivitiesPromise =
             // Only fetch when activity types are explicitly stated
             shouldUseUAA && filteredActivityTypes.length
-                ? this.fetchFileActivities(permissions, filteredActivityTypes, shouldShowReplies)
+                ? this.fetchFileActivities(
+                      permissions,
+                      filteredActivityTypes,
+                      shouldShowReplies,
+                      shouldUseEnhancedActivities,
+                  )
                 : Promise.resolve();
 
         const handleFeedItems = (feedItems: FeedItems) => {
@@ -816,6 +821,7 @@ class Feed extends Base {
         permissions: BoxItemPermission,
         activityTypes: FileActivityTypes[],
         shouldShowReplies?: boolean = false,
+        shouldUseEnhancedActivities?: boolean = false,
     ): Promise<Object> {
         this.fileActivitiesAPI = new FileActivitiesAPI(this.options);
         return new Promise(resolve => {
@@ -826,6 +832,7 @@ class Feed extends Base {
                 successCallback: resolve,
                 activityTypes,
                 shouldShowReplies,
+                shouldUseEnhancedActivities,
             });
         });
     }

--- a/src/api/FileActivities.js
+++ b/src/api/FileActivities.js
@@ -16,18 +16,20 @@ import type { BoxItemPermission } from '../common/types/core';
 import type { ElementsXhrError } from '../common/types/api';
 import type { FileActivity, FileActivityTypes } from '../common/types/feed';
 
-// We only show the latest reply in the UI
-const REPLY_LIMIT = 1;
+const V1_REPLY_LIMIT = 1;
+const V2_REPLY_LIMIT = 1000;
 
 const getFileActivityQueryParams = (
     fileID: string,
     activityTypes?: FileActivityTypes[] = [],
     shouldShowReplies?: boolean = false,
+    shouldUseEnhancedActivities?: boolean = false,
 ) => {
     const baseEndpoint = `/file_activities?file_id=${fileID}`;
     const hasActivityTypes = !!activityTypes && !!activityTypes.length;
     const enableReplies = shouldShowReplies ? 'true' : 'false';
-    const enabledRepliesQueryParam = `&enable_replies=${enableReplies}&reply_limit=${REPLY_LIMIT}`;
+    const replyLimit = shouldUseEnhancedActivities ? V2_REPLY_LIMIT : V1_REPLY_LIMIT;
+    const enabledRepliesQueryParam = `&enable_replies=${enableReplies}&reply_limit=${replyLimit}`;
     const activityTypeQueryParam = hasActivityTypes ? `&activity_types=${activityTypes.join()}` : '';
 
     return `${baseEndpoint}${activityTypeQueryParam}${enabledRepliesQueryParam}`;
@@ -42,8 +44,13 @@ class FileActivities extends Base {
      * @param {boolean} shouldShowReplies - optional. Specify if replies should be included in the response
      * @return {string} base url for files
      */
-    getFilteredUrl(id: string, activityTypes?: FileActivityTypes[], shouldShowReplies?: boolean): string {
-        return `${this.getBaseApiUrl()}${getFileActivityQueryParams(id, activityTypes, shouldShowReplies)}`;
+    getFilteredUrl(
+        id: string,
+        activityTypes?: FileActivityTypes[],
+        shouldShowReplies?: boolean,
+        shouldUseEnhancedActivities?: boolean,
+    ): string {
+        return `${this.getBaseApiUrl()}${getFileActivityQueryParams(id, activityTypes, shouldShowReplies, shouldUseEnhancedActivities)}`;
     }
 
     /**
@@ -65,6 +72,7 @@ class FileActivities extends Base {
         permissions,
         repliesCount,
         shouldShowReplies,
+        shouldUseEnhancedActivities,
         successCallback,
     }: {
         activityTypes: FileActivityTypes[],
@@ -73,6 +81,7 @@ class FileActivities extends Base {
         permissions: BoxItemPermission,
         repliesCount?: number,
         shouldShowReplies?: boolean,
+        shouldUseEnhancedActivities?: boolean,
         successCallback: (activity: FileActivity) => void,
     }): void {
         this.errorCode = ERROR_CODE_FETCH_ACTIVITY;
@@ -99,7 +108,7 @@ class FileActivities extends Base {
             requestData: {
                 ...(repliesCount ? { replies_count: repliesCount } : null),
             },
-            url: this.getFilteredUrl(fileID, activityTypes, shouldShowReplies),
+            url: this.getFilteredUrl(fileID, activityTypes, shouldShowReplies, shouldUseEnhancedActivities),
         });
     }
 }

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -630,6 +630,7 @@ describe('api/Feed', () => {
                         FILE_ACTIVITY_TYPE_VERSION,
                     ],
                     true,
+                    false,
                 );
                 expect(feed.fetchThreadedComments).toBeCalled();
                 done();
@@ -656,6 +657,7 @@ describe('api/Feed', () => {
                         FILE_ACTIVITY_TYPE_TASK,
                         FILE_ACTIVITY_TYPE_VERSION,
                     ],
+                    true,
                     true,
                 );
                 done();
@@ -903,6 +905,7 @@ describe('api/Feed', () => {
                     fileID: feed.file.id,
                     permissions,
                     shouldShowReplies: false,
+                    shouldUseEnhancedActivities: false,
                     successCallback: expect.any(Function),
                 });
                 expect(fileActivityItems).resolves.toEqual({ entries: mockFileActivities });

--- a/src/api/__tests__/FileActivities.test.js
+++ b/src/api/__tests__/FileActivities.test.js
@@ -44,6 +44,18 @@ describe('api/FileActivities', () => {
                 );
             },
         );
+
+        test('should use reply_limit=1000 when shouldUseEnhancedActivities is true (V2)', () => {
+            expect(fileActivities.getFilteredUrl('1', ['comment'], true, true)).toBe(
+                'https://api.box.com/2.0/file_activities?file_id=1&activity_types=comment&enable_replies=true&reply_limit=1000',
+            );
+        });
+
+        test('should use reply_limit=1 when shouldUseEnhancedActivities is false (V1)', () => {
+            expect(fileActivities.getFilteredUrl('1', ['comment'], true, false)).toBe(
+                'https://api.box.com/2.0/file_activities?file_id=1&activity_types=comment&enable_replies=true&reply_limit=1',
+            );
+        });
     });
 
     describe('getActivities()', () => {
@@ -69,8 +81,31 @@ describe('api/FileActivities', () => {
                 errorCallback,
                 requestData: {},
                 successCallback,
-                url:
-                    'https://api.box.com/2.0/file_activities?file_id=123&activity_types=comment,task&enable_replies=true&reply_limit=1',
+                url: 'https://api.box.com/2.0/file_activities?file_id=123&activity_types=comment,task&enable_replies=true&reply_limit=1',
+            });
+        });
+
+        test('should use reply_limit=1000 when shouldUseEnhancedActivities is true', () => {
+            const permissions = {
+                can_comment: true,
+            };
+
+            fileActivities.getActivities({
+                fileID: '123',
+                activityTypes: ['comment', 'task'],
+                permissions,
+                successCallback,
+                errorCallback,
+                shouldShowReplies: true,
+                shouldUseEnhancedActivities: true,
+            });
+
+            expect(fileActivities.get).toBeCalledWith({
+                id: '123',
+                errorCallback,
+                requestData: {},
+                successCallback,
+                url: 'https://api.box.com/2.0/file_activities?file_id=123&activity_types=comment,task&enable_replies=true&reply_limit=1000',
             });
         });
 


### PR DESCRIPTION
## Summary
- Bump UAA `/file_activities` `reply_limit` from `1` to `1000` for V2 (`shouldUseEnhancedActivities`) so threads return the full reply list instead of just the latest one.
- V1 keeps `reply_limit=1` since the legacy sidebar only renders the latest reply inline; paying for more would be wasted bandwidth and server work.
- Adds `FileActivities.js` and its test to `@box/preview` ownership in CODEOWNERS, matching `Feed.js`.

## Context
The two flags are independent: `activityFeed.uaaIntegration.enabled` gates the UAA endpoint and `activityFeed.threadedRepliesV2.enabled` (which sets `shouldUseEnhancedActivities`) gates V2 rendering. A user can be on UAA without V2, so the higher cap must be gated on the V2 signal rather than the UAA signal.

## Test plan
- [x] `yarn test --watchAll=false --testPathPattern="api/__tests__/(FileActivities|Feed)"` passes (152/152), including new tests for both V1 and V2 query string shapes.
- [ ] Verify in V2 sidebar that threads with multiple replies render the full reply list rather than just the latest one.
- [ ] Verify in V1+UAA that the request still includes `reply_limit=1`.
