### PR TITLE
chore(deps): bump activity-feed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "@babel/preset-typescript": "^7.24.7",
         "@babel/template": "^7.24.7",
         "@babel/types": "^7.24.7",
-        "@box/activity-feed": "^2.2.1",
+        "@box/activity-feed": "^2.2.18",
         "@box/blueprint-web": "^16.8.0",
         "@box/blueprint-web-assets": "^5.4.3",
         "@box/box-ai-agent-selector": "^1.39.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,10 +1067,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@box/activity-feed@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@box/activity-feed/-/activity-feed-2.2.1.tgz#5363244d744d0b57681705d4ce7250dead441eac"
-  integrity sha512-RcA+U4ZyeJAy3Dics6iR5yxVJ1F841IAxyrwrG1SVBQV6pk5i4ZqbXlVvdARlJrx279TJ+Leo5ozi+8ti2Hxug==
+"@box/activity-feed@^2.2.18":
+  version "2.2.18"
+  resolved "https://registry.yarnpkg.com/@box/activity-feed/-/activity-feed-2.2.18.tgz#0cf2c5b0369e56bb054cc0d6a5b38daad9c711c0"
+  integrity sha512-hfFyKGMJsswSWE7as/ytH3o7RnVSRn/nnPVzViB9AjAULFrdEy8n7IYusBUqot6f9Usc1LcET/Y/34b7d1GcNg==
 
 "@box/blueprint-web-assets@^5.4.3":
   version "5.4.3"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

- Bump @box/activity-feed from 2.2.1 to 2.2.18
- Picks up upstream changes that linkify URLs in task items within the activity feed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a development tooling dependency (`@box/activity-feed`) to a newer version for improved maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->