### PR TITLE
fix(activity-feed-v2): derive task completedAt from assignee entries

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
@@ -382,6 +382,70 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const result = transformTaskToProps(taskWithMore as unknown as TaskNew);
             expect(result.hasNextPage).toBe(true);
         });
+
+        test('should use task-level completed_at when present', () => {
+            const completedTask = {
+                ...mockTask,
+                completed_at: '2024-03-10T00:00:00Z',
+                status: 'COMPLETED',
+            };
+            const result = transformTaskToProps(completedTask as unknown as TaskNew);
+            expect(result.completedAt).toBe(new Date('2024-03-10T00:00:00Z').getTime());
+        });
+
+        test.each([['APPROVED'], ['COMPLETED'], ['REJECTED']])(
+            'should fall back to latest assignee completed_at for terminal status %s',
+            status => {
+                const terminalTask = {
+                    ...mockTask,
+                    assigned_to: {
+                        ...mockTask.assigned_to,
+                        entries: [
+                            {
+                                ...mockTask.assigned_to.entries[0],
+                                completed_at: '2024-03-08T00:00:00Z',
+                                status,
+                            },
+                            {
+                                ...mockTask.assigned_to.entries[0],
+                                completed_at: '2024-03-09T00:00:00Z',
+                                id: 'tc-2',
+                                status,
+                                target: { id: '101', name: 'Assignee Two', type: 'user' },
+                            },
+                        ],
+                    },
+                    status,
+                };
+                const result = transformTaskToProps(terminalTask as unknown as TaskNew);
+                expect(result.completedAt).toBe(new Date('2024-03-09T00:00:00Z').getTime());
+            },
+        );
+
+        test('should leave completedAt undefined for non-terminal status even when an assignee has completed_at', () => {
+            const inProgressTask = {
+                ...mockTask,
+                assigned_to: {
+                    ...mockTask.assigned_to,
+                    entries: [
+                        {
+                            ...mockTask.assigned_to.entries[0],
+                            completed_at: '2024-03-08T00:00:00Z',
+                            status: 'APPROVED',
+                        },
+                    ],
+                },
+                status: 'IN_PROGRESS',
+            };
+            const result = transformTaskToProps(inProgressTask as unknown as TaskNew);
+            expect(result.completedAt).toBeUndefined();
+        });
+
+        test('should leave completedAt undefined for terminal status when no assignee has completed_at', () => {
+            const rejectedTask = { ...mockTask, status: 'REJECTED' };
+            const result = transformTaskToProps(rejectedTask as unknown as TaskNew);
+            expect(result.completedAt).toBeUndefined();
+        });
     });
 
     describe('transformVersionToProps()', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -133,6 +133,21 @@ const toUpdatedAt = (createdAt: string, modifiedAt: string): number | undefined 
     return toUnixMs(modifiedAt);
 };
 
+const TERMINAL_TASK_STATUSES = new Set(['APPROVED', 'COMPLETED', 'REJECTED']);
+
+// The file activities endpoint does not populate task-level completed_at, so for tasks in a
+// terminal status the latest assignee completion is the only available completion timestamp.
+const getTaskCompletedAt = (task: TaskNew): number | undefined => {
+    const taskCompletedAt = toUnixMs(task.completed_at);
+    if (taskCompletedAt !== undefined) return taskCompletedAt;
+    if (!TERMINAL_TASK_STATUSES.has(task.status)) return undefined;
+
+    const assigneeCompletedTimes = (task.assigned_to?.entries ?? [])
+        .map(entry => toUnixMs(entry.completed_at))
+        .filter((ms): ms is number => ms !== undefined);
+    return assigneeCompletedTimes.length > 0 ? Math.max(...assigneeCompletedTimes) : undefined;
+};
+
 const resolveAvatarUrl = (userId: string | undefined, avatarUrls?: AvatarUrlMap): string | undefined =>
     userId ? avatarUrls?.[userId] : undefined;
 
@@ -235,7 +250,7 @@ export const transformTaskToProps = (
         id: task.created_by?.target?.id ?? '',
         name: task.created_by?.target?.name ?? '',
     },
-    completedAt: toUnixMs(task.completed_at),
+    completedAt: getTaskCompletedAt(task),
     completionRule:
         task.completion_rule === 'ALL_ASSIGNEES' ? TaskCompletionRule.ALL_ASSIGNEES : TaskCompletionRule.ANY_ASSIGNEE,
     createdAt: toUnixMs(task.created_at) ?? 0,


### PR DESCRIPTION
## Description

In activity feed v2, completed/approved/rejected tasks showed the task creation date in the status banner instead of the completion date.

The file activities endpoint does not populate task-level `completed_at` (only the per-assignee `assigned_to.entries[].completed_at`), so `transformTaskToProps` passed `completedAt: undefined` to `TaskItem`, which falls back to `createdAt` for the banner timestamp.

## Changes

- Added `getTaskCompletedAt` to the activity feed v2 transformers: uses task-level `completed_at` when present, and for tasks in a terminal status (approved / completed / rejected) falls back to the latest assignee `completed_at`. Taking the latest entry handles the `all_assignees` completion rule, where the task completes when the last assignee finishes.
- Non-terminal tasks keep `completedAt` undefined even if some assignees have completed.

## Testing

- Added unit tests covering: task-level `completed_at` preferred, fallback to the latest assignee timestamp for each terminal status, no fallback for in-progress tasks, and undefined when a terminal task has no assignee timestamps.
- `yarn test --watchAll=false --testPathPattern="activity-feed-v2/__tests__/transformers"` - 84 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task completion timestamps in the activity feed.
  * Completed tasks now display the task’s completion time or, when unavailable, the latest completion time from assigned participants.
  * Non-completed tasks continue to show no completion timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->