### PR TITLE
fix(activity-feed-v2): preserve timestamp markup when editing video comment

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
@@ -118,7 +118,10 @@ const FeedItemRow = ({
                 const serialized = serializeEditorContent(content);
                 if (!serialized || !serialized.text.trim()) return;
                 if (id === item.id) {
-                    onCommentUpdate?.(id, serialized.text, undefined, serialized.hasMention, permissions);
+                    const text = item.annotationTimestampMarkup
+                        ? `${item.annotationTimestampMarkup} ${serialized.text}`
+                        : serialized.text;
+                    onCommentUpdate?.(id, text, undefined, serialized.hasMention, permissions);
                     return;
                 }
                 dispatchReplyEdit({

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
@@ -417,6 +417,44 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
 
             expect(mockedSeekVideoToMs).toHaveBeenCalledWith(8055);
         });
+
+        test('should re-prepend timestamp markup when editing a video comment so the badge survives the update', () => {
+            mockedSerializeEditorContent.mockReturnValue({ hasMention: false, text: 'edited-text' });
+            const onCommentUpdate = jest.fn();
+            const timestampedComment: TransformedCommentItem = {
+                ...mockComment,
+                annotationTarget: { timestamp: '0:08', type: AnnotationBadgeType.Frame },
+                annotationTimestampMarkup: '#[timestamp:8055,versionId:2390295731268]',
+                annotationTimestampMs: 8055,
+            };
+            render(<FeedItemRow {...defaultProps} item={timestampedComment} onCommentUpdate={onCommentUpdate} />);
+
+            lastThreadedAnnotationProps.onEdit?.('comment-1', { type: 'doc', content: [] });
+
+            expect(onCommentUpdate).toHaveBeenCalledWith(
+                'comment-1',
+                '#[timestamp:8055,versionId:2390295731268] edited-text',
+                undefined,
+                false,
+                commentPermissions,
+            );
+        });
+
+        test('should not modify edit text for a regular comment without timestamp markup', () => {
+            mockedSerializeEditorContent.mockReturnValue({ hasMention: false, text: 'edited-text' });
+            const onCommentUpdate = jest.fn();
+            render(<FeedItemRow {...defaultProps} item={mockComment} onCommentUpdate={onCommentUpdate} />);
+
+            lastThreadedAnnotationProps.onEdit?.('comment-1', { type: 'doc', content: [] });
+
+            expect(onCommentUpdate).toHaveBeenCalledWith(
+                'comment-1',
+                'edited-text',
+                undefined,
+                false,
+                commentPermissions,
+            );
+        });
     });
 
     describe('annotation rendering', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
@@ -689,6 +689,7 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = extractTimestampMarkup('#[timestamp:8055,versionId:2390295731268]  wowo');
             expect(result.cleanText).toBe('wowo');
             expect(result.target).toEqual({ timestamp: '0:08', type: 'frame' });
+            expect(result.timestampMarkup).toBe('#[timestamp:8055,versionId:2390295731268]');
             expect(result.timestampMs).toBe(8055);
         });
 
@@ -696,6 +697,7 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = extractTimestampMarkup('#[timestamp:65000] hello');
             expect(result.cleanText).toBe('hello');
             expect(result.target).toEqual({ timestamp: '1:05', type: 'frame' });
+            expect(result.timestampMarkup).toBe('#[timestamp:65000]');
             expect(result.timestampMs).toBe(65000);
         });
 
@@ -759,6 +761,7 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             expect(result!.type).toBe('comment');
             if (result!.type === 'comment') {
                 expect(result.annotationTarget).toEqual({ timestamp: '0:08', type: 'frame' });
+                expect(result.annotationTimestampMarkup).toBe('#[timestamp:8055,versionId:2390295731268]');
                 expect(result.annotationTimestampMs).toBe(8055);
             }
         });
@@ -778,6 +781,7 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = transformFeedItem(comment as unknown as FeedItem);
             if (result!.type === 'comment') {
                 expect(result.annotationTarget).toBeUndefined();
+                expect(result.annotationTimestampMarkup).toBeUndefined();
                 expect(result.annotationTimestampMs).toBeUndefined();
             }
         });

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -46,7 +46,12 @@ const TIMESTAMP_MARKUP_REGEX = /^#\[timestamp:(\d+)(?:,versionId:\d+)?\]\s*/;
 
 export const extractTimestampMarkup = (
     text: string,
-): { cleanText: string; target?: AnnotationBadgeTargetType; timestampMs?: number } => {
+): {
+    cleanText: string;
+    target?: AnnotationBadgeTargetType;
+    timestampMarkup?: string;
+    timestampMs?: number;
+} => {
     if (!text) return { cleanText: '' };
     const match = text.match(TIMESTAMP_MARKUP_REGEX);
     if (!match) return { cleanText: text };
@@ -60,7 +65,7 @@ export const extractTimestampMarkup = (
         timestamp: convertMillisecondsToTimestamp(ms),
         type: AnnotationBadgeType.Frame,
     };
-    return { cleanText, target, timestampMs: ms };
+    return { cleanText, target, timestampMarkup: fullMatch.trimEnd(), timestampMs: ms };
 };
 
 const parseLine = (line: string, authorId: string): (MentionNode | TextNode)[] => {
@@ -292,11 +297,17 @@ export const transformFeedItem = (item: FeedItem, currentUserId?: string): Trans
             const comment = item as unknown as Comment;
             const commentIsResolved = comment.status === 'resolved';
             const rawText = comment.tagged_message || comment.message || '';
-            const { cleanText, target: annotationTarget, timestampMs } = extractTimestampMarkup(rawText);
+            const {
+                cleanText,
+                target: annotationTarget,
+                timestampMarkup,
+                timestampMs,
+            } = extractTimestampMarkup(rawText);
             const root = commentToTextMessage(comment, cleanText);
             const replies = (comment.replies ?? []).map(reply => commentToTextMessage(reply));
             return {
                 annotationTarget,
+                annotationTimestampMarkup: timestampMarkup,
                 annotationTimestampMs: timestampMs,
                 id: comment.id,
                 isResolved: commentIsResolved,

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -47,6 +47,7 @@ type ResolvedInfo = {
 
 export type TransformedCommentItem = {
     annotationTarget?: AnnotationBadgeTargetType;
+    annotationTimestampMarkup?: string;
     annotationTimestampMs?: number;
     id: string;
     messages: TextMessageType[];


### PR DESCRIPTION
## Summary
- Video comments encode their frame timestamp inline as a `#[timestamp:NNN,versionId:NNN]` markup prefix on the comment message. The transformer strips that prefix for display, so the editor only contains the visible text and editing the comment dropped the markup from the payload, which lost the badge on the comment.
- Capture the original markup token in `extractTimestampMarkup`, expose it on `TransformedCommentItem` as `annotationTimestampMarkup`, and re-prepend it to the serialized text when the root of a video comment is edited. Replies and non-timestamped comments are unchanged. Annotations are not affected because they store the timestamp on `target.location`, separate from the message.

## Test Plan
- [x] `yarn test --watchAll=false --testPathPattern="activity-feed-v2"` (217 passed)
- [ ] Manually edit a video comment with a frame timestamp in the v2 feed and confirm the timestamp badge survives the edit
- [ ] Edit a regular (non-video) comment and confirm the message is updated as before
- [ ] Edit a reply on a video-timestamped comment and confirm the parent badge is preserved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp information being lost when editing timestamped comments. Timestamp markup is now correctly preserved during edits.

* **Tests**
  * Added test coverage for timestamp preservation in comment edits and timestamp markup extraction validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->