### PR TITLE
feat(content-uploader): allow host app to reset upload items state

### DIFF
--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -233,6 +233,8 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      * @return {void}
      */
     componentWillUnmount() {
+        const { setClearItemsCallback } = this.props;
+        setClearItemsCallback?.(noop);
         this.cancel();
     }
 

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -110,6 +110,7 @@ export interface ContentUploaderProps {
     uploadHost: string;
     useUploadsManager?: boolean;
     enableModernizedUploads?: boolean;
+    setClearItemsCallback?: (callback: () => void) => void;
 }
 
 type State = {
@@ -213,6 +214,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      * @return {void}
      */
     componentDidMount() {
+        const { setClearItemsCallback } = this.props;
         this.rootElement = document.getElementById(this.id);
         this.appElement = this.rootElement;
         const { files, isPrepopulateFilesEnabled } = this.props;
@@ -220,6 +222,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         if (isPrepopulateFilesEnabled && files && files.length > 0) {
             this.addFilesToUploadQueue(files, this.upload);
         }
+        setClearItemsCallback?.(this.resetUploadsManagerItemsWhenUploadsComplete);
     }
 
     /**
@@ -1323,6 +1326,11 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      * @return {void}
      */
     checkClearUploadItems = () => {
+        const { enableModernizedUploads } = this.props;
+        if (enableModernizedUploads) {
+            return;
+        }
+
         this.resetItemsTimeout = setTimeout(
             this.resetUploadsManagerItemsWhenUploadsComplete,
             HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT,
@@ -1394,12 +1402,15 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      * @return {void}
      */
     resetUploadsManagerItemsWhenUploadsComplete = (): void => {
-        const { onCancel, useUploadsManager } = this.props;
+        const { onCancel, useUploadsManager, enableModernizedUploads } = this.props;
         const { isUploadsManagerExpanded, view } = this.state;
 
-        // Do not reset items when upload manger is expanded or there're uploads in progress
+        // Do not reset items when upload manger is expanded (for non-modernized uploader) or there're uploads in progress
         if (
-            (isUploadsManagerExpanded && useUploadsManager && !!this.itemsRef.current.length) ||
+            (isUploadsManagerExpanded &&
+                useUploadsManager &&
+                !!this.itemsRef.current.length &&
+                !enableModernizedUploads) ||
             view === VIEW_UPLOAD_IN_PROGRESS
         ) {
             return;

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -728,6 +728,175 @@ describe('elements/content-uploader/ContentUploader', () => {
             // Assert that addFilesToUploadQueue is not called when isPrepopulateFilesEnabled is false
             expect(instance.addFilesToUploadQueue).not.toHaveBeenCalled();
         });
+
+        test('calls setClearItemsCallback with the reset method when prop is provided', () => {
+            const setClearItemsCallback = jest.fn();
+            const wrapper = getWrapper({ setClearItemsCallback });
+            const instance = wrapper.instance();
+
+            instance.componentDidMount();
+
+            expect(setClearItemsCallback).toHaveBeenCalledWith(instance.resetUploadsManagerItemsWhenUploadsComplete);
+        });
+    });
+
+    describe('checkClearUploadItems()', () => {
+        const HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT = 8000;
+        let setTimeoutSpy;
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+            setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+        });
+
+        afterEach(() => {
+            setTimeoutSpy.mockRestore();
+            jest.useRealTimers();
+        });
+
+        test('does not schedule reset when enableModernizedUploads is true', () => {
+            const wrapper = getWrapper({ enableModernizedUploads: true });
+            const instance = wrapper.instance();
+
+            instance.checkClearUploadItems();
+
+            expect(setTimeoutSpy).not.toHaveBeenCalled();
+            expect(instance.resetItemsTimeout).toBeUndefined();
+        });
+
+        test('schedules reset via setTimeout when enableModernizedUploads is false', () => {
+            const wrapper = getWrapper({ enableModernizedUploads: false });
+            const instance = wrapper.instance();
+            const resetSpy = jest.spyOn(instance, 'resetUploadsManagerItemsWhenUploadsComplete');
+
+            instance.checkClearUploadItems();
+
+            expect(instance.resetItemsTimeout).toBeDefined();
+            expect(setTimeoutSpy).toHaveBeenCalledWith(
+                instance.resetUploadsManagerItemsWhenUploadsComplete,
+                HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT,
+            );
+
+            jest.runAllTimers();
+
+            expect(resetSpy).toHaveBeenCalled();
+        });
+
+        test('schedules reset via setTimeout when enableModernizedUploads is undefined', () => {
+            const wrapper = getWrapper();
+            const instance = wrapper.instance();
+
+            instance.checkClearUploadItems();
+
+            expect(instance.resetItemsTimeout).toBeDefined();
+            expect(setTimeoutSpy).toHaveBeenCalledWith(
+                instance.resetUploadsManagerItemsWhenUploadsComplete,
+                HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT,
+            );
+        });
+    });
+
+    describe('resetUploadsManagerItemsWhenUploadsComplete()', () => {
+        const createUploadItem = () => ({
+            api: {},
+            extension: '',
+            file: new File(['contents'], 'upload_file.txt', { type: 'text/plain' }),
+            name: 'upload_file.txt',
+            progress: 100,
+            size: 1000,
+            status: STATUS_COMPLETE,
+        });
+
+        const setupResetTest = ({
+            props = {},
+            isUploadsManagerExpanded = false,
+            view = VIEW_UPLOAD_SUCCESS,
+            items = [createUploadItem()],
+        } = {}) => {
+            const onCancel = jest.fn();
+            const wrapper = getWrapper({ onCancel, ...props });
+            const instance = wrapper.instance();
+
+            instance.itemsRef.current = items;
+            instance.itemIdsRef.current = { 'upload_file.txt': true };
+            wrapper.setState({ isUploadsManagerExpanded, view, items, itemIds: { 'upload_file.txt': true } });
+
+            return { wrapper, instance, onCancel, items };
+        };
+
+        test('clears items when manager is expanded with items present and enableModernizedUploads is true', () => {
+            const { wrapper, instance, onCancel, items } = setupResetTest({
+                props: { useUploadsManager: true, enableModernizedUploads: true },
+                isUploadsManagerExpanded: true,
+            });
+
+            instance.resetUploadsManagerItemsWhenUploadsComplete();
+
+            expect(onCancel).toHaveBeenCalledWith(items);
+            expect(instance.itemsRef.current).toEqual([]);
+            expect(instance.itemIdsRef.current).toEqual({});
+            expect(wrapper.state().items).toEqual([]);
+            expect(wrapper.state().itemIds).toEqual({});
+        });
+
+        test('does not clear items when manager is expanded with items present and enableModernizedUploads is false', () => {
+            const { wrapper, instance, onCancel, items } = setupResetTest({
+                props: { useUploadsManager: true, enableModernizedUploads: false },
+                isUploadsManagerExpanded: true,
+            });
+
+            instance.resetUploadsManagerItemsWhenUploadsComplete();
+
+            expect(onCancel).not.toHaveBeenCalled();
+            expect(instance.itemsRef.current).toEqual(items);
+            expect(wrapper.state().items).toEqual(items);
+        });
+
+        test.each([true, false])(
+            'does not clear items when view is VIEW_UPLOAD_IN_PROGRESS and enableModernizedUploads is %s',
+            enableModernizedUploads => {
+                const { wrapper, instance, onCancel, items } = setupResetTest({
+                    props: { useUploadsManager: true, enableModernizedUploads },
+                    isUploadsManagerExpanded: true,
+                    view: VIEW_UPLOAD_IN_PROGRESS,
+                });
+
+                instance.resetUploadsManagerItemsWhenUploadsComplete();
+
+                expect(onCancel).not.toHaveBeenCalled();
+                expect(instance.itemsRef.current).toEqual(items);
+                expect(wrapper.state().items).toEqual(items);
+            },
+        );
+
+        test.each([true, false])(
+            'clears items when manager is not expanded and enableModernizedUploads is %s',
+            enableModernizedUploads => {
+                const { wrapper, instance, onCancel, items } = setupResetTest({
+                    props: { useUploadsManager: true, enableModernizedUploads },
+                    isUploadsManagerExpanded: false,
+                });
+
+                instance.resetUploadsManagerItemsWhenUploadsComplete();
+
+                expect(onCancel).toHaveBeenCalledWith(items);
+                expect(instance.itemsRef.current).toEqual([]);
+                expect(wrapper.state().items).toEqual([]);
+            },
+        );
+
+        test('clears items when useUploadsManager is false even if manager is expanded', () => {
+            const { wrapper, instance, onCancel, items } = setupResetTest({
+                props: { useUploadsManager: false, enableModernizedUploads: false },
+                isUploadsManagerExpanded: true,
+            });
+
+            instance.resetUploadsManagerItemsWhenUploadsComplete();
+
+            expect(onCancel).toHaveBeenCalledWith(items);
+            expect(instance.itemsRef.current).toEqual([]);
+            expect(wrapper.state().items).toEqual([]);
+        });
     });
 
     describe('addFileDataTransferItemsToUploadQueue()', () => {


### PR DESCRIPTION
### Summary

Currently the state of the upload items is reset internally in the `ContentUploader` by calling `resetUploadsManagerItemsWhenUploadsComplete` method with a timer. This PR allows to register `resetUploadsManagerItemsWhenUploadsComplete` as a callback that can be used in the host application using `setClearItemsCallback` and disables internal state reset for modernized uploader. This change ensures that the modernized uploads experience is more flexible and can be adjusted to the requirements in the host applications.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload-item clearing so items are retained while the upload view/manager is active and are reliably cleared when uploads complete, including with the modernized uploads flow; added support for wiring an external “clear items after uploads complete” callback.
* **Tests**
  * Added coverage for lifecycle and clearing behaviors to prevent regressions in upload cleanup logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->