### PR TITLE
feat(activity-feed-v2): scaffold accessible task modal v2 shell

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -872,6 +872,16 @@ be.sort = Sort
 be.statusSkill = Status
 # Generic success label.
 be.success = Success
+# aria-label for the task modal close button
+be.taskModalV2.close = Close
+# Title of the modal for creating an approval task
+be.taskModalV2.createApprovalTask = Create Approval Task
+# Title of the modal for creating a general task
+be.taskModalV2.createGeneralTask = Create General Task
+# Title of the modal for editing an existing approval task
+be.taskModalV2.editApprovalTask = Modify Approval Task
+# Title of the modal for editing an existing general task
+be.taskModalV2.editGeneralTask = Modify General Task
 # Shown instead of todays date.
 be.today = today
 # Label for keywords/topics skill section in the preview sidebar

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.scss
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.scss
@@ -1,0 +1,5 @@
+.bcs-NewTaskModal {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bp-space-040);
+}

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { useIntl } from 'react-intl';
+import type { MessageDescriptor } from 'react-intl';
+
+import { Modal } from '@box/blueprint-web';
+
+import { TASK_EDIT_MODE_CREATE, TASK_TYPE_APPROVAL, TASK_TYPE_GENERAL } from '../../../../constants';
+
+import type { TaskEditMode, TaskType } from '../../../../common/types/tasks';
+
+import messages from './messages';
+
+import './TaskModalV2.scss';
+
+export type TaskModalV2Props = {
+    editMode?: TaskEditMode;
+    isOpen: boolean;
+    onClose: () => void;
+    taskType: TaskType;
+};
+
+const getTitleMessage = (taskType: TaskType, editMode: TaskEditMode): MessageDescriptor => {
+    const isCreate = editMode === TASK_EDIT_MODE_CREATE;
+    if (taskType === TASK_TYPE_GENERAL) {
+        return isCreate ? messages.createGeneralTaskTitle : messages.editGeneralTaskTitle;
+    }
+    return isCreate ? messages.createApprovalTaskTitle : messages.editApprovalTaskTitle;
+};
+
+const TaskModalV2 = ({
+    editMode = TASK_EDIT_MODE_CREATE,
+    isOpen,
+    onClose,
+    taskType = TASK_TYPE_APPROVAL,
+}: TaskModalV2Props) => {
+    const { formatMessage } = useIntl();
+    const titleMessage = getTitleMessage(taskType, editMode);
+
+    const handleOpenChange = (open: boolean) => {
+        if (!open) {
+            onClose();
+        }
+    };
+
+    return (
+        <Modal open={isOpen} onOpenChange={handleOpenChange}>
+            <Modal.Content className="bcs-NewTaskModal" data-testid="task-modal-v2" size="medium">
+                <Modal.Header>{formatMessage(titleMessage)}</Modal.Header>
+                <Modal.Body>
+                    <div>Form goes here</div>
+                </Modal.Body>
+                <Modal.Close aria-label={formatMessage(messages.closeLabel)} />
+            </Modal.Content>
+        </Modal>
+    );
+};
+
+export default TaskModalV2;

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/__tests__/TaskModalV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/__tests__/TaskModalV2.test.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { render, screen, userEvent } from '../../../../../test-utils/testing-library';
+import {
+    TASK_EDIT_MODE_CREATE,
+    TASK_EDIT_MODE_EDIT,
+    TASK_TYPE_APPROVAL,
+    TASK_TYPE_GENERAL,
+} from '../../../../../constants';
+import TaskModalV2 from '../TaskModalV2';
+
+import type { TaskModalV2Props } from '../TaskModalV2';
+
+describe('elements/content-sidebar/task-modal-v2/TaskModalV2', () => {
+    const renderModal = (props: Partial<TaskModalV2Props> = {}) =>
+        render(<TaskModalV2 isOpen onClose={jest.fn()} taskType={TASK_TYPE_APPROVAL} {...props} />);
+
+    test('renders nothing when isOpen is false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByTestId('task-modal-v2')).not.toBeInTheDocument();
+    });
+
+    test('renders the modal with a placeholder form region when isOpen is true', () => {
+        renderModal();
+        expect(screen.getByTestId('task-modal-v2')).toBeVisible();
+        expect(screen.getByText('Form goes here')).toBeVisible();
+    });
+
+    test.each([
+        [TASK_TYPE_APPROVAL, TASK_EDIT_MODE_CREATE, 'Create Approval Task'],
+        [TASK_TYPE_APPROVAL, TASK_EDIT_MODE_EDIT, 'Modify Approval Task'],
+        [TASK_TYPE_GENERAL, TASK_EDIT_MODE_CREATE, 'Create General Task'],
+        [TASK_TYPE_GENERAL, TASK_EDIT_MODE_EDIT, 'Modify General Task'],
+    ])('renders the correct title for taskType=%s editMode=%s', (taskType, editMode, expectedTitle) => {
+        renderModal({ taskType, editMode });
+        expect(screen.getByRole('heading', { name: expectedTitle })).toBeVisible();
+    });
+
+    test('calls onClose when the close button is clicked', async () => {
+        const user = userEvent();
+        const onClose = jest.fn();
+        renderModal({ onClose });
+        await user.click(screen.getByRole('button', { name: 'Close' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('calls onClose when Escape is pressed', async () => {
+        const user = userEvent();
+        const onClose = jest.fn();
+        renderModal({ onClose });
+        await user.keyboard('{Escape}');
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/index.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/index.ts
@@ -1,0 +1,2 @@
+export { default } from './TaskModalV2';
+export type { TaskModalV2Props } from './TaskModalV2';

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/messages.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/messages.ts
@@ -1,0 +1,31 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+    closeLabel: {
+        id: 'be.taskModalV2.close',
+        defaultMessage: 'Close',
+        description: 'aria-label for the task modal close button',
+    },
+    createApprovalTaskTitle: {
+        id: 'be.taskModalV2.createApprovalTask',
+        defaultMessage: 'Create Approval Task',
+        description: 'Title of the modal for creating an approval task',
+    },
+    createGeneralTaskTitle: {
+        id: 'be.taskModalV2.createGeneralTask',
+        defaultMessage: 'Create General Task',
+        description: 'Title of the modal for creating a general task',
+    },
+    editApprovalTaskTitle: {
+        id: 'be.taskModalV2.editApprovalTask',
+        defaultMessage: 'Modify Approval Task',
+        description: 'Title of the modal for editing an existing approval task',
+    },
+    editGeneralTaskTitle: {
+        id: 'be.taskModalV2.editGeneralTask',
+        defaultMessage: 'Modify General Task',
+        description: 'Title of the modal for editing an existing general task',
+    },
+});
+
+export default messages;


### PR DESCRIPTION
## Summary

Scaffolds a new V2 task-creation/edit modal under `src/elements/content-sidebar/task-modal-v2/`. This is the first PR in a multi-PR effort to migrate the task modal off `PillSelectorDropdown` (which has known keyboard-focus and accessible-name gaps) and onto `@box/blueprint-web` Modal + `@box/user-selector`.

Scope of this PR is intentionally narrow: it ships only the modal shell and its tests. The shell renders a placeholder body. Form content, the user-selector swap, and the `ActivityFeedV2` integration land in follow-up PRs so each change stays small and reviewable.

## Changes

- New folder `src/elements/content-sidebar/task-modal-v2/`:
  - `TaskModalV2.tsx` — functional component, built on `@box/blueprint-web` `Modal` (`Modal.Content` + `Modal.Header` + `Modal.Body` + `Modal.Close`).
  - `messages.ts` — V2-local i18n message keys.
  - `index.ts` — default export plus exported `TaskModalV2Props` type.
  - `TaskModalV2.scss` — minimal layout hook; Blueprint Modal owns chrome.
  - `__tests__/TaskModalV2.test.tsx` — RTL coverage of the shell.
- V1 (`TaskModal.js`, `activity-feed/task-form/`, `AddTaskButton.js`, `ActivitySidebar.js`) is **not** touched. No call sites consume `TaskModalV2` yet.

## Design notes

- **Pure Blueprint Modal.** The shell uses Radix's controlled `open`/`onOpenChange` API (via Blueprint's `Modal` wrapper) — no `appElement` plumbing, no react-modal wrapper. Existing dialogs in the repo (`CreateFolderDialog`, `RenameDialog`, etc.) wrap Blueprint chrome inside react-modal; this component skips that layer because Blueprint Modal is fully self-contained.
- **Class name is `bcs-NewTaskModal`** rather than `bcs-TaskModalV2` because stylelint's `selector-class-pattern` regex disallows digits. Matches the precedent set by `bcs-NewActivityFeed`.
- **V2 owns its strings.** The message file lives next to the component (`be.taskModalV2.*`) rather than threading through the existing v1 keys in `../messages.js`.

## Test plan

- [x] `yarn test --testPathPattern="task-modal-v2"` — 8/8 pass
- [x] `npx eslint --max-warnings=0 src/elements/content-sidebar/task-modal-v2/` — clean
- [x] `npx stylelint "src/elements/content-sidebar/task-modal-v2/**/*.scss"` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Manual smoke test in Storybook (wired temporarily into a local `ContentSidebar` story to verify the modal opens, closes via Escape and close-button, and renders the right localized title for all `(taskType, editMode)` permutations; the temporary wiring is NOT part of this PR)

## Follow-ups

- Contact-shape mapper utility (`UserMini | GroupMini` <-> `UserContactType` <-> `TaskCollabAssignee`).
- `TaskFormV2` built on `UserSelectorContainer` and Blueprint form primitives (TextArea, Checkbox, DatePicker, Button).
- Wire `TaskFormV2` into `TaskModalV2` including edit-mode prefill and submit handling.
- Switch `ActivityFeedV2.tsx` to render `TaskModalV2`.
- Manual a11y and visual smoke test pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new task modal for creating and editing tasks, with title text that adapts to task type and edit mode.
  * Included localized UI text for the modal close control and improved modal accessibility.
* **Bug Fixes**
  * Modal now reliably closes via the close button or the Escape key, and only renders when intended.
* **Tests**
  * Added Jest/React Testing Library coverage for visibility, dynamic headings, and close interactions.
* **Style**
  * Updated modal layout spacing to better structure modal content vertically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->