### PR TITLE
fix(metadata-sidebar): prevent duplicate metadata fetches on file load

### DIFF
--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import getProp from 'lodash/get';
 import { type MessageDescriptor } from 'react-intl';
 import {
     type JSONPatchOperations,
@@ -19,7 +18,6 @@ import {
     ERROR_CODE_UNKNOWN,
     ERROR_CODE_METADATA_PRECONDITION_FAILED,
     FIELD_IS_EXTERNALLY_OWNED,
-    FIELD_PERMISSIONS_CAN_UPLOAD,
     FIELD_PERMISSIONS,
     SUCCESS_CODE_UPDATE_METADATA_TEMPLATE_INSTANCE,
     SUCCESS_CODE_DELETE_METADATA_TEMPLATE_INSTANCE,
@@ -144,18 +142,14 @@ function useSidebarMetadataFetcher(
 
     const fetchFileSuccessCallback = React.useCallback(
         (fetchedFile: BoxItem) => {
-            const { currentFile } = file ?? {};
-            const currentFileCanUpload = getProp(currentFile, FIELD_PERMISSIONS_CAN_UPLOAD, false);
-            const newFileCanUpload = getProp(fetchedFile, FIELD_PERMISSIONS_CAN_UPLOAD, false);
-            const shouldFetchMetadata = !currentFile || currentFileCanUpload !== newFileCanUpload;
             setFile(fetchedFile);
-            if (shouldFetchMetadata && fetchedFile) {
+            if (fetchedFile) {
                 fetchMetadata(fetchedFile);
             } else {
                 setStatus(STATUS.SUCCESS);
             }
         },
-        [fetchMetadata, file],
+        [fetchMetadata],
     );
 
     const fetchFileErrorCallback = React.useCallback(
@@ -321,12 +315,14 @@ function useSidebarMetadataFetcher(
     React.useEffect(() => {
         if (status === STATUS.IDLE) {
             setStatus(STATUS.LOADING);
+            // Avoid refreshCache: true — File.getFile invokes success twice (cache, then network)
+            // which would duplicate the metadata fetch. Cache hit or a single network fetch is enough;
+            // missing fields are still requested when not present on the cached file.
             api.getFileAPI().getFile(fileId, fetchFileSuccessCallback, fetchFileErrorCallback, {
                 fields: [FIELD_IS_EXTERNALLY_OWNED, FIELD_PERMISSIONS],
-                refreshCache: true,
             });
         }
-    }, [api, fetchFileErrorCallback, fetchFileSuccessCallback, fileId, status]);
+    }, [api, fetchFileErrorCallback, fetchFileSuccessCallback, fileId]);
 
     return {
         clearExtractError: () => setExtractErrorCode(null),

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -322,7 +322,7 @@ function useSidebarMetadataFetcher(
                 fields: [FIELD_IS_EXTERNALLY_OWNED, FIELD_PERMISSIONS],
             });
         }
-    }, [api, fetchFileErrorCallback, fetchFileSuccessCallback, fileId]);
+    }, [api, fetchFileErrorCallback, fetchFileSuccessCallback, fileId, status]);
 
     return {
         clearExtractError: () => setExtractErrorCode(null),


### PR DESCRIPTION
## Description
Opening the redesigned metadata sidebar was triggering duplicate metadata/template network requests. `getFile` was called with `refreshCache: true`, which invokes the success callback twice when the file is already in the API cache (immediate cached result, then again after the background refresh). Each success kicked off `getMetadata`, so templates were fetched twice.

This change removes `refreshCache` from that `getFile` call so the file resolve completes once (cache hit or a single network fetch). Missing fields are still requested when not present on the cached file. The unused permission-comparison path in the success callback (which never worked correctly under hooks due to a stale/`currentFile` bug) is removed as well.

## Screenshots/Videos
N/A — verify in Network tab that template endpoints are no longer requested twice on sidebar open.

## Related issues
N/A

## Changes made
- Remove `refreshCache: true` from `getFile` in `useSidebarMetadataFetcher`
- Always fetch metadata once after a successful file resolve
- Drop broken/`unused` upload-permission comparison and related imports
- Remove `status` from the initial-load effect deps to avoid a redundant effect run after `IDLE → LOADING`

## Type of change
- [x] Bug fix (non-breaking change addressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Code refactor (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] CI/CD configuration change

## Testing done
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Dependencies
None

## Deployment notes
None

## How to test
1. Open a file in Content Sidebar with the redesigned metadata sidebar enabled
2. Open the Network tab and filter for metadata template requests
3. Confirm each scope (`global` / `enterprise`) is fetched once on sidebar open (not twice)
4. Confirm metadata still loads, edit/add still respects upload permissions, and externally owned files still behave as before

## How to review
- Focus on `useSidebarMetadataFetcher.ts`: `getFile` options and `fetchFileSuccessCallback`
- Confirm we’re OK relying on the existing API file cache (usually populated by Content Sidebar) instead of a background file refresh

## Self-review checklist
- [x] Code follows the project's style guidelines
- [x] Code is properly documented (comments, JSDoc/docstrings, etc.)
- [ ] Changes are covered by tests
- [ ] All tests pass locally
- [x] No unnecessary console logs or debugging code
- [x] No sensitive information is exposed
- [x] No new warnings or errors are introduced
- [x] PR title follows conventional commit format

## Running package.json scripts
1. Please use yarn instead of npm.
2. Before executing ANY script from package.json, please execute `nvm use`

## Additional notes
Tradeoff: we no longer force a background refresh of an already-complete cached file on metadata sidebar open. If upload permission changed after the file was cached in-memory, the sidebar won’t notice until something else refreshes that cache. That matches typical Content Sidebar usage where the file was just fetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar file loading so fetched files and their associated metadata appear more consistently.
  * Reduced unnecessary refresh behavior during file requests, helping the sidebar load more efficiently.
  * Improved handling when no file is available, preventing incomplete or unsuccessful loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->