### PR TITLE
feat(activity-feed-v2): emit timestamped comment markers to video player

### DIFF
--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -116,6 +116,7 @@ type ExternalProps = {
 type PropsWithoutContext = {
     elementId: string,
     file: BoxItem,
+    getViewer?: Function,
     hasSidebarInitialized?: boolean,
     isDisabled: boolean,
     onAnnotationSelect: Function,
@@ -1425,6 +1426,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                         createTask={this.createTask}
                         currentUser={currentUser}
                         feedItems={this.getFilteredFeedItems()}
+                        getViewer={this.props.getViewer}
                         file={file}
                         getApproverWithQuery={this.getApprover}
                         getAvatarUrl={this.getAvatarUrl}

--- a/src/elements/content-sidebar/SidebarPanels.js
+++ b/src/elements/content-sidebar/SidebarPanels.js
@@ -435,6 +435,7 @@ class SidebarPanels extends React.Component<Props, State> {
                                     currentUser={currentUser}
                                     currentUserError={currentUserError}
                                     file={file}
+                                    getViewer={getViewer}
                                     hasSidebarInitialized={isInitialized}
                                     onAnnotationSelect={onAnnotationSelect}
                                     onVersionChange={onVersionChange}

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -73,6 +73,8 @@ const ActivityFeedV2 = ({
     const intl = useIntl();
     const scrollHandle = useActivityFeedScroll();
     const currentUserId = currentUser?.id;
+    const scrollHandleRef = React.useRef<typeof scrollHandle | null>(null);
+    scrollHandleRef.current = scrollHandle;
     const headerTitle = intl.formatMessage(commonMessages.sidebarActivityTitle);
 
     const scrolledEntryIdRef = React.useRef<string | null>(null);
@@ -308,8 +310,11 @@ const ActivityFeedV2 = ({
         ? { formattedTimestamp, isPressed: isTimestampPressed, onPressedChange }
         : undefined;
 
-    const commentMarkers = React.useMemo(() => {
-        if (!isVideo) return [];
+    React.useEffect(() => {
+        if (!getViewer || !isVideo) return undefined;
+        const viewer = getViewer();
+        if (!viewer) return undefined;
+
         const markers: Array<{
             avatarUrl?: string;
             colorIndex?: number;
@@ -344,35 +349,19 @@ const ActivityFeedV2 = ({
                 }
             }
         }
-        return markers;
-    }, [filteredItems, isVideo]);
-
-    React.useEffect(() => {
-        if (!getViewer || !isVideo) return;
-        const viewer = getViewer();
-        if (!viewer) return;
-        viewer.emit('comment_markers', commentMarkers);
-    }, [commentMarkers, getViewer, isVideo]);
-
-    React.useEffect(() => {
-        if (!getViewer || !isVideo) return undefined;
-        const viewer = getViewer();
-        if (!viewer) return undefined;
+        viewer.emit('comment_markers', markers);
 
         const handleMarkerSelect = ({ id }: { id: string }) => {
             requestAnimationFrame(() => {
-                const el = document.querySelector(`[data-activity-id="${CSS.escape(id)}"]`);
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }
+                scrollHandleRef.current?.scrollTo(id);
             });
         };
         viewer.addListener('comment_marker_select', handleMarkerSelect);
         return () => {
-            viewer.emit('comment_markers', []);
             viewer.removeListener('comment_marker_select', handleMarkerSelect);
+            viewer.emit('comment_markers', []);
         };
-    }, [getViewer, isVideo]);
+    }, [filteredItems, getViewer, isVideo]);
 
     const handleCommentPost = React.useCallback(
         async (content: unknown) => {

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -72,6 +72,8 @@ const ActivityFeedV2 = ({
 }: ActivityFeedV2Props) => {
     const intl = useIntl();
     const scrollHandle = useActivityFeedScroll();
+    const scrollHandleRef = React.useRef(scrollHandle);
+    scrollHandleRef.current = scrollHandle;
     const currentUserId = currentUser?.id;
     const headerTitle = intl.formatMessage(commonMessages.sidebarActivityTitle);
 
@@ -308,11 +310,8 @@ const ActivityFeedV2 = ({
         ? { formattedTimestamp, isPressed: isTimestampPressed, onPressedChange }
         : undefined;
 
-    React.useEffect(() => {
-        if (!getViewer || !isVideo) return undefined;
-        const viewer = getViewer();
-        if (!viewer) return undefined;
-
+    const commentMarkers = React.useMemo(() => {
+        if (!isVideo) return [];
         const markers: Array<{
             avatarUrl?: string;
             colorIndex?: number;
@@ -347,21 +346,32 @@ const ActivityFeedV2 = ({
                 }
             }
         }
-        viewer.emit('commentmarkers', markers);
+        return markers;
+    }, [filteredItems, isVideo]);
+
+    React.useEffect(() => {
+        if (!getViewer || !isVideo) return;
+        const viewer = getViewer();
+        if (!viewer) return;
+        viewer.emit('commentmarkers', commentMarkers);
+    }, [commentMarkers, getViewer, isVideo]);
+
+    React.useEffect(() => {
+        if (!getViewer || !isVideo) return undefined;
+        const viewer = getViewer();
+        if (!viewer) return undefined;
 
         const handleMarkerSelect = ({ id }: { id: string }) => {
             requestAnimationFrame(() => {
-                const el = document.querySelector(`[data-activity-id="${CSS.escape(id)}"]`);
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }
+                scrollHandleRef.current?.scrollTo(id);
             });
         };
         viewer.addListener('commentmarkerselect', handleMarkerSelect);
         return () => {
+            viewer.emit('commentmarkers', []);
             viewer.removeListener('commentmarkerselect', handleMarkerSelect);
         };
-    }, [filteredItems, getViewer, isVideo]);
+    }, [getViewer, isVideo]);
 
     const handleCommentPost = React.useCallback(
         async (content: unknown) => {

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -350,10 +350,12 @@ const ActivityFeedV2 = ({
         viewer.emit('commentmarkers', markers);
 
         const handleMarkerSelect = ({ id }: { id: string }) => {
-            const el = document.querySelector(`[data-activity-id="${CSS.escape(id)}"]`);
-            if (el) {
-                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }
+            requestAnimationFrame(() => {
+                const el = document.querySelector(`[data-activity-id="${CSS.escape(id)}"]`);
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            });
         };
         viewer.addListener('commentmarkerselect', handleMarkerSelect);
         return () => {

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -44,6 +44,7 @@ const ActivityFeedV2 = ({
     getAvatarUrl,
     getMentionAsync,
     getTaskCollaborators,
+    getViewer,
     hasTasks = true,
     isDisabled = false,
     isTimestampedCommentsEnabled = false,
@@ -306,6 +307,59 @@ const ActivityFeedV2 = ({
     const editorVideoTimestamp = allowVideoTimestamps
         ? { formattedTimestamp, isPressed: isTimestampPressed, onPressedChange }
         : undefined;
+
+    React.useEffect(() => {
+        if (!getViewer || !isVideo) return undefined;
+        const viewer = getViewer();
+        if (!viewer) return undefined;
+
+        const markers: Array<{
+            avatarUrl?: string;
+            colorIndex?: number;
+            id: string;
+            initial?: string;
+            time: number;
+            type: 'annotation' | 'comment';
+        }> = [];
+        for (const item of filteredItems) {
+            if (item.type === 'comment' && item.annotationTimestampMs != null) {
+                const author = item.messages[0]?.author;
+                markers.push({
+                    avatarUrl: author?.avatarUrl ?? undefined,
+                    colorIndex: author?.id ?? 0,
+                    id: item.id,
+                    initial: author?.name?.[0] ?? undefined,
+                    time: item.annotationTimestampMs / 1000,
+                    type: 'comment',
+                });
+            } else if (item.type === 'annotation') {
+                const loc = item.annotation?.target?.location;
+                if (loc?.type === 'frame' && loc.value != null) {
+                    const author = item.messages[0]?.author;
+                    markers.push({
+                        avatarUrl: author?.avatarUrl ?? undefined,
+                        colorIndex: author?.id ?? 0,
+                        id: item.id,
+                        initial: author?.name?.[0] ?? undefined,
+                        time: loc.value / 1000,
+                        type: 'annotation',
+                    });
+                }
+            }
+        }
+        viewer.emit('commentmarkers', markers);
+
+        const handleMarkerSelect = ({ id }: { id: string }) => {
+            const el = document.querySelector(`[data-activity-id="${CSS.escape(id)}"]`);
+            if (el) {
+                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        };
+        viewer.addListener('commentmarkerselect', handleMarkerSelect);
+        return () => {
+            viewer.removeListener('commentmarkerselect', handleMarkerSelect);
+        };
+    }, [filteredItems, getViewer, isVideo]);
 
     const handleCommentPost = React.useCallback(
         async (content: unknown) => {

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -72,8 +72,6 @@ const ActivityFeedV2 = ({
 }: ActivityFeedV2Props) => {
     const intl = useIntl();
     const scrollHandle = useActivityFeedScroll();
-    const scrollHandleRef = React.useRef(scrollHandle);
-    scrollHandleRef.current = scrollHandle;
     const currentUserId = currentUser?.id;
     const headerTitle = intl.formatMessage(commonMessages.sidebarActivityTitle);
 
@@ -353,7 +351,7 @@ const ActivityFeedV2 = ({
         if (!getViewer || !isVideo) return;
         const viewer = getViewer();
         if (!viewer) return;
-        viewer.emit('commentmarkers', commentMarkers);
+        viewer.emit('comment_markers', commentMarkers);
     }, [commentMarkers, getViewer, isVideo]);
 
     React.useEffect(() => {
@@ -363,13 +361,16 @@ const ActivityFeedV2 = ({
 
         const handleMarkerSelect = ({ id }: { id: string }) => {
             requestAnimationFrame(() => {
-                scrollHandleRef.current?.scrollTo(id);
+                const el = document.querySelector(`[data-activity-id="${CSS.escape(id)}"]`);
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
             });
         };
-        viewer.addListener('commentmarkerselect', handleMarkerSelect);
+        viewer.addListener('comment_marker_select', handleMarkerSelect);
         return () => {
-            viewer.emit('commentmarkers', []);
-            viewer.removeListener('commentmarkerselect', handleMarkerSelect);
+            viewer.emit('comment_markers', []);
+            viewer.removeListener('comment_marker_select', handleMarkerSelect);
         };
     }, [getViewer, isVideo]);
 

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -1046,4 +1046,112 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             expect(mockScrollTo).toHaveBeenLastCalledWith('new-comment');
         });
     });
+
+    describe('comment markers', () => {
+        const mockViewer = {
+            addListener: jest.fn(),
+            emit: jest.fn(),
+            removeListener: jest.fn(),
+        };
+        const mockGetViewer = jest.fn(() => mockViewer);
+
+        const timestampedComment = {
+            ...mockComment,
+            id: 'ts-comment-1',
+            tagged_message: '#[timestamp:5000,versionId:123] Hello',
+        };
+
+        const frameAnnotation = {
+            ...mockAnnotation,
+            id: 'frame-ann-1',
+            target: { location: { type: 'frame', value: 10000 }, type: 'region' },
+        };
+
+        const renderComponentWithMarkers = (props: Partial<ActivityFeedV2Props> = {}) =>
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[timestampedComment] as ActivityFeedV2Props['feedItems']}
+                    file={{ extension: 'mp4', file_version: { id: '1' } }}
+                    getViewer={mockGetViewer}
+                    isTimestampedCommentsEnabled
+                    {...props}
+                />,
+            );
+
+        beforeEach(() => {
+            mockViewer.addListener.mockClear();
+            mockViewer.emit.mockClear();
+            mockViewer.removeListener.mockClear();
+            mockGetViewer.mockClear();
+        });
+
+        test('should not emit commentmarkers when getViewer is not provided', () => {
+            renderComponentWithMarkers({ getViewer: undefined });
+            expect(mockViewer.emit).not.toHaveBeenCalled();
+        });
+
+        test('should not emit commentmarkers when file is not a video', () => {
+            renderComponentWithMarkers({ file: { extension: 'pdf', file_version: { id: '1' } } });
+            expect(mockViewer.emit).not.toHaveBeenCalledWith('commentmarkers', expect.anything());
+        });
+
+        test('should not emit commentmarkers when getViewer returns null', () => {
+            renderComponentWithMarkers({ getViewer: jest.fn(() => null) });
+            expect(mockViewer.emit).not.toHaveBeenCalled();
+        });
+
+        test('should emit commentmarkers with timestamped comment data', () => {
+            renderComponentWithMarkers();
+            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', [
+                expect.objectContaining({
+                    id: 'ts-comment-1',
+                    time: 5,
+                    type: 'comment',
+                }),
+            ]);
+        });
+
+        test('should emit commentmarkers with frame annotation data', () => {
+            renderComponentWithMarkers({ feedItems: [frameAnnotation] as ActivityFeedV2Props['feedItems'] });
+            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', [
+                expect.objectContaining({
+                    id: 'frame-ann-1',
+                    time: 10,
+                    type: 'annotation',
+                }),
+            ]);
+        });
+
+        test('should include author avatar and initial in markers', () => {
+            renderComponentWithMarkers();
+            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', [
+                expect.objectContaining({
+                    initial: 'C',
+                    colorIndex: 2,
+                }),
+            ]);
+        });
+
+        test('should register commentmarkerselect listener on viewer', () => {
+            renderComponentWithMarkers();
+            expect(mockViewer.addListener).toHaveBeenCalledWith('commentmarkerselect', expect.any(Function));
+        });
+
+        test('should remove commentmarkerselect listener on unmount', () => {
+            const { unmount } = renderComponentWithMarkers();
+            unmount();
+            expect(mockViewer.removeListener).toHaveBeenCalledWith('commentmarkerselect', expect.any(Function));
+        });
+
+        test('should not include non-timestamped comments in markers', () => {
+            renderComponentWithMarkers({ feedItems: [mockComment] as ActivityFeedV2Props['feedItems'] });
+            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', []);
+        });
+
+        test('should not include page-based annotations in markers', () => {
+            renderComponentWithMarkers({ feedItems: [mockAnnotation] as ActivityFeedV2Props['feedItems'] });
+            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', []);
+        });
+    });
 });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -1086,24 +1086,24 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             mockGetViewer.mockClear();
         });
 
-        test('should not emit commentmarkers when getViewer is not provided', () => {
+        test('should not emit comment_markers when getViewer is not provided', () => {
             renderComponentWithMarkers({ getViewer: undefined });
             expect(mockViewer.emit).not.toHaveBeenCalled();
         });
 
-        test('should not emit commentmarkers when file is not a video', () => {
+        test('should not emit comment_markers when file is not a video', () => {
             renderComponentWithMarkers({ file: { extension: 'pdf', file_version: { id: '1' } } });
-            expect(mockViewer.emit).not.toHaveBeenCalledWith('commentmarkers', expect.anything());
+            expect(mockViewer.emit).not.toHaveBeenCalledWith('comment_markers', expect.anything());
         });
 
-        test('should not emit commentmarkers when getViewer returns null', () => {
+        test('should not emit comment_markers when getViewer returns null', () => {
             renderComponentWithMarkers({ getViewer: jest.fn(() => null) });
             expect(mockViewer.emit).not.toHaveBeenCalled();
         });
 
-        test('should emit commentmarkers with timestamped comment data', () => {
+        test('should emit comment_markers with timestamped comment data', () => {
             renderComponentWithMarkers();
-            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', [
+            expect(mockViewer.emit).toHaveBeenCalledWith('comment_markers', [
                 expect.objectContaining({
                     id: 'ts-comment-1',
                     time: 5,
@@ -1112,9 +1112,9 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             ]);
         });
 
-        test('should emit commentmarkers with frame annotation data', () => {
+        test('should emit comment_markers with frame annotation data', () => {
             renderComponentWithMarkers({ feedItems: [frameAnnotation] as ActivityFeedV2Props['feedItems'] });
-            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', [
+            expect(mockViewer.emit).toHaveBeenCalledWith('comment_markers', [
                 expect.objectContaining({
                     id: 'frame-ann-1',
                     time: 10,
@@ -1125,7 +1125,7 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
 
         test('should include author avatar and initial in markers', () => {
             renderComponentWithMarkers();
-            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', [
+            expect(mockViewer.emit).toHaveBeenCalledWith('comment_markers', [
                 expect.objectContaining({
                     initial: 'C',
                     colorIndex: 2,
@@ -1133,27 +1133,27 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             ]);
         });
 
-        test('should register commentmarkerselect listener on viewer', () => {
+        test('should register comment_marker_select listener on viewer', () => {
             renderComponentWithMarkers();
-            expect(mockViewer.addListener).toHaveBeenCalledWith('commentmarkerselect', expect.any(Function));
+            expect(mockViewer.addListener).toHaveBeenCalledWith('comment_marker_select', expect.any(Function));
         });
 
-        test('should remove commentmarkerselect listener on unmount', () => {
+        test('should remove comment_marker_select listener on unmount', () => {
             const { unmount } = renderComponentWithMarkers();
             mockViewer.emit.mockClear();
             unmount();
-            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', []);
-            expect(mockViewer.removeListener).toHaveBeenCalledWith('commentmarkerselect', expect.any(Function));
+            expect(mockViewer.emit).toHaveBeenCalledWith('comment_markers', []);
+            expect(mockViewer.removeListener).toHaveBeenCalledWith('comment_marker_select', expect.any(Function));
         });
 
         test('should not include non-timestamped comments in markers', () => {
             renderComponentWithMarkers({ feedItems: [mockComment] as ActivityFeedV2Props['feedItems'] });
-            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', []);
+            expect(mockViewer.emit).toHaveBeenCalledWith('comment_markers', []);
         });
 
         test('should not include page-based annotations in markers', () => {
             renderComponentWithMarkers({ feedItems: [mockAnnotation] as ActivityFeedV2Props['feedItems'] });
-            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', []);
+            expect(mockViewer.emit).toHaveBeenCalledWith('comment_markers', []);
         });
     });
 });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -1140,7 +1140,9 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
 
         test('should remove commentmarkerselect listener on unmount', () => {
             const { unmount } = renderComponentWithMarkers();
+            mockViewer.emit.mockClear();
             unmount();
+            expect(mockViewer.emit).toHaveBeenCalledWith('commentmarkers', []);
             expect(mockViewer.removeListener).toHaveBeenCalledWith('commentmarkerselect', expect.any(Function));
         });
 

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -94,6 +94,8 @@ export type ActivityFeedV2Props = {
     getAvatarUrl?: GetAvatarUrl;
     getMentionAsync?: (searchStr: string) => Promise<Array<Record<string, unknown>>>;
     getTaskCollaborators?: (task: TaskNew) => Promise<TaskAssigneeCollection>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getViewer?: () => any;
     hasTasks?: boolean;
     isDisabled?: boolean;
     isTimestampedCommentsEnabled?: boolean;

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -83,6 +83,12 @@ export type ActivityFeedV2File = {
     file_version?: { id: string };
 };
 
+export type ViewerHandle = {
+    addListener: (event: string, handler: (payload: unknown) => void) => void;
+    emit: (event: string, payload: unknown) => void;
+    removeListener: (event: string, handler: (payload: unknown) => void) => void;
+};
+
 export type ActivityFeedV2Props = {
     activeFeedEntryId?: string;
     approverSelectorContacts?: Array<Record<string, unknown>>;
@@ -94,8 +100,7 @@ export type ActivityFeedV2Props = {
     getAvatarUrl?: GetAvatarUrl;
     getMentionAsync?: (searchStr: string) => Promise<Array<Record<string, unknown>>>;
     getTaskCollaborators?: (task: TaskNew) => Promise<TaskAssigneeCollection>;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getViewer?: () => any;
+    getViewer?: () => ViewerHandle | null;
     hasTasks?: boolean;
     isDisabled?: boolean;
     isTimestampedCommentsEnabled?: boolean;


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

## Summary
- `ActivityFeedV2` now extracts timestamped comments and frame annotations from `filteredItems` and emits them to the video viewer via the `commentmarkers` event
- Listens for `commentmarkerselect` events from the viewer to scroll the sidebar to the selected item when a scrubber marker is clicked
- Threads the existing `getViewer` prop from `SidebarPanels` → `ActivitySidebar` → `ActivityFeedV2`

## Modified files
- `ActivityFeedV2.tsx` — Added `useEffect` to build markers array and emit to viewer, registers/cleans up `commentmarkerselect` listener
- `types.ts` — Added `getViewer` prop to `ActivityFeedV2Props`
- `ActivitySidebar.js` — Added `getViewer` to props type, passes it to `ActivityFeedV2`
- `SidebarPanels.js` — Passes `getViewer` to `LoadableActivitySidebar`
- `ActivityFeedV2.test.tsx` — 10 new tests for marker emission, listener lifecycle, and filtering

## Depends on
- `box-content-preview` PR that adds the `commentmarkers` event listener and `commentmarkerselect` event emission

## Test plan 
- [ ] Open a video file with timestamped comments — verify markers appear on scrubber
- [ ] Open a video with frame annotations — verify annotation markers appear
- [ ] Verify non-timestamped comments and page-based annotations do not produce markers
- [ ] Click a marker on the scrubber — verify the sidebar scrolls to the corresponding feed item
- [ ] Post a new timestamped comment — verify markers update
- [ ] Filter the feed (e.g., "only mentions me") — verify markers update to match filtered items
- [ ] Switch to a non-video file — verify no markers are emitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video activity feeds can now synchronize comment/annotation “markers” with the viewer when available via an optional viewer callback passed through the activity sidebar.
  * Selecting a viewer marker scrolls directly to the corresponding activity item.
* **Bug Fixes**
  * Marker emission is now correctly gated to video content and timestamped/frame-based annotations, with proper viewer event setup and cleanup.
* **Tests**
  * Added test coverage for marker payload accuracy, viewer event wiring, filtering behavior, and unmount cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->