### PR TITLE
feat(content-uploader): pass version_number to modernized uploader items list

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,11 +98,7 @@
             "last 2 Edge versions",
             "last 2 iOS versions"
         ],
-        "development": [
-            "last 1 Chrome versions",
-            "last 1 Firefox versions",
-            "last 1 Safari versions"
-        ]
+        "development": ["last 1 Chrome versions", "last 1 Firefox versions", "last 1 Safari versions"]
     },
     "husky": {
         "hooks": {
@@ -140,7 +136,7 @@
         "@box/content-field": "^1.40.23",
         "@box/copy-input": "^1.42.16",
         "@box/frontend": "^11.0.1",
-        "@box/item-icon": "^2.32.14",
+        "@box/item-icon": "^2.37.5",
         "@box/languages": "^1.0.0",
         "@box/metadata-editor": "^1.69.6",
         "@box/metadata-filter": "^1.80.23",
@@ -372,8 +368,6 @@
         "tar": "^7.5.11"
     },
     "msw": {
-        "workerDirectory": [
-            ".storybook/public"
-        ]
+        "workerDirectory": [".storybook/public"]
     }
 }

--- a/package.json
+++ b/package.json
@@ -304,7 +304,7 @@
         "@box/combobox-with-api": "^1.42.22",
         "@box/content-field": "^1.40.23",
         "@box/copy-input": "^1.42.16",
-        "@box/item-icon": "^2.32.14",
+        "@box/item-icon": "^2.37.5",
         "@box/metadata-editor": "^1.69.6",
         "@box/metadata-filter": "^1.80.23",
         "@box/metadata-view": "^1.53.26",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,11 @@
             "last 2 Edge versions",
             "last 2 iOS versions"
         ],
-        "development": ["last 1 Chrome versions", "last 1 Firefox versions", "last 1 Safari versions"]
+        "development": [
+            "last 1 Chrome versions",
+            "last 1 Firefox versions",
+            "last 1 Safari versions"
+        ]
     },
     "husky": {
         "hooks": {
@@ -147,7 +151,7 @@
         "@box/types": "^2.1.8",
         "@box/unified-share-modal": "^2.15.16",
         "@box/user-selector": "^1.78.5",
-        "@box/uploads-manager": "^1.15.0",
+        "@box/uploads-manager": "^1.17.2",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@chromatic-com/storybook": "^4.0.1",
         "@commitlint/cli": "^19.8.0",
@@ -314,7 +318,7 @@
         "@box/types": "^2.1.8",
         "@box/unified-share-modal": "^2.15.16",
         "@box/user-selector": "^1.78.5",
-        "@box/uploads-manager": "^1.15.0",
+        "@box/uploads-manager": "^1.17.2",
         "@hapi/address": "^2.1.4",
         "@tanstack/react-virtual": "^3.13.12",
         "axios": "^0.32.0",
@@ -368,6 +372,8 @@
         "tar": "^7.5.11"
     },
     "msw": {
-        "workerDirectory": [".storybook/public"]
+        "workerDirectory": [
+            ".storybook/public"
+        ]
     }
 }

--- a/src/api/uploads/PlainUpload.js
+++ b/src/api/uploads/PlainUpload.js
@@ -73,10 +73,10 @@ class PlainUpload extends BaseUpload {
             if (this.fileId) {
                 uploadUrl = uploadUrl.replace('content', `${this.fileId}/content`);
             }
+        }
 
-            if (this.fields) {
-                uploadUrl = updateQueryParameters(uploadUrl, { fields: this.fields.toString() });
-            }
+        if (this.fields) {
+            uploadUrl = updateQueryParameters(uploadUrl, { fields: this.fields.toString() });
         }
 
         const attributes = JSON.stringify({

--- a/src/api/uploads/__tests__/PlainUpload.test.js
+++ b/src/api/uploads/__tests__/PlainUpload.test.js
@@ -174,6 +174,27 @@ describe('api/uploads/PlainUpload', () => {
             });
         });
 
+        test('should append fields query parameter to upload URL when fields are provided', () => {
+            upload.isDestroyed = jest.fn().mockReturnValueOnce(false);
+            upload.computeSHA1 = jest.fn().mockReturnValueOnce(Promise.resolve('somehash'));
+            upload.file = {
+                name: 'warlock',
+            };
+            upload.folderId = '123';
+            upload.fields = ['content_created_at', 'version_number'];
+            upload.xhr = {
+                uploadFile: jest.fn(),
+            };
+
+            return upload.preflightSuccessHandler({ data: {} }).then(() => {
+                expect(upload.xhr.uploadFile).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        url: `${upload.uploadHost}/api/2.0/files/content?fields=content_created_at%2Cversion_number`,
+                    }),
+                );
+            });
+        });
+
         test('should upload with no Content-MD5 hash if hashing fails', () => {
             upload.isDestroyed = jest.fn().mockReturnValueOnce(false);
             upload.computeSHA1 = jest.fn().mockReturnValueOnce(Promise.resolve(''));

--- a/src/elements/content-uploader/utils/__tests__/mapToModernizedUploadItem.test.ts
+++ b/src/elements/content-uploader/utils/__tests__/mapToModernizedUploadItem.test.ts
@@ -30,6 +30,7 @@ describe('mapToModernizedUploadItem()', () => {
             status: 'uploading',
             isFolder: undefined,
             errorMessage: undefined,
+            versionNumber: undefined,
         });
     });
 
@@ -62,6 +63,22 @@ describe('mapToModernizedUploadItem()', () => {
         const result = mapToModernizedUploadItem(buildLegacyItem({ extension: undefined, progress: undefined }), '0');
         expect(result.extension).toBe('');
         expect(result.progress).toBe(0);
+    });
+
+    test('forwards versionNumber from item.boxFile.version_number', () => {
+        const result = mapToModernizedUploadItem(
+            buildLegacyItem({
+                status: STATUS_COMPLETE,
+                boxFile: { version_number: '2' },
+            }),
+            '0',
+        );
+        expect(result.versionNumber).toBe('2');
+    });
+
+    test('leaves versionNumber undefined when boxFile is missing', () => {
+        const result = mapToModernizedUploadItem(buildLegacyItem({ status: STATUS_IN_PROGRESS }), '0');
+        expect(result.versionNumber).toBeUndefined();
     });
 });
 

--- a/src/elements/content-uploader/utils/mapToModernizedUploadItem.ts
+++ b/src/elements/content-uploader/utils/mapToModernizedUploadItem.ts
@@ -44,6 +44,7 @@ export function mapToModernizedUploadItem(item: LegacyUploadItem | FolderUploadI
         status: STATUS_MAP[item.status] ?? 'pending',
         isFolder: item.isFolder,
         errorMessage,
+        versionNumber: item.boxFile?.version_number,
     };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,10 +1169,10 @@
     rimraf "^3.0.0"
     semver "^7.4.0"
 
-"@box/item-icon@^2.32.14":
-  version "2.32.14"
-  resolved "https://registry.yarnpkg.com/@box/item-icon/-/item-icon-2.32.14.tgz#e9aa6b5297e34a310814e7f12adfcd14f2528adf"
-  integrity sha512-+VYA+gqiWWmdd4cEHyE6TMmuBUSGQLROoz0b/+TkG7dwMMXMfHylnVuI0Fqy5E955TvNTVxOLN1t+ejtlpmHhw==
+"@box/item-icon@^2.37.1":
+  version "2.37.5"
+  resolved "https://registry.yarnpkg.com/@box/item-icon/-/item-icon-2.37.5.tgz#887b58a66dee13f494d38709d7d6c0f7bdcc995f"
+  integrity sha512-GNcFK2Ehq0RFHxq8lbZD4J9UZZyxf/Y9l4PdoLQsfQWi/phWw27+v5dQBdfTBNHZGmfs4hNe+M2mUxqnOlG+Ng==
 
 "@box/languages@^1.0.0":
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,10 +1243,10 @@
   resolved "https://registry.yarnpkg.com/@box/unified-share-modal/-/unified-share-modal-2.15.16.tgz#49deb182bf1ac7f1ffe4bae713ab12ff2822533e"
   integrity sha512-Y1bE+JWDQm058lT+AcsfwJqK3WvGAsZj6ro9PLvejJZ1LxzexvOzyQFkM0sL4Kmj/93k2VEKoAJ/onBgheAJoQ==
 
-"@box/uploads-manager@^1.15.0":
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/@box/uploads-manager/-/uploads-manager-1.15.0.tgz#59e68734bb2dd0c84b356e3270f7d41e964dcbc9"
-  integrity sha512-pvz8wsZbhfoDK6tPfYl3Yo+48++C9Rcx6NxNVQxeq0dTGCjQeP4z0nLPvEaAGOUDI6osyF31pKSTDhwBSQsM7g==
+"@box/uploads-manager@^1.17.2":
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/@box/uploads-manager/-/uploads-manager-1.17.2.tgz#e7640ca60c0b1eac6fda1ab6dc5d8269a124eb69"
+  integrity sha512-pVXoPDFmAYx/ErD8+kP3yi4/EOG331tWl4yiO7cEDE1ia5X6mmKGp3va5twJfiqmTmnxBJJZAFEBa4QYb5yV5Q==
 
 "@box/user-selector@^1.78.5":
   version "1.78.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,7 +1169,7 @@
     rimraf "^3.0.0"
     semver "^7.4.0"
 
-"@box/item-icon@^2.37.1":
+"@box/item-icon@^2.37.5":
   version "2.37.5"
   resolved "https://registry.yarnpkg.com/@box/item-icon/-/item-icon-2.37.5.tgz#887b58a66dee13f494d38709d7d6c0f7bdcc995f"
   integrity sha512-GNcFK2Ehq0RFHxq8lbZD4J9UZZyxf/Y9l4PdoLQsfQWi/phWw27+v5dQBdfTBNHZGmfs4hNe+M2mUxqnOlG+Ng==


### PR DESCRIPTION
### Summary

- Passed `version_number` to the modernized upload items list
- Extracted the logic that appends `version_number` query param to the upload url outside of `if (!uploadUrl)` so that it can be called when we receive a url from preflight request

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated upload-related dependencies to newer versions.

* **Bug Fixes**
  * Fixed upload URL generation so the `fields` query parameter is consistently included, even when the upload URL is constructed internally.

* **Features**
  * Added `versionNumber` to modernized upload item mapping, sourced from legacy file data when available.

* **Tests**
  * Added/updated Jest coverage for `fields` URL inclusion and `versionNumber` mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->