### PR TITLE
feat(content-uploader): controlled expanded state

### DIFF
--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -970,7 +970,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      *
      * @return {boolean}
      */
-    isExpandControlled = (): boolean => typeof this.props.isExpanded === 'boolean';
+    isExpandControlled = (): boolean => this.props.isExpanded !== undefined;
 
     /**
      * Returns the resolved expanded state. When `isExpanded` prop is provided
@@ -1372,19 +1372,17 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     toggleUploadsManager = (): void => {
         const { onToggle } = this.props;
         const isExpanded = this.getIsExpanded();
+        const nextExpanded = !isExpanded;
 
-        if (this.isExpandControlled()) {
-            if (onToggle) {
-                onToggle(!isExpanded);
+        if (!this.isExpandControlled()) {
+            if (isExpanded) {
+                this.minimizeUploadsManager();
+            } else {
+                this.expandUploadsManager();
             }
-            return;
         }
 
-        if (isExpanded) {
-            this.minimizeUploadsManager();
-        } else {
-            this.expandUploadsManager();
-        }
+        onToggle?.(nextExpanded);
     };
 
     /**

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -1374,12 +1374,10 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         const isExpanded = this.getIsExpanded();
         const nextExpanded = !isExpanded;
 
-        if (!this.isExpandControlled()) {
-            if (isExpanded) {
-                this.minimizeUploadsManager();
-            } else {
-                this.expandUploadsManager();
-            }
+        if (isExpanded) {
+            this.minimizeUploadsManager();
+        } else if (!this.isExpandControlled()) {
+            this.expandUploadsManager();
         }
 
         onToggle?.(nextExpanded);

--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -110,6 +110,8 @@ export interface ContentUploaderProps {
     uploadHost: string;
     useUploadsManager?: boolean;
     enableModernizedUploads?: boolean;
+    isExpanded?: boolean;
+    onToggle?: (isExpanded: boolean) => void;
 }
 
 type State = {
@@ -653,7 +655,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      */
     addToQueue = (newItems: UploadItem[], itemUpdateCallback: Function) => {
         const { fileLimit, useUploadsManager } = this.props;
-        const { isUploadsManagerExpanded } = this.state;
+        const isUploadsManagerExpanded = this.getIsExpanded();
 
         let updatedItems = [];
         const prevItemsNum = this.itemsRef.current.length;
@@ -963,8 +965,35 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         });
     };
 
+    /**
+     * Whether the component is in controlled-expand mode.
+     *
+     * @return {boolean}
+     */
+    isExpandControlled = (): boolean => typeof this.props.isExpanded === 'boolean';
+
+    /**
+     * Returns the resolved expanded state. When `isExpanded` prop is provided
+     * the component is in controlled mode and the prop wins; otherwise the
+     * internal state is used (uncontrolled mode).
+     *
+     * @return {boolean}
+     */
+    getIsExpanded = (): boolean => {
+        if (this.isExpandControlled()) {
+            return this.props.isExpanded;
+        }
+
+        return this.state.isUploadsManagerExpanded;
+    };
+
     resetUploadManagerExpandState = () => {
         this.isAutoExpanded = false;
+        // In controlled mode the consumer owns the expanded state. Auto-collapse
+        // (post-completion timeout, cancel-all) must not mutate that preference.
+        if (this.isExpandControlled()) {
+            return;
+        }
         this.setState({
             isUploadsManagerExpanded: false,
         });
@@ -1295,6 +1324,12 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
 
         clearTimeout(this.resetItemsTimeout);
 
+        // In controlled mode the consumer owns the expanded state. Auto-expand
+        // (file-count threshold) must not mutate that preference.
+        if (this.isExpandControlled()) {
+            return;
+        }
+
         this.setState({ isUploadsManagerExpanded: true });
     };
 
@@ -1335,9 +1370,17 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      * @return {void}
      */
     toggleUploadsManager = (): void => {
-        const { isUploadsManagerExpanded } = this.state;
+        const { onToggle } = this.props;
+        const isExpanded = this.getIsExpanded();
 
-        if (isUploadsManagerExpanded) {
+        if (this.isExpandControlled()) {
+            if (onToggle) {
+                onToggle(!isExpanded);
+            }
+            return;
+        }
+
+        if (isExpanded) {
             this.minimizeUploadsManager();
         } else {
             this.expandUploadsManager();
@@ -1395,7 +1438,8 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
      */
     resetUploadsManagerItemsWhenUploadsComplete = (): void => {
         const { onCancel, useUploadsManager } = this.props;
-        const { isUploadsManagerExpanded, view } = this.state;
+        const { view } = this.state;
+        const isUploadsManagerExpanded = this.getIsExpanded();
 
         // Do not reset items when upload manger is expanded or there're uploads in progress
         if (
@@ -1455,7 +1499,8 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
             theme,
             useUploadsManager,
         }: ContentUploaderProps = this.props;
-        const { view, items, errorCode, isCancelAllModalOpen, isUploadsManagerExpanded }: State = this.state;
+        const { view, items, errorCode, isCancelAllModalOpen }: State = this.state;
+        const isUploadsManagerExpanded = this.getIsExpanded();
         const isEmpty = items.length === 0;
         const isVisible = !isEmpty || !!isDraggingItemsToUploadsManager;
 

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -713,14 +713,22 @@ describe('elements/content-uploader/ContentUploader', () => {
             expect(wrapper.state().isUploadsManagerExpanded).toBe(false);
         });
 
-        test('toggleUploadsManager flips internal state in uncontrolled mode and does not call onToggle', () => {
+        test('toggleUploadsManager flips internal state in uncontrolled mode and fires onToggle', () => {
             const onToggle = jest.fn();
             const wrapper = getWrapper({ useUploadsManager: true, onToggle });
 
             wrapper.instance().toggleUploadsManager();
 
             expect(wrapper.state().isUploadsManagerExpanded).toBe(true);
-            expect(onToggle).not.toHaveBeenCalled();
+            expect(onToggle).toHaveBeenCalledTimes(1);
+            expect(onToggle).toHaveBeenCalledWith(true);
+        });
+
+        test('toggleUploadsManager does not require onToggle in uncontrolled mode', () => {
+            const wrapper = getWrapper({ useUploadsManager: true });
+
+            expect(() => wrapper.instance().toggleUploadsManager()).not.toThrow();
+            expect(wrapper.state().isUploadsManagerExpanded).toBe(true);
         });
 
         test('auto-expand on file-count threshold does not mutate state in controlled mode', () => {

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -680,6 +680,89 @@ describe('elements/content-uploader/ContentUploader', () => {
         });
     });
 
+    describe('controlled isExpanded / onToggle', () => {
+        test('uses isExpanded prop value when in controlled mode', () => {
+            const wrapper = getWrapper({ enableModernizedUploads: true, isExpanded: true, onToggle: jest.fn() });
+            expect(wrapper.find(UploadsManagerBP).prop('isExpanded')).toBe(true);
+
+            wrapper.setProps({ isExpanded: false });
+            expect(wrapper.find(UploadsManagerBP).prop('isExpanded')).toBe(false);
+        });
+
+        test('falls back to internal state when isExpanded prop is not provided', () => {
+            const wrapper = getWrapper({ enableModernizedUploads: true });
+            expect(wrapper.find(UploadsManagerBP).prop('isExpanded')).toBe(false);
+
+            wrapper.setState({ isUploadsManagerExpanded: true });
+            expect(wrapper.find(UploadsManagerBP).prop('isExpanded')).toBe(true);
+        });
+
+        test('toggleUploadsManager calls onToggle with next value in controlled mode and does not mutate internal state', () => {
+            const onToggle = jest.fn();
+            const wrapper = getWrapper({
+                enableModernizedUploads: true,
+                useUploadsManager: true,
+                isExpanded: false,
+                onToggle,
+            });
+
+            wrapper.instance().toggleUploadsManager();
+
+            expect(onToggle).toHaveBeenCalledTimes(1);
+            expect(onToggle).toHaveBeenCalledWith(true);
+            expect(wrapper.state().isUploadsManagerExpanded).toBe(false);
+        });
+
+        test('toggleUploadsManager flips internal state in uncontrolled mode and does not call onToggle', () => {
+            const onToggle = jest.fn();
+            const wrapper = getWrapper({ useUploadsManager: true, onToggle });
+
+            wrapper.instance().toggleUploadsManager();
+
+            expect(wrapper.state().isUploadsManagerExpanded).toBe(true);
+            expect(onToggle).not.toHaveBeenCalled();
+        });
+
+        test('auto-expand on file-count threshold does not mutate state in controlled mode', () => {
+            const onToggle = jest.fn();
+            const wrapper = getWrapper({
+                useUploadsManager: true,
+                isExpanded: false,
+                onToggle,
+            });
+            const instance = wrapper.instance();
+            const mockAPI = { upload: () => {} };
+            instance.createAPIFactory = jest.fn().mockReturnValue({
+                getPlainUploadAPI: () => mockAPI,
+                getChunkedUploadAPI: () => mockAPI,
+            });
+
+            const files = createMockFiles(EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD + 1);
+            wrapper.setProps({ files });
+
+            expect(wrapper.state().isUploadsManagerExpanded).toBe(false);
+            // Auto-expand must not leak into the persisted preference via onToggle.
+            expect(onToggle).not.toHaveBeenCalled();
+        });
+
+        test('auto-collapse via resetUploadManagerExpandState is a no-op in controlled mode', () => {
+            const onToggle = jest.fn();
+            const wrapper = getWrapper({
+                useUploadsManager: true,
+                isExpanded: true,
+                onToggle,
+            });
+            const instance = wrapper.instance();
+            instance.isAutoExpanded = true;
+
+            instance.resetUploadManagerExpandState();
+
+            expect(instance.isAutoExpanded).toBe(false);
+            expect(wrapper.state().isUploadsManagerExpanded).toBe(false); // initial default
+            expect(onToggle).not.toHaveBeenCalled();
+        });
+    });
+
     describe('componentDidMount()', () => {
         test('adds files to upload queue if isPrepopulateFilesEnabled is true and files are provided', () => {
             const files = createMockFiles(3);

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -753,6 +753,32 @@ describe('elements/content-uploader/ContentUploader', () => {
             expect(onToggle).not.toHaveBeenCalled();
         });
 
+        test('controlled-mode collapse runs minimizeUploadsManager side effects (onMinimize, cleanup timer, isAutoExpanded reset)', () => {
+            jest.useFakeTimers();
+            const onToggle = jest.fn();
+            const onMinimize = jest.fn();
+            const wrapper = getWrapper({
+                enableModernizedUploads: true,
+                useUploadsManager: true,
+                isExpanded: true,
+                onToggle,
+                onMinimize,
+            });
+            const instance = wrapper.instance();
+            instance.isAutoExpanded = true;
+            instance.checkClearUploadItems = jest.fn();
+
+            instance.toggleUploadsManager();
+
+            expect(onToggle).toHaveBeenCalledWith(false);
+            expect(onMinimize).toHaveBeenCalledTimes(1);
+            expect(instance.isAutoExpanded).toBe(false);
+            expect(instance.checkClearUploadItems).toHaveBeenCalledTimes(1);
+            // Internal state still owned by consumer — untouched.
+            expect(wrapper.state().isUploadsManagerExpanded).toBe(false);
+            jest.useRealTimers();
+        });
+
         test('auto-collapse via resetUploadManagerExpandState is a no-op in controlled mode', () => {
             const onToggle = jest.fn();
             const wrapper = getWrapper({


### PR DESCRIPTION
This PR is a part of making an expanded state persistent. The persistent logic will be handled from the outside.

1. Added `isExpanded` and `onToggle` props
2. Logic without `isExpanded` and `onToggle` preserved
3. Tests added

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The uploads manager now supports parent-controlled expand/collapse via new optional props to set the expanded state and receive toggle events.
  * Auto-expand and minimize/reset behaviors now consistently respect controlled mode, keeping internal expansion from changing unexpectedly.

* **Tests**
  * Added Jest coverage for controlled vs. uncontrolled modes, including `onToggle` callback behavior, auto-expand threshold handling, and ensuring reset/minimize don’t mutate internal expanded state or fire callbacks in controlled mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->