### PR TITLE
Copy paste upload

### DIFF
--- a/src/utils/__tests__/uploads.test.js
+++ b/src/utils/__tests__/uploads.test.js
@@ -18,6 +18,10 @@ import {
     DEFAULT_API_OPTIONS,
     getFileId,
     getDataTransferItemId,
+    clipboardHasFiles,
+    getFilesFromClipboard,
+    generateClipboardFileName,
+    isEditablePasteTarget,
 } from '../uploads';
 
 const mockFile = { name: 'hi' };
@@ -417,6 +421,139 @@ describe('util/uploads', () => {
             }));
             browser.isMobileSafari = jest.fn().mockReturnValueOnce(mobileSafari);
             expect(isMultiputSupported()).toEqual(expected);
+        });
+    });
+
+    describe('clipboardHasFiles()', () => {
+        test('should return false when clipboardData is null', () => {
+            expect(clipboardHasFiles({ clipboardData: null })).toBe(false);
+        });
+
+        test('should return true when clipboardData.files is not empty', () => {
+            const file = new File(['x'], 'photo.png', { type: 'image/png' });
+            expect(clipboardHasFiles({ clipboardData: { files: [file], items: [] } })).toBe(true);
+        });
+
+        test('should return true when a clipboardData item has kind file', () => {
+            const items = [
+                { kind: 'string', type: 'text/plain' },
+                { kind: 'file', type: 'image/png' },
+            ];
+            expect(clipboardHasFiles({ clipboardData: { files: [], items } })).toBe(true);
+        });
+
+        test('should return false when clipboard has only non-file items', () => {
+            const items = [{ kind: 'string', type: 'text/plain' }];
+            expect(clipboardHasFiles({ clipboardData: { files: [], items } })).toBe(false);
+        });
+    });
+
+    describe('getFilesFromClipboard()', () => {
+        test('should return an empty array when clipboardData is null', () => {
+            expect(getFilesFromClipboard({ clipboardData: null })).toEqual([]);
+        });
+
+        test('should extract from clipboardData.files first', () => {
+            const file = new File(['x'], 'photo.png', { type: 'image/png' });
+            const items = [{ kind: 'file', getAsFile: jest.fn() }];
+            const result = getFilesFromClipboard({ clipboardData: { files: [file], items } });
+
+            expect(result).toEqual([file]);
+            expect(items[0].getAsFile).not.toHaveBeenCalled();
+        });
+
+        test('should fall back to items getAsFile when files is empty', () => {
+            const file = new File(['x'], 'photo.png', { type: 'image/png' });
+            const items = [
+                { kind: 'string', type: 'text/plain', getAsFile: () => null },
+                { kind: 'file', type: 'image/png', getAsFile: () => file },
+            ];
+            const result = getFilesFromClipboard({ clipboardData: { files: [], items } });
+
+            expect(result).toEqual([file]);
+        });
+
+        test('should skip non-file items in the fallback path', () => {
+            const items = [{ kind: 'string', type: 'text/plain', getAsFile: () => null }];
+            expect(getFilesFromClipboard({ clipboardData: { files: [], items } })).toEqual([]);
+        });
+
+        test('should skip items whose getAsFile returns null', () => {
+            const items = [{ kind: 'file', type: 'image/png', getAsFile: () => null }];
+            expect(getFilesFromClipboard({ clipboardData: { files: [], items } })).toEqual([]);
+        });
+    });
+
+    describe('generateClipboardFileName()', () => {
+        beforeEach(() => {
+            jest.useFakeTimers().setSystemTime(new Date('2026-07-15T09:08:07'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        test('should preserve a meaningful file name', () => {
+            const file = new File(['x'], 'quarterly-report.pdf', { type: 'application/pdf' });
+            expect(generateClipboardFileName(file)).toBe('quarterly-report.pdf');
+        });
+
+        test('should rename a generic image name using its extension', () => {
+            const file = new File(['x'], 'image.png', { type: 'image/png' });
+            expect(generateClipboardFileName(file)).toBe('Pasted Image 2026-07-15 at 09.08.07.png');
+        });
+
+        test('should rename a generic image name with no extension using the MIME type', () => {
+            const file = new File(['x'], 'image', { type: 'image/jpeg' });
+            expect(generateClipboardFileName(file)).toBe('Pasted Image 2026-07-15 at 09.08.07.jpeg');
+        });
+
+        test('should rename a nameless file using the MIME type', () => {
+            const file = new File(['x'], '', { type: 'image/gif' });
+            expect(generateClipboardFileName(file)).toBe('Pasted Image 2026-07-15 at 09.08.07.gif');
+        });
+
+        test('should strip structured suffixes from the MIME subtype', () => {
+            const file = new File(['x'], 'image', { type: 'image/svg+xml' });
+            expect(generateClipboardFileName(file)).toBe('Pasted Image 2026-07-15 at 09.08.07.svg');
+        });
+    });
+
+    describe('isEditablePasteTarget()', () => {
+        test.each(['input', 'textarea', 'select'])('should return true for a %s element', tagName => {
+            expect(isEditablePasteTarget(document.createElement(tagName))).toBe(true);
+        });
+
+        test('should return true for a contenteditable element', () => {
+            const el = document.createElement('div');
+            el.setAttribute('contenteditable', 'true');
+            expect(isEditablePasteTarget(el)).toBe(true);
+        });
+
+        test('should return true for a node inside a contenteditable element', () => {
+            const editable = document.createElement('div');
+            editable.setAttribute('contenteditable', 'true');
+            const child = document.createElement('span');
+            editable.appendChild(child);
+            expect(isEditablePasteTarget(child)).toBe(true);
+        });
+
+        test('should return true for a role textbox element', () => {
+            const el = document.createElement('div');
+            el.setAttribute('role', 'textbox');
+            expect(isEditablePasteTarget(el)).toBe(true);
+        });
+
+        test('should return false for a non-editable element', () => {
+            expect(isEditablePasteTarget(document.createElement('div'))).toBe(false);
+        });
+
+        test('should return false for a null target', () => {
+            expect(isEditablePasteTarget(null)).toBe(false);
+        });
+
+        test('should return false for a target without closest', () => {
+            expect(isEditablePasteTarget({})).toBe(false);
         });
     });
 });

--- a/src/utils/uploads.js
+++ b/src/utils/uploads.js
@@ -360,8 +360,148 @@ function isMultiputSupported(): boolean {
     return window.location.protocol === 'https:' && cryptoObj && cryptoObj.subtle;
 }
 
+/**
+ * Returns true if the clipboard event carries at least one file
+ *
+ * @param {ClipboardEvent} event
+ * @returns {boolean}
+ */
+function clipboardHasFiles(event: ClipboardEvent): boolean {
+    const { clipboardData } = event;
+    if (!clipboardData) {
+        return false;
+    }
+
+    if (clipboardData.files && clipboardData.files.length > 0) {
+        return true;
+    }
+
+    return Array.from(clipboardData.items || []).some(item => item.kind === 'file');
+}
+
+/**
+ * Extracts File objects from a clipboard event.
+ * Prefers clipboardData.files, falling back to clipboardData.items[].getAsFile()
+ *
+ * @param {ClipboardEvent} event
+ * @returns {File[]}
+ */
+function getFilesFromClipboard(event: ClipboardEvent): File[] {
+    const { clipboardData } = event;
+    if (!clipboardData) {
+        return [];
+    }
+
+    if (clipboardData.files && clipboardData.files.length > 0) {
+        return Array.from(clipboardData.files);
+    }
+
+    return Array.from(clipboardData.items || [])
+        .filter(item => item.kind === 'file')
+        .map(item => item.getAsFile())
+        .filter(Boolean);
+}
+
+/**
+ * Zero-pads a number to 2 digits
+ *
+ * @param {number} num
+ * @returns {string}
+ */
+function padTo2Digits(num: number): string {
+    return String(num).padStart(2, '0');
+}
+
+/**
+ * Formats a Date as 'YYYY-MM-DD at HH.MM.SS' using local time
+ *
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatPastedImageTimestamp(date: Date): string {
+    const dateStr = `${date.getFullYear()}-${padTo2Digits(date.getMonth() + 1)}-${padTo2Digits(date.getDate())}`;
+    const timeStr = `${padTo2Digits(date.getHours())}.${padTo2Digits(date.getMinutes())}.${padTo2Digits(date.getSeconds())}`;
+
+    return `${dateStr} at ${timeStr}`;
+}
+
+/**
+ * Returns the extension (without the dot) from a file name, or '' if none
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function getExtensionFromFileName(name: string): string {
+    const match = /\.([a-z0-9]+)$/i.exec(name);
+    return match ? match[1] : '';
+}
+
+/**
+ * Returns the file extension implied by a MIME type, e.g. 'image/svg+xml' -> 'svg'
+ *
+ * @param {string} mimeType
+ * @returns {string}
+ */
+function getExtensionFromMimeType(mimeType: string): string {
+    if (!mimeType || !mimeType.includes('/')) {
+        return '';
+    }
+
+    const [, subtype = ''] = mimeType.split('/');
+    return subtype.split('+')[0];
+}
+
+/**
+ * Returns true if a clipboard file name is a generic placeholder (e.g. 'image.png', 'image', '')
+ * rather than a meaningful name the OS/app assigned
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isGenericClipboardFileName(name: string): boolean {
+    return !name || /^image(\.[a-z0-9]+)?$/i.test(name);
+}
+
+/**
+ * Generates a file name for a pasted clipboard file.
+ * Preserves meaningful names; renames generic placeholders (e.g. 'image.png') to
+ * 'Pasted Image YYYY-MM-DD at HH.MM.SS.<ext>'
+ *
+ * @param {File} file
+ * @returns {string}
+ */
+function generateClipboardFileName(file: File): string {
+    if (!isGenericClipboardFileName(file.name)) {
+        return file.name;
+    }
+
+    const extension = getExtensionFromFileName(file.name) || getExtensionFromMimeType(file.type);
+    const timestamp = formatPastedImageTimestamp(new Date());
+
+    return `Pasted Image ${timestamp}${extension ? `.${extension}` : ''}`;
+}
+
+/**
+ * Returns true if a paste target is an editable element (input, textarea, select,
+ * contenteditable, or textbox role) where native paste should not be intercepted
+ *
+ * @param {EventTarget | null} target
+ * @returns {boolean}
+ */
+function isEditablePasteTarget(target: EventTarget | null): boolean {
+    if (!target || typeof (target: any).closest !== 'function') {
+        return false;
+    }
+
+    return !!(target: any).closest('input, textarea, select, [contenteditable="true"], [role="textbox"]');
+}
+
 export {
     DEFAULT_API_OPTIONS,
+    clipboardHasFiles,
+    generateClipboardFileName,
+    getFilesFromClipboard,
+    isEditablePasteTarget,
     doesDataTransferItemContainAPIOptions,
     doesFileContainAPIOptions,
     getBoundedExpBackoffRetryDelay,


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and extracting files from clipboard paste events.
  * Added safeguards to preserve native paste behavior in editable fields.
  * Added descriptive, timestamp-based filenames for pasted images when original names are generic or unavailable.

* **Tests**
  * Added comprehensive coverage for clipboard file handling, filename generation, and editable paste-target detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->