### PR TITLE
chore(deps): bump immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -372,7 +372,8 @@
         "js-yaml": "^4.3.0",
         "qs": "^6.15.2",
         "serialize-javascript": "^7.0.5",
-        "tar": "^7.5.19"
+        "tar": "^7.5.19",
+        "@types/draft-js/immutable": "^3.8.3"
     },
     "msw": {
         "workerDirectory": [".storybook/public"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -11524,7 +11524,7 @@ ilib-tree-node@^1.2.0, ilib-tree-node@^1.3.2:
   resolved "https://registry.yarnpkg.com/ilib-tree-node/-/ilib-tree-node-1.3.2.tgz#eff1ab83588911ece401b5dbd8c8d13c52da59d0"
   integrity sha512-Dbg9rIOhd8TazHFwk3lFA0Gi6+fe3+YSqiuMRT46D7fomjf429vwzRzbHJB4uMyk8+bEsFUdQV23dbNvjkIdgw==
 
-immutable@^3.8.3:
+immutable@^3.8.3, immutable@~3.7.4:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
   integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
@@ -11533,11 +11533,6 @@ immutable@^4.0.0, immutable@^4.3.9:
   version "4.3.9"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
   integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
-
-immutable@~3.7.4:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-  integrity sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Ensure nested `immutable` under `draft-js` resolves to `^3.8.3` and drop the stale `3.7.6` lockfile entry.

**Why a resolution**

- `draft-js` / `@types/draft-js` pin `immutable@~3.7.4`.
- A normal bump can't reach the patched 3.x line for those nested deps.
- Top-level `immutable@^4` (sass/devDependency) must stay on v4, so the override is scoped under `draft-js` (not a global pin).

Dep chain:

```
yarn why v1.22.22
[1/4] Why do we have the module "immutable"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
info 
=> Found "immutable@4.3.9"
info Has been hoisted to "immutable"
info Reasons this module exists
   - Specified in "devDependencies"
   - Hoisted from "sass#immutable"
info Disk size without dependencies: "784KB"
info Disk size with unique dependencies: "784KB"
info Disk size with transitive dependencies: "784KB"
info Number of shared dependencies: 0
info 
=> Found "@types/draft-js#immutable@3.8.3"
info This module exists because "@types#draft-js" depends on it.
info Disk size without dependencies: "464KB"
info Disk size with unique dependencies: "464KB"
info Disk size with transitive dependencies: "464KB"
info Number of shared dependencies: 0
info 
=> Found "draft-js#immutable@3.8.3"
info This module exists because "draft-js" depends on it.
info Disk size without dependencies: "464KB"
info Disk size with unique dependencies: "464KB"
info Disk size with transitive dependencies: "464KB"
info Number of shared dependencies: 0
Done in 0.43s.
```

**Steps taken**

1. Added `@types/draft-js/immutable` resolution (`^3.8.3`) alongside existing `draft-js/immutable`; merged the stale `immutable@~3.7.4` lock entry onto `3.8.3` (removed `3.7.6`).
2. `yarn install` — Already up-to-date.
3. `npx yarn-deduplicate yarn.lock` then `yarn install` — lockfile stable.
4. `yarn audit` — no `immutable` versions below `3.8.3` remain in `yarn.lock` (nested installs resolve to `3.8.3`; top-level dev/sass stays on `4.3.9`).
5. Full test suite passes (976 suites, 11527 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a package resolution to improve compatibility with Draft.js type definitions.
  * Preserved the existing tar package resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->