### PR TITLE
feat(content-sidebar): add data-target-id to integrations tabs

### DIFF
--- a/src/elements/content-sidebar/SidebarNav.js
+++ b/src/elements/content-sidebar/SidebarNav.js
@@ -362,6 +362,7 @@ const SidebarNav = ({
                         className={classNames('bcs-SidebarNav-overflow', {
                             'bcs-SidebarNav-overflow--modernized': isPreviewModernizationEnabled,
                         })}
+                        data-target-id="SidebarNav-additionalTabsOverflow"
                         data-testid="additional-tabs-overflow"
                     >
                         <AdditionalTabs

--- a/src/elements/content-sidebar/additional-tabs/AdditionalTab.js
+++ b/src/elements/content-sidebar/additional-tabs/AdditionalTab.js
@@ -5,6 +5,7 @@
  */
 
 import * as React from 'react';
+import camelCase from 'lodash/camelCase';
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
@@ -29,6 +30,8 @@ type State = {
 };
 
 const BLOCKED_BY_SHEILD = 'BLOCKED_BY_SHIELD_ACCESS_POLICY';
+
+const TARGET_ID_PREFIX = 'AdditionalTab';
 
 class AdditionalTab extends React.PureComponent<Props, State> {
     state = {
@@ -56,6 +59,32 @@ class AdditionalTab extends React.PureComponent<Props, State> {
             // noop
         }
         return reason;
+    }
+
+    /**
+     * Analytics target id for this tab.
+     *
+     * Consumers may set targetId explicitly; otherwise it is derived from the integration's
+     * backend serviceName ("Adobe Sign" -> AdditionalTab-adobeSign) so each app in the rail is
+     * distinguishable. The overflow tab has no service of its own, and a tab whose serviceName
+     * is missing falls back to a shared id rather than an unusable one.
+     *
+     * @return {string} the data-target-id value
+     */
+    getTargetId(isOverflow: boolean) {
+        const { serviceName, targetId } = this.props;
+
+        if (targetId) {
+            return targetId;
+        }
+
+        if (isOverflow) {
+            return `${TARGET_ID_PREFIX}-moreButton`;
+        }
+
+        const slug = camelCase(serviceName || '');
+
+        return slug ? `${TARGET_ID_PREFIX}-${slug}` : `${TARGET_ID_PREFIX}-integrationButton`;
     }
 
     getTabIcon() {
@@ -92,6 +121,9 @@ class AdditionalTab extends React.PureComponent<Props, State> {
             ftuxTooltipData,
             onImageLoad,
             title,
+            // Analytics-only; excluded so it does not reach consumers through callbackData.
+            // Note serviceName is deliberately left in rest, since consumers read it from there.
+            targetId: unusedTargetId,
             ...rest
         } = this.props;
 
@@ -115,7 +147,7 @@ class AdditionalTab extends React.PureComponent<Props, State> {
                 <PlainButton
                     aria-label={title}
                     className={className}
-                    data-target-id={isOverflow ? 'AdditionalTab-moreButton' : 'AdditionalTab-integrationButton'}
+                    data-target-id={this.getTargetId(isOverflow)}
                     data-testid="additionaltab"
                     type="button"
                     isDisabled={isDisabled}

--- a/src/elements/content-sidebar/additional-tabs/AdditionalTab.js
+++ b/src/elements/content-sidebar/additional-tabs/AdditionalTab.js
@@ -96,11 +96,12 @@ class AdditionalTab extends React.PureComponent<Props, State> {
         } = this.props;
 
         const isDisabled = this.isDisabled();
+        const isOverflow = !!id && id < 0;
 
         const className = classNames('bdl-AdditionalTab', {
             'bdl-is-hidden': isLoading,
             'bdl-is-disabled': isDisabled,
-            'bdl-is-overflow': id && id < 0,
+            'bdl-is-overflow': isOverflow,
         });
 
         const tooltipText = isDisabled ? this.getDisabledReason() : title;
@@ -114,6 +115,7 @@ class AdditionalTab extends React.PureComponent<Props, State> {
                 <PlainButton
                     aria-label={title}
                     className={className}
+                    data-target-id={isOverflow ? 'AdditionalTab-moreButton' : 'AdditionalTab-integrationButton'}
                     data-testid="additionaltab"
                     type="button"
                     isDisabled={isDisabled}

--- a/src/elements/content-sidebar/additional-tabs/__tests__/AdditionalTab.test.js
+++ b/src/elements/content-sidebar/additional-tabs/__tests__/AdditionalTab.test.js
@@ -97,4 +97,44 @@ describe('elements/content-sidebar/additional-tabs/AdditionalTab', () => {
 
         expect(wrapper.find(AdditionalTabTooltip).exists()).toBeTruthy();
     });
+
+    describe('data-target-id', () => {
+        const getTargetId = props =>
+            getWrapper({ title: 'test title', callback: () => {}, ...props })
+                .find(PlainButton)
+                .prop('data-target-id');
+
+        test.each`
+            serviceName     | expected
+            ${'Slack'}      | ${'AdditionalTab-slack'}
+            ${'Adobe Sign'} | ${'AdditionalTab-adobeSign'}
+            ${'Gmail'}      | ${'AdditionalTab-gmail'}
+            ${'zoom.us'}    | ${'AdditionalTab-zoomUs'}
+        `('should derive $expected from serviceName $serviceName', ({ serviceName, expected }) => {
+            expect(getTargetId({ id: 4, serviceName })).toBe(expected);
+        });
+
+        test('should use the overflow id for the more tab regardless of serviceName', () => {
+            expect(getTargetId({ id: -1 })).toBe('AdditionalTab-moreButton');
+        });
+
+        test('should fall back to a shared id when serviceName is missing', () => {
+            expect(getTargetId({ id: 4 })).toBe('AdditionalTab-integrationButton');
+        });
+
+        test('should prefer an explicit targetId over the derived one', () => {
+            expect(getTargetId({ id: 4, serviceName: 'Slack', targetId: 'Custom-tab' })).toBe('Custom-tab');
+        });
+
+        test('should not leak targetId into callbackData', () => {
+            const callback = jest.fn();
+            const wrapper = getWrapper({ id: 4, serviceName: 'Slack', targetId: 'Custom-tab', callback });
+
+            wrapper.find(PlainButton).simulate('click');
+
+            const { callbackData } = callback.mock.calls[0][0];
+            expect(callbackData).not.toHaveProperty('targetId');
+            expect(callbackData.serviceName).toBe('Slack');
+        });
+    });
 });

--- a/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
+++ b/src/elements/content-sidebar/additional-tabs/__tests__/__snapshots__/AdditionalTab.test.js.snap
@@ -13,6 +13,7 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render di
   <PlainButton
     aria-label="test title"
     className="bdl-AdditionalTab bdl-is-disabled"
+    data-target-id="AdditionalTab-integrationButton"
     data-testid="additionaltab"
     isDisabled={true}
     onClick={[Function]}
@@ -36,6 +37,7 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render ic
   <PlainButton
     aria-label="test title"
     className="bdl-AdditionalTab bdl-is-overflow"
+    data-target-id="AdditionalTab-moreButton"
     data-testid="additionaltab"
     isDisabled={false}
     onClick={[Function]}
@@ -54,6 +56,7 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render th
   <PlainButton
     aria-label="test title"
     className="bdl-AdditionalTab bdl-is-overflow"
+    data-target-id="AdditionalTab-moreButton"
     data-testid="additionaltab"
     isDisabled={false}
     onClick={[Function]}
@@ -76,6 +79,7 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render th
   <PlainButton
     aria-label="test title"
     className="bdl-AdditionalTab bdl-is-overflow"
+    data-target-id="AdditionalTab-moreButton"
     data-testid="additionaltab"
     isDisabled={false}
     onClick={[Function]}
@@ -96,6 +100,7 @@ exports[`elements/content-sidebar/additional-tabs/AdditionalTab should render th
   <PlainButton
     aria-label="test title"
     className="bdl-AdditionalTab"
+    data-target-id="AdditionalTab-integrationButton"
     data-testid="additionaltab"
     isDisabled={false}
     onClick={[Function]}

--- a/src/elements/content-sidebar/flowTypes.js
+++ b/src/elements/content-sidebar/flowTypes.js
@@ -32,6 +32,10 @@ type AdditionalSidebarTab = {
     id: number,
     title: ?string,
     icon?: React.Node,
+    /** Backend identifier for the integration, e.g. "Adobe Sign". Used to derive the analytics target id. */
+    serviceName?: string,
+    /** Explicit analytics target id, taking precedence over the one derived from serviceName. */
+    targetId?: string,
 };
 
 /**


### PR DESCRIPTION
## Problem

The integrations rail in the `ContentSidebar` nav — the app icons below the primary tabs, plus the overflow "more" tab — has no `data-target-id`. Analytics tooling therefore falls back to CSS selectors (hashed module classnames, `nth-child` chains) that break silently on any refactor or build-hash change.

Tagging the rail is only useful if each app is distinguishable: a single shared id across Slack, Adobe Sign, Adobe Acrobat, Outlook and Gmail would make the attribute unusable for measuring which integrations users actually open.

## Change

Every icon in the rail is one instance of the shared `AdditionalTab` button, so the id is derived per tab rather than hardcoded:

1. **`serviceName` → slug.** `AdditionalTab` derives the id from the integration's backend `serviceName` via `lodash/camelCase`, which consumers already supply per tab:

   | `serviceName` | `data-target-id` |
   | --- | --- |
   | `Slack` | `AdditionalTab-slack` |
   | `Adobe Sign` | `AdditionalTab-adobeSign` |
   | `Adobe Acrobat` | `AdditionalTab-adobeAcrobat` |
   | `Microsoft Outlook` | `AdditionalTab-microsoftOutlook` |
   | `Gmail` | `AdditionalTab-gmail` |

   `serviceName` is a backend identifier, not a localized display name, so the id is stable across locales.

2. **Optional `targetId` override.** A consumer can set `targetId` on the tab data to pin an exact value, taking precedence over the derived one. It is excluded from `callbackData` so it does not reach consumer click handlers; `serviceName` is deliberately left in place, since consumers read it from there.

3. **Overflow and fallback.** The overflow tab (`id < 0`) gets `AdditionalTab-moreButton` — it has no service of its own. A tab with no `serviceName` falls back to the shared `AdditionalTab-integrationButton` rather than an empty or malformed id.

4. **Rail container.** `SidebarNav.js` gets `SidebarNav-additionalTabsOverflow`, matching the existing `data-testid="additional-tabs-overflow"`.

`serviceName` and `targetId` are added to the `AdditionalSidebarTab` flow type. Names follow the `SidebarNavButton-*` convention already used for the primary tabs, and sit alongside the existing `data-resin-target` attributes rather than replacing them.

## Verification

- `yarn flow check src/elements/content-sidebar` — 0 errors
- `yarn test src/elements/content-sidebar/additional-tabs` — 22 passed, 8 snapshots passed
- `yarn test src/elements/content-sidebar/__tests__/SidebarNav` — 82 passed
- `eslint` on all touched files — clean

New test coverage: slug derivation across several `serviceName` shapes (including `zoom.us` → `zoomUs`), the overflow id, the missing-`serviceName` fallback, `targetId` precedence, and an assertion that `targetId` does not leak into `callbackData` while `serviceName` still does.

Not verified in a running app. No visual or behavioral change is expected — only DOM attributes were added.

Internal ref: UXF-1331