### PR TITLE
chore(commitlint): ignore dependabot commit bodies

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = require('@box/frontend/commitlint/commitlint.config.js');
+const base = require('@box/frontend/commitlint/commitlint.config.js');
+
+module.exports = {
+    ...base,
+    ignores: [...(base.ignores || []), message => /Signed-off-by:\s*dependabot\[bot\]/i.test(message)],
+};


### PR DESCRIPTION
Dependabot commit bodies include long changelog/compare URLs that trip commitlint `body-max-line-length` (100).

There is no Dependabot config to truncate or omit the body — known gap:

https://github.com/dependabot/dependabot-core/issues/2445

Ignore Dependabot commits in `commitlint.config.js` (match `Signed-off-by: dependabot[bot]`), so version/security update PRs can pass lint without rewriting the commit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated commit message validation settings to allow automated dependency update commits with signed-off-by lines.
  * Preserved the existing shared commit message rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->