### PR TITLE
fix(activity-feed-v2): load full assignee list when expanding task assignees

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -18,7 +18,7 @@ import TaskModalV2 from './task-modal-v2';
 import FeedItemRow from './FeedItemRow';
 import { serializeEditorContent } from './helpers';
 import { mapCollaboratorToUserContact } from './task-modal-v2/utils/contactMapping';
-import { transformFeedItem } from './transformers';
+import { transformFeedItem, transformTaskAssignees } from './transformers';
 import { useAvatarUrls } from './useAvatarUrls';
 import { useTimeFormat } from './useTimeFormat';
 import { useVideoTimestamp } from './useVideoTimestamp';
@@ -229,6 +229,16 @@ const ActivityFeedV2 = ({
     );
 
     const avatarUrls = useAvatarUrls(feedItems, getAvatarUrl);
+
+    // Loads the full assignee list (up to 1000) when the assignee list's "Show more"
+    // is clicked on a task whose first page (20) did not include all assignees.
+    const handleTaskLoadAllAssignees = React.useMemo(() => {
+        if (!getTaskCollaborators) return undefined;
+        return async (task: TaskNew) => {
+            const collection = await getTaskCollaborators(task);
+            return transformTaskAssignees(collection?.entries ?? [], avatarUrls);
+        };
+    }, [avatarUrls, getTaskCollaborators]);
 
     const transformedItems: TransformedFeedItem[] = React.useMemo(() => {
         if (!feedItems) return [];
@@ -507,6 +517,7 @@ const ActivityFeedV2 = ({
                                     onTaskAssignmentUpdate={onTaskAssignmentUpdate}
                                     onTaskDelete={onTaskDelete}
                                     onTaskEdit={onTaskUpdate ? handleTaskEdit : undefined}
+                                    onTaskLoadAllAssignees={handleTaskLoadAllAssignees}
                                     onTaskView={onTaskView}
                                     onVersionHistoryClick={onVersionHistoryClick}
                                     timeFormat={timeFormat}

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -232,9 +232,11 @@ const ActivityFeedV2 = ({
 
     // Loads the full assignee list when "Show more" is clicked. Assignee-fetch failures are
     // rethrown so AssigneeList shows its inline error; avatar failures fall back to initials.
-    const handleTaskLoadAllAssignees = React.useMemo(() => {
-        if (!getTaskCollaborators) return undefined;
-        return async (task: TaskNew) => {
+    const handleTaskLoadAllAssignees = React.useCallback(
+        async (task: TaskNew) => {
+            if (!getTaskCollaborators) {
+                throw new Error('ActivityFeedV2: getTaskCollaborators is required to load assignees');
+            }
             try {
                 const collection = await getTaskCollaborators(task);
 
@@ -270,8 +272,9 @@ const ActivityFeedV2 = ({
                 console.error(`ActivityFeedV2: failed to load assignees for task "${task.id}"`, error);
                 throw error;
             }
-        };
-    }, [avatarUrls, getAvatarUrl, getTaskCollaborators]);
+        },
+        [avatarUrls, getAvatarUrl, getTaskCollaborators],
+    );
 
     const transformedItems: TransformedFeedItem[] = React.useMemo(() => {
         if (!feedItems) return [];
@@ -550,7 +553,9 @@ const ActivityFeedV2 = ({
                                     onTaskAssignmentUpdate={onTaskAssignmentUpdate}
                                     onTaskDelete={onTaskDelete}
                                     onTaskEdit={onTaskUpdate ? handleTaskEdit : undefined}
-                                    onTaskLoadAllAssignees={handleTaskLoadAllAssignees}
+                                    onTaskLoadAllAssignees={
+                                        getTaskCollaborators ? handleTaskLoadAllAssignees : undefined
+                                    }
                                     onTaskView={onTaskView}
                                     onVersionHistoryClick={onVersionHistoryClick}
                                     timeFormat={timeFormat}

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -232,26 +232,34 @@ const ActivityFeedV2 = ({
 
     // Loads the full assignee list (limit=API_PAGE_LIMIT via getTaskCollaborators) when the
     // assignee list's "Show more" is clicked on a task whose embedded first page of assignees
-    // was incomplete (assigned_to.next_marker present, i.e. hasNextPage). Rejections are
-    // rethrown so AssigneeList can render its inline load error.
+    // was incomplete (assigned_to.next_marker present, i.e. hasNextPage). Assignee-fetch
+    // rejections are rethrown so AssigneeList can render its inline load error; avatar-fetch
+    // rejections are non-fatal and fall back to initials.
     const handleTaskLoadAllAssignees = React.useMemo(() => {
         if (!getTaskCollaborators) return undefined;
         return async (task: TaskNew) => {
             try {
                 const collection = await getTaskCollaborators(task);
 
-                // Resolve avatars for assignees beyond the embedded first page, which
-                // useAvatarUrls never saw. Failures fall back to initials (null), matching
-                // useAvatarUrls behavior — only the assignee fetch itself is fatal.
-                const missingIds = collection.entries
-                    .map(entry => entry.target?.id)
-                    .filter((id): id is string => Boolean(id) && !(id in avatarUrls));
+                // Resolve avatars for any assignee ids missing from the useAvatarUrls map —
+                // typically those beyond the embedded first page, which the hook never saw.
+                // Per-avatar failures fall back to initials (null), matching useAvatarUrls
+                // behavior — only the assignee fetch itself is fatal.
+                const missingIds = Array.from(
+                    new Set<string>(
+                        collection.entries
+                            .map(entry => entry.target?.id)
+                            .filter((id): id is string => Boolean(id) && !(id in avatarUrls)),
+                    ),
+                );
                 const fetchedEntries = getAvatarUrl
                     ? await Promise.all(
                           missingIds.map(async id => {
                               try {
                                   return [id, await getAvatarUrl(id)] as const;
-                              } catch {
+                              } catch (avatarError) {
+                                  // eslint-disable-next-line no-console
+                                  console.warn(`ActivityFeedV2: failed to load avatar for user "${id}"`, avatarError);
                                   return [id, null] as const;
                               }
                           }),

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -230,13 +230,21 @@ const ActivityFeedV2 = ({
 
     const avatarUrls = useAvatarUrls(feedItems, getAvatarUrl);
 
-    // Loads the full assignee list (up to 1000) when the assignee list's "Show more"
-    // is clicked on a task whose first page (20) did not include all assignees.
+    // Loads the full assignee list (limit=API_PAGE_LIMIT via getTaskCollaborators) when the
+    // assignee list's "Show more" is clicked on a task whose embedded first page of assignees
+    // was incomplete (assigned_to.next_marker present, i.e. hasNextPage). Rejections are
+    // rethrown so AssigneeList can render its inline load error.
     const handleTaskLoadAllAssignees = React.useMemo(() => {
         if (!getTaskCollaborators) return undefined;
         return async (task: TaskNew) => {
-            const collection = await getTaskCollaborators(task);
-            return transformTaskAssignees(collection?.entries ?? [], avatarUrls);
+            try {
+                const collection = await getTaskCollaborators(task);
+                return transformTaskAssignees(collection.entries, avatarUrls);
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error(`ActivityFeedV2: failed to load assignees for task "${task.id}"`, error);
+                throw error;
+            }
         };
     }, [avatarUrls, getTaskCollaborators]);
 

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -230,21 +230,15 @@ const ActivityFeedV2 = ({
 
     const avatarUrls = useAvatarUrls(feedItems, getAvatarUrl);
 
-    // Loads the full assignee list (limit=API_PAGE_LIMIT via getTaskCollaborators) when the
-    // assignee list's "Show more" is clicked on a task whose embedded first page of assignees
-    // was incomplete (assigned_to.next_marker present, i.e. hasNextPage). Assignee-fetch
-    // rejections are rethrown so AssigneeList can render its inline load error; avatar-fetch
-    // rejections are non-fatal and fall back to initials.
+    // Loads the full assignee list when "Show more" is clicked. Assignee-fetch failures are
+    // rethrown so AssigneeList shows its inline error; avatar failures fall back to initials.
     const handleTaskLoadAllAssignees = React.useMemo(() => {
         if (!getTaskCollaborators) return undefined;
         return async (task: TaskNew) => {
             try {
                 const collection = await getTaskCollaborators(task);
 
-                // Resolve avatars for any assignee ids missing from the useAvatarUrls map —
-                // typically those beyond the embedded first page, which the hook never saw.
-                // Per-avatar failures fall back to initials (null), matching useAvatarUrls
-                // behavior — only the assignee fetch itself is fatal.
+                // Resolve avatars for assignee ids the useAvatarUrls map doesn't have yet
                 const missingIds = Array.from(
                     new Set<string>(
                         collection.entries

--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -239,14 +239,37 @@ const ActivityFeedV2 = ({
         return async (task: TaskNew) => {
             try {
                 const collection = await getTaskCollaborators(task);
-                return transformTaskAssignees(collection.entries, avatarUrls);
+
+                // Resolve avatars for assignees beyond the embedded first page, which
+                // useAvatarUrls never saw. Failures fall back to initials (null), matching
+                // useAvatarUrls behavior — only the assignee fetch itself is fatal.
+                const missingIds = collection.entries
+                    .map(entry => entry.target?.id)
+                    .filter((id): id is string => Boolean(id) && !(id in avatarUrls));
+                const fetchedEntries = getAvatarUrl
+                    ? await Promise.all(
+                          missingIds.map(async id => {
+                              try {
+                                  return [id, await getAvatarUrl(id)] as const;
+                              } catch {
+                                  return [id, null] as const;
+                              }
+                          }),
+                      )
+                    : [];
+                const mergedAvatarUrls: Record<string, string> = { ...avatarUrls };
+                fetchedEntries.forEach(([id, url]) => {
+                    if (url) mergedAvatarUrls[id] = url;
+                });
+
+                return transformTaskAssignees(collection.entries, mergedAvatarUrls);
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error(`ActivityFeedV2: failed to load assignees for task "${task.id}"`, error);
                 throw error;
             }
         };
-    }, [avatarUrls, getTaskCollaborators]);
+    }, [avatarUrls, getAvatarUrl, getTaskCollaborators]);
 
     const transformedItems: TransformedFeedItem[] = React.useMemo(() => {
         if (!feedItems) return [];

--- a/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/FeedItemRow.tsx
@@ -18,7 +18,7 @@ import { annotationTargetToBadge } from './transformers';
 import { formatByTimeFormat } from './useTimeFormat';
 import { seekVideoToMs } from './useVideoTimestamp';
 
-import type { OnReplyDelete, OnReplyUpdate, TransformedFeedItem, UserSelectorProps } from './types';
+import type { OnReplyDelete, OnReplyUpdate, TaskItemProps, TransformedFeedItem, UserSelectorProps } from './types';
 
 import {
     FEED_ITEM_TYPE_ANNOTATION,
@@ -61,6 +61,7 @@ type FeedItemRowProps = {
     onTaskAssignmentUpdate?: (taskId: string, taskAssignmentId: string, status: TaskCollabStatus) => void;
     onTaskDelete?: (task: TaskNew) => void;
     onTaskEdit?: (task: TaskNew) => void;
+    onTaskLoadAllAssignees?: (task: TaskNew) => Promise<TaskItemProps['assignees']>;
     onTaskView?: (id: string, isCreator: boolean) => void;
     onVersionHistoryClick?: (version: { id: string; version_number: number }) => void;
     timeFormat: TimeFormat;
@@ -101,6 +102,7 @@ const FeedItemRow = ({
     onTaskAssignmentUpdate,
     onTaskDelete,
     onTaskEdit,
+    onTaskLoadAllAssignees,
     onTaskView,
     onVersionHistoryClick,
     timeFormat,
@@ -269,6 +271,9 @@ const FeedItemRow = ({
                     onComplete={canActOnAssignment ? () => handleAssignmentUpdate(TASK_NEW_COMPLETED) : undefined}
                     onDelete={onTaskDelete ? () => onTaskDelete(item.originalTask) : undefined}
                     onEdit={onTaskEdit ? () => onTaskEdit(item.originalTask) : undefined}
+                    onLoadAllAssignee={
+                        onTaskLoadAllAssignees ? () => onTaskLoadAllAssignees(item.originalTask) : undefined
+                    }
                     onReject={canActOnAssignment ? () => handleAssignmentUpdate(TASK_NEW_REJECTED) : undefined}
                     onView={
                         onTaskView

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -28,12 +28,18 @@ const mockScrollTo = jest.fn<boolean, [string]>(() => true);
 type FilterMenuProps = { children?: React.ReactNode; hasActiveFilters?: boolean };
 type FilterOptionProps = { checked?: boolean; onCheckedChange?: (checked: boolean) => void };
 type RootProps = React.ComponentProps<typeof ActivityFeed.Root>;
+type TaskListItemProps = {
+    hasNextPage?: boolean;
+    id: string;
+    onLoadAllAssignee?: () => Promise<unknown>;
+};
 let lastFilterMenuProps: FilterMenuProps = {};
 let lastShowResolvedOptionProps: FilterOptionProps = {};
 let lastMentionMeOptionProps: FilterOptionProps = {};
 let lastEditorProps: Partial<EditorProps> = {};
 let lastRootProps: Partial<RootProps> = {};
 let lastTaskModalProps: Partial<TaskModalV2Props> = {};
+let lastTaskItemProps: Partial<TaskListItemProps> = {};
 
 jest.mock('../task-modal-v2', () => ({
     __esModule: true,
@@ -55,7 +61,10 @@ jest.mock('@box/activity-feed', () => {
     ActivityFeedList.AppActivity = (props: { id: string }) => (
         <div data-testid={`app-activity-${props.id}`}>AppActivity</div>
     );
-    ActivityFeedList.Task = (props: { id: string }) => <div data-testid={`task-${props.id}`}>Task</div>;
+    ActivityFeedList.Task = (props: TaskListItemProps) => {
+        lastTaskItemProps = props;
+        return <div data-testid={`task-${props.id}`}>Task</div>;
+    };
     ActivityFeedList.ThreadedAnnotation = (props: { messages?: Array<{ id: string }> }) => (
         <div data-testid={`threaded-annotation-${props.messages?.[0]?.id}`}>ThreadedAnnotation</div>
     );
@@ -186,6 +195,7 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         lastEditorProps = {};
         lastRootProps = {};
         lastTaskModalProps = {};
+        lastTaskItemProps = {};
         mockSerializeMentionMarkup.mockImplementation((doc: unknown) => ({
             hasMention: false,
             text: JSON.stringify(doc),
@@ -250,6 +260,87 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         );
 
         expect(screen.getByTestId('task-task-1')).toBeVisible();
+    });
+
+    describe('task assignee loading', () => {
+        // First page of assignees is partial (next_marker set), so the assignee list shows "Show more"
+        const taskWithMoreAssignees = {
+            ...mockTask,
+            assigned_to: {
+                entries: [
+                    {
+                        id: 'assignment-1',
+                        permissions: { can_delete: true, can_update: true },
+                        role: 'ASSIGNEE',
+                        status: 'NOT_STARTED',
+                        target: { id: 'user-2', name: 'Assignee One', type: 'user' },
+                        type: 'task_collaborator',
+                    },
+                ],
+                limit: 20,
+                next_marker: 'marker-1',
+            },
+        };
+
+        test('should fetch and transform the full assignee list when onLoadAllAssignee fires', async () => {
+            const getTaskCollaborators = jest.fn().mockResolvedValue({
+                entries: [
+                    {
+                        id: 'assignment-1',
+                        permissions: { can_delete: true, can_update: true },
+                        role: 'ASSIGNEE',
+                        status: 'NOT_STARTED',
+                        target: { id: 'user-2', name: 'Assignee One', type: 'user' },
+                        type: 'task_collaborator',
+                    },
+                    {
+                        completed_at: '2024-03-02T00:00:00Z',
+                        id: 'assignment-2',
+                        permissions: { can_delete: false, can_update: false },
+                        role: 'ASSIGNEE',
+                        status: 'COMPLETED',
+                        target: { id: 'user-3', name: 'Assignee Two', type: 'user' },
+                        type: 'task_collaborator',
+                    },
+                ],
+                limit: 1000,
+                next_marker: null,
+            });
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[taskWithMoreAssignees] as ActivityFeedV2Props['feedItems']}
+                    getTaskCollaborators={getTaskCollaborators}
+                />,
+            );
+
+            expect(lastTaskItemProps.hasNextPage).toBe(true);
+
+            const result = await lastTaskItemProps.onLoadAllAssignee?.();
+
+            expect(getTaskCollaborators).toHaveBeenCalledWith(taskWithMoreAssignees);
+            expect(result).toEqual([
+                expect.objectContaining({ id: 'user-2', name: 'Assignee One', status: 'NOT_STARTED' }),
+                expect.objectContaining({
+                    completedAt: new Date('2024-03-02T00:00:00Z').getTime(),
+                    id: 'user-3',
+                    name: 'Assignee Two',
+                    status: 'COMPLETED',
+                }),
+            ]);
+        });
+
+        test('should omit onLoadAllAssignee when getTaskCollaborators is not provided', () => {
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[taskWithMoreAssignees] as ActivityFeedV2Props['feedItems']}
+                />,
+            );
+
+            expect(lastTaskItemProps.hasNextPage).toBe(true);
+            expect(lastTaskItemProps.onLoadAllAssignee).toBeUndefined();
+        });
     });
 
     test('should render version feed items alongside other items', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -386,7 +386,9 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
 
         test('should fall back to initials (no avatarUrl) when getAvatarUrl rejects for a revealed assignee', async () => {
             const getTaskCollaborators = jest.fn().mockResolvedValue(fullAssigneeCollection);
-            const getAvatarUrl = jest.fn().mockRejectedValue(new Error('avatar service down'));
+            const avatarError = new Error('avatar service down');
+            const getAvatarUrl = jest.fn().mockRejectedValue(avatarError);
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
             render(
                 <ActivityFeedV2
                     currentUser={mockCurrentUser}
@@ -403,6 +405,15 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
                 expect.objectContaining({ avatarUrl: undefined, id: 'user-2' }),
                 expect.objectContaining({ avatarUrl: undefined, id: 'user-3' }),
             ]);
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'ActivityFeedV2: failed to load avatar for user "user-2"',
+                avatarError,
+            );
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'ActivityFeedV2: failed to load avatar for user "user-3"',
+                avatarError,
+            );
+            consoleWarnSpy.mockRestore();
         });
 
         test('should omit onLoadAllAssignee when getTaskCollaborators is not provided', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -331,6 +331,80 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
             ]);
         });
 
+        const fullAssigneeCollection = {
+            entries: [
+                {
+                    id: 'assignment-1',
+                    permissions: { can_delete: true, can_update: true },
+                    role: 'ASSIGNEE',
+                    status: 'NOT_STARTED',
+                    target: { id: 'user-2', name: 'Assignee One', type: 'user' },
+                    type: 'task_collaborator',
+                },
+                {
+                    id: 'assignment-2',
+                    permissions: { can_delete: false, can_update: false },
+                    role: 'ASSIGNEE',
+                    status: 'COMPLETED',
+                    target: { id: 'user-3', name: 'Assignee Two', type: 'user' },
+                    type: 'task_collaborator',
+                },
+            ],
+            limit: 1000,
+            next_marker: null,
+        };
+
+        test('should resolve avatar urls for assignees revealed by onLoadAllAssignee', async () => {
+            const getTaskCollaborators = jest.fn().mockResolvedValue(fullAssigneeCollection);
+            const avatarUrlsByUserId: Record<string, string> = {
+                'user-2': 'https://example.com/avatar-2.png',
+                'user-3': 'https://example.com/avatar-3.png',
+            };
+            const getAvatarUrl = jest.fn(async (userId: string) => avatarUrlsByUserId[userId] ?? null);
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[taskWithMoreAssignees] as ActivityFeedV2Props['feedItems']}
+                    getAvatarUrl={getAvatarUrl}
+                    getTaskCollaborators={getTaskCollaborators}
+                />,
+            );
+
+            // Let useAvatarUrls resolve the first-page ids (author user-1, assignee user-2)
+            await act(() => Promise.resolve());
+            getAvatarUrl.mockClear();
+
+            const result = await lastTaskItemProps.onLoadAllAssignee?.();
+
+            // Only user-3 was missing from the avatar map; user-2 was already resolved
+            expect(getAvatarUrl.mock.calls.map(([id]) => id)).toEqual(['user-3']);
+            expect(result).toEqual([
+                expect.objectContaining({ avatarUrl: 'https://example.com/avatar-2.png', id: 'user-2' }),
+                expect.objectContaining({ avatarUrl: 'https://example.com/avatar-3.png', id: 'user-3' }),
+            ]);
+        });
+
+        test('should fall back to initials (no avatarUrl) when getAvatarUrl rejects for a revealed assignee', async () => {
+            const getTaskCollaborators = jest.fn().mockResolvedValue(fullAssigneeCollection);
+            const getAvatarUrl = jest.fn().mockRejectedValue(new Error('avatar service down'));
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[taskWithMoreAssignees] as ActivityFeedV2Props['feedItems']}
+                    getAvatarUrl={getAvatarUrl}
+                    getTaskCollaborators={getTaskCollaborators}
+                />,
+            );
+            await act(() => Promise.resolve());
+
+            const result = await lastTaskItemProps.onLoadAllAssignee?.();
+
+            expect(result).toEqual([
+                expect.objectContaining({ avatarUrl: undefined, id: 'user-2' }),
+                expect.objectContaining({ avatarUrl: undefined, id: 'user-3' }),
+            ]);
+        });
+
         test('should omit onLoadAllAssignee when getTaskCollaborators is not provided', () => {
             render(
                 <ActivityFeedV2

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -263,7 +263,8 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
     });
 
     describe('task assignee loading', () => {
-        // First page of assignees is partial (next_marker set), so the assignee list shows "Show more"
+        // First page of assignees is partial (next_marker set), so hasNextPage is passed as true
+        // to the Task item (which is what makes the real AssigneeList offer "Show more")
         const taskWithMoreAssignees = {
             ...mockTask,
             assigned_to: {
@@ -340,6 +341,27 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
 
             expect(lastTaskItemProps.hasNextPage).toBe(true);
             expect(lastTaskItemProps.onLoadAllAssignee).toBeUndefined();
+        });
+
+        test('should log and rethrow when getTaskCollaborators rejects so AssigneeList can show its error state', async () => {
+            const loadError = new Error('network failure');
+            const getTaskCollaborators = jest.fn().mockRejectedValue(loadError);
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+            render(
+                <ActivityFeedV2
+                    currentUser={mockCurrentUser}
+                    feedItems={[taskWithMoreAssignees] as ActivityFeedV2Props['feedItems']}
+                    getTaskCollaborators={getTaskCollaborators}
+                />,
+            );
+
+            await expect(lastTaskItemProps.onLoadAllAssignee?.()).rejects.toThrow('network failure');
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'ActivityFeedV2: failed to load assignees for task "task-1"',
+                loadError,
+            );
+            consoleSpy.mockRestore();
         });
     });
 

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
@@ -882,6 +882,23 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
 
             expect(lastTaskProps.onEdit).toBeUndefined();
         });
+
+        test('should call onTaskLoadAllAssignees with the original task when onLoadAllAssignee fires', async () => {
+            const allAssignees = [{ id: 'user-1', name: 'Creator', status: 'NOT_STARTED' }];
+            const onTaskLoadAllAssignees = jest.fn().mockResolvedValue(allAssignees);
+            render(<FeedItemRow {...defaultProps} item={mockTask} onTaskLoadAllAssignees={onTaskLoadAllAssignees} />);
+
+            const result = await lastTaskProps.onLoadAllAssignee?.();
+
+            expect(onTaskLoadAllAssignees).toHaveBeenCalledWith(mockOriginalTask);
+            expect(result).toEqual(allAssignees);
+        });
+
+        test('should omit onLoadAllAssignee when onTaskLoadAllAssignees is not provided', () => {
+            render(<FeedItemRow {...defaultProps} item={mockTask} />);
+
+            expect(lastTaskProps.onLoadAllAssignee).toBeUndefined();
+        });
     });
 
     describe('version rendering', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -23,7 +23,7 @@ import { convertMillisecondsToTimestamp } from '../../../utils/timestamp';
 import type { Annotation, Target } from '../../../common/types/annotations';
 import type { AppActivityItem as BUIEAppActivityItem, Comment, FeedItem } from '../../../common/types/feed';
 import type { BoxItemVersion, User } from '../../../common/types/core';
-import type { TaskNew } from '../../../common/types/tasks';
+import type { TaskCollabAssignee, TaskNew } from '../../../common/types/tasks';
 
 import type {
     AnnotationBadgeTargetType,
@@ -230,12 +230,11 @@ export const transformAnnotationToMessages = (annotation: Annotation, avatarUrls
     return [root, ...replies];
 };
 
-export const transformTaskToProps = (
-    task: TaskNew,
-    currentUserId?: string,
+export const transformTaskAssignees = (
+    entries: TaskCollabAssignee[],
     avatarUrls?: AvatarUrlMap,
-): TaskItemProps => ({
-    assignees: (task.assigned_to?.entries ?? []).map(entry => ({
+): TaskItemProps['assignees'] =>
+    entries.map(entry => ({
         avatarUrl: resolveAvatarUrl(entry.target?.id, avatarUrls),
         completedAt: toUnixMs(entry.completed_at),
         id: entry.target?.id ?? entry.id,
@@ -244,7 +243,14 @@ export const transformTaskToProps = (
             ? { canDelete: entry.permissions.can_delete, canUpdate: entry.permissions.can_update }
             : undefined,
         status: entry.status as TaskItemProps['assignees'][number]['status'],
-    })),
+    }));
+
+export const transformTaskToProps = (
+    task: TaskNew,
+    currentUserId?: string,
+    avatarUrls?: AvatarUrlMap,
+): TaskItemProps => ({
+    assignees: transformTaskAssignees(task.assigned_to?.entries ?? [], avatarUrls),
     author: {
         avatarUrl: resolveAvatarUrl(task.created_by?.target?.id, avatarUrls),
         id: task.created_by?.target?.id ?? '',


### PR DESCRIPTION
## Summary

- Tasks with more than 20 assignees only ever displayed the first page returned by the file activities endpoint: the assignee list's "Show more" button expanded the already-loaded entries but never fetched the rest, so the list appeared stuck at 20.
- `transformTaskToProps` already set `hasNextPage` from `assigned_to.next_marker`, but no consumer supplied the `onLoadAllAssignee` callback that `AssigneeList` (from `@box/activity-feed`) needs to fetch the remaining assignees.
- Wire `onLoadAllAssignee` through `ActivityFeedV2` → `FeedItemRow` → `ActivityFeed.List.Task`, reusing the existing `getTaskCollaborators` fetch (`/undoc/tasks/{id}/task_collaborators?role=ASSIGNEE&limit=1000`) that the task edit modal already uses. This matches the legacy task card's expand behavior (`activity-feed/task-new/Task.js`).
- Extract the assignee mapping into `transformTaskAssignees` so the initial transform and the load-all path share the same logic.

## Test Plan

- [x] Unit tests added: `FeedItemRow` passes the original task to `onTaskLoadAllAssignees` and omits `onLoadAllAssignee` when no loader is provided; `ActivityFeedV2` fetches via `getTaskCollaborators` and returns transformed assignees, and omits the loader when the prop is absent (all 237 tests in the three touched suites pass)
- [x] `tsc` and `eslint` clean
- [x] Verified in Storybook (`Elements/ContentSidebar` with live token) and in a linked webapp: clicking "Show more" on a 26-assignee task fires the `task_collaborators?role=ASSIGNEE&limit=1000` request and renders all 26 assignees with loading state; "Show less" collapses back

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity feed task rows can now load and display the complete assignee list when more assignees exist beyond the initial preview.
  * Assignee details are rendered consistently, including completed time, status, permissions, and avatars.
* **Bug Fixes**
  * Improved handling for incomplete/paginated assignee data, with graceful avatar lookup failures and clear error reporting when assignee loading fails.
* **Tests**
  * Added/extended tests for full assignee loading, avatar URL resolution, and error/no-callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->