### PR TITLE
feat(content-preview): support externally-managed preview instance

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -153,6 +153,13 @@ type Props = {
     previewExperiences?: {
         [name: string]: TargetingApi,
     },
+    /**
+     * Optional externally-managed Box.Preview instance. When provided,
+     * ContentPreview reuses it instead of constructing its own, and on
+     * cleanup it only detaches its listeners rather than destroying the
+     * instance — the host application retains ownership of its lifecycle.
+     */
+    previewInstance?: Object,
     previewLibraryVersion: string,
     previewMode?: 'default' | 'shared_file' | 'shared_folder' | 'editable_shared_file' | 'inline_feed',
     requestInterceptor?: Function,
@@ -426,8 +433,15 @@ class ContentPreview extends React.PureComponent<Props, State> {
         this.clearLoadingIndicatorDelayTimeout();
         const { onPreviewDestroy } = this.props;
         if (this.preview) {
-            this.preview.destroy();
-            this.preview.removeAllListeners();
+            if (this.props.previewInstance) {
+                this.preview.removeListener('load', this.onPreviewLoad);
+                this.preview.removeListener('preload', this.endLoadingSession);
+                this.preview.removeListener('preview_error', this.onPreviewError);
+                this.preview.removeListener('preview_metric', this.onPreviewMetric);
+            } else {
+                this.preview.destroy();
+                this.preview.removeAllListeners();
+            }
             this.preview = undefined;
 
             onPreviewDestroy(shouldReset);
@@ -1008,7 +1022,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
             useHotkeys: false,
         };
         const { Preview } = global.Box;
-        this.preview = new Preview();
+        this.preview = this.props.previewInstance || new Preview();
         this.preview.addListener('load', this.onPreviewLoad);
         this.preview.addListener('preload', this.endLoadingSession);
 


### PR DESCRIPTION
## Summary

- Adds an optional `previewInstance` prop to `ContentPreview` that lets host applications pass in an existing `Box.Preview` instance instead of having the component construct its own.
- On cleanup, when an external instance was provided, `ContentPreview` detaches only the listeners it attached (`load`, `preload`, `preview_error`, `preview_metric`) rather than calling `destroy()` and `removeAllListeners()`, so the host application retains ownership of the instance lifecycle.
- When the prop is not provided, behavior is unchanged: `ContentPreview` creates and destroys its own instance as before.

## Test Plan

- [x] `yarn flow check` passes (0 errors)
- [x] All content-preview unit tests pass (180 tests)
- [ ] Verify default behavior is unchanged when `previewInstance` is not provided
- [ ] Verify that a provided external `Preview` instance is reused and not destroyed on unmount

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content previews can now use an externally managed preview instance.
  * Existing preview behavior remains unchanged when no instance is provided.

* **Bug Fixes**
  * Prevented externally managed preview instances from being destroyed during component cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->