### PR TITLE
[WIP/RFC] feat(portal): PortalContainerContext for federated portal isolation

### DIFF
--- a/src/common/PortalContainerContext.tsx
+++ b/src/common/PortalContainerContext.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+/**
+ * Provides a default DOM element for portaled UI (Tooltip, Flyout, Portal/Modal)
+ * to render into, instead of document.body.
+ *
+ * Federated consumers that scope their CSS under a root element (e.g. a Module
+ * Federation remote embedded in a host document) can wrap their subtree in this
+ * provider so portaled content mounts inside that root and picks up the scoped
+ * styles, rather than escaping to document.body in the shared host document.
+ *
+ * A null value (the default) preserves the historical document.body behavior.
+ * Components consuming this context must still treat an explicit prop as taking
+ * precedence over the context value.
+ */
+const PortalContainerContext = React.createContext<HTMLElement | null>(null);
+
+PortalContainerContext.displayName = 'PortalContainerContext';
+
+export default PortalContainerContext;

--- a/src/components/flyout/Flyout.js
+++ b/src/components/flyout/Flyout.js
@@ -6,6 +6,7 @@ import uniqueId from 'lodash/uniqueId';
 import { KEYS } from '../../constants';
 
 import FlyoutContext from './FlyoutContext';
+import PortalContainerContext from '../../common/PortalContainerContext';
 
 import './Flyout.scss';
 
@@ -181,6 +182,8 @@ type State = {
 type Props = FlyoutProps;
 
 class Flyout extends React.Component<Props, State> {
+    static contextType = PortalContainerContext;
+
     static defaultProps = {
         className: '',
         closeOnClick: true,
@@ -485,6 +488,15 @@ class Flyout extends React.Component<Props, State> {
                 default:
                 // no default
             }
+        }
+
+        // Explicit context container wins, else react-tether defaults to document.body.
+        // renderElementTo controls react-tether's initial mount; bodyElement controls
+        // where Tether's positioning engine re-parents the element. Both must point at
+        // the container or Tether moves the element back to document.body.
+        if (this.context instanceof HTMLElement) {
+            tetherProps.renderElementTo = this.context;
+            tetherProps.bodyElement = this.context;
         }
 
         return (

--- a/src/components/portal/Portal.tsx
+++ b/src/components/portal/Portal.tsx
@@ -1,20 +1,23 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import PortalContainerContext from '../../common/PortalContainerContext';
 
 export interface PortalProps {
+    children?: React.ReactNode;
     className?: string;
-    container: HTMLElement | null | undefined;
+    container?: HTMLElement | null | undefined;
     style?: { [arg: string]: string | number };
 }
 
 class Portal extends React.PureComponent<PortalProps> {
-    static defaultProps = {
-        container: document.body,
-    };
+    static contextType = PortalContainerContext;
 
-    constructor(props: PortalProps) {
-        super(props);
-        this.container = this.props.container;
+    context!: React.ContextType<typeof PortalContainerContext>;
+
+    constructor(props: PortalProps, context: React.ContextType<typeof PortalContainerContext>) {
+        super(props, context);
+        // Explicit prop wins, then the context container, then document.body.
+        this.container = props.container ?? context ?? document.body;
         this.layer = document.createElement('div');
         this.layer.setAttribute('data-portal', '');
         if (this.container && this.layer) {
@@ -34,7 +37,9 @@ class Portal extends React.PureComponent<PortalProps> {
     container: HTMLElement | null | undefined;
 
     render(): null | React.ReactPortal {
-        const { ...elementProps }: PortalProps = this.props;
+        // Exclude container from the props spread onto the rendered div.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { container, ...elementProps }: PortalProps = this.props;
         if (!this.layer) {
             return null;
         }

--- a/src/components/portal/__tests__/Portal.test.tsx
+++ b/src/components/portal/__tests__/Portal.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { mount, MountRendererProps, ReactWrapper } from 'enzyme';
 
 import Portal from '../Portal';
+import PortalContainerContext from '../../../common/PortalContainerContext';
 
 describe('components/portal/Portal', () => {
     let attachTo: HTMLElement | null;
@@ -103,6 +104,40 @@ describe('components/portal/Portal', () => {
         }
         const portal = document.querySelector('[data-portal]');
         expect(portal && portal.textContent).toEqual('boo');
+    });
+
+    test('should render into the PortalContainerContext container when no container prop is given', () => {
+        const contextContainer = document.createElement('div');
+        contextContainer.setAttribute('data-context-container', '');
+        document.body.appendChild(contextContainer);
+
+        mountToBody(
+            <PortalContainerContext.Provider value={contextContainer}>
+                <Portal>text</Portal>
+            </PortalContainerContext.Provider>,
+        );
+
+        expect(contextContainer.querySelector('[data-portal]')).toBeTruthy();
+        document.body.removeChild(contextContainer);
+    });
+
+    test('should prefer an explicit container prop over the PortalContainerContext', () => {
+        const contextContainer = document.createElement('div');
+        const propContainer = document.createElement('div');
+        propContainer.setAttribute('data-prop-container', '');
+        document.body.appendChild(contextContainer);
+        document.body.appendChild(propContainer);
+
+        mountToBody(
+            <PortalContainerContext.Provider value={contextContainer}>
+                <Portal container={propContainer}>text</Portal>
+            </PortalContainerContext.Provider>,
+        );
+
+        expect(propContainer.querySelector('[data-portal]')).toBeTruthy();
+        expect(contextContainer.querySelector('[data-portal]')).toBeFalsy();
+        document.body.removeChild(contextContainer);
+        document.body.removeChild(propContainer);
     });
 
     test('should used a passed in document if provided', () => {

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -5,6 +5,7 @@ import getProp from 'lodash/get';
 import TetherComponent, { type TetherProps } from 'react-tether';
 
 import TetherPosition from '../../common/tether-positions';
+import PortalContainerContext from '../../common/PortalContainerContext';
 import CloseButton from './CloseButton';
 
 import './Tooltip.scss';
@@ -115,6 +116,10 @@ type State = {
 };
 
 class Tooltip extends React.Component<TooltipProps, State> {
+    static contextType = PortalContainerContext;
+
+    context!: React.ContextType<typeof PortalContainerContext>;
+
     static defaultProps: DefaultTooltipProps = {
         constrainToScrollParent: false,
         constrainToWindow: true,
@@ -307,7 +312,9 @@ class Tooltip extends React.Component<TooltipProps, State> {
             }
         }
 
-        const bodyEl = bodyElement instanceof HTMLElement ? bodyElement : document.body;
+        // Explicit prop wins, then the context container, then document.body.
+        const contextContainer = this.context instanceof HTMLElement ? this.context : null;
+        const bodyEl = bodyElement instanceof HTMLElement ? bodyElement : contextContainer ?? document.body;
 
         const classes = classNames('tooltip', 'bdl-Tooltip', className, {
             'is-callout': theme === TooltipTheme.CALLOUT,
@@ -321,12 +328,16 @@ class Tooltip extends React.Component<TooltipProps, State> {
         > & {
             offset?: string;
             className?: string;
+            bodyElement?: HTMLElement;
         } = {
             attachment: tetherPosition.attachment,
             classPrefix: 'tooltip',
             constraints,
             targetAttachment: tetherPosition.targetAttachment,
+            // renderElementTo controls react-tether's mount; bodyElement controls where
+            // Tether's positioning re-parents the element. Set both to keep it in place.
             renderElementTo: bodyEl,
+            bodyElement: bodyEl,
         };
 
         if (tetherElementClassName) {

--- a/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`components/tooltip/Tooltip render() should match snapshot when stopBubb
 exports[`components/tooltip/Tooltip render() should not render the close button if wasClosedByUser state is true 1`] = `
 <d
   attachment="bottom center"
+  bodyElement={<body />}
   classPrefix="tooltip"
   constraints={
     [
@@ -44,6 +45,7 @@ exports[`components/tooltip/Tooltip render() should not render the close button 
 exports[`components/tooltip/Tooltip render() should not render with close button if isShown is false 1`] = `
 <d
   attachment="bottom center"
+  bodyElement={<body />}
   classPrefix="tooltip"
   constraints={
     [
@@ -63,6 +65,7 @@ exports[`components/tooltip/Tooltip render() should not render with close button
 exports[`components/tooltip/Tooltip render() should not render with close button if showCloseButton is false 1`] = `
 <d
   attachment="bottom center"
+  bodyElement={<body />}
   classPrefix="tooltip"
   constraints={
     [
@@ -88,6 +91,208 @@ exports[`components/tooltip/Tooltip render() should render children only when to
 exports[`components/tooltip/Tooltip render() should render children wrapped in tether when tooltip has text missing 1`] = `
 <d
   attachment="bottom center"
+  bodyElement={
+    <body>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip7"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        data-tether-id="1"
+        style="top: 0px; left: 0px; position: absolute;"
+      />
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip8"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip testing"
+          data-testid="bdl-Tooltip"
+          id="tooltip9"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip15"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip16"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip17"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip18"
+          role="tooltip"
+        >
+          test
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip19"
+          role="tooltip"
+        >
+          test
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip20"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip21"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip22"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip23"
+          role="tooltip"
+        >
+          Im a long tooltip description
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip is-error"
+          data-testid="bdl-Tooltip"
+          id="tooltip24"
+        >
+          hi
+        </div>
+      </div>
+    </body>
+  }
   classPrefix="tooltip"
   constraints={
     [
@@ -308,6 +513,7 @@ exports[`components/tooltip/Tooltip render() should render children wrapped in t
 exports[`components/tooltip/Tooltip render() should render correctly with callout theme 1`] = `
 <d
   attachment="bottom center"
+  bodyElement={<body />}
   classPrefix="tooltip"
   constraints={
     [
@@ -327,6 +533,242 @@ exports[`components/tooltip/Tooltip render() should render correctly with callou
 exports[`components/tooltip/Tooltip render() should render correctly with tetherElementClassName 1`] = `
 <d
   attachment="bottom center"
+  bodyElement={
+    <body>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip7"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        data-tether-id="1"
+        style="top: 0px; left: 0px; position: absolute;"
+      />
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip8"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip testing"
+          data-testid="bdl-Tooltip"
+          id="tooltip9"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip15"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip16"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip17"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip18"
+          role="tooltip"
+        >
+          test
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip19"
+          role="tooltip"
+        >
+          test
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip20"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="true"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip21"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip22"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip23"
+          role="tooltip"
+        >
+          Im a long tooltip description
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip is-error"
+          data-testid="bdl-Tooltip"
+          id="tooltip24"
+        >
+          hi
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          class="tooltip bdl-Tooltip"
+          id="tooltip27"
+          role="presentation"
+        >
+          <div
+            aria-hidden="false"
+            aria-live="polite"
+            data-testid="bdl-Tooltip"
+            role="tooltip"
+          >
+            hi
+          </div>
+        </div>
+      </div>
+      <div
+        class="tooltip-element tooltip-enabled tooltip-abutted tooltip-abutted-left tooltip-abutted-right tooltip-abutted-top tooltip-abutted-bottom tooltip-element-attached-bottom tooltip-element-attached-center tooltip-target-attached-top tooltip-target-attached-center"
+        style="top: 0px; left: 0px; position: absolute; transform: translateX(0px) translateY(0px) translateZ(0);"
+      >
+        <div
+          aria-hidden="false"
+          aria-live="polite"
+          class="tooltip bdl-Tooltip"
+          data-testid="bdl-Tooltip"
+          id="tooltip28"
+          role="tooltip"
+        >
+          hi
+        </div>
+      </div>
+    </body>
+  }
   className="tether-element-class-name"
   classPrefix="tooltip"
   constraints={
@@ -582,6 +1024,7 @@ exports[`components/tooltip/Tooltip render() should render correctly with tether
 exports[`components/tooltip/Tooltip render() should render with close button if isShown and showCloseButton are true 1`] = `
 <d
   attachment="bottom center"
+  bodyElement={<body />}
   classPrefix="tooltip"
   constraints={
     [

--- a/src/elements/content-sidebar/AddTaskMenuV2.tsx
+++ b/src/elements/content-sidebar/AddTaskMenuV2.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { DropdownMenu, TriggerButton } from '@box/blueprint-web';
 import { ApprovalTask } from '@box/blueprint-web-assets/icons/Fill';
 import { Tasks } from '@box/blueprint-web-assets/icons/MediumFilled';
+import PortalContainerContext from '../../common/PortalContainerContext';
 import messages from './messages';
 import { TASK_TYPE_APPROVAL, TASK_TYPE_GENERAL } from '../../constants';
 import type { TaskType } from '../../common/types/tasks';
@@ -18,6 +19,7 @@ export interface AddTaskMenuV2Props {
 
 const AddTaskMenuV2: React.FC<AddTaskMenuV2Props> = ({ isDisabled, onMenuItemClick, setAddTaskButtonRef }) => {
     const { formatMessage } = useIntl();
+    const portalContainer = React.useContext(PortalContainerContext);
 
     const [isOpen, setIsOpen] = React.useState(false);
 
@@ -46,6 +48,7 @@ const AddTaskMenuV2: React.FC<AddTaskMenuV2Props> = ({ isDisabled, onMenuItemCli
             <DropdownMenu.Content
                 align="end"
                 className="bcs-AddTaskMenu-v-two"
+                container={portalContainer ?? undefined}
                 onCloseAutoFocus={(event: Event) => {
                     // Prevent focus from returning to the trigger button when the menu closes.
                     // This allows the Modal (which was just opened) to keep focus on its input field

--- a/src/elements/content-sidebar/ContentSidebar.js
+++ b/src/elements/content-sidebar/ContentSidebar.js
@@ -10,6 +10,7 @@ import noop from 'lodash/noop';
 import flow from 'lodash/flow';
 import { TooltipProvider } from '@box/blueprint-web';
 import type { RouterHistory } from 'react-router-dom';
+import PortalContainerContext from '../../common/PortalContainerContext';
 import API from '../../api';
 import APIContext from '../common/api-context';
 import Internationalize from '../common/Internationalize';
@@ -136,6 +137,8 @@ const MARK_NAME_JS_READY = `${ORIGIN_CONTENT_SIDEBAR}_${EVENT_JS_READY}`;
 mark(MARK_NAME_JS_READY);
 
 class ContentSidebar extends React.Component<Props, State> {
+    static contextType = PortalContainerContext;
+
     props: Props;
 
     state: State = { isLoading: true };
@@ -423,7 +426,7 @@ class ContentSidebar extends React.Component<Props, State> {
             <Internationalize language={language} messages={messages}>
                 <APIContext.Provider value={(this.api: any)}>
                     <NavRouter history={history} initialEntries={[initialPath]} features={features}>
-                        <TooltipProvider>
+                        <TooltipProvider container={this.context instanceof HTMLElement ? this.context : undefined}>
                             <Sidebar
                                 activitySidebarProps={activitySidebarProps}
                                 additionalTabs={additionalTabs}

--- a/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/task-modal-v2/TaskModalV2.tsx
@@ -5,6 +5,7 @@ import type { MessageDescriptor } from 'react-intl';
 import { Modal } from '@box/blueprint-web';
 import type { FetchedAvatarUrls, UserContactType } from '@box/user-selector';
 
+import PortalContainerContext from '../../../../common/PortalContainerContext';
 import { TASK_COMPLETION_RULE_ALL, TASK_EDIT_MODE_EDIT, TASK_TYPE_GENERAL } from '../../../../constants';
 
 import type { ElementsXhrError } from '../../../../common/types/api';
@@ -105,6 +106,7 @@ const TaskModalV2 = ({
     const editTask = isEditMode ? editProps.editTask : undefined;
 
     const { formatMessage } = useIntl();
+    const portalContainer = React.useContext(PortalContainerContext);
     const titleMessage = getTitleMessage(taskType, editMode);
 
     const [isSubmitting, setIsSubmitting] = React.useState(false);
@@ -175,6 +177,7 @@ const TaskModalV2 = ({
         <Modal open={isOpen} onOpenChange={handleOpenChange}>
             <Modal.Content
                 className="bcs-NewTaskModal"
+                container={portalContainer instanceof HTMLElement ? portalContainer : undefined}
                 data-resin-component="taskmodalv2"
                 data-resin-feature="activityfeedv2"
                 data-resin-fileid={fileId}


### PR DESCRIPTION
> **Status: WIP / RFC — for discussion, not yet ready to merge.** Part of an exploration into isolating a federated consumer's bundled box-ui-elements CSS from the host document. We may not land this exact approach; opening to discuss the pattern.

## Problem

`preview-client` is a Module Federation remote embedded in a host document (EUA). It scopes its bundled box-ui-elements CSS under a root element (`.preview-overlay`) so those global styles can't leak into / override the host (e.g. sign-client) — see PREVIEW-1152. But BUIE (and the blueprint-web components BUIE renders) portal Tooltip/Flyout/Modal/DropdownMenu to `document.body`, outside that root, so scoped rules can't reach them and preview's own portaled UI renders unstyled / invisible.

## Change

Introduce `PortalContainerContext` (default `null` = current behavior). A consumer wraps its subtree in one provider pointing at its own root; portals resolve their target as **explicit prop > context container > document.body**.

Wired: Portal / Tooltip / Flyout consume the context (Tooltip & Flyout set both react-tether `renderElementTo` and Tether `bodyElement`); ContentSidebar passes the container to its internal `TooltipProvider`; AddTaskMenuV2 (`DropdownMenu.Content`) and TaskModalV2 (`Modal.Content`) pass it per call site.

## Open questions / known gaps (why WIP)

- **No unified blueprint portal provider (DSYS-440).** blueprint's Select/Modal/DropdownMenu/DatePicker take `container` as a prop only (no context fallback), so every call site must be wired individually. A unified provider in blueprint is the real durable fix.
- **External packages out of reach.** `@box/activity-feed` renders its own blueprint portals; not fixable here.
- One case (AddTask dropdown) still resolved `container` to null at runtime during testing — root cause unconfirmed (provider ancestry vs. MF module identity). Needs follow-up.

## Backward compatibility

No behavior change when no provider is present. Existing Portal/Tooltip/Flyout tests pass (snapshots updated for `bodyElement`); ContentSidebar/AddTaskMenuV2/TaskModalV2 suites pass (88 tests).

Ref: PREVIEW-1156