### PR TITLE
feat(activity-feed-v2): wire video timestamp toggle for main composer

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -1411,14 +1411,6 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
             const label = `${elementId}${elementId === '' ? '' : '_'}${SIDEBAR_VIEW_ACTIVITY}`;
             const timestampedCommentsConfig = getFeatureConfig(features, 'activityFeed.timestampedComments');
             const isTimestampedCommentsEnabled = timestampedCommentsConfig?.enabled === true;
-            // eslint-disable-next-line no-console
-            console.log('[BUIE-LOCAL] ActivitySidebar -> ActivityFeedV2', {
-                fileExtension: file?.extension,
-                fileVersionId: file?.file_version?.id,
-                isTimestampedCommentsEnabled,
-                isThreadedRepliesV2Enabled,
-                timestampedCommentsConfig,
-            });
             return (
                 <div
                     aria-labelledby={label}

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -26,7 +26,7 @@ import { mark } from '../../utils/performance';
 import { withAnnotatorContext } from '../common/annotator-context';
 import { withAPIContext } from '../common/api-context';
 import { withErrorBoundary } from '../common/error-boundary';
-import { withFeatureConsumer, isFeatureEnabled } from '../common/feature-checking';
+import { withFeatureConsumer, isFeatureEnabled, getFeatureConfig } from '../common/feature-checking';
 import { withLogger } from '../common/logger';
 import { withRouterAndRef } from '../common/routing';
 import ActivitySidebarFilter from './ActivitySidebarFilter';
@@ -1409,6 +1409,16 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
 
         if (isThreadedRepliesV2Enabled) {
             const label = `${elementId}${elementId === '' ? '' : '_'}${SIDEBAR_VIEW_ACTIVITY}`;
+            const timestampedCommentsConfig = getFeatureConfig(features, 'activityFeed.timestampedComments');
+            const isTimestampedCommentsEnabled = timestampedCommentsConfig?.enabled === true;
+            // eslint-disable-next-line no-console
+            console.log('[BUIE-LOCAL] ActivitySidebar -> ActivityFeedV2', {
+                fileExtension: file?.extension,
+                fileVersionId: file?.file_version?.id,
+                isTimestampedCommentsEnabled,
+                isThreadedRepliesV2Enabled,
+                timestampedCommentsConfig,
+            });
             return (
                 <div
                     aria-labelledby={label}
@@ -1423,12 +1433,14 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                         createTask={this.createTask}
                         currentUser={currentUser}
                         feedItems={this.getFilteredFeedItems()}
+                        file={file}
                         getApproverWithQuery={this.getApprover}
                         getAvatarUrl={this.getAvatarUrl}
                         getMentionAsync={this.getMentionAsync}
                         getTaskCollaborators={this.getTaskCollaborators}
                         hasTasks={this.props.hasTasks}
                         isDisabled={isDisabled}
+                        isTimestampedCommentsEnabled={isTimestampedCommentsEnabled}
                         onAnnotationCopyLink={onAnnotationCopyLink}
                         onAnnotationDelete={this.handleAnnotationDelete}
                         onAnnotationEdit={this.handleAnnotationEdit}

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -283,26 +283,19 @@ const ActivityFeedV2 = ({
     }, [currentUserId, filteredItems, scrollHandle]);
 
     const isVideo = file?.extension ? FILE_EXTENSIONS.video.includes(file.extension) : false;
-    const allowVideoTimestamps = isVideo && isTimestampedCommentsEnabled;
     const fileVersionId = file?.file_version?.id;
+    const allowVideoTimestamps = isVideo && isTimestampedCommentsEnabled && Boolean(fileVersionId);
 
-    // eslint-disable-next-line no-console
-    console.log('[BUIE-LOCAL] ActivityFeedV2 render', {
-        allowVideoTimestamps,
-        extension: file?.extension,
-        fileVersionId,
-        isTimestampedCommentsEnabled,
-        isVideo,
-    });
+    const {
+        formattedTimestamp,
+        isPressed: isTimestampPressed,
+        onPressedChange,
+        timestampMs,
+    } = useVideoTimestamp(allowVideoTimestamps);
 
-    const videoTimestamp = useVideoTimestamp(allowVideoTimestamps);
-    const { formattedTimestamp, getTimestampMs, isPressed: isTimestampPressed, onPressedChange } = videoTimestamp;
-
-    const editorVideoTimestamp = React.useMemo(
-        () =>
-            allowVideoTimestamps ? { formattedTimestamp, isPressed: isTimestampPressed, onPressedChange } : undefined,
-        [allowVideoTimestamps, formattedTimestamp, isTimestampPressed, onPressedChange],
-    );
+    const editorVideoTimestamp = allowVideoTimestamps
+        ? { formattedTimestamp, isPressed: isTimestampPressed, onPressedChange }
+        : undefined;
 
     const handleCommentPost = React.useCallback(
         async (content: unknown) => {
@@ -311,7 +304,7 @@ const ActivityFeedV2 = ({
             if (!serialized || !serialized.text) return;
             const text =
                 allowVideoTimestamps && isTimestampPressed && fileVersionId
-                    ? `#[timestamp:${getTimestampMs()},versionId:${fileVersionId}] ${serialized.text}`
+                    ? `#[timestamp:${timestampMs},versionId:${fileVersionId}] ${serialized.text}`
                     : serialized.text;
             try {
                 const snapshot = new Set(filteredItems.map(item => item.id));
@@ -322,7 +315,7 @@ const ActivityFeedV2 = ({
                 console.error('ActivityFeedV2: failed to post comment', error);
             }
         },
-        [allowVideoTimestamps, filteredItems, fileVersionId, getTimestampMs, isTimestampPressed, onCommentCreate],
+        [allowVideoTimestamps, filteredItems, fileVersionId, isTimestampPressed, onCommentCreate, timestampMs],
     );
 
     return (

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -17,10 +17,12 @@ import TaskModal from '../TaskModal';
 import FeedItemRow from './FeedItemRow';
 import { serializeEditorContent } from './helpers';
 import { transformFeedItem } from './transformers';
+import { useVideoTimestamp } from './useVideoTimestamp';
 
 import type { ActivityFeedV2Props, TransformedFeedItem, UserContact } from './types';
 import type { TaskAssigneeCollection, TaskNew } from '../../../common/types/tasks';
 
+import { FILE_EXTENSIONS } from '../../common/item/constants';
 import { TASK_COMPLETION_RULE_ALL, TASK_EDIT_MODE_EDIT, TASK_TYPE_APPROVAL } from '../../../constants';
 
 import commonMessages from '../../common/messages';
@@ -35,12 +37,14 @@ const ActivityFeedV2 = ({
     createTask,
     currentUser,
     feedItems,
+    file,
     getApproverWithQuery,
     getAvatarUrl,
     getMentionAsync,
     getTaskCollaborators,
     hasTasks = true,
     isDisabled = false,
+    isTimestampedCommentsEnabled = false,
     onAnnotationCopyLink,
     onAnnotationDelete,
     onAnnotationEdit,
@@ -278,21 +282,47 @@ const ActivityFeedV2 = ({
         }
     }, [currentUserId, filteredItems, scrollHandle]);
 
+    const isVideo = file?.extension ? FILE_EXTENSIONS.video.includes(file.extension) : false;
+    const allowVideoTimestamps = isVideo && isTimestampedCommentsEnabled;
+    const fileVersionId = file?.file_version?.id;
+
+    // eslint-disable-next-line no-console
+    console.log('[BUIE-LOCAL] ActivityFeedV2 render', {
+        allowVideoTimestamps,
+        extension: file?.extension,
+        fileVersionId,
+        isTimestampedCommentsEnabled,
+        isVideo,
+    });
+
+    const videoTimestamp = useVideoTimestamp(allowVideoTimestamps);
+    const { formattedTimestamp, getTimestampMs, isPressed: isTimestampPressed, onPressedChange } = videoTimestamp;
+
+    const editorVideoTimestamp = React.useMemo(
+        () =>
+            allowVideoTimestamps ? { formattedTimestamp, isPressed: isTimestampPressed, onPressedChange } : undefined,
+        [allowVideoTimestamps, formattedTimestamp, isTimestampPressed, onPressedChange],
+    );
+
     const handleCommentPost = React.useCallback(
         async (content: unknown) => {
             if (!onCommentCreate) return;
             const serialized = serializeEditorContent(content);
             if (!serialized || !serialized.text) return;
+            const text =
+                allowVideoTimestamps && isTimestampPressed && fileVersionId
+                    ? `#[timestamp:${getTimestampMs()},versionId:${fileVersionId}] ${serialized.text}`
+                    : serialized.text;
             try {
                 const snapshot = new Set(filteredItems.map(item => item.id));
-                await onCommentCreate(serialized.text, serialized.hasMention);
+                await onCommentCreate(text, serialized.hasMention);
                 knownIdsBeforePostRef.current = snapshot;
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error('ActivityFeedV2: failed to post comment', error);
             }
         },
-        [filteredItems, onCommentCreate],
+        [allowVideoTimestamps, filteredItems, fileVersionId, getTimestampMs, isTimestampPressed, onCommentCreate],
     );
 
     return (
@@ -358,6 +388,7 @@ const ActivityFeedV2 = ({
                         disableComponent={isDisabled || !currentUser}
                         onPost={handleCommentPost}
                         userSelectorProps={userSelectorProps}
+                        videoTimestamp={editorVideoTimestamp}
                     />
                 </div>
             </ActivityFeed.Root>

--- a/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
@@ -14,6 +14,7 @@ import type { TaskCollabStatus, TaskNew } from '../../../common/types/tasks';
 
 import { dispatchReplyDelete, dispatchReplyEdit, logEditError, serializeEditorContent } from './helpers';
 import { annotationTargetToBadge } from './transformers';
+import { seekVideoToMs } from './useVideoTimestamp';
 
 import type { OnReplyDelete, OnReplyUpdate, TransformedFeedItem, UserSelectorProps } from './types';
 
@@ -128,6 +129,8 @@ const FeedItemRow = ({
                     text: serialized.text,
                 });
             };
+            const timestampMs = item.annotationTimestampMs;
+            const handleBadgeClick = timestampMs !== undefined ? () => seekVideoToMs(timestampMs) : undefined;
             return (
                 <ActivityFeed.List.ThreadedAnnotation
                     key={item.id}
@@ -136,6 +139,7 @@ const FeedItemRow = ({
                     isEditDisabled={isDisabled || item.isResolved}
                     isResolved={item.isResolved}
                     messages={item.messages}
+                    onAnnotationBadgeClick={handleBadgeClick}
                     onAvatarClick={noop}
                     onCopyLink={onCommentCopyLink ? (id: string) => onCommentCopyLink({ id }) : undefined}
                     onDelete={handleDelete}

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -587,6 +587,23 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
                 cleanup();
             }
         });
+
+        test('should not pass videoTimestamp when fileVersionId is missing', () => {
+            const { cleanup } = mountVideo();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={{ extension: 'mp4' }}
+                        isTimestampedCommentsEnabled
+                    />,
+                );
+                expect(lastEditorProps.videoTimestamp).toBeUndefined();
+            } finally {
+                cleanup();
+            }
+        });
     });
 
     describe('filter controls', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -467,6 +467,128 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         });
     });
 
+    describe('video timestamp', () => {
+        const mountVideo = (currentTime: number = 0) => {
+            const container = document.createElement('div');
+            container.className = 'bp-media-container';
+            const video = document.createElement('video');
+            Object.defineProperty(video, 'currentTime', {
+                configurable: true,
+                value: currentTime,
+                writable: true,
+            });
+            Object.defineProperty(video, 'paused', { configurable: true, value: true, writable: true });
+            video.pause = jest.fn();
+            container.appendChild(video);
+            document.body.appendChild(container);
+            return { cleanup: () => container.remove(), video };
+        };
+
+        test('should not pass videoTimestamp when file is not a video', () => {
+            const { cleanup } = mountVideo();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={{ extension: 'pdf', file_version: { id: '1' } }}
+                        isTimestampedCommentsEnabled
+                    />,
+                );
+                expect(lastEditorProps.videoTimestamp).toBeUndefined();
+            } finally {
+                cleanup();
+            }
+        });
+
+        test('should not pass videoTimestamp when isTimestampedCommentsEnabled is false', () => {
+            const { cleanup } = mountVideo();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={{ extension: 'mp4', file_version: { id: '1' } }}
+                    />,
+                );
+                expect(lastEditorProps.videoTimestamp).toBeUndefined();
+            } finally {
+                cleanup();
+            }
+        });
+
+        test('should pass videoTimestamp with default 0:00 for videos when enabled', () => {
+            const { cleanup } = mountVideo();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={{ extension: 'mp4', file_version: { id: '1' } }}
+                        isTimestampedCommentsEnabled
+                    />,
+                );
+                expect(lastEditorProps.videoTimestamp).toEqual({
+                    formattedTimestamp: '0:00',
+                    isPressed: false,
+                    onPressedChange: expect.any(Function),
+                });
+            } finally {
+                cleanup();
+            }
+        });
+
+        test('should prepend timestamp markup to posted text when toggle is pressed', async () => {
+            const { cleanup, video } = mountVideo();
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: 'great frame' });
+            const onCommentCreate = jest.fn();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={{ extension: 'mp4', file_version: { id: '99' } }}
+                        isTimestampedCommentsEnabled
+                        onCommentCreate={onCommentCreate}
+                    />,
+                );
+                Object.defineProperty(video, 'currentTime', { configurable: true, value: 8.055, writable: true });
+                await act(async () => {
+                    lastEditorProps.videoTimestamp?.onPressedChange(true);
+                });
+                await act(async () => {
+                    await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+                });
+                expect(onCommentCreate).toHaveBeenCalledWith('#[timestamp:8055,versionId:99] great frame', false);
+            } finally {
+                cleanup();
+            }
+        });
+
+        test('should post the original text when the toggle is not pressed', async () => {
+            const { cleanup } = mountVideo();
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: 'plain comment' });
+            const onCommentCreate = jest.fn();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={{ extension: 'mp4', file_version: { id: '99' } }}
+                        isTimestampedCommentsEnabled
+                        onCommentCreate={onCommentCreate}
+                    />,
+                );
+                await act(async () => {
+                    await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+                });
+                expect(onCommentCreate).toHaveBeenCalledWith('plain comment', false);
+            } finally {
+                cleanup();
+            }
+        });
+    });
+
     describe('filter controls', () => {
         test('should default showResolved and showOnlyMentionsMe to false in the filter menu', () => {
             render(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[] as ActivityFeedV2Props['feedItems']} />);

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
@@ -7,6 +7,7 @@ import { render, screen } from '../../../../test-utils/testing-library';
 import FeedItemRow from '../FeedItemRow';
 import { dispatchReplyDelete, dispatchReplyEdit, logEditError, serializeEditorContent } from '../helpers';
 import { annotationTargetToBadge } from '../transformers';
+import { seekVideoToMs } from '../useVideoTimestamp';
 
 import type { TaskNew } from '../../../../common/types/tasks';
 import type {
@@ -52,10 +53,15 @@ jest.mock('../transformers', () => ({
     annotationTargetToBadge: jest.fn(),
 }));
 
+jest.mock('../useVideoTimestamp', () => ({
+    seekVideoToMs: jest.fn(),
+}));
+
 const mockedSerializeEditorContent = jest.mocked(serializeEditorContent);
 const mockedDispatchReplyDelete = jest.mocked(dispatchReplyDelete);
 const mockedDispatchReplyEdit = jest.mocked(dispatchReplyEdit);
 const mockedAnnotationTargetToBadge = jest.mocked(annotationTargetToBadge);
+const mockedSeekVideoToMs = jest.mocked(seekVideoToMs);
 
 const userSelectorProps: UserSelectorProps = {
     ariaRoleDescription: 'user selector',
@@ -392,6 +398,24 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
         test('should wire onEditError to the logEditError helper', () => {
             render(<FeedItemRow {...defaultProps} item={mockComment} />);
             expect(lastThreadedAnnotationProps.onEditError).toBe(logEditError);
+        });
+
+        test('should not pass onAnnotationBadgeClick when the comment has no timestamp markup', () => {
+            render(<FeedItemRow {...defaultProps} item={mockComment} />);
+            expect(lastThreadedAnnotationProps.onAnnotationBadgeClick).toBeUndefined();
+        });
+
+        test('should seek the video on badge click when the comment carries a timestamp', () => {
+            const timestampedComment: TransformedCommentItem = {
+                ...mockComment,
+                annotationTarget: { timestamp: '0:08', type: AnnotationBadgeType.Frame },
+                annotationTimestampMs: 8055,
+            };
+            render(<FeedItemRow {...defaultProps} item={timestampedComment} />);
+
+            lastThreadedAnnotationProps.onAnnotationBadgeClick?.('comment-1');
+
+            expect(mockedSeekVideoToMs).toHaveBeenCalledWith(8055);
         });
     });
 

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
@@ -689,12 +689,14 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = extractTimestampMarkup('#[timestamp:8055,versionId:2390295731268]  wowo');
             expect(result.cleanText).toBe('wowo');
             expect(result.target).toEqual({ timestamp: '0:08', type: 'frame' });
+            expect(result.timestampMs).toBe(8055);
         });
 
         test('should extract timestamp markup without versionId', () => {
             const result = extractTimestampMarkup('#[timestamp:65000] hello');
             expect(result.cleanText).toBe('hello');
             expect(result.target).toEqual({ timestamp: '1:05', type: 'frame' });
+            expect(result.timestampMs).toBe(65000);
         });
 
         test('should leave timestamp markup that does not anchor at the start of the message untouched', () => {
@@ -719,6 +721,7 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = extractTimestampMarkup('#[timestamp:99999999999999999999] hello');
             expect(result.cleanText).toBe('hello');
             expect(result.target).toBeUndefined();
+            expect(result.timestampMs).toBeUndefined();
         });
     });
 
@@ -756,6 +759,7 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             expect(result!.type).toBe('comment');
             if (result!.type === 'comment') {
                 expect(result.annotationTarget).toEqual({ timestamp: '0:08', type: 'frame' });
+                expect(result.annotationTimestampMs).toBe(8055);
             }
         });
 
@@ -774,6 +778,7 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = transformFeedItem(comment as unknown as FeedItem);
             if (result!.type === 'comment') {
                 expect(result.annotationTarget).toBeUndefined();
+                expect(result.annotationTimestampMs).toBeUndefined();
             }
         });
     });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useVideoTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useVideoTimestamp.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { act, render, screen } from '@testing-library/react';
 
-import { useVideoTimestamp } from '../useVideoTimestamp';
+import { seekVideoToMs, useVideoTimestamp } from '../useVideoTimestamp';
 
 const createVideoElement = (currentTime: number = 0): HTMLVideoElement => {
     const video = document.createElement('video');
@@ -261,5 +261,55 @@ describe('useVideoTimestamp', () => {
         } finally {
             cleanup();
         }
+    });
+
+    test('should not capture from a pause/seek that fires after onPressedChange(false) in the same tick', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 10, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:10');
+
+            // Unpress and synchronously dispatch a pause event before any
+            // useEffect would run. The captured value must not change.
+            act(() => {
+                screen.getByText('unpress').click();
+                Object.defineProperty(video, 'currentTime', { configurable: true, value: 50, writable: true });
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:10');
+        } finally {
+            cleanup();
+        }
+    });
+});
+
+describe('seekVideoToMs', () => {
+    afterEach(() => {
+        document.querySelectorAll('.bp-media-container').forEach(node => node.remove());
+    });
+
+    test('should set currentTime in seconds and pause when a video is present', () => {
+        const video = createVideoElement(0);
+        Object.defineProperty(video, 'paused', { configurable: true, value: false, writable: true });
+        const cleanup = mountVideoInDom(video);
+        try {
+            seekVideoToMs(8055);
+            expect(video.currentTime).toBe(8.055);
+            expect(video.pause).toHaveBeenCalled();
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should be a no-op when no video element is present', () => {
+        expect(() => seekVideoToMs(1000)).not.toThrow();
     });
 });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useVideoTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useVideoTimestamp.test.tsx
@@ -32,11 +32,11 @@ const mountVideoInDom = (video: HTMLVideoElement) => {
 };
 
 const TestHarness = ({ enabled }: { enabled: boolean }) => {
-    const { formattedTimestamp, getTimestampMs, isPressed, onPressedChange } = useVideoTimestamp(enabled);
+    const { formattedTimestamp, isPressed, onPressedChange, timestampMs } = useVideoTimestamp(enabled);
     return (
         <div>
             <span data-testid="timestamp">{formattedTimestamp}</span>
-            <span data-testid="ms">{String(getTimestampMs())}</span>
+            <span data-testid="ms">{String(timestampMs)}</span>
             <span data-testid="pressed">{String(isPressed)}</span>
             <button onClick={() => onPressedChange(true)} type="button">
                 press
@@ -60,6 +60,23 @@ describe('useVideoTimestamp', () => {
         expect(screen.getByTestId('pressed').textContent).toBe('false');
     });
 
+    test('should ignore press attempts when disabled', () => {
+        const video = createVideoElement(15);
+        Object.defineProperty(video, 'paused', { configurable: true, value: false, writable: true });
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled={false} />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            expect(video.pause).not.toHaveBeenCalled();
+            expect(screen.getByTestId('pressed').textContent).toBe('false');
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
+        } finally {
+            cleanup();
+        }
+    });
+
     test('should capture current time and pause the video when toggled on while playing', () => {
         const video = createVideoElement(43.5);
         Object.defineProperty(video, 'paused', { configurable: true, value: false, writable: true });
@@ -78,7 +95,7 @@ describe('useVideoTimestamp', () => {
         }
     });
 
-    test('should not change captured value when pressed and the video is playing', () => {
+    test('should keep the captured value frozen while playing (no pause/seek listeners apart from those)', () => {
         const video = createVideoElement(0);
         const cleanup = mountVideoInDom(video);
         try {
@@ -86,12 +103,14 @@ describe('useVideoTimestamp', () => {
             act(() => {
                 screen.getByText('press').click();
             });
-            // simulate playback advancing then a play event (no pause/seek yet)
+            // currentTime advances during playback but no pause/seek fires.
             Object.defineProperty(video, 'currentTime', { configurable: true, value: 30, writable: true });
+            // Sanity: a non-subscribed event must not trigger a capture.
             act(() => {
-                video.dispatchEvent(new Event('playing'));
+                video.dispatchEvent(new Event('timeupdate'));
             });
             expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
+            expect(screen.getByTestId('ms').textContent).toBe('0');
         } finally {
             cleanup();
         }
@@ -142,13 +161,11 @@ describe('useVideoTimestamp', () => {
             act(() => {
                 screen.getByText('press').click();
             });
-            // capture an initial value
             Object.defineProperty(video, 'currentTime', { configurable: true, value: 5, writable: true });
             act(() => {
                 video.dispatchEvent(new Event('pause'));
             });
             expect(screen.getByTestId('timestamp').textContent).toBe('0:05');
-            // unpress and continue playback past it
             act(() => {
                 screen.getByText('unpress').click();
             });
@@ -180,6 +197,67 @@ describe('useVideoTimestamp', () => {
             });
             expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
             expect(screen.getByTestId('pressed').textContent).toBe('true');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should ignore pause/seek captures while loadstart -> loadeddata is in progress', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 25, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:25');
+
+            act(() => {
+                video.dispatchEvent(new Event('loadstart'));
+            });
+            // Mid-load currentTime jitter must not get captured.
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 99, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('seeked'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
+
+            act(() => {
+                video.dispatchEvent(new Event('loadeddata'));
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 4, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('seeked'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:04');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should reset state when transitioning from enabled to disabled', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            const { rerender } = render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 33, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:33');
+            expect(screen.getByTestId('pressed').textContent).toBe('true');
+
+            rerender(<TestHarness enabled={false} />);
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
+            expect(screen.getByTestId('pressed').textContent).toBe('false');
+            expect(screen.getByTestId('ms').textContent).toBe('0');
         } finally {
             cleanup();
         }

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useVideoTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useVideoTimestamp.test.tsx
@@ -1,0 +1,187 @@
+import * as React from 'react';
+import { act, render, screen } from '@testing-library/react';
+
+import { useVideoTimestamp } from '../useVideoTimestamp';
+
+const createVideoElement = (currentTime: number = 0): HTMLVideoElement => {
+    const video = document.createElement('video');
+    Object.defineProperty(video, 'currentTime', {
+        configurable: true,
+        get: () => currentTime,
+        set: (value: number) => {
+            currentTime = value;
+        },
+    });
+    Object.defineProperty(video, 'paused', {
+        configurable: true,
+        value: true,
+        writable: true,
+    });
+    video.pause = jest.fn(() => {
+        Object.defineProperty(video, 'paused', { configurable: true, value: true, writable: true });
+    });
+    return video;
+};
+
+const mountVideoInDom = (video: HTMLVideoElement) => {
+    const container = document.createElement('div');
+    container.className = 'bp-media-container';
+    container.appendChild(video);
+    document.body.appendChild(container);
+    return () => container.remove();
+};
+
+const TestHarness = ({ enabled }: { enabled: boolean }) => {
+    const { formattedTimestamp, getTimestampMs, isPressed, onPressedChange } = useVideoTimestamp(enabled);
+    return (
+        <div>
+            <span data-testid="timestamp">{formattedTimestamp}</span>
+            <span data-testid="ms">{String(getTimestampMs())}</span>
+            <span data-testid="pressed">{String(isPressed)}</span>
+            <button onClick={() => onPressedChange(true)} type="button">
+                press
+            </button>
+            <button onClick={() => onPressedChange(false)} type="button">
+                unpress
+            </button>
+        </div>
+    );
+};
+
+describe('useVideoTimestamp', () => {
+    afterEach(() => {
+        document.querySelectorAll('.bp-media-container').forEach(node => node.remove());
+    });
+
+    test('should return defaults when disabled', () => {
+        render(<TestHarness enabled={false} />);
+        expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
+        expect(screen.getByTestId('ms').textContent).toBe('0');
+        expect(screen.getByTestId('pressed').textContent).toBe('false');
+    });
+
+    test('should capture current time and pause the video when toggled on while playing', () => {
+        const video = createVideoElement(43.5);
+        Object.defineProperty(video, 'paused', { configurable: true, value: false, writable: true });
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            expect(video.pause).toHaveBeenCalled();
+            expect(screen.getByTestId('pressed').textContent).toBe('true');
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:43');
+            expect(screen.getByTestId('ms').textContent).toBe('43500');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should not change captured value when pressed and the video is playing', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            // simulate playback advancing then a play event (no pause/seek yet)
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 30, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('playing'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should update captured value when pressed and the video pauses', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 12, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:12');
+            expect(screen.getByTestId('ms').textContent).toBe('12000');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should update captured value when pressed and the video is seeked', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 7, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('seeked'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:07');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should not update captured value on pause when toggle is off', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            // capture an initial value
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 5, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:05');
+            // unpress and continue playback past it
+            act(() => {
+                screen.getByText('unpress').click();
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 90, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:05');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should reset captured value to 0 on loadstart while preserving pressed state', () => {
+        const video = createVideoElement(0);
+        const cleanup = mountVideoInDom(video);
+        try {
+            render(<TestHarness enabled />);
+            act(() => {
+                screen.getByText('press').click();
+            });
+            Object.defineProperty(video, 'currentTime', { configurable: true, value: 18, writable: true });
+            act(() => {
+                video.dispatchEvent(new Event('pause'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:18');
+            act(() => {
+                video.dispatchEvent(new Event('loadstart'));
+            });
+            expect(screen.getByTestId('timestamp').textContent).toBe('0:00');
+            expect(screen.getByTestId('pressed').textContent).toBe('true');
+        } finally {
+            cleanup();
+        }
+    });
+});

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -44,7 +44,9 @@ import {
 const MENTION_REGEX = /@\[(\d+):([^\]]+)\]/g;
 const TIMESTAMP_MARKUP_REGEX = /^#\[timestamp:(\d+)(?:,versionId:\d+)?\]\s*/;
 
-export const extractTimestampMarkup = (text: string): { cleanText: string; target?: AnnotationBadgeTargetType } => {
+export const extractTimestampMarkup = (
+    text: string,
+): { cleanText: string; target?: AnnotationBadgeTargetType; timestampMs?: number } => {
     if (!text) return { cleanText: '' };
     const match = text.match(TIMESTAMP_MARKUP_REGEX);
     if (!match) return { cleanText: text };
@@ -58,7 +60,7 @@ export const extractTimestampMarkup = (text: string): { cleanText: string; targe
         timestamp: convertMillisecondsToTimestamp(ms),
         type: AnnotationBadgeType.Frame,
     };
-    return { cleanText, target };
+    return { cleanText, target, timestampMs: ms };
 };
 
 const parseLine = (line: string, authorId: string): (MentionNode | TextNode)[] => {
@@ -290,11 +292,12 @@ export const transformFeedItem = (item: FeedItem, currentUserId?: string): Trans
             const comment = item as unknown as Comment;
             const commentIsResolved = comment.status === 'resolved';
             const rawText = comment.tagged_message || comment.message || '';
-            const { cleanText, target: annotationTarget } = extractTimestampMarkup(rawText);
+            const { cleanText, target: annotationTarget, timestampMs } = extractTimestampMarkup(rawText);
             const root = commentToTextMessage(comment, cleanText);
             const replies = (comment.replies ?? []).map(reply => commentToTextMessage(reply));
             return {
                 annotationTarget,
+                annotationTimestampMs: timestampMs,
                 id: comment.id,
                 isResolved: commentIsResolved,
                 messages: [root, ...replies],

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -83,13 +83,13 @@ export type ActivityFeedV2Props = {
     currentUser?: User;
     feedItems?: FeedItems;
     file?: ActivityFeedV2File;
-    isTimestampedCommentsEnabled?: boolean;
     getApproverWithQuery?: (searchStr: string) => void;
     getAvatarUrl?: (userId: string) => Promise<string | null | undefined>;
     getMentionAsync?: (searchStr: string) => Promise<Array<Record<string, unknown>>>;
     getTaskCollaborators?: (task: TaskNew) => Promise<TaskAssigneeCollection>;
     hasTasks?: boolean;
     isDisabled?: boolean;
+    isTimestampedCommentsEnabled?: boolean;
     onAnnotationCopyLink?: (params: { annotationId: string; fileVersionId: string }) => void;
     onAnnotationDelete?: (params: { id: string; permissions: AnnotationPermission }) => void;
     onAnnotationEdit?: (params: { id: string; permissions: AnnotationPermission; text: string }) => void;

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -71,12 +71,19 @@ export type TransformedFeedItem =
     | { type: 'version'; id: string; props: VersionItemProps }
     | { type: 'app_activity'; id: string; props: AppActivityItemProps };
 
+export type ActivityFeedV2File = {
+    extension?: string;
+    file_version?: { id: string };
+};
+
 export type ActivityFeedV2Props = {
     activeFeedEntryId?: string;
     approverSelectorContacts?: Array<Record<string, unknown>>;
     createTask?: (...args: Array<unknown>) => void;
     currentUser?: User;
     feedItems?: FeedItems;
+    file?: ActivityFeedV2File;
+    isTimestampedCommentsEnabled?: boolean;
     getApproverWithQuery?: (searchStr: string) => void;
     getAvatarUrl?: (userId: string) => Promise<string | null | undefined>;
     getMentionAsync?: (searchStr: string) => Promise<Array<Record<string, unknown>>>;

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -47,6 +47,7 @@ type ResolvedInfo = {
 
 export type TransformedCommentItem = {
     annotationTarget?: AnnotationBadgeTargetType;
+    annotationTimestampMs?: number;
     id: string;
     messages: TextMessageType[];
     originalText: string;

--- a/src/elements/content-sidebar/activity-feed-v2/useVideoTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useVideoTimestamp.ts
@@ -1,0 +1,135 @@
+/**
+ * @file Hook that tracks video playback time for the timestamped-comment toggle.
+ * @author Box
+ */
+
+import * as React from 'react';
+
+import { convertMillisecondsToTimestamp } from '../../../utils/timestamp';
+
+const VIDEO_CONTAINER_SELECTOR = '.bp-media-container';
+
+const findVideoElement = (): HTMLVideoElement | null => {
+    if (typeof document === 'undefined') {
+        return null;
+    }
+    const container = document.querySelector(VIDEO_CONTAINER_SELECTOR);
+    return container?.querySelector<HTMLVideoElement>('video') ?? null;
+};
+
+const captureCurrentMs = (video: HTMLVideoElement | null): number => {
+    if (!video) {
+        return 0;
+    }
+    return Math.floor(video.currentTime * 1000);
+};
+
+export interface UseVideoTimestampResult {
+    /** Display string (e.g. "0:43"). "0:00" until first capture. */
+    formattedTimestamp: string;
+    /** Toggle pressed state. */
+    isPressed: boolean;
+    /** Read the current captured ms - used when posting. */
+    getTimestampMs: () => number;
+    /** Pressed-state setter passed to the editor toggle. */
+    onPressedChange: (pressed: boolean) => void;
+}
+
+/**
+ * Tracks video playback time for the editor timestamp toggle.
+ *
+ * Behavior:
+ * - Pressed off: captured value never updates (last selected value preserved).
+ * - Pressed on while video is playing: captured value frozen until pause/seek.
+ * - Pressed on while video is paused: captured value updates on pause/seek.
+ * - Toggle off->on: captures current time and pauses the video if it was playing.
+ * - New video src: captured value resets to 0; pressed state persists.
+ *
+ * `enabled` should be true only for video files where timestamped comments are
+ * allowed; the hook returns inert defaults otherwise.
+ */
+export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => {
+    const [isPressed, setIsPressed] = React.useState(false);
+    const [timestampMs, setTimestampMs] = React.useState(0);
+    const isPressedRef = React.useRef(isPressed);
+
+    React.useEffect(() => {
+        isPressedRef.current = isPressed;
+    }, [isPressed]);
+
+    const getTimestampMs = React.useCallback(() => timestampMs, [timestampMs]);
+
+    const onPressedChange = React.useCallback((pressed: boolean) => {
+        setIsPressed(pressed);
+        if (!pressed) {
+            return;
+        }
+        const video = findVideoElement();
+        if (!video) {
+            return;
+        }
+        if (!video.paused) {
+            video.pause();
+        }
+        setTimestampMs(captureCurrentMs(video));
+    }, []);
+
+    React.useEffect(() => {
+        if (!enabled || typeof document === 'undefined') {
+            return undefined;
+        }
+
+        let observer: MutationObserver | null = null;
+        let attached: HTMLVideoElement | null = null;
+
+        const handlePauseOrSeek = () => {
+            if (isPressedRef.current && attached) {
+                setTimestampMs(captureCurrentMs(attached));
+            }
+        };
+
+        const handleLoadStart = () => {
+            setTimestampMs(0);
+        };
+
+        const detach = () => {
+            if (!attached) return;
+            attached.removeEventListener('pause', handlePauseOrSeek);
+            attached.removeEventListener('seeked', handlePauseOrSeek);
+            attached.removeEventListener('loadstart', handleLoadStart);
+            attached = null;
+        };
+
+        const tryAttach = () => {
+            const video = findVideoElement();
+            if (!video || video === attached) {
+                return Boolean(attached);
+            }
+            detach();
+            video.addEventListener('pause', handlePauseOrSeek);
+            video.addEventListener('seeked', handlePauseOrSeek);
+            video.addEventListener('loadstart', handleLoadStart);
+            attached = video;
+            return true;
+        };
+
+        if (!tryAttach() && typeof MutationObserver !== 'undefined') {
+            observer = new MutationObserver(() => {
+                tryAttach();
+            });
+            observer.observe(document.body, { childList: true, subtree: true });
+        }
+
+        return () => {
+            observer?.disconnect();
+            detach();
+        };
+    }, [enabled]);
+
+    return {
+        formattedTimestamp: convertMillisecondsToTimestamp(timestampMs),
+        getTimestampMs,
+        isPressed,
+        onPressedChange,
+    };
+};

--- a/src/elements/content-sidebar/activity-feed-v2/useVideoTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useVideoTimestamp.ts
@@ -1,8 +1,3 @@
-/**
- * @file Hook that tracks video playback time for the timestamped-comment toggle.
- * @author Box
- */
-
 import * as React from 'react';
 
 import { convertMillisecondsToTimestamp } from '../../../utils/timestamp';
@@ -25,54 +20,62 @@ const captureCurrentMs = (video: HTMLVideoElement | null): number => {
 };
 
 export interface UseVideoTimestampResult {
-    /** Display string (e.g. "0:43"). "0:00" until first capture. */
+    /** Defaults to "0:00" until the first capture. */
     formattedTimestamp: string;
-    /** Toggle pressed state. */
     isPressed: boolean;
-    /** Read the current captured ms - used when posting. */
-    getTimestampMs: () => number;
-    /** Pressed-state setter passed to the editor toggle. */
     onPressedChange: (pressed: boolean) => void;
+    timestampMs: number;
 }
 
 /**
- * Tracks video playback time for the editor timestamp toggle.
- *
  * Behavior:
- * - Pressed off: captured value never updates (last selected value preserved).
+ * - Pressed off: captured value never updates.
  * - Pressed on while video is playing: captured value frozen until pause/seek.
  * - Pressed on while video is paused: captured value updates on pause/seek.
  * - Toggle off->on: captures current time and pauses the video if it was playing.
  * - New video src: captured value resets to 0; pressed state persists.
- *
- * `enabled` should be true only for video files where timestamped comments are
- * allowed; the hook returns inert defaults otherwise.
  */
 export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => {
     const [isPressed, setIsPressed] = React.useState(false);
     const [timestampMs, setTimestampMs] = React.useState(0);
     const isPressedRef = React.useRef(isPressed);
+    const isLoadingRef = React.useRef(false);
 
     React.useEffect(() => {
         isPressedRef.current = isPressed;
     }, [isPressed]);
 
-    const getTimestampMs = React.useCallback(() => timestampMs, [timestampMs]);
+    // Reset state when disabled (e.g. switching from a video to a non-video file)
+    // so a re-enable does not leak the previous file's pressed state or captured ms.
+    React.useEffect(() => {
+        if (!enabled) {
+            setIsPressed(false);
+            setTimestampMs(0);
+            isLoadingRef.current = false;
+        }
+    }, [enabled]);
 
-    const onPressedChange = React.useCallback((pressed: boolean) => {
-        setIsPressed(pressed);
-        if (!pressed) {
-            return;
-        }
-        const video = findVideoElement();
-        if (!video) {
-            return;
-        }
-        if (!video.paused) {
-            video.pause();
-        }
-        setTimestampMs(captureCurrentMs(video));
-    }, []);
+    const onPressedChange = React.useCallback(
+        (pressed: boolean) => {
+            if (!enabled) {
+                return;
+            }
+            if (!pressed) {
+                setIsPressed(false);
+                return;
+            }
+            const video = findVideoElement();
+            if (!video) {
+                return;
+            }
+            if (!video.paused) {
+                video.pause();
+            }
+            setIsPressed(true);
+            setTimestampMs(captureCurrentMs(video));
+        },
+        [enabled],
+    );
 
     React.useEffect(() => {
         if (!enabled || typeof document === 'undefined') {
@@ -83,13 +86,23 @@ export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => 
         let attached: HTMLVideoElement | null = null;
 
         const handlePauseOrSeek = () => {
+            // Skip captures during a fresh-src load: currentTime is mid-reset and
+            // would clobber the value handleLoadStart already set to 0.
+            if (isLoadingRef.current) {
+                return;
+            }
             if (isPressedRef.current && attached) {
                 setTimestampMs(captureCurrentMs(attached));
             }
         };
 
         const handleLoadStart = () => {
+            isLoadingRef.current = true;
             setTimestampMs(0);
+        };
+
+        const handleLoadedData = () => {
+            isLoadingRef.current = false;
         };
 
         const detach = () => {
@@ -97,28 +110,40 @@ export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => 
             attached.removeEventListener('pause', handlePauseOrSeek);
             attached.removeEventListener('seeked', handlePauseOrSeek);
             attached.removeEventListener('loadstart', handleLoadStart);
+            attached.removeEventListener('loadeddata', handleLoadedData);
             attached = null;
         };
 
-        const tryAttach = () => {
+        const tryAttach = (): boolean => {
             const video = findVideoElement();
-            if (!video || video === attached) {
-                return Boolean(attached);
+            if (!video) {
+                return false;
+            }
+            if (video === attached) {
+                return true;
             }
             detach();
             video.addEventListener('pause', handlePauseOrSeek);
             video.addEventListener('seeked', handlePauseOrSeek);
             video.addEventListener('loadstart', handleLoadStart);
+            video.addEventListener('loadeddata', handleLoadedData);
             attached = video;
             return true;
         };
 
-        if (!tryAttach() && typeof MutationObserver !== 'undefined') {
+        // Keep observing so listeners migrate when preview replaces the <video>
+        // element (different file). Element-replacement is invisible to loadstart,
+        // which only fires for src changes on the same element.
+        if (typeof MutationObserver !== 'undefined') {
             observer = new MutationObserver(() => {
-                tryAttach();
+                if (findVideoElement() !== attached) {
+                    tryAttach();
+                }
             });
             observer.observe(document.body, { childList: true, subtree: true });
         }
+
+        tryAttach();
 
         return () => {
             observer?.disconnect();
@@ -128,8 +153,8 @@ export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => 
 
     return {
         formattedTimestamp: convertMillisecondsToTimestamp(timestampMs),
-        getTimestampMs,
         isPressed,
         onPressedChange,
+        timestampMs,
     };
 };

--- a/src/elements/content-sidebar/activity-feed-v2/useVideoTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useVideoTimestamp.ts
@@ -19,6 +19,13 @@ const captureCurrentMs = (video: HTMLVideoElement | null): number => {
     return Math.floor(video.currentTime * 1000);
 };
 
+export const seekVideoToMs = (ms: number): void => {
+    const video = findVideoElement();
+    if (!video) return;
+    video.currentTime = ms / 1000;
+    video.pause();
+};
+
 export interface UseVideoTimestampResult {
     /** Defaults to "0:00" until the first capture. */
     formattedTimestamp: string;
@@ -41,14 +48,11 @@ export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => 
     const isPressedRef = React.useRef(isPressed);
     const isLoadingRef = React.useRef(false);
 
-    React.useEffect(() => {
-        isPressedRef.current = isPressed;
-    }, [isPressed]);
-
     // Reset state when disabled (e.g. switching from a video to a non-video file)
     // so a re-enable does not leak the previous file's pressed state or captured ms.
     React.useEffect(() => {
         if (!enabled) {
+            isPressedRef.current = false;
             setIsPressed(false);
             setTimestampMs(0);
             isLoadingRef.current = false;
@@ -61,6 +65,7 @@ export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => 
                 return;
             }
             if (!pressed) {
+                isPressedRef.current = false;
                 setIsPressed(false);
                 return;
             }
@@ -71,6 +76,7 @@ export const useVideoTimestamp = (enabled: boolean): UseVideoTimestampResult => 
             if (!video.paused) {
                 video.pause();
             }
+            isPressedRef.current = true;
             setIsPressed(true);
             setTimestampMs(captureCurrentMs(video));
         },


### PR DESCRIPTION
## Summary
- Add `useVideoTimestamp` hook that tracks the playback time of the preview video and drives the editor timestamp toggle for the v2 activity feed.
- Wire `videoTimestamp` through `ActivityFeedV2` to the published `ActivityFeed.Editor` only for video files when the host enables `features.activityFeed.timestampedComments` AND a `file_version.id` is loaded.
- Prepend `#[timestamp:<ms>,versionId:<v>] ` to the editor text on post when the toggle is pressed, matching the v1 markup format read by `transformers.ts`.
- Toggle only appears on the main composer; reply composers do not receive the prop.

## Behavior (per spec)
- Pressed off: captured value never updates.
- Pressed on while playing: captured value frozen until pause/seek.
- Pressed on while paused: captured value updates on pause/seek.
- Toggle off-to-on: captures current time and pauses the video if it was playing.
- New video src: captured value resets to 0; pressed state persists.
- Switching from a video to a non-video file: hook resets pressed state and captured ms.

## Test plan
- [x] `yarn test --watchAll=false --testPathPattern="useVideoTimestamp|activity-feed-v2"` -> 208/208 passing
- [x] `yarn test --watchAll=false --testPathPattern="content-sidebar/__tests__/ActivitySidebar"` -> 167/167 passing
- [x] `yarn lint:ts` clean
- [ ] Manually verify on a video file with the timestamped-comments feature config enabled: toggle appears, reflects current time, prepended markup posts correctly, and the timestamp clicks back to the right frame in the comment list.
- [ ] Verify reply composers do not show the toggle.
- [ ] Verify switching from a video to a non-video file in the same sidebar instance hides the toggle and resets state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timestamped comments for videos in the activity feed — capture and embed the current video time when posting.
  * Posted comments with timestamps link back to the exact moment: annotation badges let users jump/seek the video to the referenced time.
  * UI shows a default 0:00 timestamp when enabled and preserves timestamp state while composing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->