### PR TITLE
feat(classification): fixed typo

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1589,11 +1589,11 @@ boxui.securityControls.appPreviewBlacklistOverflow = Read restricted for some ap
 # Bullet point that summarizes application preview restriction applied to classification
 boxui.securityControls.appPreviewRestricted = Read restricted for some applications.
 # Bullet point that summarizes application preview restriction applied to classification
-boxui.securityControls.appPreviewWhitelist = Only select applications can read: {appNames}
+boxui.securityControls.appPreviewWhitelist = Only selected applications can read: {appNames}
 # Bullet point that summarizes application preview restriction applied to classification when the allowed application list is not provided
-boxui.securityControls.appPreviewWhitelistDefault = Only select applications can read.
+boxui.securityControls.appPreviewWhitelistDefault = Only selected applications can read.
 # Bullet point that summarizes application preview restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold
-boxui.securityControls.appPreviewWhitelistOverflow = Only select applications can read: {appNames} +{remainingAppCount} more
+boxui.securityControls.appPreviewWhitelistOverflow = Only selected applications can read: {appNames} +{remainingAppCount} more
 # Bullet point that summarizes Box Sign request restrictions applied to items. Box Sign is a product name
 boxui.securityControls.boxSignRequestRestricted = Sign restrictions apply.
 # Bullet point that summarizes desktop download restrictions applied to classification, when restriction applies to external users and managed users except Owners/Co-Owners. Box Drive is a product name and not translated

--- a/src/features/classification/security-controls/messages.js
+++ b/src/features/classification/security-controls/messages.js
@@ -386,12 +386,12 @@ const messages = defineMessages({
         id: 'boxui.securityControls.integrationPreviewDenylistOverflow',
     },
     appPreviewWhitelist: {
-        defaultMessage: 'Only select applications can read: {appNames}',
+        defaultMessage: 'Only selected applications can read: {appNames}',
         description: 'Bullet point that summarizes application preview restriction applied to classification',
         id: 'boxui.securityControls.appPreviewWhitelist',
     },
     appPreviewWhitelistDefault: {
-        defaultMessage: 'Only select applications can read.',
+        defaultMessage: 'Only selected applications can read.',
         description:
             'Bullet point that summarizes application preview restriction applied to classification when the allowed application list is not provided',
         id: 'boxui.securityControls.appPreviewWhitelistDefault',
@@ -408,7 +408,7 @@ const messages = defineMessages({
         id: 'boxui.securityControls.integrationPreviewAllowlistDefault',
     },
     appPreviewWhitelistOverflow: {
-        defaultMessage: 'Only select applications can read: {appNames} +{remainingAppCount} more',
+        defaultMessage: 'Only selected applications can read: {appNames} +{remainingAppCount} more',
         description:
             'Bullet point that summarizes application preview restriction applied to classification. This variation is used when the list of applications is longer than the configured threshold',
         id: 'boxui.securityControls.appPreviewWhitelistOverflow',


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

## Summary
Typo fix for preview restriction controls. Follow-up fix to https://github.com/box/box-ui-elements/pull/4678

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated security-control messages to use clearer, more consistent wording (“Only selected …” instead of “Only select …”).
  * Kept the same message content structure, including application-name and remaining-count details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->