### PR TITLE
fix(activity-feed-v2): anchor feed to sidebar to prevent page scroll

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.scss
@@ -1,22 +1,17 @@
-// CSS isolation layer for ActivityFeedV2.
-// BUIE global styles (.bcs scope from base.scss) apply broad rules to native
-// elements (inputs, contenteditable, buttons, links, textareas). These leak
-// into Blueprint and @box/threaded-annotations components, breaking their
-// styling. This file resets those rules within the v2 adapter boundary.
+// Resets BUIE .bcs global styles that leak into Blueprint and
+// @box/threaded-annotations components.
 
 .bcs-NewActivityFeed {
+    position: absolute;
+    inset: 0;
     display: flex;
     flex-direction: column;
-    height: 100%;
     overflow: hidden;
 
-    // `display: contents` keeps the wrapper transparent to the vendor's flex layout.
     &-list {
         display: contents;
     }
 
-    // Forms: BUIE sets width, padding, border, box-shadow, border-radius on
-    // contenteditable and inputs via _forms.scss inside .bcs scope.
     div[contenteditable='true'],
     div[contenteditable='true']:hover,
     div[contenteditable='true']:focus {
@@ -31,8 +26,6 @@
         transition: none;
     }
 
-    // Links: BUIE forces color and text-decoration on all <a> elements
-    // via _links.scss.
     a {
         color: inherit;
         text-decoration: inherit;
@@ -42,8 +35,6 @@
         text-decoration: inherit;
     }
 
-    // BUIE sets pointer-events: none on <svg> inside <a> and <button>,
-    // which breaks Blueprint icon buttons.
     a svg,
     button svg {
         pointer-events: auto;
@@ -54,7 +45,10 @@
     }
 }
 
-// Lets inner ellipsis truncation resolve against the sidebar width.
+// Containing block for the absolutely positioned .bcs-NewActivityFeed child,
+// so the feed fills the sidebar even when ancestors lack a definite height
+// (e.g., shared-link pages).
 .bcs-NewActivityFeedContent {
+    position: relative;
     min-width: 0;
 }


### PR DESCRIPTION
## Summary
- Anchor `.bcs-NewActivityFeed` to its sidebar container with `position: absolute; inset: 0` and give `.bcs-NewActivityFeedContent` `position: relative` so it acts as the containing block.
- Fixes the v2 feed expanding the page on shared-link pages (the whole page scrolled instead of the feed, with no way to scroll back up).
- v1 sidebar path is untouched. Both v2 selectors are only rendered when `isThreadedRepliesV2Enabled` is on.

## Why
The previous v2 wrapper used `height: 100%`, which depends on every ancestor propagating a definite height. The regular preview path runs inside `.preview-overlay` (`position: fixed; inset: 0`) which satisfies that. The shared-link path runs inside `.shared-file-page` -> `main` -> `body` whose chain bottoms out at a `min-height: 100vh` ancestor, so `height: 100%` collapsed to content height and the feed pushed the page taller than the viewport.

Absolutely positioning the wrapper against `.bcs-NewActivityFeedContent` mirrors the approach v1 already takes via `.bcs-scroll-content-wrapper` in `SidebarContent.tsx`.

## Test plan
- [ ] Open a shared-link preview with v2 enabled; confirm the feed scrolls internally and the page does not grow past the viewport.
- [ ] Open a regular file preview with v2 enabled; confirm no regression in feed scroll behavior.
- [ ] Confirm v1 (`activityFeed.threadedRepliesV2.enabled` off) is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the activity feed layout so it now fills the available sidebar space more reliably.
  * Prevented the feed from depending on parent height settings, which helps avoid empty or mis-sized content areas.
  * Kept link and icon interactions working as expected inside the feed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->