### PR TITLE
Quality: Unimplemented stub methods in Channel class

### DIFF
--- a/src/api/box-edit/Channel.js
+++ b/src/api/box-edit/Channel.js
@@ -43,7 +43,7 @@ class Channel {
         browserToComServerTimeoutMS: number,
         comServerToApplicationTimeoutSec: number,
     ): Promise<any> {
-        return Promise.resolve('TODO');
+        return Promise.reject(new Error('sendCommand is not implemented'));
     }
 
     sendRequest(
@@ -51,11 +51,11 @@ class Channel {
         browserToComServerTimeoutMS: number,
         comServerToApplicationTimeoutSec: number,
     ): Promise<any> {
-        return Promise.resolve('TODO');
+        return Promise.reject(new Error('sendRequest is not implemented'));
     }
 
     getComServerStatus(browserToComServerTimeoutMS: number, comServerToApplicationTimeoutSec: number): Promise<any> {
-        return Promise.resolve('TODO');
+        return Promise.reject(new Error('getComServerStatus is not implemented'));
     }
 
     destroy(): void {}


### PR DESCRIPTION
## Summary

Quality: Unimplemented stub methods in Channel class

## Problem

**Severity**: `Medium` | **File**: `src/api/box-edit/Channel.js:L51`

The `sendCommand`, `sendRequest`, and `getComServerStatus` methods in the `Channel` class return `Promise.resolve('TODO')` and the `destroy` method is empty. This indicates incomplete implementation which can lead to unexpected behavior if these methods are called in production environments.

## Solution

Implement the logic for these methods or throw a `NotImplementedError` to prevent accidental usage of incomplete functionality.

## Changes

- `src/api/box-edit/Channel.js` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unimplemented API operations now report clear errors instead of returning placeholder results.
  - Improved error handling for command sending, request sending, and communication server status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->