### PR TITLE
feat(classification): add preview restriction controls

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1582,6 +1582,18 @@ boxui.securityControls.appDownloadRestricted = Download restricted for some appl
 boxui.securityControls.appDownloadWhitelist = Only select applications are allowed: {appNames}
 # Bullet point that summarizes application download restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
 boxui.securityControls.appDownloadWhitelistOverflow = Only select applications are allowed: {appNames} +{remainingAppCount} more
+# Bullet point that summarizes application preview restriction applied to classification
+boxui.securityControls.appPreviewBlacklist = Read restricted for some applications: {appNames}
+# Bullet point that summarizes application preview restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
+boxui.securityControls.appPreviewBlacklistOverflow = Read restricted for some applications: {appNames} +{remainingAppCount} more
+# Bullet point that summarizes application preview restriction applied to classification
+boxui.securityControls.appPreviewRestricted = Read restricted for some applications.
+# Bullet point that summarizes application preview restriction applied to classification
+boxui.securityControls.appPreviewWhitelist = Only select applications can read: {appNames}
+# Bullet point that summarizes application preview restriction applied to classification when the allowed application list is not provided
+boxui.securityControls.appPreviewWhitelistDefault = Only select applications can read.
+# Bullet point that summarizes application preview restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
+boxui.securityControls.appPreviewWhitelistOverflow = Only select applications can read: {appNames} +{remainingAppCount} more
 # Bullet point that summarizes Box Sign request restrictions applied to items. Box Sign is a product name
 boxui.securityControls.boxSignRequestRestricted = Sign restrictions apply.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners. Box Drive is a product name and not translated
@@ -1608,6 +1620,18 @@ boxui.securityControls.integrationDownloadDenylist = Download restricted for som
 boxui.securityControls.integrationDownloadDenylistOverflow = Download restricted for some integrations: {appNames} +{remainingAppCount} more
 # Bullet point that summarizes integration download restriction applied to classification
 boxui.securityControls.integrationDownloadRestricted = Download restricted for some integrations.
+# Bullet point that summarizes integration preview restriction applied to classification
+boxui.securityControls.integrationPreviewAllowlist = Only select integrations can read: {appNames}
+# Bullet point that summarizes integration preview restriction applied to classification when the allowed integration list is not provided
+boxui.securityControls.integrationPreviewAllowlistDefault = Only select integrations can read.
+# Bullet point that summarizes integration preview restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold
+boxui.securityControls.integrationPreviewAllowlistOverflow = Only select integrations can read: {appNames} +{remainingAppCount} more
+# Bullet point that summarizes integration preview restriction applied to classification
+boxui.securityControls.integrationPreviewDenylist = Read restricted for some integrations: {appNames}
+# Bullet point that summarizes integration preview restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold
+boxui.securityControls.integrationPreviewDenylistOverflow = Read restricted for some integrations: {appNames} +{remainingAppCount} more
+# Bullet point that summarizes integration preview restriction applied to classification
+boxui.securityControls.integrationPreviewRestricted = Read restricted for some integrations.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users
 boxui.securityControls.mobileDownloadExternal = Download restricted on mobile for external users.
 # Bullet point that summarizes mobile download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners

--- a/src/features/classification/constants.js
+++ b/src/features/classification/constants.js
@@ -13,6 +13,7 @@ const SECURITY_CONTROLS_FORMAT: {
 
 const ACCESS_POLICY_RESTRICTION: {
     APP: 'app',
+    APP_PREVIEW: 'appPreview',
     BOX_SIGN_REQUEST: 'boxSignRequest',
     DOWNLOAD: 'download',
     EXTERNAL_COLLAB: 'externalCollab',
@@ -22,6 +23,7 @@ const ACCESS_POLICY_RESTRICTION: {
     WATERMARK: 'watermark',
 } = {
     APP: 'app',
+    APP_PREVIEW: 'appPreview',
     BOX_SIGN_REQUEST: 'boxSignRequest',
     DOWNLOAD: 'download',
     EXTERNAL_COLLAB: 'externalCollab',
@@ -50,6 +52,14 @@ const LIST_ACCESS_LEVEL: {
 } = {
     BLACKLIST: 'blacklist',
     BLOCK: 'block',
+    WHITELIST: 'whitelist',
+};
+
+const PREVIEW_ACCESS_LEVEL: {
+    BLACKLIST: 'blacklist',
+    WHITELIST: 'whitelist',
+} = {
+    BLACKLIST: 'blacklist',
     WHITELIST: 'whitelist',
 };
 
@@ -106,4 +116,5 @@ export {
     MANAGED_USERS_ACCESS_LEVEL,
     SECURITY_CONTROLS_FORMAT,
     SHARED_LINK_ACCESS_LEVEL,
+    PREVIEW_ACCESS_LEVEL,
 };

--- a/src/features/classification/flowTypes.js
+++ b/src/features/classification/flowTypes.js
@@ -4,6 +4,7 @@ import type { MessageDescriptor } from 'react-intl';
 
 import {
     LIST_ACCESS_LEVEL,
+    PREVIEW_ACCESS_LEVEL,
     MANAGED_USERS_ACCESS_LEVEL,
     SECURITY_CONTROLS_FORMAT,
     SHARED_LINK_ACCESS_LEVEL,
@@ -30,6 +31,8 @@ type ExternalCollabAccessLevel = $Values<typeof LIST_ACCESS_LEVEL> | null;
 
 type ApplicationAccessLevel = $Values<typeof LIST_ACCESS_LEVEL> | null;
 
+type AppPreviewAccessLevel = $Values<typeof PREVIEW_ACCESS_LEVEL> | null;
+
 type App = {
     displayText: string,
 };
@@ -40,6 +43,11 @@ type ExternalCollabRestriction = {
 
 type ApplicationRestriction = {
     accessLevel?: ApplicationAccessLevel,
+    apps: Array<App>,
+};
+
+type AppPreviewRestriction = {
+    accessLevel?: AppPreviewAccessLevel,
     apps: Array<App>,
 };
 
@@ -70,6 +78,7 @@ type SharedLinkAutoExpirationRestriction = {};
 
 type Controls = {
     app?: ApplicationRestriction,
+    appPreview?: AppPreviewRestriction,
     boxSignRequest?: BoxSignRequestRestriction,
     download?: DownloadRestrictions,
     externalCollab?: ExternalCollabRestriction,
@@ -88,6 +97,7 @@ type MessageItem = {
 export type {
     AiClassificationReason,
     ApplicationRestriction,
+    AppPreviewRestriction,
     Controls,
     ControlsFormat,
     DownloadRestrictions,

--- a/src/features/classification/security-controls/__tests__/utils.test.js
+++ b/src/features/classification/security-controls/__tests__/utils.test.js
@@ -1,6 +1,8 @@
 import messages from '../messages';
 import appRestrictionsMessageMap from '../appRestrictionsMessageMap';
+import appPreviewRestrictionsMessageMap from '../appPreviewRestrictionsMessageMap';
 import integrationRestrictionsMessageMap from '../integrationRestrictionsMessageMap';
+import integrationPreviewRestrictionsMessageMap from '../integrationPreviewRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from '../downloadRestrictionsMessageMap';
 import { getShortSecurityControlsMessage, getFullSecurityControlsMessages } from '../utils';
 import {
@@ -8,12 +10,14 @@ import {
     DOWNLOAD_CONTROL,
     LIST_ACCESS_LEVEL,
     MANAGED_USERS_ACCESS_LEVEL,
+    PREVIEW_ACCESS_LEVEL,
     SHARED_LINK_ACCESS_LEVEL,
 } from '../../constants';
 
 const { DEFAULT, WITH_APP_LIST, WITH_OVERFLOWN_APP_LIST } = APP_RESTRICTION_MESSAGE_TYPE;
 const { DESKTOP, MOBILE, WEB } = DOWNLOAD_CONTROL;
 const { BLOCK, WHITELIST, BLACKLIST } = LIST_ACCESS_LEVEL;
+const { WHITELIST: PREVIEW_WHITELIST, BLACKLIST: PREVIEW_BLACKLIST } = PREVIEW_ACCESS_LEVEL;
 const { OWNERS_AND_COOWNERS, OWNERS_COOWNERS_AND_EDITORS } = MANAGED_USERS_ACCESS_LEVEL;
 const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVEL;
 
@@ -59,6 +63,7 @@ describe('features/classification/security-controls/utils', () => {
             ${{ externalCollab: {} }}                                                                            | ${[messages.shortSharing]}                                            | ${'external collab restrictions are present'}
             ${{ download: {} }}                                                                                  | ${[messages.shortDownload]}                                           | ${'download restrictions are present'}
             ${{ app: {} }}                                                                                       | ${[messages.shortApp]}                                                | ${'app restrictions are present'}
+            ${{ appPreview: {} }}                                                                                | ${[messages.shortApp]}                                                | ${'app preview restrictions are present'}
             ${{ watermark: {} }}                                                                                 | ${[messages.shortWatermarking]}                                       | ${'watermark restrictions are present'}
             ${{ boxSignRequest: {} }}                                                                            | ${[messages.shortSign]}                                               | ${'sign restrictions are present'}
             ${{ sharedLinkAutoExpiration: true }}                                                                | ${[messages.shortSharedLinkAutoExpiration]}                           | ${'Shared Link Auto-Expiration restriction is present'}
@@ -119,6 +124,7 @@ describe('features/classification/security-controls/utils', () => {
             ${{ externalCollab: {} }}                                                                            | ${[messages.shortSharing]}                                                    | ${'external collab restrictions are present'}
             ${{ download: {} }}                                                                                  | ${[messages.shortDownload]}                                                   | ${'download restrictions are present'}
             ${{ app: {} }}                                                                                       | ${[messages.shortIntegration]}                                                | ${'integration restrictions are present'}
+            ${{ appPreview: {} }}                                                                                | ${[messages.shortIntegration]}                                                | ${'integration preview restrictions are present'}
             ${{ watermark: {} }}                                                                                 | ${[messages.shortWatermarking]}                                               | ${'watermark restrictions are present'}
             ${{ boxSignRequest: {} }}                                                                            | ${[messages.shortSign]}                                                       | ${'sign restrictions are present'}
             ${{ sharedLinkAutoExpiration: true }}                                                                | ${[messages.shortSharedLinkAutoExpiration]}                                   | ${'Shared Link Auto-Expiration restriction is present'}
@@ -226,6 +232,162 @@ describe('features/classification/security-controls/utils', () => {
             ]);
         });
 
+        test.each([PREVIEW_WHITELIST, PREVIEW_BLACKLIST])(
+            'should include correct message when app preview is restricted by %s and apps list is not provided',
+            listType => {
+                accessPolicy = {
+                    appPreview: {
+                        accessLevel: listType,
+                        apps: [],
+                    },
+                };
+                const expectedMessage = appPreviewRestrictionsMessageMap[listType][DEFAULT];
+
+                expect(expectedMessage).toBeTruthy();
+                expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
+                    {
+                        message: {
+                            ...expectedMessage,
+                            values: { appNames: '' },
+                        },
+                    },
+                ]);
+            },
+        );
+
+        test.each([PREVIEW_WHITELIST, PREVIEW_BLACKLIST])(
+            'should include correct variable when integration preview is restricted by %s and integrations list is not provided and shouldDisplayAppsAsIntegrations is true',
+            listType => {
+                accessPolicy = {
+                    appPreview: {
+                        accessLevel: listType,
+                        apps: [],
+                    },
+                };
+                const expectedMessage = integrationPreviewRestrictionsMessageMap[listType][DEFAULT];
+
+                expect(expectedMessage).toBeTruthy();
+                expect(getFullSecurityControlsMessages(accessPolicy, 3, true)).toEqual([
+                    {
+                        message: {
+                            ...expectedMessage,
+                            values: { appNames: '' },
+                        },
+                    },
+                ]);
+            },
+        );
+
+        test('should include allowlist message when app preview is allowlisted and apps list is not provided', () => {
+            accessPolicy = {
+                appPreview: {
+                    accessLevel: PREVIEW_WHITELIST,
+                    apps: [],
+                },
+            };
+
+            expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
+                {
+                    message: {
+                        ...messages.appPreviewWhitelistDefault,
+                        values: { appNames: '' },
+                    },
+                },
+            ]);
+        });
+
+        test('should include allowlist message when integration preview is allowlisted and integrations list is not provided', () => {
+            accessPolicy = {
+                appPreview: {
+                    accessLevel: PREVIEW_WHITELIST,
+                    apps: [],
+                },
+            };
+
+            expect(getFullSecurityControlsMessages(accessPolicy, 3, true)).toEqual([
+                {
+                    message: {
+                        ...messages.integrationPreviewAllowlistDefault,
+                        values: { appNames: '' },
+                    },
+                },
+            ]);
+        });
+
+        test('should include general message when integration preview is restricted but integration names are not provided', () => {
+            accessPolicy = {
+                appPreview: {
+                    accessLevel: PREVIEW_BLACKLIST,
+                    apps: [{ displayText: '' }],
+                },
+            };
+
+            expect(getFullSecurityControlsMessages(accessPolicy, 3, true)).toEqual([
+                {
+                    message: {
+                        ...messages.integrationPreviewRestricted,
+                        values: { appNames: '' },
+                    },
+                },
+            ]);
+        });
+
+        test.each([PREVIEW_WHITELIST, PREVIEW_BLACKLIST])(
+            'should include correct message when app preview is restricted by %s and apps are less than maxAppCount',
+            listType => {
+                accessPolicy = {
+                    appPreview: {
+                        accessLevel: listType,
+                        apps: [{ displayText: 'a' }, { displayText: 'b' }, { displayText: 'c' }],
+                    },
+                };
+                const expectedMessage = appPreviewRestrictionsMessageMap[listType][WITH_APP_LIST];
+
+                expect(expectedMessage).toBeTruthy();
+                expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
+                    {
+                        message: {
+                            ...expectedMessage,
+                            values: { appNames: 'a, b, c' },
+                        },
+                    },
+                ]);
+            },
+        );
+
+        test.each([PREVIEW_WHITELIST, PREVIEW_BLACKLIST])(
+            'should include correct message and tooltipMessage when app preview is restricted by %s and apps are maxAppCount or more',
+            listType => {
+                accessPolicy = {
+                    appPreview: {
+                        accessLevel: listType,
+                        apps: [
+                            { displayText: 'a' },
+                            { displayText: 'b' },
+                            { displayText: 'c' },
+                            { displayText: 'd' },
+                            { displayText: 'e' },
+                        ],
+                    },
+                };
+                const expectedMessage = appPreviewRestrictionsMessageMap[listType][WITH_OVERFLOWN_APP_LIST];
+
+                expect(expectedMessage).toBeTruthy();
+                expect(getFullSecurityControlsMessages(accessPolicy, 3)).toEqual([
+                    {
+                        message: {
+                            ...expectedMessage,
+                            values: { appNames: 'a, b, c', remainingAppCount: 2 },
+                        },
+                        tooltipMessage: {
+                            ...messages.allAppNames,
+                            values: { appsList: 'a, b, c, d, e' },
+                        },
+                    },
+                ]);
+            },
+        );
+
         test.each([WHITELIST, BLACKLIST])(
             'should include correct message when app download is restricted by %s and apps list is not provided',
             listType => {
@@ -271,6 +433,24 @@ describe('features/classification/security-controls/utils', () => {
                 ]);
             },
         );
+
+        test('should include general message when integration download is restricted but integration names are not provided', () => {
+            accessPolicy = {
+                app: {
+                    accessLevel: BLACKLIST,
+                    apps: [{ displayText: '' }],
+                },
+            };
+
+            expect(getFullSecurityControlsMessages(accessPolicy, 3, true)).toEqual([
+                {
+                    message: {
+                        ...messages.integrationDownloadRestricted,
+                        values: { appNames: '' },
+                    },
+                },
+            ]);
+        });
 
         test.each([WHITELIST, BLACKLIST])(
             'should include correct message when app download is restricted by %s and apps are less than maxAppCount',

--- a/src/features/classification/security-controls/appPreviewRestrictionsMessageMap.js
+++ b/src/features/classification/security-controls/appPreviewRestrictionsMessageMap.js
@@ -1,0 +1,21 @@
+// @flow
+import messages from './messages';
+import { APP_RESTRICTION_MESSAGE_TYPE, PREVIEW_ACCESS_LEVEL } from '../constants';
+
+const { BLACKLIST, WHITELIST } = PREVIEW_ACCESS_LEVEL;
+const { DEFAULT, WITH_APP_LIST, WITH_OVERFLOWN_APP_LIST } = APP_RESTRICTION_MESSAGE_TYPE;
+
+const appPreviewRestrictionsMessageMap = {
+    [BLACKLIST]: {
+        [DEFAULT]: messages.appPreviewRestricted,
+        [WITH_APP_LIST]: messages.appPreviewBlacklist,
+        [WITH_OVERFLOWN_APP_LIST]: messages.appPreviewBlacklistOverflow,
+    },
+    [WHITELIST]: {
+        [DEFAULT]: messages.appPreviewWhitelistDefault,
+        [WITH_APP_LIST]: messages.appPreviewWhitelist,
+        [WITH_OVERFLOWN_APP_LIST]: messages.appPreviewWhitelistOverflow,
+    },
+};
+
+export default appPreviewRestrictionsMessageMap;

--- a/src/features/classification/security-controls/integrationPreviewRestrictionsMessageMap.js
+++ b/src/features/classification/security-controls/integrationPreviewRestrictionsMessageMap.js
@@ -1,0 +1,21 @@
+// @flow
+import messages from './messages';
+import { APP_RESTRICTION_MESSAGE_TYPE, PREVIEW_ACCESS_LEVEL } from '../constants';
+
+const { BLACKLIST, WHITELIST } = PREVIEW_ACCESS_LEVEL;
+const { DEFAULT, WITH_APP_LIST, WITH_OVERFLOWN_APP_LIST } = APP_RESTRICTION_MESSAGE_TYPE;
+
+const integrationPreviewRestrictionsMessageMap = {
+    [BLACKLIST]: {
+        [DEFAULT]: messages.integrationPreviewRestricted,
+        [WITH_APP_LIST]: messages.integrationPreviewDenylist,
+        [WITH_OVERFLOWN_APP_LIST]: messages.integrationPreviewDenylistOverflow,
+    },
+    [WHITELIST]: {
+        [DEFAULT]: messages.integrationPreviewAllowlistDefault,
+        [WITH_APP_LIST]: messages.integrationPreviewAllowlist,
+        [WITH_OVERFLOWN_APP_LIST]: messages.integrationPreviewAllowlistOverflow,
+    },
+};
+
+export default integrationPreviewRestrictionsMessageMap;

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -353,6 +353,72 @@ const messages = defineMessages({
         description: 'Bullet point that summarizes integration download restriction applied to classification',
         id: 'boxui.securityControls.integrationDownloadRestricted',
     },
+    appPreviewRestricted: {
+        defaultMessage: 'Read restricted for some applications.',
+        description: 'Bullet point that summarizes application preview restriction applied to classification',
+        id: 'boxui.securityControls.appPreviewRestricted',
+    },
+    integrationPreviewRestricted: {
+        defaultMessage: 'Read restricted for some integrations.',
+        description: 'Bullet point that summarizes integration preview restriction applied to classification',
+        id: 'boxui.securityControls.integrationPreviewRestricted',
+    },
+    appPreviewBlacklist: {
+        defaultMessage: 'Read restricted for some applications: {appNames}',
+        description: 'Bullet point that summarizes application preview restriction applied to classification',
+        id: 'boxui.securityControls.appPreviewBlacklist',
+    },
+    integrationPreviewDenylist: {
+        defaultMessage: 'Read restricted for some integrations: {appNames}',
+        description: 'Bullet point that summarizes integration preview restriction applied to classification',
+        id: 'boxui.securityControls.integrationPreviewDenylist',
+    },
+    appPreviewBlacklistOverflow: {
+        defaultMessage: 'Read restricted for some applications: {appNames} +{remainingAppCount} more',
+        description:
+            'Bullet point that summarizes application preview restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
+        id: 'boxui.securityControls.appPreviewBlacklistOverflow',
+    },
+    integrationPreviewDenylistOverflow: {
+        defaultMessage: 'Read restricted for some integrations: {appNames} +{remainingAppCount} more',
+        description:
+            'Bullet point that summarizes integration preview restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold',
+        id: 'boxui.securityControls.integrationPreviewDenylistOverflow',
+    },
+    appPreviewWhitelist: {
+        defaultMessage: 'Only select applications can read: {appNames}',
+        description: 'Bullet point that summarizes application preview restriction applied to classification',
+        id: 'boxui.securityControls.appPreviewWhitelist',
+    },
+    appPreviewWhitelistDefault: {
+        defaultMessage: 'Only select applications can read.',
+        description:
+            'Bullet point that summarizes application preview restriction applied to classification when the allowed application list is not provided',
+        id: 'boxui.securityControls.appPreviewWhitelistDefault',
+    },
+    integrationPreviewAllowlist: {
+        defaultMessage: 'Only select integrations can read: {appNames}',
+        description: 'Bullet point that summarizes integration preview restriction applied to classification',
+        id: 'boxui.securityControls.integrationPreviewAllowlist',
+    },
+    integrationPreviewAllowlistDefault: {
+        defaultMessage: 'Only select integrations can read.',
+        description:
+            'Bullet point that summarizes integration preview restriction applied to classification when the allowed integration list is not provided',
+        id: 'boxui.securityControls.integrationPreviewAllowlistDefault',
+    },
+    appPreviewWhitelistOverflow: {
+        defaultMessage: 'Only select applications can read: {appNames} +{remainingAppCount} more',
+        description:
+            'Bullet point that summarizes application preview restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
+        id: 'boxui.securityControls.appPreviewWhitelistOverflow',
+    },
+    integrationPreviewAllowlistOverflow: {
+        defaultMessage: 'Only select integrations can read: {appNames} +{remainingAppCount} more',
+        description:
+            'Bullet point that summarizes integration preview restriction applied to classification. This variation is used when the list of integrations is longer than the configured threshold',
+        id: 'boxui.securityControls.integrationPreviewAllowlistOverflow',
+    },
     appDownloadBlacklist: {
         defaultMessage: 'Download restricted for some applications: {appNames}',
         description: 'Bullet point that summarizes application download restriction applied to classification',

--- a/src/features/classification/security-controls/utils.js
+++ b/src/features/classification/security-controls/utils.js
@@ -5,7 +5,9 @@ import isNil from 'lodash/isNil';
 import type { Controls, MessageItem } from '../flowTypes';
 
 import appRestrictionsMessageMap from './appRestrictionsMessageMap';
+import appPreviewRestrictionsMessageMap from './appPreviewRestrictionsMessageMap';
 import integrationRestrictionsMessageMap from './integrationRestrictionsMessageMap';
+import integrationPreviewRestrictionsMessageMap from './integrationPreviewRestrictionsMessageMap';
 import downloadRestrictionsMessageMap from './downloadRestrictionsMessageMap';
 import messages from './messages';
 import {
@@ -13,29 +15,81 @@ import {
     APP_RESTRICTION_MESSAGE_TYPE,
     DOWNLOAD_CONTROL,
     LIST_ACCESS_LEVEL,
+    PREVIEW_ACCESS_LEVEL,
     SHARED_LINK_ACCESS_LEVEL,
 } from '../constants';
 
-const { APP, BOX_SIGN_REQUEST, DOWNLOAD, EXTERNAL_COLLAB, SHARED_LINK, WATERMARK, SHARED_LINK_AUTO_EXPIRATION } =
-    ACCESS_POLICY_RESTRICTION;
+const {
+    APP,
+    APP_PREVIEW,
+    BOX_SIGN_REQUEST,
+    DOWNLOAD,
+    EXTERNAL_COLLAB,
+    SHARED_LINK,
+    WATERMARK,
+    SHARED_LINK_AUTO_EXPIRATION,
+} = ACCESS_POLICY_RESTRICTION;
 const { DEFAULT, WITH_APP_LIST, WITH_OVERFLOWN_APP_LIST } = APP_RESTRICTION_MESSAGE_TYPE;
 const { DESKTOP, MOBILE, WEB } = DOWNLOAD_CONTROL;
 const { BLOCK, WHITELIST, BLACKLIST } = LIST_ACCESS_LEVEL;
+const { WHITELIST: PREVIEW_WHITELIST, BLACKLIST: PREVIEW_BLACKLIST } = PREVIEW_ACCESS_LEVEL;
 const { COLLAB_ONLY, COLLAB_AND_COMPANY_ONLY, PUBLIC } = SHARED_LINK_ACCESS_LEVEL;
+
+const getAppListMessageItem = (apps, maxAppCount, accessLevel, restrictionsMessageMap, tooltipMessage): MessageItem => {
+    const displayableApps = apps.filter(({ displayText }) => displayText);
+    const effectiveMaxAppCount = isNil(maxAppCount) ? displayableApps.length : maxAppCount;
+    const appsToDisplay = displayableApps.slice(0, effectiveMaxAppCount);
+    const remainingAppCount = Math.max(0, displayableApps.length - effectiveMaxAppCount);
+    const appNames = appsToDisplay.map(({ displayText }) => displayText).join(', ');
+
+    if (remainingAppCount) {
+        const appsList = displayableApps.map(({ displayText }) => displayText).join(', ');
+
+        return {
+            message: {
+                ...restrictionsMessageMap[accessLevel][WITH_OVERFLOWN_APP_LIST],
+                values: { appNames, remainingAppCount },
+            },
+            tooltipMessage: {
+                ...tooltipMessage,
+                values: { appsList },
+            },
+        };
+    }
+
+    const messageType = displayableApps.length ? WITH_APP_LIST : DEFAULT;
+
+    return {
+        message: {
+            ...restrictionsMessageMap[accessLevel][messageType],
+            values: { appNames },
+        },
+    };
+};
 
 const getShortSecurityControlsMessage = (
     controls: Controls,
     shouldDisplayAppsAsIntegrations?: boolean,
 ): Array<MessageItem> => {
     const items = [];
-    const { app, boxSignRequest, download, externalCollab, sharedLink, watermark, sharedLinkAutoExpiration } = controls;
+    const {
+        app,
+        appPreview,
+        boxSignRequest,
+        download,
+        externalCollab,
+        sharedLink,
+        watermark,
+        sharedLinkAutoExpiration,
+    } = controls;
+    const appRestriction = app || appPreview;
 
     // Shared link and external collab restrictions are grouped
     // together as generic "sharing" restrictions
     const sharing = (sharedLink && sharedLink.accessLevel !== PUBLIC) || externalCollab;
 
     // 5 restriction combinations
-    if (sharedLinkAutoExpiration && sharing && download && app && boxSignRequest) {
+    if (sharedLinkAutoExpiration && sharing && download && appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortSharingDownloadIntegrationSignSharedLinkAutoExpiration
@@ -43,7 +97,7 @@ const getShortSecurityControlsMessage = (
         });
     }
     // 4 restriction combinations
-    else if (sharedLinkAutoExpiration && sharing && download && app) {
+    else if (sharedLinkAutoExpiration && sharing && download && appRestriction) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortSharingDownloadIntegrationSharedLinkAutoExpiration
@@ -51,19 +105,19 @@ const getShortSecurityControlsMessage = (
         });
     } else if (sharedLinkAutoExpiration && sharing && download && boxSignRequest) {
         items.push({ message: messages.shortSharingDownloadSignSharedLinkAutoExpiration });
-    } else if (sharedLinkAutoExpiration && sharing && app && boxSignRequest) {
+    } else if (sharedLinkAutoExpiration && sharing && appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortSharingIntegrationSignSharedLinkAutoExpiration
                 : messages.shortSharingAppSignSharedLinkAutoExpiration,
         });
-    } else if (sharedLinkAutoExpiration && download && app && boxSignRequest) {
+    } else if (sharedLinkAutoExpiration && download && appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortDownloadIntegrationSignSharedLinkAutoExpiration
                 : messages.shortDownloadAppSignSharedLinkAutoExpiration,
         });
-    } else if (sharing && download && app && boxSignRequest) {
+    } else if (sharing && download && appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortSharingDownloadIntegrationSign
@@ -73,7 +127,7 @@ const getShortSecurityControlsMessage = (
     // 3 restriction combinations
     else if (sharedLinkAutoExpiration && sharing && download) {
         items.push({ message: messages.shortSharingDownloadSharedLinkAutoExpiration });
-    } else if (sharedLinkAutoExpiration && sharing && app) {
+    } else if (sharedLinkAutoExpiration && sharing && appRestriction) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortSharingIntegrationSharedLinkAutoExpiration
@@ -81,7 +135,7 @@ const getShortSecurityControlsMessage = (
         });
     } else if (sharedLinkAutoExpiration && sharing && boxSignRequest) {
         items.push({ message: messages.shortSharingSignSharedLinkAutoExpiration });
-    } else if (sharedLinkAutoExpiration && download && app) {
+    } else if (sharedLinkAutoExpiration && download && appRestriction) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortDownloadIntegrationSharedLinkAutoExpiration
@@ -89,25 +143,25 @@ const getShortSecurityControlsMessage = (
         });
     } else if (sharedLinkAutoExpiration && download && boxSignRequest) {
         items.push({ message: messages.shortDownloadSignSharedLinkAutoExpiration });
-    } else if (sharedLinkAutoExpiration && app && boxSignRequest) {
+    } else if (sharedLinkAutoExpiration && appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortIntegrationSignSharedLinkAutoExpiration
                 : messages.shortAppSignSharedLinkAutoExpiration,
         });
-    } else if (sharing && download && app) {
+    } else if (sharing && download && appRestriction) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortSharingDownloadIntegration
                 : messages.shortSharingDownloadApp,
         });
-    } else if (download && app && boxSignRequest) {
+    } else if (download && appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortDownloadIntegrationSign
                 : messages.shortDownloadAppSign,
         });
-    } else if (sharing && app && boxSignRequest) {
+    } else if (sharing && appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortSharingIntegrationSign
@@ -121,7 +175,7 @@ const getShortSecurityControlsMessage = (
         items.push({ message: messages.shortSharingSharedLinkAutoExpiration });
     } else if (sharedLinkAutoExpiration && download) {
         items.push({ message: messages.shortDownloadSharedLinkAutoExpiration });
-    } else if (sharedLinkAutoExpiration && app) {
+    } else if (sharedLinkAutoExpiration && appRestriction) {
         items.push({
             message: shouldDisplayAppsAsIntegrations
                 ? messages.shortIntegrationSharedLinkAutoExpiration
@@ -133,17 +187,17 @@ const getShortSecurityControlsMessage = (
         items.push({ message: messages.shortSharingSign });
     } else if (download && boxSignRequest) {
         items.push({ message: messages.shortDownloadSign });
-    } else if (app && boxSignRequest) {
+    } else if (appRestriction && boxSignRequest) {
         items.push({
             message: shouldDisplayAppsAsIntegrations ? messages.shortIntegrationSign : messages.shortAppSign,
         });
     } else if (sharing && download) {
         items.push({ message: messages.shortSharingDownload });
-    } else if (sharing && app) {
+    } else if (sharing && appRestriction) {
         items.push({
             message: shouldDisplayAppsAsIntegrations ? messages.shortSharingIntegration : messages.shortSharingApp,
         });
-    } else if (download && app) {
+    } else if (download && appRestriction) {
         items.push({
             message: shouldDisplayAppsAsIntegrations ? messages.shortDownloadIntegration : messages.shortDownloadApp,
         });
@@ -156,7 +210,7 @@ const getShortSecurityControlsMessage = (
         items.push({ message: messages.shortSharing });
     } else if (download) {
         items.push({ message: messages.shortDownload });
-    } else if (app) {
+    } else if (appRestriction) {
         items.push({ message: shouldDisplayAppsAsIntegrations ? messages.shortIntegration : messages.shortApp });
     } else if (sharedLinkAutoExpiration) {
         items.push({ message: messages.shortSharedLinkAutoExpiration });
@@ -246,41 +300,43 @@ const getAppDownloadMessages = (
         case WHITELIST:
         case BLACKLIST: {
             const apps = getProp(controls, `${APP}.apps`, []);
+            const restrictionsMessageMap = shouldDisplayAppsAsIntegrations
+                ? integrationRestrictionsMessageMap
+                : appRestrictionsMessageMap;
+            const tooltipMessage = shouldDisplayAppsAsIntegrations
+                ? messages.allIntegrationNames
+                : messages.allAppNames;
 
-            maxAppCount = isNil(maxAppCount) ? apps.length : maxAppCount;
-            const appsToDisplay = apps.slice(0, maxAppCount);
-            const remainingAppCount = apps.slice(maxAppCount).length;
-            const appNames = appsToDisplay.map(({ displayText }) => displayText).join(', ');
+            items.push(getAppListMessageItem(apps, maxAppCount, accessLevel, restrictionsMessageMap, tooltipMessage));
+            break;
+        }
+        default:
+            // no-op
+            break;
+    }
+    return items;
+};
 
-            if (remainingAppCount) {
-                const appsList = apps.map(({ displayText }) => displayText).join(', ');
+const getAppPreviewMessages = (
+    controls: Controls,
+    maxAppCount?: number,
+    shouldDisplayAppsAsIntegrations?: boolean,
+): Array<MessageItem> => {
+    const items = [];
+    const accessLevel = getProp(controls, `${APP_PREVIEW}.accessLevel`);
 
-                items.push({
-                    message: {
-                        ...(shouldDisplayAppsAsIntegrations
-                            ? integrationRestrictionsMessageMap[accessLevel][WITH_OVERFLOWN_APP_LIST]
-                            : appRestrictionsMessageMap[accessLevel][WITH_OVERFLOWN_APP_LIST]),
-                        values: { appNames, remainingAppCount },
-                    },
-                    tooltipMessage: {
-                        ...(shouldDisplayAppsAsIntegrations ? messages.allIntegrationNames : messages.allAppNames),
-                        values: { appsList },
-                    },
-                });
-            } else {
-                // Display list of apps if available, otherwise use generic
-                // app restriction copy
-                const messageType = apps.length ? WITH_APP_LIST : DEFAULT;
+    switch (accessLevel) {
+        case PREVIEW_BLACKLIST:
+        case PREVIEW_WHITELIST: {
+            const apps = getProp(controls, `${APP_PREVIEW}.apps`, []);
+            const restrictionsMessageMap = shouldDisplayAppsAsIntegrations
+                ? integrationPreviewRestrictionsMessageMap
+                : appPreviewRestrictionsMessageMap;
+            const tooltipMessage = shouldDisplayAppsAsIntegrations
+                ? messages.allIntegrationNames
+                : messages.allAppNames;
 
-                items.push({
-                    message: {
-                        ...(shouldDisplayAppsAsIntegrations
-                            ? integrationRestrictionsMessageMap[accessLevel][messageType]
-                            : appRestrictionsMessageMap[accessLevel][messageType]),
-                        values: { appNames },
-                    },
-                });
-            }
+            items.push(getAppListMessageItem(apps, maxAppCount, accessLevel, restrictionsMessageMap, tooltipMessage));
             break;
         }
         default:
@@ -347,6 +403,7 @@ const getFullSecurityControlsMessages = (
         ...getSharedLinkAutoExpirationMessages(controls),
         ...getDownloadMessages(controls),
         ...getAppDownloadMessages(controls, maxAppCount, shouldDisplayAppsAsIntegrations),
+        ...getAppPreviewMessages(controls, maxAppCount, shouldDisplayAppsAsIntegrations),
         ...getWatermarkingMessages(controls),
         ...getBoxSignRequestMessages(controls),
     ];


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

## Summary
- Add support for `appPreview` classification security controls in types, constants, full restriction messages, and short badge summaries.
- Add app/integration preview restriction copy for blacklist, whitelist, overflow, and empty-list cases.
- Fix preview/download integration messages to fall back to general copy when no displayable integration names are available, avoiding trailing empty `:` output.

## Test Plan
- `npm test -- --testPathPattern="features/classification/security-controls/__tests__/utils.test.js" --no-coverage`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preview-related security restrictions in classification messaging.
  * Preview access can now be shown as allowlist or denylist, with app and integration display variants.
  * Long app lists now collapse with a “more” count and still support full tooltip details.

* **Bug Fixes**
  * Improved security control message selection so preview and standard app restrictions are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->