### PR TITLE
fix(activity-feed-v2): cap task message textarea at 6 rows

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskFormV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskFormV2.tsx
@@ -189,6 +189,7 @@ const TaskFormV2 = ({
                 disabled={isDisabled}
                 error={messageError}
                 label={formatMessage(messages.messageLabel)}
+                maxRows={6}
                 minRows={3}
                 name="taskMessage"
                 onChange={event => setMessage(event.target.value)}


### PR DESCRIPTION
## Description

In the task modal v2, a long message with many line breaks grew the message textarea without bound, pushing the modal footer buttons out of view.

The Blueprint `TextArea` autosize supports a `maxRows` cap: the field grows up to the cap and then scrolls internally. Added `maxRows={6}` to the task message field (`minRows={3}` unchanged). Six rows matches the effective cap on the v1 task form, which limits the same field with `max-height: 140px` in `TaskForm.scss`.

## Testing

- `yarn test --watchAll=false --testPathPattern="task-modal-v2"` - 4 suites, 65 tests passed.
- The grow-then-scroll behavior itself is implemented and tested in `@box/blueprint-web` and is not observable in jsdom, so no new unit test; verified visually that the textarea stops growing at 6 rows and scrolls, keeping the footer buttons in view.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Limited the task message field to six visible rows for a more compact form layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->