### PR TITLE
feat(activity-feed-v2): support an optional end timestamp in comment markup

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -20,6 +20,7 @@ import TaskModalV2 from './task-modal-v2';
 import FeedItemRow from './FeedItemRow';
 import { resolveFeedItemIdForEntry, serializeEditorContent } from './helpers';
 import { mapCollaboratorToUserContact } from './task-modal-v2/utils/contactMapping';
+import { buildTimestampMarkup } from './timestampMarkup';
 import { transformFeedItem, transformTaskAssignees } from './transformers';
 import { useAvatarUrls } from './useAvatarUrls';
 import { useTimeFormat } from './useTimeFormat';
@@ -390,6 +391,7 @@ const ActivityFeedV2 = ({
         formattedTimestamp,
         isPressed: isTimestampPressed,
         onPressedChange,
+        timestampEndMs,
         timestampMs,
     } = useMediaTimestamp(allowMediaTimestamps, timeFormat, fps);
 
@@ -461,7 +463,11 @@ const ActivityFeedV2 = ({
             if (!serialized || !serialized.text) return;
             const text =
                 allowMediaTimestamps && isTimestampPressed && fileVersionId
-                    ? `#[timestamp:${timestampMs},versionId:${fileVersionId}] ${serialized.text}`
+                    ? `${buildTimestampMarkup({
+                          endMs: timestampEndMs,
+                          startMs: timestampMs,
+                          versionId: fileVersionId,
+                      })} ${serialized.text}`
                     : serialized.text;
             try {
                 const snapshot = new Set(filteredItems.map(item => item.id));
@@ -479,6 +485,7 @@ const ActivityFeedV2 = ({
             isRichTextEnabled,
             isTimestampPressed,
             onCommentCreate,
+            timestampEndMs,
             timestampMs,
         ],
     );

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/FeedItemRow.test.tsx
@@ -556,6 +556,29 @@ describe('elements/content-sidebar/activity-feed-v2/FeedItemRow', () => {
             );
         });
 
+        test('should preserve both range boundaries when editing a range-timestamped comment', () => {
+            mockedSerializeEditorContent.mockReturnValue({ hasMention: false, text: 'edited-text' });
+            const onCommentUpdate = jest.fn();
+            const rangeComment: TransformedCommentItem = {
+                ...mockComment,
+                annotationTarget: { timestamp: '0:08', type: AnnotationBadgeType.Frame },
+                annotationTimestampEndMs: 12000,
+                annotationTimestampMarkup: '#[timestamp:8055,endTimestamp:12000,versionId:2390295731268]',
+                annotationTimestampMs: 8055,
+            };
+            render(<FeedItemRow {...defaultProps} item={rangeComment} onCommentUpdate={onCommentUpdate} />);
+
+            lastThreadedAnnotationProps.onEdit?.('comment-1', { type: 'doc', content: [] });
+
+            expect(onCommentUpdate).toHaveBeenCalledWith(
+                'comment-1',
+                '#[timestamp:8055,endTimestamp:12000,versionId:2390295731268] edited-text',
+                undefined,
+                false,
+                commentPermissions,
+            );
+        });
+
         test('should not modify edit text for a regular comment without timestamp markup', () => {
             mockedSerializeEditorContent.mockReturnValue({ hasMention: false, text: 'edited-text' });
             const onCommentUpdate = jest.fn();

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/timestampMarkup.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/timestampMarkup.test.ts
@@ -1,0 +1,134 @@
+import { buildTimestampMarkup, extractTimestampMarkup } from '../timestampMarkup';
+
+describe('elements/content-sidebar/activity-feed-v2/timestampMarkup', () => {
+    describe('extractTimestampMarkup()', () => {
+        test('should return text unchanged when no timestamp markup is present', () => {
+            expect(extractTimestampMarkup('regular comment')).toEqual({ cleanText: 'regular comment' });
+        });
+
+        test('should handle empty text', () => {
+            expect(extractTimestampMarkup('')).toEqual({ cleanText: '' });
+        });
+
+        test('should extract timestamp markup with versionId and return a frame badge target', () => {
+            const result = extractTimestampMarkup('#[timestamp:8055,versionId:2390295731268]  wowo');
+            expect(result.cleanText).toBe('wowo');
+            expect(result.target).toEqual({ timestamp: '0:08', type: 'frame' });
+            expect(result.timestampMarkup).toBe('#[timestamp:8055,versionId:2390295731268]');
+            expect(result.timestampMs).toBe(8055);
+            expect(result.timestampEndMs).toBeUndefined();
+        });
+
+        test('should extract timestamp markup without versionId', () => {
+            const result = extractTimestampMarkup('#[timestamp:65000] hello');
+            expect(result.cleanText).toBe('hello');
+            expect(result.timestampMs).toBe(65000);
+            expect(result.timestampEndMs).toBeUndefined();
+        });
+
+        test('should extract the end timestamp of a range comment', () => {
+            const result = extractTimestampMarkup('#[timestamp:8055,endTimestamp:12000,versionId:99] great take');
+            expect(result.cleanText).toBe('great take');
+            expect(result.target).toEqual({ timestamp: '0:08', type: 'frame' });
+            expect(result.timestampMarkup).toBe('#[timestamp:8055,endTimestamp:12000,versionId:99]');
+            expect(result.timestampMs).toBe(8055);
+            expect(result.timestampEndMs).toBe(12000);
+        });
+
+        test('should tolerate arbitrary key order', () => {
+            const result = extractTimestampMarkup('#[versionId:99,endTimestamp:12000,timestamp:8055] hello');
+            expect(result.cleanText).toBe('hello');
+            expect(result.timestampMs).toBe(8055);
+            expect(result.timestampEndMs).toBe(12000);
+        });
+
+        test('should tolerate unknown keys without dropping the markup', () => {
+            const result = extractTimestampMarkup('#[timestamp:8055,someFutureKey:7,versionId:99] hello');
+            expect(result.cleanText).toBe('hello');
+            expect(result.timestampMs).toBe(8055);
+            expect(result.timestampMarkup).toBe('#[timestamp:8055,someFutureKey:7,versionId:99]');
+        });
+
+        test('should leave markup without a start timestamp untouched', () => {
+            const result = extractTimestampMarkup('#[endTimestamp:12000,versionId:99] hello');
+            expect(result.cleanText).toBe('#[endTimestamp:12000,versionId:99] hello');
+            expect(result.timestampMs).toBeUndefined();
+            expect(result.timestampEndMs).toBeUndefined();
+        });
+
+        test('should leave timestamp markup that does not anchor at the start of the message untouched', () => {
+            const result = extractTimestampMarkup('see #[timestamp:8055,versionId:1] this');
+            expect(result.cleanText).toBe('see #[timestamp:8055,versionId:1] this');
+            expect(result.target).toBeUndefined();
+        });
+
+        test('should return empty cleanText when the message is only timestamp markup', () => {
+            const result = extractTimestampMarkup('#[timestamp:8055,versionId:1]');
+            expect(result.cleanText).toBe('');
+            expect(result.target).toEqual({ timestamp: '0:08', type: 'frame' });
+        });
+
+        test('should leave malformed timestamp markup untouched', () => {
+            const result = extractTimestampMarkup('#[timestamp:abc] hello');
+            expect(result.cleanText).toBe('#[timestamp:abc] hello');
+            expect(result.target).toBeUndefined();
+        });
+
+        test('should drop the badge when the timestamp value exceeds Number.MAX_SAFE_INTEGER', () => {
+            const result = extractTimestampMarkup('#[timestamp:99999999999999999999] hello');
+            expect(result.cleanText).toBe('hello');
+            expect(result.target).toBeUndefined();
+            expect(result.timestampMs).toBeUndefined();
+        });
+
+        test.each([
+            ['an end before the start', '#[timestamp:12000,endTimestamp:8055,versionId:99] hello', 12000],
+            ['an end equal to the start', '#[timestamp:8055,endTimestamp:8055,versionId:99] hello', 8055],
+            [
+                'an end beyond Number.MAX_SAFE_INTEGER',
+                '#[timestamp:8055,endTimestamp:99999999999999999999] hello',
+                8055,
+            ],
+        ])('should fall back to a single timestamp for %s', (_label, text, expectedStartMs) => {
+            const result = extractTimestampMarkup(text);
+            expect(result.cleanText).toBe('hello');
+            expect(result.timestampMs).toBe(expectedStartMs);
+            expect(result.timestampEndMs).toBeUndefined();
+        });
+
+        test('should keep the full markup so an edit can re-prepend a range verbatim', () => {
+            const markup = '#[timestamp:8055,endTimestamp:12000,versionId:99]';
+            expect(extractTimestampMarkup(`${markup} hello`).timestampMarkup).toBe(markup);
+        });
+    });
+
+    describe('buildTimestampMarkup()', () => {
+        test('should emit markup identical to the single-timestamp format when there is no range', () => {
+            expect(buildTimestampMarkup({ startMs: 8055, versionId: '99' })).toBe('#[timestamp:8055,versionId:99]');
+        });
+
+        test('should emit the end timestamp for a range', () => {
+            expect(buildTimestampMarkup({ endMs: 12000, startMs: 8055, versionId: '99' })).toBe(
+                '#[timestamp:8055,endTimestamp:12000,versionId:99]',
+            );
+        });
+
+        test.each([
+            ['the end is before the start', 4000],
+            ['the end equals the start', 8055],
+            ['the end is not a safe integer', Number.MAX_SAFE_INTEGER + 2],
+        ])('should omit the end timestamp when %s', (_label, endMs) => {
+            expect(buildTimestampMarkup({ endMs, startMs: 8055, versionId: '99' })).toBe(
+                '#[timestamp:8055,versionId:99]',
+            );
+        });
+
+        test('should round-trip a range through the parser', () => {
+            const markup = buildTimestampMarkup({ endMs: 12000, startMs: 8055, versionId: '99' });
+            const result = extractTimestampMarkup(`${markup} great take`);
+            expect(result.timestampMs).toBe(8055);
+            expect(result.timestampEndMs).toBe(12000);
+            expect(result.cleanText).toBe('great take');
+        });
+    });
+});

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/transformers.test.ts
@@ -8,7 +8,6 @@ import type { TaskNew } from '../../../../common/types/tasks';
 
 import {
     annotationTargetToBadge,
-    extractTimestampMarkup,
     textToDocumentNode,
     transformAnnotationToMessages,
     transformAppActivityToProps,
@@ -772,57 +771,6 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
         });
     });
 
-    describe('extractTimestampMarkup()', () => {
-        test('should return text unchanged when no timestamp markup is present', () => {
-            expect(extractTimestampMarkup('regular comment')).toEqual({ cleanText: 'regular comment' });
-        });
-
-        test('should return empty input unchanged', () => {
-            expect(extractTimestampMarkup('')).toEqual({ cleanText: '' });
-        });
-
-        test('should extract timestamp markup with versionId and return a frame badge target', () => {
-            const result = extractTimestampMarkup('#[timestamp:8055,versionId:2390295731268]  wowo');
-            expect(result.cleanText).toBe('wowo');
-            expect(result.target).toEqual({ timestamp: '0:08', type: 'frame' });
-            expect(result.timestampMarkup).toBe('#[timestamp:8055,versionId:2390295731268]');
-            expect(result.timestampMs).toBe(8055);
-        });
-
-        test('should extract timestamp markup without versionId', () => {
-            const result = extractTimestampMarkup('#[timestamp:65000] hello');
-            expect(result.cleanText).toBe('hello');
-            expect(result.target).toEqual({ timestamp: '1:05', type: 'frame' });
-            expect(result.timestampMarkup).toBe('#[timestamp:65000]');
-            expect(result.timestampMs).toBe(65000);
-        });
-
-        test('should leave timestamp markup that does not anchor at the start of the message untouched', () => {
-            const result = extractTimestampMarkup('see #[timestamp:8055,versionId:1] this');
-            expect(result.cleanText).toBe('see #[timestamp:8055,versionId:1] this');
-            expect(result.target).toBeUndefined();
-        });
-
-        test('should return empty cleanText when the message is only timestamp markup', () => {
-            const result = extractTimestampMarkup('#[timestamp:8055,versionId:1]');
-            expect(result.cleanText).toBe('');
-            expect(result.target).toEqual({ timestamp: '0:08', type: 'frame' });
-        });
-
-        test('should leave malformed timestamp markup untouched', () => {
-            const result = extractTimestampMarkup('#[timestamp:abc] hello');
-            expect(result.cleanText).toBe('#[timestamp:abc] hello');
-            expect(result.target).toBeUndefined();
-        });
-
-        test('should drop the badge when the timestamp value exceeds Number.MAX_SAFE_INTEGER', () => {
-            const result = extractTimestampMarkup('#[timestamp:99999999999999999999] hello');
-            expect(result.cleanText).toBe('hello');
-            expect(result.target).toBeUndefined();
-            expect(result.timestampMs).toBeUndefined();
-        });
-    });
-
     describe('transformCommentToMessages() with timestamp markup', () => {
         test('should strip #[timestamp:...] markup from rendered message text', () => {
             const comment = {
@@ -859,6 +807,30 @@ describe('elements/content-sidebar/activity-feed-v2/transformers', () => {
                 expect(result.annotationTarget).toEqual({ timestamp: '0:08', type: 'frame' });
                 expect(result.annotationTimestampMarkup).toBe('#[timestamp:8055,versionId:2390295731268]');
                 expect(result.annotationTimestampMs).toBe(8055);
+                expect(result.annotationTimestampEndMs).toBeUndefined();
+            }
+        });
+
+        test('should populate annotationTimestampEndMs for a comment carrying a time range', () => {
+            const comment = {
+                created_at: '2024-01-01T00:00:00Z',
+                created_by: { id: '1', name: 'User', type: 'user' },
+                id: 'c1',
+                message: '#[timestamp:8055,endTimestamp:12000,versionId:2390295731268] great take',
+                modified_at: '2024-01-01T00:00:00Z',
+                permissions: {},
+                status: 'open',
+                tagged_message: '',
+                type: 'comment',
+            };
+            const result = transformFeedItem(comment as unknown as FeedItem);
+            if (result!.type === 'comment') {
+                expect(result.annotationTimestampMs).toBe(8055);
+                expect(result.annotationTimestampEndMs).toBe(12000);
+                expect(result.annotationTimestampMarkup).toBe(
+                    '#[timestamp:8055,endTimestamp:12000,versionId:2390295731268]',
+                );
+                expect(result.messages[0].message.content[0].content).toEqual([{ type: 'text', text: 'great take' }]);
             }
         });
 

--- a/src/elements/content-sidebar/activity-feed-v2/timestampMarkup.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/timestampMarkup.ts
@@ -1,0 +1,76 @@
+/**
+ * @file Serialization for the leading timestamp markup carried inside a comment message.
+ *
+ * There is no API field for a comment timestamp: the value is written into the message string
+ * and parsed back out on render. The format is `#[key:value,...]` with numeric values, and is
+ * shared with other clients, so the parser tolerates arbitrary key order and unknown keys.
+ * @author Box
+ */
+
+import { AnnotationBadgeType } from '@box/threaded-annotations';
+import { convertMillisecondsToTimestamp } from '../../../utils/timestamp';
+
+import type { AnnotationBadgeTargetType } from './types';
+
+const TIMESTAMP_MARKUP_REGEX = /^#\[([a-zA-Z][a-zA-Z0-9]*:\d+(?:,[a-zA-Z][a-zA-Z0-9]*:\d+)*)\]\s*/;
+
+const KEY_START = 'timestamp';
+const KEY_END = 'endTimestamp';
+const KEY_VERSION_ID = 'versionId';
+
+const toMs = (raw: string | undefined): number | undefined => {
+    if (raw === undefined) return undefined;
+    const ms = Number(raw);
+    return Number.isSafeInteger(ms) && ms >= 0 ? ms : undefined;
+};
+
+export const extractTimestampMarkup = (
+    text: string,
+): {
+    cleanText: string;
+    target?: AnnotationBadgeTargetType;
+    timestampEndMs?: number;
+    timestampMarkup?: string;
+    timestampMs?: number;
+} => {
+    if (!text) return { cleanText: '' };
+    const match = text.match(TIMESTAMP_MARKUP_REGEX);
+    if (!match) return { cleanText: text };
+
+    const [fullMatch, keyValues] = match;
+    const values = new Map(keyValues.split(',').map(pair => pair.split(':') as [string, string]));
+    // Markup that carries no start timestamp is not ours; leave the message untouched.
+    if (!values.has(KEY_START)) return { cleanText: text };
+
+    const cleanText = text.slice(fullMatch.length);
+    const ms = toMs(values.get(KEY_START));
+    if (ms === undefined) return { cleanText };
+
+    const endMs = toMs(values.get(KEY_END));
+    const target: AnnotationBadgeTargetType = {
+        timestamp: convertMillisecondsToTimestamp(ms),
+        type: AnnotationBadgeType.Frame,
+    };
+    return {
+        cleanText,
+        target,
+        // A range that does not move forward is not a range.
+        timestampEndMs: endMs !== undefined && endMs > ms ? endMs : undefined,
+        timestampMarkup: fullMatch.trimEnd(),
+        timestampMs: ms,
+    };
+};
+
+export const buildTimestampMarkup = ({
+    endMs,
+    startMs,
+    versionId,
+}: {
+    endMs?: number;
+    startMs: number;
+    versionId: string;
+}): string => {
+    const hasRange = endMs !== undefined && Number.isSafeInteger(endMs) && endMs > startMs;
+    const end = hasRange ? `,${KEY_END}:${endMs}` : '';
+    return `#[${KEY_START}:${startMs}${end},${KEY_VERSION_ID}:${versionId}]`;
+};

--- a/src/elements/content-sidebar/activity-feed-v2/transformers.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/transformers.ts
@@ -20,6 +20,7 @@ import type {
 } from '@box/threaded-annotations';
 
 import { convertMillisecondsToTimestamp } from '../../../utils/timestamp';
+import { extractTimestampMarkup } from './timestampMarkup';
 
 import type { Annotation, Target } from '../../../common/types/annotations';
 import type { AppActivityItem as BUIEAppActivityItem, Comment, FeedItem } from '../../../common/types/feed';
@@ -44,31 +45,6 @@ import {
 } from '../../../constants';
 
 const MENTION_REGEX = /@\[(\d+):([^\]]+)\]/g;
-const TIMESTAMP_MARKUP_REGEX = /^#\[timestamp:(\d+)(?:,versionId:\d+)?\]\s*/;
-
-export const extractTimestampMarkup = (
-    text: string,
-): {
-    cleanText: string;
-    target?: AnnotationBadgeTargetType;
-    timestampMarkup?: string;
-    timestampMs?: number;
-} => {
-    if (!text) return { cleanText: '' };
-    const match = text.match(TIMESTAMP_MARKUP_REGEX);
-    if (!match) return { cleanText: text };
-
-    const [fullMatch, timestampMs] = match;
-    const cleanText = text.slice(fullMatch.length);
-    const ms = Number(timestampMs);
-    if (!Number.isSafeInteger(ms) || ms < 0) return { cleanText };
-
-    const target: AnnotationBadgeTargetType = {
-        timestamp: convertMillisecondsToTimestamp(ms),
-        type: AnnotationBadgeType.Frame,
-    };
-    return { cleanText, target, timestampMarkup: fullMatch.trimEnd(), timestampMs: ms };
-};
 
 const parseLine = (line: string, authorId: string): (MentionNode | TextNode)[] => {
     const nodes: (MentionNode | TextNode)[] = [];
@@ -375,6 +351,7 @@ export const transformFeedItem = (
             const {
                 cleanText,
                 target: annotationTarget,
+                timestampEndMs,
                 timestampMarkup,
                 timestampMs,
             } = extractTimestampMarkup(rawText);
@@ -384,6 +361,7 @@ export const transformFeedItem = (
             );
             return {
                 annotationTarget,
+                annotationTimestampEndMs: timestampEndMs,
                 annotationTimestampMarkup: timestampMarkup,
                 annotationTimestampMs: timestampMs,
                 id: comment.id,

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -46,6 +46,8 @@ type ResolvedInfo = {
 
 export type TransformedCommentItem = {
     annotationTarget?: AnnotationBadgeTargetType;
+    // End of a comment's time range. Undefined for single-timestamp comments.
+    annotationTimestampEndMs?: number;
     annotationTimestampMarkup?: string;
     annotationTimestampMs?: number;
     id: string;

--- a/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
@@ -38,6 +38,8 @@ export interface UseMediaTimestampResult {
     formattedTimestamp: string;
     isPressed: boolean;
     onPressedChange: (pressed: boolean) => void;
+    /** End of the composer's selected range. Undefined until the user drags a waveform handle. */
+    timestampEndMs?: number;
     timestampMs: number;
 }
 


### PR DESCRIPTION
## Summary

Comment timestamps are not an API field: the value is written into the comment message as leading markup (`#[timestamp:8055,versionId:99] great take`) and parsed back out on render. This extends that markup so a comment can carry an optional end timestamp, `#[timestamp:8055,endTimestamp:12000,versionId:99]`, which is the serialization groundwork for audio comments that span a time range.

This is the serialization layer only — bytes to numbers. Nothing renders differently. A ranged comment now round-trips through the API and survives an edit, but the UI looks exactly as it does today.

- Parse an optional `endTimestamp` and surface it as `annotationTimestampEndMs` on the transformed comment item.
- Write `endTimestamp` on post when the composer holds a range.
- Preserve both boundaries verbatim through the edit path.

## Structural decision

The format previously lived as a single regex inside `transformers.ts`, with the write side as a template literal in `ActivityFeedV2.tsx`, so the two directions could drift. Both now live in a new `timestampMarkup.ts` that owns parsing and building, and the format is defined in exactly one place.

The parser no longer hardcodes the key sequence. It matches a generic `#[key:value,...]` block, splits it into a map, and requires only a `timestamp` key. Arbitrary key order and unknown keys both parse, so a future addition to this format does not require another migration of every consumer.

## Intentional choices

- **A non-forward range is not a range.** An end value that is missing, malformed, equal to the start, or before it collapses to a plain single timestamp on both read and write. The markup string itself is still preserved verbatim, so a malformed value written by another client is not destroyed on edit — it just does not surface as a range.
- **Markup that carries no start timestamp is left alone.** The generic block pattern could otherwise match and strip unrelated text like `#[foo:1] hello`, so a block without a `timestamp` key is treated as not ours and the message is returned untouched.
- **Output is byte-identical to today when there is no end value**, so video and undragged audio comments produce exactly the string they produce now.
- **The edit path needed no change.** It re-prepends the captured markup verbatim, and the parser now captures the whole block including `endTimestamp`, so both boundaries survive an edit. Added a test to pin that rather than leaving it implicit.
- **`timestampEndMs` is declared on `UseMediaTimestampResult` but not yet set by the hook.** It is `undefined` in production, so no end value can currently be written. That is the seam a follow-up fills when the waveform range handles are wired into composer state; the serialization layer is fully tested against ranges in the meantime.

Note for rollout: other clients parse this same markup and require a `]` immediately after `versionId`, so they need to tolerate the new key before ranges are written in production.

## Test plan

- [ ] On a video file, confirm posting with the timestamp toggle pressed produces the same markup as before and the badge still seeks.
- [ ] On an audio file with the audio player enabled, confirm the timestamp toggle, post, and badge click are unchanged.
- [ ] Edit an existing timestamped comment and confirm the badge survives the update.
- [ ] Confirm a comment whose message already contains range markup renders its text without leaking the markup.
- [ ] Confirm a plain comment containing bracket text such as `#[foo:1] hello` renders unchanged.