### PR TITLE
fix(content-preview): Prevent stuck loading mask for custom previews

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -511,7 +511,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
      * @return {void}
      */
     componentDidUpdate(prevProps: Props, prevState: State): void {
-        const { features, previewExperiences, token } = this.props;
+        const { features, previewExperiences, renderCustomPreview, token } = this.props;
         const { features: prevFeatures, previewExperiences: prevPreviewExperiences, token: prevToken } = prevProps;
         const { currentFileId } = this.state;
         const hasFileIdChanged = prevState.currentFileId !== currentFileId;
@@ -539,8 +539,10 @@ class ContentPreview extends React.PureComponent<Props, State> {
             this.fetchFile(currentFileId);
         } else if (this.shouldLoadPreview(prevState)) {
             this.destroyPreview(false);
-            this.setState({ isLoading: true });
-            this.loadPreview();
+            if (!renderCustomPreview) {
+                this.setState({ isLoading: true });
+                this.loadPreview();
+            }
         } else if (hasTokenChanged) {
             this.updatePreviewToken();
         }

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -113,6 +113,23 @@ describe('elements/content-preview/ContentPreview', () => {
             expect(instance.loadPreview).toHaveBeenCalledTimes(1);
         });
 
+        test('should not show loading state or reload preview when a custom preview version changes', () => {
+            file = { id: '123', file_version: { id: '1' } };
+
+            const wrapper = getWrapper({ renderCustomPreview: jest.fn() });
+            wrapper.setState({ file, isLoading: false });
+            const instance = wrapper.instance();
+
+            instance.destroyPreview = jest.fn();
+            instance.loadPreview = jest.fn();
+
+            wrapper.setState({ selectedVersion: { id: '2' } });
+
+            expect(instance.destroyPreview).toHaveBeenCalledWith(false);
+            expect(wrapper.state('isLoading')).toBe(false);
+            expect(instance.loadPreview).not.toHaveBeenCalled();
+        });
+
         test('should destroy preview and reset selectedVersion state on new fileId', () => {
             file = { id: '123' };
 


### PR DESCRIPTION
### Description

Custom previews no longer start the preview loading state when the selected version changes. This prevents the loading mask from remaining over rendered content while preserving standard preview loading behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom content previews no longer attempt to load the standard preview library.
  * Updating a custom preview now avoids unnecessary loading states and preview reloads.
  * Preview cleanup continues to work correctly when custom preview versions change.

* **Tests**
  * Added regression coverage for custom preview updates and loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->