### PR TITLE
fix(content-sidebar): Open activity tab for deep-linked URLs

### DIFF
--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -314,7 +314,7 @@ class Sidebar extends React.Component<Props, State> {
 
     isActivityDeepLinkPath(): boolean {
         const { location } = this.props;
-        return matchPath(location.pathname, { exact: true, path: ACTIVITY_DEEP_LINK_PATHS }) !== null;
+        return ACTIVITY_DEEP_LINK_PATHS.some(path => matchPath(location.pathname, { exact: true, path }) !== null);
     }
 
     getDefaultPanel(): string | typeof undefined {

--- a/src/elements/content-sidebar/Sidebar.js
+++ b/src/elements/content-sidebar/Sidebar.js
@@ -10,7 +10,7 @@ import flow from 'lodash/flow';
 import getProp from 'lodash/get';
 import noop from 'lodash/noop';
 import uniqueid from 'lodash/uniqueId';
-import { withRouter } from 'react-router-dom';
+import { matchPath, withRouter } from 'react-router-dom';
 import type { Location, RouterHistory } from 'react-router-dom';
 import LoadingIndicator from '../../components/loading-indicator/LoadingIndicator';
 import LocalStore from '../../utils/LocalStore';
@@ -38,7 +38,7 @@ import type { SignSidebarProps } from './SidebarNavSign';
 import type { Errors } from '../common/flowTypes';
 // $FlowFixMe TypeScript file
 import type { Theme } from '../common/theming';
-import { SIDEBAR_VIEW_DOCGEN, SIDEBAR_VIEW_BOXAI } from '../../constants';
+import { SIDEBAR_VIEW_ACTIVITY, SIDEBAR_VIEW_BOXAI, SIDEBAR_VIEW_DOCGEN } from '../../constants';
 import API from '../../api';
 
 type Props = {
@@ -100,6 +100,13 @@ const SIDEBAR_DEFAULT_WIDTH = 400;
 const SIDEBAR_DEFAULT_WIDTH_WIDER = 440;
 // Cap dragged width at this fraction of the current viewport width.
 const SIDEBAR_MAX_WIDTH_RATIO = 0.5;
+
+// Mirror the deep-link patterns declared by SidebarPanels' Activity Route.
+// Keep in sync with `src/elements/content-sidebar/SidebarPanels.js`.
+const ACTIVITY_DEEP_LINK_PATHS = [
+    `/${SIDEBAR_VIEW_ACTIVITY}/:activeFeedEntryType(annotations)/:fileVersionId/:activeFeedEntryId?`,
+    `/${SIDEBAR_VIEW_ACTIVITY}/:activeFeedEntryType(comments|tasks)/:activeFeedEntryId?`,
+];
 
 class Sidebar extends React.Component<Props, State> {
     static defaultProps = {
@@ -305,8 +312,18 @@ class Sidebar extends React.Component<Props, State> {
         }
     }
 
+    isActivityDeepLinkPath(): boolean {
+        const { location } = this.props;
+        return matchPath(location.pathname, { exact: true, path: ACTIVITY_DEEP_LINK_PATHS }) !== null;
+    }
+
     getDefaultPanel(): string | typeof undefined {
         const { features } = this.props;
+
+        // Deep links override persisted selection and default-panel fallback order.
+        if (this.isActivityDeepLinkPath()) {
+            return SIDEBAR_VIEW_ACTIVITY;
+        }
 
         if (!isFeatureEnabled(features, 'panelSelectionPreservation')) {
             return undefined;

--- a/src/elements/content-sidebar/__tests__/Sidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/Sidebar.test.js
@@ -458,6 +458,55 @@ describe('elements/content-sidebar/Sidebar', () => {
                     );
                 },
             );
+
+            test.each`
+                pathname                             | savedDefaultPanel
+                ${'/activity/comments/1'}            | ${'details'}
+                ${'/activity/tasks/2'}               | ${'boxai'}
+                ${'/activity/annotations/3/4'}       | ${null}
+                ${'/activity/comments'}              | ${'details'}
+                ${'/activity/tasks'}                 | ${'details'}
+                ${'/activity/annotations/version-1'} | ${'details'}
+            `(
+                'should force defaultPanel = "activity" when location.pathname = $pathname (saved panel = $savedDefaultPanel)',
+                ({ pathname, savedDefaultPanel }) => {
+                    mockGetItem.mockReturnValue(savedDefaultPanel);
+                    render(
+                        getSidebar({
+                            features: { panelSelectionPreservation: true },
+                            location: { pathname },
+                        }),
+                    );
+                    expect(MockSidebarPanels).toHaveBeenCalledWith(
+                        expect.objectContaining({ defaultPanel: 'activity' }),
+                        {},
+                    );
+                },
+            );
+
+            test.each`
+                pathname                            | savedDefaultPanel | expected
+                ${'/activity/reactions/1'}          | ${'details'}      | ${'details'}
+                ${'/activity/comments/1/replies/2'} | ${'details'}      | ${'details'}
+                ${'/activity/annotations'}          | ${'details'}      | ${'details'}
+                ${'/activity-log/1'}                | ${'details'}      | ${'details'}
+                ${'/activity/reactions/1'}          | ${null}           | ${undefined}
+            `(
+                'should fall through to persisted panel for unmatched pathname = $pathname (saved = $savedDefaultPanel, expected = $expected)',
+                ({ pathname, savedDefaultPanel, expected }) => {
+                    mockGetItem.mockReturnValue(savedDefaultPanel);
+                    render(
+                        getSidebar({
+                            features: { panelSelectionPreservation: true },
+                            location: { pathname },
+                        }),
+                    );
+                    expect(MockSidebarPanels).toHaveBeenCalledWith(
+                        expect.objectContaining({ defaultPanel: expected }),
+                        {},
+                    );
+                },
+            );
         });
     });
 


### PR DESCRIPTION
## Summary
- ContentSidebar deep-link URLs (`/activity/comments/:id`, `/activity/tasks/:id`, `/activity/annotations/:versionId/:id?`) now open the Activity panel even when the user has a different persisted last-selected panel or when the default-panel fallback order would otherwise pick a different panel.
- Uses `matchPath` against the same three route patterns declared in `SidebarPanels`, so only URLs the Activity Route actually accepts trigger the override. Unknown or malformed `/activity/...` paths fall through to the existing persisted-panel / fallback logic instead of being silently rewritten.

## Test Plan
- [x] Unit tests in `Sidebar.test.js` cover the recognized deep-link shapes and negative cases (unknown segment, extra depth, no version id).
- [ ] Manually verify in a host app: with `sidebar-selected-panel=details` in localStorage, load a file with a URL routing the sidebar to `/activity/comments/:id` and confirm the Activity tab opens.
- [ ] Verify no-deep-link behavior: with no activity deep-link path, the persisted panel still wins.
- [ ] Verify permissions gate: when `hasActivityFeed={false}`, the override is filtered out by the existing eligibility check in `SidebarPanels` and the user lands on the next eligible panel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Activity deep-link pages now open the Activity panel by default, taking priority over any previously saved sidebar panel selection.
  * Sidebar panel selection is now more consistent when navigating across activity-related routes.
* **Tests**
  * Added additional coverage to verify default sidebar panel behavior for multiple activity route patterns, including cases with and without saved panel preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->