### PR TITLE
refactor(content-uploader): hide modernized uploads manager in 5000

### DIFF
--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -138,6 +138,7 @@ type State = {
 const CHUNKED_UPLOAD_MIN_SIZE_BYTES = 104857600; // 100MB
 const FILE_LIMIT_DEFAULT = 100; // Upload at most 100 files at once by default
 const HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT = 8000;
+const HIDE_MODERNIZED_UPLOAD_MANAGER_DELAY_MS = 5000;
 const SLIDE_OUT_ANIMATION_NAME = 'bcu-modernized-slideOut';
 const EXPAND_UPLOADS_MANAGER_ITEMS_NUM_THRESHOLD = 5;
 const UPLOAD_CONCURRENCY = 6;
@@ -1580,7 +1581,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         this.modernizedDismissTimer = setTimeout(() => {
             this.setState({ modernizedPanelState: 'dismissing' });
             this.modernizedDismissTimer = null;
-        }, HIDE_UPLOAD_MANAGER_DELAY_MS_DEFAULT);
+        }, HIDE_MODERNIZED_UPLOAD_MANAGER_DELAY_MS);
     };
 
     finalizeModernizedDismiss = (): void => {

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -1641,7 +1641,7 @@ describe('elements/content-uploader/ContentUploader', () => {
     });
 
     describe('modernized panel open/close lifecycle', () => {
-        const HIDE_DELAY_MS = 8000;
+        const HIDE_DELAY_MS = 5000;
 
         const makeItem = (name, status) => {
             let progress = 0;
@@ -1838,10 +1838,10 @@ describe('elements/content-uploader/ContentUploader', () => {
             });
             expect(instance.modernizedDismissTimer).not.toBeNull();
 
-            jest.advanceTimersByTime(3000);
+            jest.advanceTimersByTime(HIDE_DELAY_MS - 1);
             expect(wrapper.state('modernizedPanelState')).toBe('shown');
 
-            jest.advanceTimersByTime(5000);
+            jest.advanceTimersByTime(1);
             expect(wrapper.state('modernizedPanelState')).toBe('dismissing');
         });
 


### PR DESCRIPTION
Modernized uploads manager should be hidden in 5s instead of 8s.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the modern upload panel’s auto-dismiss timing to close after 5 seconds to match the expected behavior.
* **Tests**
  * Adjusted the timer-based test to reflect the new 5-second delay, ensuring panel state transitions are validated accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->