### PR TITLE
feat: add modernizedDismissDelayMs prop for override

### DIFF
--- a/src/elements/content-uploader/ContentUploader.tsx
+++ b/src/elements/content-uploader/ContentUploader.tsx
@@ -120,6 +120,7 @@ export interface ContentUploaderProps {
     isExpanded?: boolean;
     onToggle?: (isExpanded: boolean) => void;
     maxFileSize?: number;
+    modernizedDismissDelayMs?: number;
 }
 
 type ModernizedPanelState = 'hidden' | 'shown' | 'dismissing';
@@ -203,6 +204,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         useUploadsManager: false,
         enableModernizedUploads: false,
         isUpgradeModalEnabled: false,
+        modernizedDismissDelayMs: HIDE_MODERNIZED_UPLOAD_MANAGER_DELAY_MS,
     };
 
     /**
@@ -893,7 +895,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     upload = () => {
         const { enableModernizedUploads, isUpgradeModalEnabled, maxFileSize } = this.props;
 
-        if (this.isCancelAllPaused) { 
+        if (this.isCancelAllPaused) {
             return;
         }
 
@@ -1637,6 +1639,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
     startModernizedDismissTimer = (): void => {
         this.clearModernizedDismissTimer();
 
+        const { modernizedDismissDelayMs } = this.props;
         const { modernizedPanelState, items } = this.state;
         const isUploadsBatchSuccessfullyComplete = items.every(
             item => item.status === STATUS_COMPLETE || item.status === STATUS_CANCELED,
@@ -1654,7 +1657,7 @@ class ContentUploader extends Component<ContentUploaderProps, State> {
         this.modernizedDismissTimer = setTimeout(() => {
             this.setState({ modernizedPanelState: 'dismissing' });
             this.modernizedDismissTimer = null;
-        }, HIDE_MODERNIZED_UPLOAD_MANAGER_DELAY_MS);
+        }, modernizedDismissDelayMs);
     };
 
     finalizeModernizedDismiss = (): void => {

--- a/src/elements/content-uploader/__tests__/ContentUploader.test.js
+++ b/src/elements/content-uploader/__tests__/ContentUploader.test.js
@@ -1787,6 +1787,22 @@ describe('elements/content-uploader/ContentUploader', () => {
             expect(wrapper.state('modernizedPanelState')).toBe('dismissing');
         });
 
+        test('honors a custom modernizedDismissDelayMs', () => {
+            const CUSTOM_DELAY_MS = 3000;
+            const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+            const wrapper = getWrapper({ enableModernizedUploads: true, modernizedDismissDelayMs: CUSTOM_DELAY_MS });
+            armDismissTimer(wrapper);
+
+            expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), CUSTOM_DELAY_MS);
+
+            jest.advanceTimersByTime(CUSTOM_DELAY_MS - 1);
+            expect(wrapper.state('modernizedPanelState')).toBe('shown');
+
+            jest.advanceTimersByTime(1);
+            expect(wrapper.state('modernizedPanelState')).toBe('dismissing');
+            setTimeoutSpy.mockRestore();
+        });
+
         test('clears timer when a new in-progress item is added mid-wait', () => {
             const wrapper = getWrapper({ enableModernizedUploads: true });
             const instance = armDismissTimer(wrapper);


### PR DESCRIPTION
Add prop for overriding timer
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to customize how long the modernized uploads panel remains visible before dismissing.

* **Bug Fixes**
  * Improved the uploads panel dismissal behavior to consistently honor the configured timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->