### PR TITLE
fix(activity-feed-v2): Hide inline task actions for multi-file tasks

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
@@ -247,7 +247,11 @@ const FeedItemRow = ({
             const currentUserAssignment = currentUserId
                 ? item.originalTask.assigned_to?.entries?.find(entry => entry.target?.id === currentUserId)
                 : undefined;
+            // Multi-file tasks cannot be updated inline: the Preview file-scoped token lacks
+            // permissions on the other linked files, so route users to the task details view.
+            const isMultiFileTask = (item.originalTask.task_links?.entries?.length ?? 0) > 1;
             const canActOnAssignment =
+                !isMultiFileTask &&
                 !!onTaskAssignmentUpdate &&
                 !!currentUserAssignment &&
                 currentUserAssignment.permissions?.can_update === true &&

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
@@ -787,6 +787,35 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
             expect(lastTaskProps.onReject).toBeUndefined();
         });
 
+        test('should omit onApprove/onComplete/onReject when the task is linked to multiple files', () => {
+            const multiFileTask: TransformedFeedItem = {
+                ...mockTask,
+                originalTask: {
+                    ...mockOriginalTask,
+                    task_links: {
+                        entries: [
+                            { id: 'link-1', target: { id: 'file-1', type: 'file' }, type: 'task_link' },
+                            { id: 'link-2', target: { id: 'file-2', type: 'file' }, type: 'task_link' },
+                        ],
+                        limit: 20,
+                        next_marker: null,
+                    },
+                } as unknown as TaskNew,
+            };
+            render(
+                <FeedItemRow
+                    {...defaultProps}
+                    currentUserId="user-1"
+                    item={multiFileTask}
+                    onTaskAssignmentUpdate={jest.fn()}
+                />,
+            );
+
+            expect(lastTaskProps.onApprove).toBeUndefined();
+            expect(lastTaskProps.onComplete).toBeUndefined();
+            expect(lastTaskProps.onReject).toBeUndefined();
+        });
+
         test('should omit onApprove/onComplete/onReject when assignment status is not NOT_STARTED', () => {
             const completedTask: TransformedFeedItem = {
                 ...mockTask,

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
@@ -369,6 +369,28 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             expect(result.taskType).toBe('APPROVAL');
         });
 
+        test('should set fileCount from the number of task_links entries', () => {
+            const multiFileTask = {
+                ...mockTask,
+                task_links: {
+                    entries: [
+                        { id: 'link-1', target: { id: 'file-1', type: 'file' }, type: 'task_link' },
+                        { id: 'link-2', target: { id: 'file-2', type: 'file' }, type: 'task_link' },
+                    ],
+                    limit: 20,
+                    next_marker: null,
+                },
+            };
+            const result = transformTaskToProps(multiFileTask as unknown as TaskNew);
+            expect(result.fileCount).toBe(2);
+        });
+
+        test('should set fileCount to undefined when task_links is missing', () => {
+            const taskWithoutLinks = { ...mockTask, task_links: undefined };
+            const result = transformTaskToProps(taskWithoutLinks as unknown as TaskNew);
+            expect(result.fileCount).toBeUndefined();
+        });
+
         test('should set hasNextPage=false when assigned_to.next_marker is null', () => {
             const result = transformTaskToProps(mockTask as unknown as TaskNew);
             expect(result.hasNextPage).toBe(false);

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -257,6 +257,7 @@ export const transformTaskToProps = (
     currentUserId,
     description: task.description,
     dueDate: toUnixMs(task.due_at),
+    fileCount: task.task_links?.entries?.length,
     hasNextPage: Boolean(task.assigned_to?.next_marker),
     id: task.id,
     permissions: {


### PR DESCRIPTION
## Summary

- Activity Feed V2 rendered inline Approve / Reject / Complete buttons for tasks linked to multiple files. Acting on those buttons sends the task assignment update with a token scoped to the file currently open in Preview, which lacks permissions on the other linked files, so the request fails with an authorization error. The previous activity feed handles this by showing a View details action for multi-file tasks instead of the inline buttons.
- `transformTaskToProps` now passes `fileCount` (from `task_links.entries.length`) to the `TaskItem` component, which already hides the inline footer actions and surfaces "View Task Details" when a task spans more than one file.
- `FeedItemRow` additionally omits the `onApprove` / `onComplete` / `onReject` callbacks for multi-file tasks so the inline update path cannot be reached.

## Test Plan

- [x] Added `transformers` tests covering `fileCount` derived from `task_links` entries and `undefined` when `task_links` is missing
- [x] Added `FeedItemRow` test asserting the action callbacks are omitted for a task linked to two files
- [x] Full `activity-feed-v2` suite passes (353 tests) and `tsc` is clean
- [ ] Manual: open a multi-file task in the V2 activity feed and verify Approve / Reject are replaced by "View Task Details" in the options menu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Task activity entries now indicate how many files are associated with a task when applicable.
  
- **Bug Fixes**
  - Inline approve, complete, and reject actions are no longer shown for tasks linked to multiple files, preventing unsupported updates.
  - Existing navigation to view task details remains available for multi-file tasks.

- **Tests**
  - Added coverage to verify file counts and multi-file task action behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->