### PR TITLE
feat(activity-feed-v2): Hide wrapping markdown when flag off

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/stripWrappingMarkdown.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/stripWrappingMarkdown.test.ts
@@ -1,0 +1,38 @@
+import { stripWrappingMarkdown } from '../stripWrappingMarkdown';
+
+describe('stripWrappingMarkdown', () => {
+    test('returns empty input unchanged', () => {
+        expect(stripWrappingMarkdown('')).toBe('');
+    });
+
+    test('strips bold, italic, and underline wraps', () => {
+        expect(stripWrappingMarkdown('**bold**')).toBe('bold');
+        expect(stripWrappingMarkdown('_italic_')).toBe('italic');
+        expect(stripWrappingMarkdown('*italic*')).toBe('italic');
+        expect(stripWrappingMarkdown('++under++')).toBe('under');
+        expect(stripWrappingMarkdown('__bold__')).toBe('bold');
+    });
+
+    test('strips stacked wraps', () => {
+        expect(stripWrappingMarkdown('++**_stacked_**++')).toBe('stacked');
+    });
+
+    test('preserves mention tokens and strips wraps around adjacent text', () => {
+        expect(stripWrappingMarkdown('@[7340978551:Jose Gaston] ++pie++')).toBe('@[7340978551:Jose Gaston] pie');
+        expect(stripWrappingMarkdown('**@[7340978551:Jose Gaston]**')).toBe('@[7340978551:Jose Gaston]');
+    });
+
+    test('leaves list markers unchanged', () => {
+        expect(stripWrappingMarkdown('- @[7340978551:Jose Gaston] dogs')).toBe('- @[7340978551:Jose Gaston] dogs');
+        expect(stripWrappingMarkdown('1. numbered')).toBe('1. numbered');
+    });
+
+    test('leaves plain text and newlines unchanged', () => {
+        expect(stripWrappingMarkdown('Hello world')).toBe('Hello world');
+        expect(stripWrappingMarkdown('Line 1\nLine 2')).toBe('Line 1\nLine 2');
+    });
+
+    test('leaves unclosed underline literal', () => {
+        expect(stripWrappingMarkdown('++unclosed')).toBe('++unclosed');
+    });
+});

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
@@ -194,6 +194,51 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
             const messages = transformCommentToMessages(editedComment as unknown as Comment);
             expect(messages[0].updatedAt).toBe(new Date('2024-01-02T00:00:00Z').getTime());
         });
+
+        test('should strip wrapping markdown from comment message text', () => {
+            const richComment = { ...mockComment, tagged_message: '**another one**' };
+            const messages = transformCommentToMessages(richComment as unknown as Comment);
+            expect(messages[0].message.content[0].content).toEqual([{ type: 'text', text: 'another one' }]);
+        });
+
+        test('should strip wrapping markdown from replies but leave list markers', () => {
+            const commentWithReplies = {
+                ...mockComment,
+                tagged_message: '',
+                message: '**test**',
+                replies: [
+                    {
+                        ...mockComment,
+                        id: 'reply-1',
+                        tagged_message: '',
+                        message: '- @[456:Jane] dogs',
+                    },
+                    {
+                        ...mockComment,
+                        id: 'reply-2',
+                        tagged_message: '',
+                        message: '@[456:Jane] ++pie++',
+                    },
+                ],
+            };
+            const messages = transformCommentToMessages(commentWithReplies as unknown as Comment);
+            expect(messages[0].message.content[0].content).toEqual([{ type: 'text', text: 'test' }]);
+            expect(messages[1].message.content[0].content).toEqual([
+                { type: 'text', text: '- ' },
+                {
+                    type: 'mention',
+                    attrs: { authorId: '123', mentionId: '456', mentionedUserId: '456', mentionedUserName: 'Jane' },
+                },
+                { type: 'text', text: ' dogs' },
+            ]);
+            expect(messages[2].message.content[0].content).toEqual([
+                {
+                    type: 'mention',
+                    attrs: { authorId: '123', mentionId: '456', mentionedUserId: '456', mentionedUserName: 'Jane' },
+                },
+                { type: 'text', text: ' pie' },
+            ]);
+        });
     });
 
     describe('transformAnnotationToMessages()', () => {
@@ -230,6 +275,15 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
                 type: 'text',
                 text: 'Annotation text',
             });
+        });
+
+        test('should strip wrapping markdown from annotation description message', () => {
+            const richAnnotation = {
+                ...mockAnnotation,
+                description: { message: '**another one**' },
+            };
+            const messages = transformAnnotationToMessages(richAnnotation as unknown as Annotation);
+            expect(messages[0].message.content[0].content).toEqual([{ type: 'text', text: 'another one' }]);
         });
 
         test('should handle annotation with replies', () => {

--- a/src/elements/content-sidebar/activity-feed-v2/stripWrappingMarkdown.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/stripWrappingMarkdown.ts
@@ -1,0 +1,64 @@
+/**
+ * @file Strips wrapping rich-text markdown delimiters for flag-off read paths.
+ * Handles **bold**, __bold__, _italic_, *italic*, and ++underline++ only.
+ * List markers (- , 1.) are intentionally left unchanged.
+ */
+
+const MENTION_PATTERN = /@\[([^:\]]+):([^\]]+)\]/g;
+
+const MENTION_PLACEHOLDER_PREFIX = '\u0000mention:';
+const MENTION_PLACEHOLDER_SUFFIX = '\u0000';
+
+const WRAP_DELIMITERS = ['++', '**', '__', '_', '*'] as const;
+
+const protectMentions = (text: string): { protectedText: string; mentions: string[] } => {
+    const mentions: string[] = [];
+    const protectedText = text.replace(MENTION_PATTERN, mention => {
+        mentions.push(mention);
+        return `${MENTION_PLACEHOLDER_PREFIX}${mentions.length - 1}${MENTION_PLACEHOLDER_SUFFIX}`;
+    });
+
+    return { protectedText, mentions };
+};
+
+const restoreMentions = (text: string, mentions: string[]): string =>
+    text.replace(
+        new RegExp(`${MENTION_PLACEHOLDER_PREFIX}(\\d+)${MENTION_PLACEHOLDER_SUFFIX}`, 'g'),
+        (_, index) => mentions[Number(index)] ?? '',
+    );
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const unwrapDelimiter = (text: string, delimiter: string): string => {
+    const escaped = escapeRegExp(delimiter);
+    return text.replace(new RegExp(`${escaped}([\\s\\S]*?)${escaped}`, 'g'), '$1');
+};
+
+const stripProtectedText = (text: string): string => {
+    let result = text;
+    let previous: string;
+
+    do {
+        previous = result;
+        for (const delimiter of WRAP_DELIMITERS) {
+            result = unwrapDelimiter(result, delimiter);
+        }
+    } while (result !== previous);
+
+    return result;
+};
+
+/**
+ * Removes wrapping markdown syntax from a wire-format message string.
+ * Mention tokens `@[id:name]` are preserved. List syntax is not interpreted.
+ */
+export const stripWrappingMarkdown = (text: string): string => {
+    if (!text) {
+        return text;
+    }
+
+    const { protectedText, mentions } = protectMentions(text);
+    const stripped = stripProtectedText(protectedText);
+
+    return restoreMentions(stripped, mentions);
+};

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -26,6 +26,15 @@ import type { AppActivityItem as BUIEAppActivityItem, Comment, FeedItem } from '
 import type { BoxItemVersion, User } from '../../../common/types/core';
 import type { TaskCollabAssignee, TaskNew } from '../../../common/types/tasks';
 
+import {
+    FEED_ITEM_TYPE_ANNOTATION,
+    FEED_ITEM_TYPE_APP_ACTIVITY,
+    FEED_ITEM_TYPE_COMMENT,
+    FEED_ITEM_TYPE_TASK,
+    FEED_ITEM_TYPE_VERSION,
+} from '../../../constants';
+
+import { stripWrappingMarkdown } from './stripWrappingMarkdown';
 import type {
     AnnotationBadgeTargetType,
     AppActivityItemProps,
@@ -34,14 +43,6 @@ import type {
     TransformedFeedItem,
     VersionItemProps,
 } from './types';
-
-import {
-    FEED_ITEM_TYPE_ANNOTATION,
-    FEED_ITEM_TYPE_APP_ACTIVITY,
-    FEED_ITEM_TYPE_COMMENT,
-    FEED_ITEM_TYPE_TASK,
-    FEED_ITEM_TYPE_VERSION,
-} from '../../../constants';
 
 const MENTION_REGEX = /@\[(\d+):([^\]]+)\]/g;
 const TIMESTAMP_MARKUP_REGEX = /^#\[timestamp:(\d+)(?:,versionId:\d+)?\]\s*/;
@@ -206,7 +207,7 @@ const commentToTextMessage = (
         id: comment.id,
         message: isRichTextEnabled
             ? parseRichText(cleanText, comment.created_by?.id ?? '')
-            : textToDocumentNode(cleanText, comment.created_by?.id ?? ''),
+            : textToDocumentNode(stripWrappingMarkdown(cleanText), comment.created_by?.id ?? ''),
         permissions: toPermissions(comment.permissions),
         updatedAt: toUpdatedAt(comment.created_at, comment.modified_at),
     };
@@ -256,7 +257,7 @@ export const transformAnnotationToMessages = (
         id: annotation.id,
         message: isRichTextEnabled
             ? parseRichText(messageText, annotation.created_by?.id ?? '')
-            : textToDocumentNode(messageText, annotation.created_by?.id ?? ''),
+            : textToDocumentNode(stripWrappingMarkdown(messageText), annotation.created_by?.id ?? ''),
         permissions: toPermissions(annotation.permissions),
         updatedAt: toUpdatedAt(annotation.created_at, annotation.modified_at),
     };


### PR DESCRIPTION
### Description

When `isRichTextEnabled` is false, activity-feed v2 now unwraps wrapping markdown (`**`, `__`, `*`, `_`, `++`) before `textToDocumentNode`, so the sidebar shows the inner text instead of the marks.

When the flag is on, messages still go through `parseRichText`. Mentions (`@[id:name]`) stay intact. List prefixes (`- `, `1.`) are not stripped. Composer serialize is unchanged.

Quirk: unmatched leftover marks stay visible — this is unwrap, not a markdown parser.
