### PR TITLE
fix(activity-sidebar): remove UAA parity logging

### DIFF
--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -92,7 +92,6 @@ import type {
     Tasks,
     ThreadedComments as ThreadedCommentsType,
 } from '../common/types/feed';
-import { collapseFeedState } from '../elements/content-sidebar/activity-feed/activity-feed/activityFeedUtils';
 
 const TASK_NEW_INITIAL_STATUS = TASK_NEW_NOT_STARTED;
 
@@ -591,7 +590,6 @@ class Feed extends Base {
             shouldUseEnhancedActivities?: boolean,
             shouldUseUAA?: boolean,
         } = {},
-        logAPIParity?: Function,
     ): void {
         const { id, permissions = {} } = file;
         const cachedItems = this.getCachedItems(id);
@@ -613,16 +611,20 @@ class Feed extends Base {
         this.errorCallback = onError;
 
         // Using the UAA File Activities endpoint replaces the need for these calls
-        const annotationsPromise = shouldShowAnnotations
-            ? this.fetchAnnotations(permissions, shouldShowReplies)
-            : Promise.resolve();
+        const annotationsPromise =
+            !shouldUseUAA && shouldShowAnnotations
+                ? this.fetchAnnotations(permissions, shouldShowReplies)
+                : Promise.resolve();
         const commentsPromise = () => {
+            if (shouldUseUAA) return Promise.resolve();
             return shouldShowReplies ? this.fetchThreadedComments(permissions) : this.fetchComments(permissions);
         };
-        const tasksPromise = shouldShowTasks ? this.fetchTasksNew() : Promise.resolve();
-        const appActivityPromise = shouldShowAppActivity ? this.fetchAppActivity(permissions) : Promise.resolve();
-        const versionsPromise = shouldShowVersions ? this.fetchVersions() : Promise.resolve();
-        const currentVersionPromise = shouldShowVersions ? this.fetchCurrentVersion() : Promise.resolve();
+        const tasksPromise = !shouldUseUAA && shouldShowTasks ? this.fetchTasksNew() : Promise.resolve();
+        const appActivityPromise =
+            !shouldUseUAA && shouldShowAppActivity ? this.fetchAppActivity(permissions) : Promise.resolve();
+        const versionsPromise = !shouldUseUAA && shouldShowVersions ? this.fetchVersions() : Promise.resolve();
+        const currentVersionPromise =
+            !shouldUseUAA && shouldShowVersions ? this.fetchCurrentVersion() : Promise.resolve();
 
         const annotationActivityType =
             shouldShowAnnotations && permissions[PERMISSION_CAN_VIEW_ANNOTATIONS]
@@ -684,25 +686,9 @@ class Feed extends Base {
             );
         };
 
-        const compareV2AndUaaFeedItems = async (uaaFeedItems, uaaResponse) => {
-            fetchV2FeedItems(v2Promises).then(v2FeedItems => {
-                const transformedV2FeedItems = collapseFeedState(v2FeedItems);
-                const transformedUAAFeedItems = collapseFeedState(uaaFeedItems);
-
-                if (logAPIParity) {
-                    logAPIParity({
-                        uaaResponse,
-                        uaaFeedItems: transformedUAAFeedItems,
-                        v2FeedItems: transformedV2FeedItems,
-                    });
-                }
-            });
-        };
-
         if (shouldUseUAA) {
             fileActivitiesPromise.then(response => {
                 const uaaFeedItems = getParsedFileActivitiesResponse(response, permissions);
-                compareV2AndUaaFeedItems(uaaFeedItems, response);
                 handleFeedItems(uaaFeedItems);
             });
         } else {

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -610,7 +610,7 @@ describe('api/Feed', () => {
             });
         });
 
-        test('should use the file activities api if shouldUseUAA is true and shadow call v2 APIs', done => {
+        test('should use the file activities api if shouldUseUAA is true', done => {
             feed.feedItems(file, false, successCb, errorCb, errorCb, {
                 shouldUseUAA: true,
                 shouldShowAnnotations: true,
@@ -632,7 +632,13 @@ describe('api/Feed', () => {
                     true,
                     false,
                 );
-                expect(feed.fetchThreadedComments).toBeCalled();
+                expect(feed.fetchComments).not.toBeCalled();
+                expect(feed.fetchThreadedComments).not.toBeCalled();
+                expect(feed.fetchAnnotations).not.toBeCalled();
+                expect(feed.fetchTasksNew).not.toBeCalled();
+                expect(feed.fetchAppActivity).not.toBeCalled();
+                expect(feed.fetchVersions).not.toBeCalled();
+                expect(feed.fetchCurrentVersion).not.toBeCalled();
                 done();
             });
         });

--- a/src/common/types/logging.js
+++ b/src/common/types/logging.js
@@ -3,14 +3,12 @@ import {
     METRIC_TYPE_PREVIEW,
     METRIC_TYPE_ELEMENTS_LOAD_METRIC,
     METRIC_TYPE_ELEMENTS_PERFORMANCE_METRIC,
-    METRIC_TYPE_UAA_PARITY_METRIC,
 } from '../../constants';
 
 type MetricType =
     | typeof METRIC_TYPE_PREVIEW
     | typeof METRIC_TYPE_ELEMENTS_LOAD_METRIC
-    | typeof METRIC_TYPE_ELEMENTS_PERFORMANCE_METRIC
-    | typeof METRIC_TYPE_UAA_PARITY_METRIC;
+    | typeof METRIC_TYPE_ELEMENTS_PERFORMANCE_METRIC;
 
 type ElementsLoadMetricData = {
     endMarkName: string,

--- a/src/constants.js
+++ b/src/constants.js
@@ -375,7 +375,6 @@ export const ORIGIN_OPEN_WITH: 'open_with' = 'open_with';
 export const METRIC_TYPE_PREVIEW: 'preview_metric' = 'preview_metric';
 export const METRIC_TYPE_ELEMENTS_PERFORMANCE_METRIC: 'elements_performance_metric' = 'elements_performance_metric';
 export const METRIC_TYPE_ELEMENTS_LOAD_METRIC: 'elements_load_metric' = 'elements_load_metric';
-export const METRIC_TYPE_UAA_PARITY_METRIC = 'uaa_parity_metric';
 
 /* ------------------ Error Keys ---------------------- */
 export const IS_ERROR_DISPLAYED = 'isErrorDisplayed'; // used to determine if user will see some error state or message

--- a/src/elements/common/logger/Logger.js
+++ b/src/elements/common/logger/Logger.js
@@ -4,11 +4,7 @@ import noop from 'lodash/noop';
 import { v4 as uuidv4 } from 'uuid';
 import { isMarkSupported } from '../../../utils/performance';
 import { EVENT_DATA_READY, EVENT_JS_READY } from './constants';
-import {
-    METRIC_TYPE_PREVIEW,
-    METRIC_TYPE_ELEMENTS_LOAD_METRIC,
-    METRIC_TYPE_UAA_PARITY_METRIC,
-} from '../../../constants';
+import { METRIC_TYPE_PREVIEW, METRIC_TYPE_ELEMENTS_LOAD_METRIC } from '../../../constants';
 import type { ElementOrigin } from '../flowTypes';
 import type { MetricType, ElementsLoadMetricData, LoggerProps } from '../../../common/types/logging';
 
@@ -128,17 +124,10 @@ class Logger extends React.Component<Props> {
     handlePreviewMetric = (data: Object) => {
         const { onMetric } = this.props;
 
-        if (data.type === METRIC_TYPE_UAA_PARITY_METRIC) {
-            onMetric({
-                ...data,
-                type: METRIC_TYPE_UAA_PARITY_METRIC,
-            });
-        } else {
-            onMetric({
-                ...data,
-                type: METRIC_TYPE_PREVIEW,
-            });
-        }
+        onMetric({
+            ...data,
+            type: METRIC_TYPE_PREVIEW,
+        });
     };
 
     /**

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -45,7 +45,6 @@ import {
     ORIGIN_ACTIVITY_SIDEBAR,
     SIDEBAR_VIEW_ACTIVITY,
     TASK_COMPLETION_RULE_ALL,
-    METRIC_TYPE_UAA_PARITY_METRIC,
 } from '../../constants';
 import type {
     TaskAssigneeCollection,
@@ -816,7 +815,6 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                 shouldUseEnhancedActivities: isThreadedRepliesV2Enabled,
                 shouldUseUAA,
             },
-            shouldUseUAA ? this.logAPIParity : undefined,
         );
     }
 
@@ -874,22 +872,6 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         }
 
         this.setState({ feedItems, activityFeedError: undefined });
-    };
-
-    /**
-     * Logs diff between UAA and v2 API data
-     *
-     * @param {{}[]} responseParity array of aggragated responses from UAA and v2
-     * @param {{}} parsedDataParity parsed data from UAA and v2
-     * @return {void}
-     */
-    logAPIParity = (parityData: { uaaFeedItems: FeedItems, v2FeedItems: FeedItems }): void => {
-        const { logger } = this.props;
-
-        logger.onPreviewMetric({
-            parityData,
-            type: METRIC_TYPE_UAA_PARITY_METRIC,
-        });
     };
 
     /**

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -789,7 +789,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.errorCallback = jest.fn();
                 instance.fetchFeedItemsErrorCallback = jest.fn();
                 instance.fetchFeedItemsSuccessCallback = jest.fn();
-                instance.logAPIParity = jest.fn();
 
                 instance.fetchFeedItems();
                 expect(feedAPI.feedItems).toHaveBeenCalledWith(
@@ -807,7 +806,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                         shouldUseEnhancedActivities: false,
                         shouldUseUAA: expectedUseUAA,
                     },
-                    expectedUseUAA ? instance.logAPIParity : undefined,
                 );
             },
         );
@@ -842,7 +840,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                     shouldUseEnhancedActivities: false,
                     shouldUseUAA: false,
                 },
-                undefined,
             );
         });
 
@@ -869,7 +866,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
                 expect.objectContaining({ shouldShowReplies: true, shouldUseEnhancedActivities: true }),
-                undefined,
             );
         });
 
@@ -896,7 +892,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
                 expect.objectContaining({ shouldShowReplies: true, shouldUseEnhancedActivities: true }),
-                undefined,
             );
         });
 
@@ -926,7 +921,6 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
                 expect.objectContaining({ shouldShowReplies: true }),
-                undefined,
             );
         });
     });


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->
  
## Summary
- Remove the `compareV2AndUaaFeedItems` parity check that fired the full legacy v2 API fan-out (comments, annotations, tasks, versions, app activity) on every preview load when UAA was enabled, solely for comparison logging
- Guard legacy API calls with `!shouldUseUAA` so they are never fired when the UAA `/file_activities` endpoint is in use
- Remove the `METRIC_TYPE_UAA_PARITY_METRIC` constant and associated logging infrastructure (`logAPIParity`, Logger special case)

## Context
When `activityFeed.uaaIntegration.enabled` is on, the sidebar renders from the UAA response but still fired ~6 legacy API calls per preview load for parity validation. This added ~12.6M `getComments` calls/day to the annotations service (~2x its total volume). Parity has been validated and is no longer needed.

The original PR which added UAA parity logging is: https://github.com/box/box-ui-elements/pull/3629 

## Test plan
  - [x] `yarn test src/api/__tests__/Feed.test.js` — 138 tests pass
  - [x] `yarn test src/elements/content-sidebar/__tests__/ActivitySidebar.test.js` — 133 tests pass
  - [x] `yarn test src/elements/common/logger/__tests__/Logger.test.js` — 10 tests pass
  - [x] `yarn flow check` passes on modified files
  - [ ] Verify in preview that activity sidebar loads correctly with UAA enabled
  - [ ] Confirm annotations service traffic drops after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced file activity feed processing for improved UAA-based activity handling.
  * Added clearer initial status for newly created pending task feed items.
* **Bug Fixes**
  * Prevented unnecessary legacy V2 feed requests when the enhanced/UAA flow is enabled.
* **Refactor**
  * Removed legacy V2 vs UAA parity comparison and related parity logging.
* **Tests**
  * Updated feed and activity sidebar tests to match the new request and metric behavior.
* **Chores**
  * Simplified preview/activity metric types and standardized preview metric emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->