### PR TITLE
fix(deps): Bump @box/threaded-annotations from 4.1.12 to 4.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
         "@box/metadata-view": "^1.53.26",
         "@box/react-virtualized": "^9.22.3-rc-box.10",
         "@box/readable-time": "^2.2.21",
-        "@box/threaded-annotations": "^4.11.0",
+        "@box/threaded-annotations": "^4.11.3",
         "@box/types": "^2.1.8",
         "@box/unified-share-modal": "^2.15.16",
         "@box/uploads-manager": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,10 +1219,10 @@
   resolved "https://registry.yarnpkg.com/@box/readable-time/-/readable-time-2.2.21.tgz#d7b425f2f42e619d196670e11073764cd73e706b"
   integrity sha512-yh/eUMZidTUfntCiV/7BwW8Pof7rL9Us1HVYYtKcM1rMz7lmMI96xrFHj+JylP5A/tNRoNClTYNX0XuIMDk2zw==
 
-"@box/threaded-annotations@^4.11.0":
-  version "4.11.2"
-  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-4.11.2.tgz#767cceb45b85ab4921349b0318ff88b95bd5be21"
-  integrity sha512-XRgmuv85IGrcptVsVXEEnS3+uAbvZBStna6STITJKtHQ+NDJKgaX32u38Gs5Pd8qDC5m3386cbBrgoQEZo0zZw==
+"@box/threaded-annotations@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@box/threaded-annotations/-/threaded-annotations-4.11.3.tgz#a31421a57b87100810afdbbb269579c30093b948"
+  integrity sha512-dlv51XHTzDfrh+S13bvgUCbHd9wuxQNAPSef+qNLv6VBuZWlmZMMzmeJOOqTJ/vOVr0jcTEJ/py4znesHmvwEg==
   dependencies:
     "@floating-ui/dom" "^1.6.0"
     "@tanstack/react-virtual" "^3.10.8"


### PR DESCRIPTION
## Summary
- Bumps `@box/threaded-annotations` from `4.1.12` to `4.11.3` in `devDependencies` and `peerDependencies`

## Test Plan
- [x] Verify threaded annotations render correctly in the activity feed
- [x] Run `yarn test` to confirm no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal development dependency to a newer maintenance release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->