### PR TITLE
fix(activity-feed-v2): document divider override between nav tabs and v2 feed

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
@@ -58,6 +58,7 @@
 .bcs-NewActivityFeedContent {
     min-width: 0;
 
+    // Hide the divider between the nav tabs and the v2 feed
     &.bcs-content {
         border-left-color: transparent;
     }


### PR DESCRIPTION
## Summary
- Adds a clarifying comment in `ActivityFeedV2.scss` explaining that the `border-left-color: transparent` override hides the divider between the nav tabs and the v2 feed.
- Uses a `fix` commit type so semantic-release generates a patch release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Clarified styling note indicating the divider between nav tabs and the v2 activity feed is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->