### PR TITLE
fix(fonts): add nested style for strong and em

### DIFF
--- a/src/styles/common/_typography.scss
+++ b/src/styles/common/_typography.scss
@@ -79,6 +79,17 @@ em {
     font-style: italic;
 }
 
+// Nested tags do not inherit both properties; the inner tag only has italic or bold.
+.strong em,
+.strong .em,
+strong em,
+.em strong,
+.em .strong,
+em strong {
+    font-weight: bold;
+    font-style: italic;
+}
+
 small {
     font-size: 85%;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling for nested bold and italic text so it consistently displays with both emphasis styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->