### PR TITLE
fix(activity-feed-v2): restore sidebar content left border

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
@@ -57,9 +57,4 @@
 // Lets inner ellipsis truncation resolve against the sidebar width.
 .bcs-NewActivityFeedContent {
     min-width: 0;
-
-    // Hide the divider between the nav tabs and the v2 feed
-    &.bcs-content {
-        border-left-color: transparent;
-    }
 }


### PR DESCRIPTION
## Summary
- Removes the `border-left-color: transparent` override on `.bcs-NewActivityFeedContent.bcs-content` in `ActivityFeedV2.scss`.
- The divider between the sidebar nav tabs and the v2 feed now renders again.

## Test plan
- [ ] Open the content sidebar with the v2 activity feed and confirm the left border / divider between the nav tabs and the feed is visible.
- [ ] Confirm no other sidebar layouts regressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue where a divider between navigation tabs and the activity feed was not visible. The divider now displays with its default styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->