### PR TITLE
fix(activity-feed-v2): empty state when feed has only version rows

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -214,7 +214,7 @@ const ActivityFeedV2 = ({
     }, [currentUserId, feedItems]);
 
     const filteredItems = React.useMemo(() => {
-        return transformedItems.filter(item => {
+        const filtered = transformedItems.filter(item => {
             if ((item.type === 'comment' || item.type === 'annotation') && item.isResolved && !showResolved) {
                 return false;
             }
@@ -240,6 +240,11 @@ const ActivityFeedV2 = ({
             }
             return true;
         });
+        const filtersDroppedItems = filtered.length < transformedItems.length;
+        if (!filtersDroppedItems && filtered.every(item => item.type === 'version')) {
+            return [];
+        }
+        return filtered;
     }, [currentUserId, showOnlyMentionsMe, showResolved, transformedItems]);
 
     React.useEffect(() => {

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -223,7 +223,18 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         expect(screen.getByTestId('task-task-1')).toBeVisible();
     });
 
-    test('should render version feed items', () => {
+    test('should render version feed items alongside other items', () => {
+        render(
+            <ActivityFeedV2
+                currentUser={mockCurrentUser}
+                feedItems={[mockComment, mockVersion] as ActivityFeedV2Props['feedItems']}
+            />,
+        );
+
+        expect(screen.getByTestId('version-version-1')).toBeVisible();
+    });
+
+    test('should suppress version-only feeds so the empty state can render', () => {
         render(
             <ActivityFeedV2
                 currentUser={mockCurrentUser}
@@ -231,6 +242,20 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             />,
         );
 
+        expect(screen.queryByTestId('version-version-1')).not.toBeInTheDocument();
+        expect(screen.getByTestId('activity-feed-list').children).toHaveLength(0);
+    });
+
+    test('should keep version rows when filters dropped other items', () => {
+        const resolvedComment = { ...mockComment, id: 'resolved-1', status: 'resolved' };
+        render(
+            <ActivityFeedV2
+                currentUser={mockCurrentUser}
+                feedItems={[resolvedComment, mockVersion] as ActivityFeedV2Props['feedItems']}
+            />,
+        );
+
+        expect(screen.queryByTestId('threaded-annotation-resolved-1')).not.toBeInTheDocument();
         expect(screen.getByTestId('version-version-1')).toBeVisible();
     });
 


### PR DESCRIPTION
## Summary
- The `/file_activities` endpoint always returns at least one `version` row per upload, so a freshly uploaded file with no comments, tasks, or annotations rendered a single version row instead of the activity-feed empty state.
- In `ActivityFeedV2`, when the filtered feed contains only `version` items, return `[]` so the shared `@box/activity-feed` `ActivityFeed.List` renders its existing `EmptyState`.
- Skip the suppression when the filter step has already dropped items, so an empty filtered result does not get re-labeled as "No comments yet" when the user could recover the items by toggling a filter.

## Test plan
- [x] `yarn test --watchAll=false --testPathPattern="activity-feed-v2/__tests__/ActivityFeedV2"` -> 58/58 passing
- [x] New test: version-only feed renders empty list (no version row).
- [x] New test: when a resolved comment is filtered out, the version row is still kept (so a filter-induced empty result does not collapse into the same empty state).
- [ ] Manually verify on a freshly uploaded file with no comments: empty state appears.
- [ ] Manually verify on a file with comments + a version row: both render normally.
- [ ] Manually verify with `Show resolved` off and only resolved comments + a version row: version row still renders so the user can toggle the filter back on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed activity feed filtering behavior to display an empty state when certain filter combinations result in version-only content, rather than showing version entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->