### PR TITLE
feat: add a new flag for fetching detailed extract metadata

### DIFF
--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -950,10 +950,14 @@ class Metadata extends File {
         instances: Array<MetadataInstanceV2>,
         globalTemplates: Array<MetadataTemplate>,
         enterpriseTemplates: Array<MetadataTemplate>,
-        shouldFetchDetailedExtractMeta: boolean,
     }> {
         const [instances, globalTemplates, enterpriseTemplates] = await Promise.all([
-            this.getInstances(id, isMetadataRedesign, isBoundingBoxOrConfidenceScoreReviewEnabled, shouldFetchDetailedExtractMeta),
+            this.getInstances(
+                id,
+                isMetadataRedesign,
+                isBoundingBoxOrConfidenceScoreReviewEnabled,
+                shouldFetchDetailedExtractMeta,
+            ),
             this.getTemplates(id, this.getScopeOrNamespace(METADATA_SCOPE_GLOBAL)),
             hasMetadataFeature ? this.getTemplates(id, METADATA_SCOPE_ENTERPRISE) : Promise.resolve([]),
         ]);
@@ -975,10 +979,14 @@ class Metadata extends File {
         instances: Array<MetadataInstanceV2>,
         globalTemplates: Array<MetadataTemplate>,
         enterpriseTemplates: Array<MetadataTemplate>,
-        shouldFetchDetailedExtractMeta: boolean,
     }> {
         const [instances, globalTemplates] = await Promise.all([
-            this.getInstances(id, isMetadataRedesign, isBoundingBoxOrConfidenceScoreReviewEnabled, shouldFetchDetailedExtractMeta),
+            this.getInstances(
+                id,
+                isMetadataRedesign,
+                isBoundingBoxOrConfidenceScoreReviewEnabled,
+                shouldFetchDetailedExtractMeta,
+            ),
             this.getTemplates(id, this.getScopeOrNamespace(METADATA_SCOPE_GLOBAL)),
         ]);
         const enterpriseNamespace = enterpriseFqn || resolveEnterpriseNamespaceFromInstances(instances);

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -622,19 +622,21 @@ class Metadata extends File {
      * @param {string} id - file id
      * @param {boolean} isMetadataRedesign - feature flag
      * @param {boolean} isBoundingBoxOrConfidenceScoreReviewEnabled - whether to fetch detailed view
+     * @param {boolean} shouldFetchDetailedExtractMeta - whether to fetch detailed view for extract metadata
      * @return {Object} array of metadata instances
      */
     async getInstances(
         id: string,
         isMetadataRedesign: boolean = false,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean = false,
+        shouldFetchDetailedExtractMeta: boolean = false,
     ): Promise<Array<MetadataInstanceV2>> {
         this.errorCode = ERROR_CODE_FETCH_METADATA;
 
         const baseUrl = this.getMetadataUrl(id);
         const requestId = getTypedFileId(id);
 
-        if (isMetadataRedesign && isBoundingBoxOrConfidenceScoreReviewEnabled) {
+        if (isMetadataRedesign && (isBoundingBoxOrConfidenceScoreReviewEnabled || shouldFetchDetailedExtractMeta)) {
             return this.getDetailedInstancesWithHydratedTaxonomy(baseUrl, requestId);
         }
 
@@ -943,13 +945,15 @@ class Metadata extends File {
         hasMetadataFeature: boolean,
         isMetadataRedesign: boolean,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean,
+        shouldFetchDetailedExtractMeta: boolean = false,
     ): Promise<{
         instances: Array<MetadataInstanceV2>,
         globalTemplates: Array<MetadataTemplate>,
         enterpriseTemplates: Array<MetadataTemplate>,
+        shouldFetchDetailedExtractMeta: boolean,
     }> {
         const [instances, globalTemplates, enterpriseTemplates] = await Promise.all([
-            this.getInstances(id, isMetadataRedesign, isBoundingBoxOrConfidenceScoreReviewEnabled),
+            this.getInstances(id, isMetadataRedesign, isBoundingBoxOrConfidenceScoreReviewEnabled, shouldFetchDetailedExtractMeta),
             this.getTemplates(id, this.getScopeOrNamespace(METADATA_SCOPE_GLOBAL)),
             hasMetadataFeature ? this.getTemplates(id, METADATA_SCOPE_ENTERPRISE) : Promise.resolve([]),
         ]);
@@ -966,13 +970,15 @@ class Metadata extends File {
         isMetadataRedesign: boolean,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean,
         enterpriseFqn?: string,
+        shouldFetchDetailedExtractMeta: boolean = false,
     ): Promise<{
         instances: Array<MetadataInstanceV2>,
         globalTemplates: Array<MetadataTemplate>,
         enterpriseTemplates: Array<MetadataTemplate>,
+        shouldFetchDetailedExtractMeta: boolean,
     }> {
         const [instances, globalTemplates] = await Promise.all([
-            this.getInstances(id, isMetadataRedesign, isBoundingBoxOrConfidenceScoreReviewEnabled),
+            this.getInstances(id, isMetadataRedesign, isBoundingBoxOrConfidenceScoreReviewEnabled, shouldFetchDetailedExtractMeta),
             this.getTemplates(id, this.getScopeOrNamespace(METADATA_SCOPE_GLOBAL)),
         ]);
         const enterpriseNamespace = enterpriseFqn || resolveEnterpriseNamespaceFromInstances(instances);
@@ -991,6 +997,7 @@ class Metadata extends File {
      * @param {Object} options - fetch options
      * @param {boolean} isMetadataRedesign - is Metadata Sidebar redesigned
      * @param {boolean} isBoundingBoxOrConfidenceScoreReviewEnabled - whether to include bounding box or confidence score details in the payload
+     * @param {boolean} shouldFetchDetailedExtractMeta - whether to fetch detailed view for extract metadata
      * @return {Promise}
      */
     async getMetadata(
@@ -1005,6 +1012,7 @@ class Metadata extends File {
         options: MetadataGetOptions = {},
         isMetadataRedesign: boolean = false,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean = false,
+        shouldFetchDetailedExtractMeta: boolean = false,
     ): Promise<void> {
         const { id, permissions, is_externally_owned }: BoxItem = file;
         this.errorCode = ERROR_CODE_FETCH_METADATA;
@@ -1051,12 +1059,14 @@ class Metadata extends File {
                           isMetadataRedesign,
                           isBoundingBoxOrConfidenceScoreReviewEnabled,
                           options.enterpriseFqn,
+                          shouldFetchDetailedExtractMeta,
                       )
                     : await this.fetchTemplatesAndInstancesScoped(
                           id,
                           hasMetadataFeature,
                           isMetadataRedesign,
                           isBoundingBoxOrConfidenceScoreReviewEnabled,
+                          shouldFetchDetailedExtractMeta,
                       );
 
             // Filter out classification

--- a/src/api/Metadata.js
+++ b/src/api/Metadata.js
@@ -622,21 +622,21 @@ class Metadata extends File {
      * @param {string} id - file id
      * @param {boolean} isMetadataRedesign - feature flag
      * @param {boolean} isBoundingBoxOrConfidenceScoreReviewEnabled - whether to fetch detailed view
-     * @param {boolean} shouldFetchDetailedExtractMeta - whether to fetch detailed view for extract metadata
+     * @param {boolean} shouldFetchDetailedMetadata - whether to fetch the detailed metadata view
      * @return {Object} array of metadata instances
      */
     async getInstances(
         id: string,
         isMetadataRedesign: boolean = false,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean = false,
-        shouldFetchDetailedExtractMeta: boolean = false,
+        shouldFetchDetailedMetadata: boolean = false,
     ): Promise<Array<MetadataInstanceV2>> {
         this.errorCode = ERROR_CODE_FETCH_METADATA;
 
         const baseUrl = this.getMetadataUrl(id);
         const requestId = getTypedFileId(id);
 
-        if (isMetadataRedesign && (isBoundingBoxOrConfidenceScoreReviewEnabled || shouldFetchDetailedExtractMeta)) {
+        if (isMetadataRedesign && (isBoundingBoxOrConfidenceScoreReviewEnabled || shouldFetchDetailedMetadata)) {
             return this.getDetailedInstancesWithHydratedTaxonomy(baseUrl, requestId);
         }
 
@@ -945,7 +945,7 @@ class Metadata extends File {
         hasMetadataFeature: boolean,
         isMetadataRedesign: boolean,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean,
-        shouldFetchDetailedExtractMeta: boolean = false,
+        shouldFetchDetailedMetadata: boolean = false,
     ): Promise<{
         instances: Array<MetadataInstanceV2>,
         globalTemplates: Array<MetadataTemplate>,
@@ -956,7 +956,7 @@ class Metadata extends File {
                 id,
                 isMetadataRedesign,
                 isBoundingBoxOrConfidenceScoreReviewEnabled,
-                shouldFetchDetailedExtractMeta,
+                shouldFetchDetailedMetadata,
             ),
             this.getTemplates(id, this.getScopeOrNamespace(METADATA_SCOPE_GLOBAL)),
             hasMetadataFeature ? this.getTemplates(id, METADATA_SCOPE_ENTERPRISE) : Promise.resolve([]),
@@ -974,7 +974,7 @@ class Metadata extends File {
         isMetadataRedesign: boolean,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean,
         enterpriseFqn?: string,
-        shouldFetchDetailedExtractMeta: boolean = false,
+        shouldFetchDetailedMetadata: boolean = false,
     ): Promise<{
         instances: Array<MetadataInstanceV2>,
         globalTemplates: Array<MetadataTemplate>,
@@ -985,7 +985,7 @@ class Metadata extends File {
                 id,
                 isMetadataRedesign,
                 isBoundingBoxOrConfidenceScoreReviewEnabled,
-                shouldFetchDetailedExtractMeta,
+                shouldFetchDetailedMetadata,
             ),
             this.getTemplates(id, this.getScopeOrNamespace(METADATA_SCOPE_GLOBAL)),
         ]);
@@ -1005,7 +1005,7 @@ class Metadata extends File {
      * @param {Object} options - fetch options
      * @param {boolean} isMetadataRedesign - is Metadata Sidebar redesigned
      * @param {boolean} isBoundingBoxOrConfidenceScoreReviewEnabled - whether to include bounding box or confidence score details in the payload
-     * @param {boolean} shouldFetchDetailedExtractMeta - whether to fetch detailed view for extract metadata
+     * @param {boolean} shouldFetchDetailedMetadata - whether to fetch the detailed metadata view
      * @return {Promise}
      */
     async getMetadata(
@@ -1020,7 +1020,7 @@ class Metadata extends File {
         options: MetadataGetOptions = {},
         isMetadataRedesign: boolean = false,
         isBoundingBoxOrConfidenceScoreReviewEnabled: boolean = false,
-        shouldFetchDetailedExtractMeta: boolean = false,
+        shouldFetchDetailedMetadata: boolean = false,
     ): Promise<void> {
         const { id, permissions, is_externally_owned }: BoxItem = file;
         this.errorCode = ERROR_CODE_FETCH_METADATA;
@@ -1067,14 +1067,14 @@ class Metadata extends File {
                           isMetadataRedesign,
                           isBoundingBoxOrConfidenceScoreReviewEnabled,
                           options.enterpriseFqn,
-                          shouldFetchDetailedExtractMeta,
+                          shouldFetchDetailedMetadata,
                       )
                     : await this.fetchTemplatesAndInstancesScoped(
                           id,
                           hasMetadataFeature,
                           isMetadataRedesign,
                           isBoundingBoxOrConfidenceScoreReviewEnabled,
-                          shouldFetchDetailedExtractMeta,
+                          shouldFetchDetailedMetadata,
                       );
 
             // Filter out classification

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -1000,6 +1000,27 @@ describe('api/Metadata', () => {
                 id: 'file_id',
             });
         });
+
+        test('should fetch detailed view when isMetadataRedesign, isBoundingBoxOrConfidenceScoreReviewEnabled and shouldFetchDetailedMetadata are all true', async () => {
+            metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
+            metadata.getDetailedInstancesWithHydratedTaxonomy = jest.fn().mockResolvedValueOnce([]);
+            await metadata.getInstances('id', true, true, true);
+            expect(metadata.getDetailedInstancesWithHydratedTaxonomy).toHaveBeenCalledWith('metadata_url', 'file_id');
+        });
+
+        test('should not fetch detailed view when isMetadataRedesign is false even if isBoundingBoxOrConfidenceScoreReviewEnabled and shouldFetchDetailedMetadata are true', async () => {
+            metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
+            metadata.xhr.get = jest.fn().mockReturnValueOnce({
+                data: {
+                    entries: [],
+                },
+            });
+            await metadata.getInstances('id', false, true, true);
+            expect(metadata.xhr.get).toHaveBeenCalledWith({
+                url: 'metadata_url',
+                id: 'file_id',
+            });
+        });
     });
 
     describe('getUserAddableTemplates()', () => {
@@ -1657,6 +1678,33 @@ describe('api/Metadata', () => {
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, {}, true, false, true);
 
             expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true, false, true);
+        });
+
+        test('should pass isBoundingBoxOrConfidenceScoreReviewEnabled and shouldFetchDetailedMetadata to getInstances when both are true', async () => {
+            const file = {
+                id: 'id',
+                is_externally_owned: false,
+                permissions: { can_upload: true },
+            };
+
+            const cache = new Cache();
+
+            metadata.errorHandler = jest.fn();
+            metadata.successHandler = jest.fn();
+            metadata.isDestroyed = jest.fn().mockReturnValueOnce(false);
+            metadata.getCache = jest.fn().mockReturnValueOnce(cache);
+            metadata.getMetadataCacheKey = jest.fn().mockReturnValueOnce('cache_id_metadata');
+            metadata.getInstances = jest.fn().mockResolvedValueOnce('instances');
+            metadata.getEditors = jest.fn().mockResolvedValueOnce('editors');
+            metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
+            metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
+            metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
+
+            await metadata.getMetadata(file, jest.fn(), jest.fn(), true, {}, true, true, true);
+
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true, true, true);
         });
 
         test('should make request and update cache and call success handler after returning cached value when refreshCache is true', async () => {

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -980,14 +980,14 @@ describe('api/Metadata', () => {
             });
         });
 
-        test('should make both detailed and hydrated calls when isMetadataRedesign and shouldFetchDetailedExtractMeta are true', async () => {
+        test('should make both detailed and hydrated calls when isMetadataRedesign and shouldFetchDetailedMetadata are true', async () => {
             metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
             metadata.getDetailedInstancesWithHydratedTaxonomy = jest.fn().mockResolvedValueOnce([]);
             await metadata.getInstances('id', true, false, true);
             expect(metadata.getDetailedInstancesWithHydratedTaxonomy).toHaveBeenCalledWith('metadata_url', 'file_id');
         });
 
-        test('should not fetch detailed view when isMetadataRedesign is false even if shouldFetchDetailedExtractMeta is true', async () => {
+        test('should not fetch detailed view when isMetadataRedesign is false even if shouldFetchDetailedMetadata is true', async () => {
             metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
             metadata.xhr.get = jest.fn().mockReturnValueOnce({
                 data: {
@@ -1632,7 +1632,7 @@ describe('api/Metadata', () => {
             );
         });
 
-        test('should pass shouldFetchDetailedExtractMeta to getInstances when true', async () => {
+        test('should pass shouldFetchDetailedMetadata to getInstances when true', async () => {
             const file = {
                 id: 'id',
                 is_externally_owned: false,

--- a/src/api/__tests__/Metadata.test.js
+++ b/src/api/__tests__/Metadata.test.js
@@ -979,6 +979,27 @@ describe('api/Metadata', () => {
                 id: 'file_id',
             });
         });
+
+        test('should make both detailed and hydrated calls when isMetadataRedesign and shouldFetchDetailedExtractMeta are true', async () => {
+            metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
+            metadata.getDetailedInstancesWithHydratedTaxonomy = jest.fn().mockResolvedValueOnce([]);
+            await metadata.getInstances('id', true, false, true);
+            expect(metadata.getDetailedInstancesWithHydratedTaxonomy).toHaveBeenCalledWith('metadata_url', 'file_id');
+        });
+
+        test('should not fetch detailed view when isMetadataRedesign is false even if shouldFetchDetailedExtractMeta is true', async () => {
+            metadata.getMetadataUrl = jest.fn().mockReturnValueOnce('metadata_url');
+            metadata.xhr.get = jest.fn().mockReturnValueOnce({
+                data: {
+                    entries: [],
+                },
+            });
+            await metadata.getInstances('id', false, false, true);
+            expect(metadata.xhr.get).toHaveBeenCalledWith({
+                url: 'metadata_url',
+                id: 'file_id',
+            });
+        });
     });
 
     describe('getUserAddableTemplates()', () => {
@@ -1444,7 +1465,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -1544,7 +1565,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true, false);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true, false, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -1598,7 +1619,7 @@ describe('api/Metadata', () => {
             // isMetadataRedesign=true, isConfidenceScoreEnabled=true
             await metadata.getMetadata(file, jest.fn(), jest.fn(), true, {}, true, true);
 
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true, true);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true, true, false);
             expect(metadata.getTemplateInstances).toHaveBeenCalledWith(
                 file.id,
                 'filteredInstances',
@@ -1609,6 +1630,33 @@ describe('api/Metadata', () => {
                 true,
                 undefined,
             );
+        });
+
+        test('should pass shouldFetchDetailedExtractMeta to getInstances when true', async () => {
+            const file = {
+                id: 'id',
+                is_externally_owned: false,
+                permissions: { can_upload: true },
+            };
+
+            const cache = new Cache();
+
+            metadata.errorHandler = jest.fn();
+            metadata.successHandler = jest.fn();
+            metadata.isDestroyed = jest.fn().mockReturnValueOnce(false);
+            metadata.getCache = jest.fn().mockReturnValueOnce(cache);
+            metadata.getMetadataCacheKey = jest.fn().mockReturnValueOnce('cache_id_metadata');
+            metadata.getInstances = jest.fn().mockResolvedValueOnce('instances');
+            metadata.getEditors = jest.fn().mockResolvedValueOnce('editors');
+            metadata.getTemplateInstances = jest.fn().mockResolvedValueOnce('templateInstances');
+            metadata.getCustomPropertiesTemplate = jest.fn().mockReturnValueOnce('custom');
+            metadata.getUserAddableTemplates = jest.fn().mockReturnValueOnce('templates');
+            metadata.getTemplates = jest.fn().mockResolvedValueOnce('global').mockResolvedValueOnce('enterprise');
+            metadata.extractClassification = jest.fn().mockReturnValueOnce('filteredInstances');
+
+            await metadata.getMetadata(file, jest.fn(), jest.fn(), true, {}, true, false, true);
+
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, true, false, true);
         });
 
         test('should make request and update cache and call success handler after returning cached value when refreshCache is true', async () => {
@@ -1641,7 +1689,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -1700,7 +1748,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -1758,7 +1806,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).not.toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');
@@ -1814,7 +1862,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).not.toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.getEditors).not.toHaveBeenCalled();
@@ -1854,7 +1902,7 @@ describe('api/Metadata', () => {
             expect(metadata.isDestroyed).toHaveBeenCalled();
             expect(metadata.getCache).toHaveBeenCalled();
             expect(metadata.getMetadataCacheKey).toHaveBeenCalledWith(file.id);
-            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false);
+            expect(metadata.getInstances).toHaveBeenCalledWith(file.id, false, false, false);
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'global');
             expect(metadata.getTemplates).toHaveBeenCalledWith(file.id, 'enterprise');
             expect(metadata.extractClassification).toBeCalledWith('id', 'instances');

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -165,6 +165,7 @@ function MetadataSidebarRedesign({
 
     const isConfidenceScoreReviewEnabled: boolean = useFeatureEnabled('metadata.confidenceScore.enabled');
     const isBoundingBoxEnabled = useFeatureEnabled('metadata.boundingBox.enabled');
+    const shouldFetchDetailedExtractMeta: boolean = useFeatureEnabled('metadata.fetchDetailedExtractMeta.enabled');
 
     const isBoundingBoxOrConfidenceScoreReviewEnabled = isBoundingBoxEnabled || isConfidenceScoreReviewEnabled;
 
@@ -204,6 +205,7 @@ function MetadataSidebarRedesign({
             isLoading: isNamespaceContextLoading,
             metadataNamespaceMode,
         },
+        shouldFetchDetailedExtractMeta,
     );
     const isSessionInitiated = useRef(false);
 

--- a/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
+++ b/src/elements/content-sidebar/MetadataSidebarRedesign.tsx
@@ -165,7 +165,7 @@ function MetadataSidebarRedesign({
 
     const isConfidenceScoreReviewEnabled: boolean = useFeatureEnabled('metadata.confidenceScore.enabled');
     const isBoundingBoxEnabled = useFeatureEnabled('metadata.boundingBox.enabled');
-    const shouldFetchDetailedExtractMeta: boolean = useFeatureEnabled('metadata.fetchDetailedExtractMeta.enabled');
+    const shouldFetchDetailedMetadata: boolean = useFeatureEnabled('metadata.fetchDetailedMetadata.enabled');
 
     const isBoundingBoxOrConfidenceScoreReviewEnabled = isBoundingBoxEnabled || isConfidenceScoreReviewEnabled;
 
@@ -205,7 +205,7 @@ function MetadataSidebarRedesign({
             isLoading: isNamespaceContextLoading,
             metadataNamespaceMode,
         },
-        shouldFetchDetailedExtractMeta,
+        shouldFetchDetailedMetadata,
     );
     const isSessionInitiated = useRef(false);
 

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -670,7 +670,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             true, // isConfidenceScoreReviewEnabled
             false, // isBoundingBoxEnabled
             { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
-            false, // shouldFetchDetailedExtractMeta
+            false, // shouldFetchDetailedMetadata
         );
     });
 
@@ -702,7 +702,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             false, // isConfidenceScoreReviewEnabled
             true, // isBoundingBoxEnabled
             { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
-            false, // shouldFetchDetailedExtractMeta
+            false, // shouldFetchDetailedMetadata
         );
     });
 
@@ -722,8 +722,8 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         );
     });
 
-    test('should pass shouldFetchDetailedExtractMeta to useSidebarMetadataFetcher', () => {
-        renderComponent({}, { 'metadata.fetchDetailedExtractMeta.enabled': true });
+    test('should pass shouldFetchDetailedMetadata to useSidebarMetadataFetcher', () => {
+        renderComponent({}, { 'metadata.fetchDetailedMetadata.enabled': true });
 
         expect(mockUseSidebarMetadataFetcher).toHaveBeenCalledWith(
             expect.anything(), // api
@@ -734,12 +734,12 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             false, // isConfidenceScoreReviewEnabled
             false, // isBoundingBoxEnabled
             { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
-            true, // shouldFetchDetailedExtractMeta
+            true, // shouldFetchDetailedMetadata
         );
     });
 
-    test('should pass shouldFetchDetailedExtractMeta=false when feature flag is off', () => {
-        renderComponent({}, { 'metadata.fetchDetailedExtractMeta.enabled': false });
+    test('should pass shouldFetchDetailedMetadata=false when feature flag is off', () => {
+        renderComponent({}, { 'metadata.fetchDetailedMetadata.enabled': false });
 
         expect(mockUseSidebarMetadataFetcher).toHaveBeenCalledWith(
             expect.anything(),

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -733,6 +733,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             expect.anything(), // isFeatureEnabled
             false, // isConfidenceScoreReviewEnabled
             false, // isBoundingBoxEnabled
+            { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
             true, // shouldFetchDetailedExtractMeta
         );
     });
@@ -748,6 +749,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             expect.anything(),
             false,
             false,
+            { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
             false,
         );
     });

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -754,6 +754,41 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
         );
     });
 
+    test('should pass isBoundingBoxEnabled and shouldFetchDetailedMetadata to useSidebarMetadataFetcher when both flags are on', () => {
+        renderComponent({}, { 'metadata.boundingBox.enabled': true, 'metadata.fetchDetailedMetadata.enabled': true });
+
+        expect(mockUseSidebarMetadataFetcher).toHaveBeenCalledWith(
+            expect.anything(), // api
+            expect.anything(), // fileId
+            expect.anything(), // onError
+            expect.anything(), // onSuccess
+            expect.anything(), // isFeatureEnabled
+            false, // isConfidenceScoreReviewEnabled
+            true, // isBoundingBoxEnabled
+            { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
+            true, // shouldFetchDetailedMetadata
+        );
+    });
+
+    test('should pass isConfidenceScoreReviewEnabled and shouldFetchDetailedMetadata to useSidebarMetadataFetcher when both flags are on', () => {
+        renderComponent(
+            {},
+            { 'metadata.confidenceScore.enabled': true, 'metadata.fetchDetailedMetadata.enabled': true },
+        );
+
+        expect(mockUseSidebarMetadataFetcher).toHaveBeenCalledWith(
+            expect.anything(), // api
+            expect.anything(), // fileId
+            expect.anything(), // onError
+            expect.anything(), // onSuccess
+            expect.anything(), // isFeatureEnabled
+            true, // isConfidenceScoreReviewEnabled
+            false, // isBoundingBoxEnabled
+            { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
+            true, // shouldFetchDetailedMetadata
+        );
+    });
+
     test('should call createSessionRequest once', async () => {
         const createSessionRequest = jest.fn().mockResolvedValue({});
         renderComponent({ api, createSessionRequest }, { 'metadata.aiSuggestions.enabled': true });

--- a/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
+++ b/src/elements/content-sidebar/__tests__/MetadataSidebarRedesign.test.tsx
@@ -670,6 +670,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             true, // isConfidenceScoreReviewEnabled
             false, // isBoundingBoxEnabled
             { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
+            false, // shouldFetchDetailedExtractMeta
         );
     });
 
@@ -685,6 +686,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             false,
             false,
             { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
+            false,
         );
     });
 
@@ -700,6 +702,7 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             false, // isConfidenceScoreReviewEnabled
             true, // isBoundingBoxEnabled
             { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
+            false, // shouldFetchDetailedExtractMeta
         );
     });
 
@@ -715,6 +718,37 @@ describe('elements/content-sidebar/Metadata/MetadataSidebarRedesign', () => {
             false,
             false,
             { enterpriseFqn: undefined, isLoading: false, metadataNamespaceMode: null },
+            false,
+        );
+    });
+
+    test('should pass shouldFetchDetailedExtractMeta to useSidebarMetadataFetcher', () => {
+        renderComponent({}, { 'metadata.fetchDetailedExtractMeta.enabled': true });
+
+        expect(mockUseSidebarMetadataFetcher).toHaveBeenCalledWith(
+            expect.anything(), // api
+            expect.anything(), // fileId
+            expect.anything(), // onError
+            expect.anything(), // onSuccess
+            expect.anything(), // isFeatureEnabled
+            false, // isConfidenceScoreReviewEnabled
+            false, // isBoundingBoxEnabled
+            true, // shouldFetchDetailedExtractMeta
+        );
+    });
+
+    test('should pass shouldFetchDetailedExtractMeta=false when feature flag is off', () => {
+        renderComponent({}, { 'metadata.fetchDetailedExtractMeta.enabled': false });
+
+        expect(mockUseSidebarMetadataFetcher).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            expect.anything(),
+            expect.anything(),
+            expect.anything(),
+            false,
+            false,
+            false,
         );
     });
 

--- a/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
+++ b/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
@@ -451,7 +451,7 @@ describe('useSidebarMetadataFetcher', () => {
     });
 
     test('should pass shouldFetchDetailedExtractMeta=true to getMetadata when enabled', async () => {
-        const { result } = setupHook('123', false, false, true);
+        const { result } = setupHook('123', false, false, {}, true);
 
         await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
 
@@ -1060,6 +1060,7 @@ describe('useSidebarMetadataFetcher', () => {
             isFeatureEnabledMock,
             { refreshCache: true, enterpriseFqn: 'enterprise_123', metadataNamespaceMode: 'MIGRATION' },
             true,
+            false,
             false,
         );
     });

--- a/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
+++ b/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
@@ -174,7 +174,7 @@ describe('useSidebarMetadataFetcher', () => {
         isConfidenceScoreEnabled = false,
         isBoundingBoxEnabled = false,
         namespaceContext: MetadataNamespaceFetchContext = {},
-        shouldFetchDetailedExtractMeta = false,
+        shouldFetchDetailedMetadata = false,
     ) =>
         renderHook(() =>
             useSidebarMetadataFetcher(
@@ -186,7 +186,7 @@ describe('useSidebarMetadataFetcher', () => {
                 isConfidenceScoreEnabled,
                 isBoundingBoxEnabled,
                 namespaceContext,
-                shouldFetchDetailedExtractMeta,
+                shouldFetchDetailedMetadata,
             ),
         );
 
@@ -450,7 +450,7 @@ describe('useSidebarMetadataFetcher', () => {
         );
     });
 
-    test('should pass shouldFetchDetailedExtractMeta=true to getMetadata when enabled', async () => {
+    test('should pass shouldFetchDetailedMetadata=true to getMetadata when enabled', async () => {
         const { result } = setupHook('123', false, false, {}, true);
 
         await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));

--- a/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
+++ b/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
@@ -467,6 +467,40 @@ describe('useSidebarMetadataFetcher', () => {
         );
     });
 
+    test('should pass true to getMetadata when isBoundingBoxEnabled and shouldFetchDetailedMetadata are true', async () => {
+        const { result } = setupHook('123', false, true, {}, true);
+
+        await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
+
+        expect(mockAPI.getMetadata).toHaveBeenCalledWith(
+            mockFile,
+            expect.any(Function),
+            expect.any(Function),
+            isFeatureEnabledMock,
+            { refreshCache: true },
+            true,
+            true,
+            true,
+        );
+    });
+
+    test('should pass true to getMetadata when isConfidenceScoreEnabled and shouldFetchDetailedMetadata are true', async () => {
+        const { result } = setupHook('123', true, false, {}, true);
+
+        await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
+
+        expect(mockAPI.getMetadata).toHaveBeenCalledWith(
+            mockFile,
+            expect.any(Function),
+            expect.any(Function),
+            isFeatureEnabledMock,
+            { refreshCache: true },
+            true,
+            true,
+            true,
+        );
+    });
+
     describe('extractSuggestions', () => {
         test('should extract suggestions successfully', async () => {
             mockAPI.extractStructured.mockResolvedValue({

--- a/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
+++ b/src/elements/content-sidebar/__tests__/useSidebarMetadataFetcher.test.tsx
@@ -174,6 +174,7 @@ describe('useSidebarMetadataFetcher', () => {
         isConfidenceScoreEnabled = false,
         isBoundingBoxEnabled = false,
         namespaceContext: MetadataNamespaceFetchContext = {},
+        shouldFetchDetailedExtractMeta = false,
     ) =>
         renderHook(() =>
             useSidebarMetadataFetcher(
@@ -185,6 +186,7 @@ describe('useSidebarMetadataFetcher', () => {
                 isConfidenceScoreEnabled,
                 isBoundingBoxEnabled,
                 namespaceContext,
+                shouldFetchDetailedExtractMeta,
             ),
         );
 
@@ -410,6 +412,7 @@ describe('useSidebarMetadataFetcher', () => {
             { refreshCache: true },
             true,
             true,
+            false,
         );
     });
 
@@ -426,6 +429,7 @@ describe('useSidebarMetadataFetcher', () => {
             { refreshCache: true },
             true,
             false,
+            false,
         );
     });
 
@@ -441,6 +445,24 @@ describe('useSidebarMetadataFetcher', () => {
             isFeatureEnabledMock,
             { refreshCache: true },
             true,
+            true,
+            false,
+        );
+    });
+
+    test('should pass shouldFetchDetailedExtractMeta=true to getMetadata when enabled', async () => {
+        const { result } = setupHook('123', false, false, true);
+
+        await waitFor(() => expect(result.current.status).toBe(STATUS.SUCCESS));
+
+        expect(mockAPI.getMetadata).toHaveBeenCalledWith(
+            mockFile,
+            expect.any(Function),
+            expect.any(Function),
+            isFeatureEnabledMock,
+            { refreshCache: true },
+            true,
+            false,
             true,
         );
     });

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -84,6 +84,7 @@ function useSidebarMetadataFetcher(
     isConfidenceScoreEnabled: boolean = false,
     isBoundingBoxEnabled: boolean = false,
     namespaceContext: MetadataNamespaceFetchContext = {},
+    shouldFetchDetailedExtractMeta: boolean = false,
 ): DataFetcher {
     const { enterpriseFqn, isLoading: isNamespaceContextLoading, metadataNamespaceMode } = namespaceContext;
     const [status, setStatus] = React.useState<STATUS>(STATUS.IDLE);
@@ -148,6 +149,7 @@ function useSidebarMetadataFetcher(
                 },
                 true,
                 isBoundingBoxOrConfidenceScoreReviewEnabled,
+                shouldFetchDetailedExtractMeta,
             );
         },
         [
@@ -158,6 +160,7 @@ function useSidebarMetadataFetcher(
             isFeatureEnabled,
             isBoundingBoxOrConfidenceScoreReviewEnabled,
             metadataNamespaceMode,
+            shouldFetchDetailedExtractMeta,
         ],
     );
 

--- a/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
+++ b/src/elements/content-sidebar/hooks/useSidebarMetadataFetcher.ts
@@ -84,7 +84,7 @@ function useSidebarMetadataFetcher(
     isConfidenceScoreEnabled: boolean = false,
     isBoundingBoxEnabled: boolean = false,
     namespaceContext: MetadataNamespaceFetchContext = {},
-    shouldFetchDetailedExtractMeta: boolean = false,
+    shouldFetchDetailedMetadata: boolean = false,
 ): DataFetcher {
     const { enterpriseFqn, isLoading: isNamespaceContextLoading, metadataNamespaceMode } = namespaceContext;
     const [status, setStatus] = React.useState<STATUS>(STATUS.IDLE);
@@ -149,7 +149,7 @@ function useSidebarMetadataFetcher(
                 },
                 true,
                 isBoundingBoxOrConfidenceScoreReviewEnabled,
-                shouldFetchDetailedExtractMeta,
+                shouldFetchDetailedMetadata,
             );
         },
         [
@@ -160,7 +160,7 @@ function useSidebarMetadataFetcher(
             isFeatureEnabled,
             isBoundingBoxOrConfidenceScoreReviewEnabled,
             metadataNamespaceMode,
-            shouldFetchDetailedExtractMeta,
+            shouldFetchDetailedMetadata,
         ],
     );
 


### PR DESCRIPTION
### Summary

Added a new flag `fetchDetailedExtractMeta` that enables fetching of the detailed metadata via `/metadata?view=detailed` (`getDetailedInstancesWithHydratedTaxonomy`). This ensures more granular control over detailed metadata fields requests.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving more detailed metadata in the redesigned metadata sidebar.
  - Detailed metadata can be enabled through the `metadata.fetchDetailedMetadata` feature flag.
  - When enabled, metadata results include expanded taxonomy details for supported reviews.
  - Metadata automatically refreshes when the feature setting changes.

- **Tests**
  - Added coverage for enabled and disabled detailed metadata behavior across metadata retrieval and sidebar workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->