### PR TITLE
feat(activity-feed-v2): add resin fileid and task modal instrumentation

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -454,7 +454,7 @@ const ActivityFeedV2 = ({
     );
 
     return (
-        <div className="bcs-NewActivityFeed" data-resin-feature="activityfeedv2">
+        <div className="bcs-NewActivityFeed" data-resin-feature="activityfeedv2" data-resin-fileid={file?.id}>
             <ActivityFeed.Root mentionContext={mentionContext} scrollTo={scrollHandle}>
                 <ActivityFeed.Header title={headerTitle}>
                     <ActivityFeed.Header.Actions>
@@ -532,6 +532,7 @@ const ActivityFeedV2 = ({
                     error={taskError}
                     fetchAvatarUrls={fetchAvatarUrls}
                     fetchUsers={fetchApprovers}
+                    fileId={file?.id}
                     isOpen={isTaskFormOpen}
                     mode="edit"
                     onClose={handleTaskModalClose}
@@ -545,6 +546,7 @@ const ActivityFeedV2 = ({
                     error={taskError}
                     fetchAvatarUrls={fetchAvatarUrls}
                     fetchUsers={fetchApprovers}
+                    fileId={file?.id}
                     isOpen={isTaskFormOpen}
                     onClose={handleTaskModalClose}
                     onSubmitError={setTaskError}

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -200,6 +200,19 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         expect(screen.getByTestId('activity-feed-editor')).toBeVisible();
     });
 
+    test('should tag the feed wrapper with resin feature and fileid', () => {
+        const { container } = render(
+            <ActivityFeedV2
+                currentUser={mockCurrentUser}
+                feedItems={[] as ActivityFeedV2Props['feedItems']}
+                file={{ id: '12345' }}
+            />,
+        );
+
+        expect(container.firstChild).toHaveAttribute('data-resin-feature', 'activityfeedv2');
+        expect(container.firstChild).toHaveAttribute('data-resin-fileid', '12345');
+    });
+
     test('should not render the list when feedItems is undefined', () => {
         render(<ActivityFeedV2 currentUser={mockCurrentUser} />);
         expect(screen.queryByTestId('activity-feed-list')).not.toBeInTheDocument();
@@ -1213,9 +1226,10 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         };
 
         test('should forward create-mode props to TaskModalV2', () => {
-            renderFeed({ createTask: jest.fn(), onTaskUpdate: jest.fn() });
+            renderFeed({ createTask: jest.fn(), file: { id: '12345' }, onTaskUpdate: jest.fn() });
             expect(lastTaskModalProps.mode).toBeUndefined();
             expect(lastTaskModalProps.editingTask).toBeUndefined();
+            expect(lastTaskModalProps.fileId).toBe('12345');
             expect(lastTaskModalProps.taskType).toBe('APPROVAL');
             expect(lastTaskModalProps.isOpen).toBe(false);
         });

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskFormV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskFormV2.tsx
@@ -11,6 +11,8 @@ import { TASK_COMPLETION_RULE_ALL, TASK_COMPLETION_RULE_ANY, TASK_EDIT_MODE_EDIT
 
 import type { TaskCompletionRule, TaskEditMode, TaskType } from '../../../../common/types/tasks';
 
+import { ACTIVITY_TARGETS } from '../../../common/interactionTargets';
+
 import { mapAssigneeToUserContact, mapUserContactToAssignee } from './utils/contactMapping';
 import type { TaskAssignee, TaskFormV2SubmitPayload } from './types';
 
@@ -198,6 +200,7 @@ const TaskFormV2 = ({
             <DatePicker
                 calendarAriaLabel={formatMessage(messages.datePickerCalendarAriaLabel)}
                 clearDatePickerAriaLabel={formatMessage(messages.datePickerClearAriaLabel)}
+                data-resin-target={ACTIVITY_TARGETS.TASK_DATE_PICKER}
                 dataTargetId="TaskFormV2-dueDateInput"
                 isDisabled={isDisabled}
                 label={formatMessage(messages.dueDateLabel)}

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.tsx
@@ -40,6 +40,7 @@ type SharedProps = {
     error?: ElementsXhrError;
     fetchAvatarUrls: (contacts: UserContactType[]) => Promise<FetchedAvatarUrls>;
     fetchUsers: (query: string) => Promise<UserContactType[]>;
+    fileId?: string;
     isOpen: boolean;
     onClose: () => void;
     onSubmitError: (error: ElementsXhrError) => void;
@@ -89,6 +90,7 @@ const TaskModalV2 = ({
     error,
     fetchAvatarUrls,
     fetchUsers,
+    fileId,
     isOpen,
     onClose,
     onSubmitError,
@@ -174,6 +176,8 @@ const TaskModalV2 = ({
             <Modal.Content
                 className="bcs-NewTaskModal"
                 data-resin-component="taskmodalv2"
+                data-resin-feature="activityfeedv2"
+                data-resin-fileid={fileId}
                 data-testid="task-modal-v2"
                 size="medium"
             >

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/__tests__/TaskFormV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/__tests__/TaskFormV2.test.tsx
@@ -46,7 +46,12 @@ jest.mock('@box/user-selector', () => ({
     },
 }));
 
-type DatePickerMockProps = { label: React.ReactNode; value?: unknown; minValue?: unknown };
+type DatePickerMockProps = {
+    'data-resin-target'?: string;
+    label: React.ReactNode;
+    minValue?: unknown;
+    value?: unknown;
+};
 
 let lastDatePickerProps: DatePickerMockProps = { label: null };
 
@@ -240,6 +245,11 @@ describe('elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskFormV2', (
     test('passes today as the DatePicker minValue for new tasks', () => {
         renderForm();
         expect(lastDatePickerProps.minValue).toBeDefined();
+    });
+
+    test('tags the DatePicker with the task datepicker resin target', () => {
+        renderForm();
+        expect(lastDatePickerProps['data-resin-target']).toBe('activityfeed-taskdatepicker');
     });
 
     test('omits the DatePicker minValue when editing a task whose due date is already in the past', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/__tests__/TaskModalV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/__tests__/TaskModalV2.test.tsx
@@ -96,6 +96,7 @@ type RenderModalOptions = {
     editingAssignees?: TaskAssignee[];
     editingTask?: TaskNew | null;
     error?: ElementsXhrError;
+    fileId?: string;
     isOpen?: boolean;
     taskType?: TaskNew['task_type'];
 };
@@ -309,9 +310,12 @@ describe('elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2', 
         expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
     });
 
-    test('tags the modal content with data-resin-component=taskmodalv2', () => {
-        renderModal();
-        expect(screen.getByTestId('task-modal-v2')).toHaveAttribute('data-resin-component', 'taskmodalv2');
+    test('tags the modal content with resin component, feature, and fileid', () => {
+        renderModal({ fileId: '12345' });
+        const modalContent = screen.getByTestId('task-modal-v2');
+        expect(modalContent).toHaveAttribute('data-resin-component', 'taskmodalv2');
+        expect(modalContent).toHaveAttribute('data-resin-feature', 'activityfeedv2');
+        expect(modalContent).toHaveAttribute('data-resin-fileid', '12345');
     });
 
     test('tags the Cancel and Create buttons with data-resin-target and data-target-id', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -81,6 +81,7 @@ export type TransformedFeedItem =
 export type ActivityFeedV2File = {
     extension?: string;
     file_version?: { id: string };
+    id?: string;
 };
 
 export type ViewerHandle = {


### PR DESCRIPTION
## Summary

Improves resin instrumentation for the V2 activity feed so click events can be attributed to the file and surface they occurred on.

- **File id on the feed wrapper**: the `ActivityFeedV2` wrapper div now carries `data-resin-fileid` alongside the existing `data-resin-feature="activityfeedv2"`. Resin resolves events by walking DOM ancestors and collecting `data-resin-*` attributes, so every event fired from inside the feed (comment post, reply, resolve, task actions, version/profile/mention links) now inherits the file id.
- **Task modal portal anchoring**: the task modal renders through a portal on `document.body`, severing it from the feed wrapper in the DOM. `Modal.Content` now carries its own `data-resin-feature="activityfeedv2"` and `data-resin-fileid` (threaded via a new optional `fileId` prop) so modal events (post, cancel, datepicker) are fully attributed.
- **Task datepicker target**: the `TaskFormV2` DatePicker now carries `data-resin-target` with the same `activityfeed-taskdatepicker` value its V1 counterpart used, restoring that signal. The blueprint DatePicker spreads unknown props onto its rendered root, so the attribute lands in the DOM without any blueprint change.

Also adds `id` to the local `ActivityFeedV2File` type; the full file object is already passed from `ActivitySidebar`.

## Known limitation

Dropdown menus rendered by the feed's inner components portal outside this wrapper and carry only their own component/feature attributes; they do not inherit `fileid` from this change. That will be addressed separately in the packages that own those portal roots.

## Tests

- New/extended assertions for the wrapper `fileid`, the modal content feature/fileid, the `fileId` prop forwarding, and the datepicker target
- `yarn test --watchAll=false --testPathPattern="activity-feed-v2"`: 343 tests passing
- `tsc` and ESLint clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced tracking metadata to the activity feed wrapper and task modal, including the related file identifier.
  * Added resin target tracking to the task due-date picker.
  * Activity feed file data now supports an optional identifier.
* **Tests**
  * Expanded coverage to validate the added tracking metadata (including file identifier) for the activity feed, task modal, and due-date picker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->