### PR TITLE
chore(deps): bump ip-address

### DIFF
--- a/package.json
+++ b/package.json
@@ -369,6 +369,7 @@
         "@sigstore/core": "3.2.1",
         "draft-js/immutable": "^3.8.3",
         "eslint-plugin-formatjs/**/minimatch": "^9.0.9",
+        "ip-address": "^10.4.0",
         "js-yaml": "^4.3.0",
         "qs": "^6.15.2",
         "serialize-javascript": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -369,7 +369,6 @@
         "@sigstore/core": "3.2.1",
         "draft-js/immutable": "^3.8.3",
         "eslint-plugin-formatjs/**/minimatch": "^9.0.9",
-        "ip-address": "^10.4.0",
         "js-yaml": "^4.3.0",
         "qs": "^6.15.2",
         "serialize-javascript": "^7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11524,7 +11524,7 @@ ilib-tree-node@^1.2.0, ilib-tree-node@^1.3.2:
   resolved "https://registry.yarnpkg.com/ilib-tree-node/-/ilib-tree-node-1.3.2.tgz#eff1ab83588911ece401b5dbd8c8d13c52da59d0"
   integrity sha512-Dbg9rIOhd8TazHFwk3lFA0Gi6+fe3+YSqiuMRT46D7fomjf429vwzRzbHJB4uMyk8+bEsFUdQV23dbNvjkIdgw==
 
-immutable@^3.8.3:
+immutable@^3.8.3, immutable@~3.7.4:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
   integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
@@ -11533,11 +11533,6 @@ immutable@^4.0.0, immutable@^4.3.9:
   version "4.3.9"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
   integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
-
-immutable@~3.7.4:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-  integrity sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -11736,10 +11731,10 @@ invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
-ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+ip-address@^10.1.1, ip-address@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.4.0.tgz#c5910bc541b6eae287765d1e4846be0308a05d93"
+  integrity sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==
 
 ip-regex@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11731,7 +11731,7 @@ invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
-ip-address@^10.1.1, ip-address@^10.4.0:
+ip-address@^10.1.1:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.4.0.tgz#c5910bc541b6eae287765d1e4846be0308a05d93"
   integrity sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==


### PR DESCRIPTION
Bump `ip-address` to `10.4.0`.

- Lockfile-only. `socks` already allows `^10.1.1`, which includes `10.4.0`.
- No `package.json` change. No resolution needed.

Dep chain:

```
$ yarn why ip-address
=> Found "ip-address@10.4.0"
   - "pacote#npm-registry-fetch#make-fetch-happen#@npmcli#agent#socks-proxy-agent#socks" depends on it
   - Hoisted from "pacote#npm-registry-fetch#make-fetch-happen#@npmcli#agent#socks-proxy-agent#socks#ip-address"
```

**Steps taken**

1. `yarn.lock` updated (`ip-address` 10.2.0 -> 10.4.0) within the existing `^10.1.1` range
2. Removed an unnecessary `resolutions` override that was added earlier on this branch
3. `yarn install` - lockfile stable
4. `npx yarn-deduplicate yarn.lock`
5. `yarn audit` - ip-address no longer flagged
6. Full test suite passes (976 suites, 11527 tests)
