### PR TITLE
fix(activity-feed): keep text when URL follows underscore (PREVIEW-1485)

### DIFF
--- a/src/elements/content-sidebar/activity-feed/utils/__tests__/formatTaggedMessage.test.js
+++ b/src/elements/content-sidebar/activity-feed/utils/__tests__/formatTaggedMessage.test.js
@@ -1,4 +1,5 @@
 import formatTaggedMessage, { renderTimestampWithText } from '../formatTaggedMessage';
+import { Link } from '../../../../../components/link';
 import UserLink from '../../common/user-link';
 
 describe('elements/content-sidebar/ActivityFeed/utils/formatTaggedMessage', () => {
@@ -43,6 +44,47 @@ describe('elements/content-sidebar/ActivityFeed/utils/formatTaggedMessage', () =
         expect(mention.type).toBe(UserLink);
         expect(mention.props.id).toBe('3203255873');
         expect(mention.props.name).toBe('@test user');
+    });
+
+    test('should keep surrounding text when a URL follows an underscore', () => {
+        const taggedMessage = formatTaggedMessage(
+            'Please review_https://example.com/foo extra',
+            123,
+            false,
+            undefined,
+            mockIntl,
+        );
+        expect(taggedMessage[0]).toBe('Please review_');
+        expect(taggedMessage[1].type).toBe(Link);
+        expect(taggedMessage[1].props.href).toBe('https://example.com/foo');
+        expect(taggedMessage[1].props.children).toBe('https://example.com/foo');
+        expect(taggedMessage[2]).toBe(' extra');
+    });
+
+    test('should keep surrounding text when a URL follows a full-width underscore', () => {
+        const taggedMessage = formatTaggedMessage(
+            'Please review＿https://example.com/foo',
+            123,
+            false,
+            undefined,
+            mockIntl,
+        );
+        expect(taggedMessage[0]).toBe('Please review＿');
+        expect(taggedMessage[1].type).toBe(Link);
+        expect(taggedMessage[1].props.href).toBe('https://example.com/foo');
+    });
+
+    test('should keep surrounding text when a URL follows a space', () => {
+        const taggedMessage = formatTaggedMessage(
+            'Please review https://example.com/foo',
+            123,
+            false,
+            undefined,
+            mockIntl,
+        );
+        expect(taggedMessage[0]).toBe('Please review ');
+        expect(taggedMessage[1].type).toBe(Link);
+        expect(taggedMessage[1].props.href).toBe('https://example.com/foo');
     });
 
     describe('renderTimestampWithText', () => {

--- a/src/elements/content-sidebar/activity-feed/utils/formatTaggedMessage.js
+++ b/src/elements/content-sidebar/activity-feed/utils/formatTaggedMessage.js
@@ -58,11 +58,14 @@ const formatTimestamp = (text: string, timestamp: string, intl: IntlShape): Reac
 
 // this regex matches one of the following regular expressions:
 // mentions: ([@＠﹫]\[[0-9]+:[^\]]+])
-// urls: (?:\b)((?:(?:ht|f)tps?:\/\/)[\w\._\-]+(:\d+)?(\/[\w\-_\.~\+\/#\?&%=:\[\]@!$'\(\)\*;,]*)?)
+// urls: (?<![A-Za-z0-9])((?:(?:ht|f)tps?:\/\/)[\w\._\-]+(:\d+)?(\/[\w\-_\.~\+\/#\?&%=:\[\]@!$'\(\)\*;,]*)?)
+// Use a lookbehind instead of \b so a preceding underscore (a JS word character)
+// still starts a URL. See PREVIEW-1485.
 // NOTE: There are useless escapes in the regex below, should probably remove them when safe
 /* eslint-disable no-useless-escape */
+const urlRegex = /((?:(?:ht|f)tps?:\/\/)[\w\._\-]+(?::\d+)?(?:\/[\w\-_\.~\+\/#\?&%=:\[\]@!$'\(\)\*;,]*)?)/i;
 const splitRegex =
-    /((?:[@＠﹫]\[[0-9]+:[^\]]+])|(?:\b(?:(?:ht|f)tps?:\/\/)[\w\._\-]+(?::\d+)?(?:\/[\w\-_\.~\+\/#\?&%=:\[\]@!$'\(\)\*;,]*)?))/gim;
+    /((?:[@＠﹫]\[[0-9]+:[^\]]+])|(?:(?<![A-Za-z0-9])(?:(?:ht|f)tps?:\/\/)[\w\._\-]+(?::\d+)?(?:\/[\w\-_\.~\+\/#\?&%=:\[\]@!$'\(\)\*;,]*)?))/gim;
 // eslint-enable no-useless-escape
 /**
  * Formats a message a string and replaces the following:
@@ -83,7 +86,7 @@ const formatTaggedMessage = (
     getUserProfileUrl?: Function,
     intl: IntlShape,
 ): string | Array<React.Node | string> => {
-    const contentItems = tagged_message.split(splitRegex).map((text: string, contentIndex: number) => {
+    const contentItems = tagged_message.split(splitRegex).flatMap((text: string, contentIndex: number) => {
         const contentKey = `${contentIndex}-${itemID}`;
         // attempt mention match
         const mentionMatch = text.match(/([@＠﹫])\[([0-9]+):([^\]]+)]/i);
@@ -115,19 +118,17 @@ const formatTaggedMessage = (
         }
 
         if (!shouldReturnString) {
-            // attempt url match
-            // NOTE: There are useless escapes in the regex below, should probably remove them when safe
-            const urlMatch = text.match(
-                // eslint-disable-next-line no-useless-escape
-                /((?:(?:ht|f)tps?:\/\/)[\w\._\-]+(?::\d+)?(?:\/[\w\-_\.~\+\/#\?&%=:\[\]@!$'\(\)\*;,]*)?)/i,
-            );
-            if (urlMatch) {
+            const urlMatch = text.match(urlRegex);
+            if (urlMatch && urlMatch.index != null) {
                 const [, url] = urlMatch;
-                return (
+                const prefix = text.slice(0, urlMatch.index);
+                const suffix = text.slice(urlMatch.index + url.length);
+                const link = (
                     <Link key={contentKey} href={url}>
                         {url}
                     </Link>
                 );
+                return [prefix, link, suffix].filter(part => part !== '');
             }
         }
 


### PR DESCRIPTION
## Summary

Activity sidebar comments and task descriptions drop surrounding text when a half-width underscore sits immediately before a URL (`Please review_https://example.com`). Email still showed the full message. That came from `formatTaggedMessage`: `\b` does not treat `_https` as a URL start because `_` is a JS word character, so the splitter never cut, and the leftover URL match then replaced the whole chunk with only the link.

This switches URL detection to a lookbehind that still treats `_` as a boundary, and keeps any prefix/suffix around a matched URL.

Fixes https://jira.inside-box.net/browse/PREVIEW-1485

## Test plan

- [ ] Unit tests in `formatTaggedMessage.test.js` (underscore, full-width underscore, and space before URL)
- [ ] In the Activity sidebar, create an approval task whose message is `Please review_https://example.com` and confirm both the text and the link render
- [ ] Confirm a space between `_` and the URL still works, and that mentions, timestamps, and standalone URLs are unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity feed message formatting when URLs follow underscores, full-width underscores, or spaces.
  * Preserved text appearing before and after links instead of omitting surrounding content.
  * Ensured matched URLs continue to display as clickable links with the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->