### PR TITLE
fix(activity-feed-v2): dedupe prosemirror-model to fix mention selection

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15761,14 +15761,7 @@ prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.2.3:
     prosemirror-state "^1.0.0"
     w3c-keyname "^2.2.0"
 
-prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.25.4:
-  version "1.25.4"
-  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.25.4.tgz#8ebfbe29ecbee9e5e2e4048c4fe8e363fcd56e7c"
-  integrity sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==
-  dependencies:
-    orderedmap "^2.0.0"
-
-prosemirror-model@^1.25.7, prosemirror-model@^1.25.8:
+prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.25.4, prosemirror-model@^1.25.7, prosemirror-model@^1.25.8:
   version "1.25.9"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.25.9.tgz#1e9f2faa5d824d65c5265f01768fcfa70bfc39dd"
   integrity sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==
@@ -15811,16 +15804,7 @@ prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transfor
   dependencies:
     prosemirror-model "^1.21.0"
 
-prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.41.4:
-  version "1.41.8"
-  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.41.8.tgz#bfb48d9dc328f1aa2a0eea1600b0828818be03f1"
-  integrity sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==
-  dependencies:
-    prosemirror-model "^1.20.0"
-    prosemirror-state "^1.0.0"
-    prosemirror-transform "^1.1.0"
-
-prosemirror-view@^1.41.8:
+prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.41.4, prosemirror-view@^1.41.8:
   version "1.42.0"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.42.0.tgz#82ed0823a1bf971d27cb647f3a23d5e005d04c00"
   integrity sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==


### PR DESCRIPTION
## Summary

- Selecting a user from the @mention dropdown in the v2 activity feed editor silently failed with `RangeError: Can not convert <mention, " "> to a Fragment (looks like multiple versions of prosemirror-model were loaded)`, so the mention was never inserted.
- Root cause: #4672 bumped `@box/threaded-annotations` to 3.x (tiptap 3). `@tiptap/pm` requires `prosemirror-model@^1.25.7`, but `yarn.lock` kept a stale `prosemirror-model@1.25.4` entry that `prosemirror-state`/`prosemirror-view`/`prosemirror-tables` still resolved to, so two copies of `prosemirror-model` (and `prosemirror-view`) were installed. The editor schema and the transaction pipeline used different copies, breaking the `instanceof` checks during mention insertion.
- Fix: dedupe `prosemirror-model` (single 1.25.9) and `prosemirror-view` (single 1.42.0) in `yarn.lock`. All existing semver ranges are satisfied by the deduped versions; no package.json changes.

## Test plan

- [x] Verified before/after with a jsdom test driving the real `@box/activity-feed` editor: typing `@Ali` opens the dropdown in both cases; selecting a user threw the RangeError before this change and correctly inserts the mention node after.
- [x] `yarn install` produces a single `prosemirror-model`/`prosemirror-view` copy (no nested copy under `@tiptap/pm/node_modules`).
- [x] Full `src/elements/content-sidebar/activity-feed-v2` jest suite passes (342 tests).
- [ ] Manual smoke test: mention a user in the v2 activity feed comment editor and post.