### PR TITLE
feat(activity-feed-v2): support selecting a time range for audio comments

### DIFF
--- a/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/ActivityFeedV2.tsx
@@ -381,9 +381,9 @@ const ActivityFeedV2 = ({
     const isVideo = file?.extension ? FILE_EXTENSIONS.video.includes(file.extension) : false;
     const isAudio = file?.extension ? FILE_EXTENSIONS.audio.includes(file.extension) : false;
     const fileVersionId = file?.file_version?.id;
+    const isAudioPlayerV2 = isAudio && isAudioPlayerV2Enabled;
     const allowVideoTimestamps = isVideo && isTimestampedCommentsEnabled && Boolean(fileVersionId);
-    const allowAudioTimestamps =
-        isAudio && isTimestampedCommentsEnabled && isAudioPlayerV2Enabled && Boolean(fileVersionId);
+    const allowAudioTimestamps = isAudioPlayerV2 && isTimestampedCommentsEnabled && Boolean(fileVersionId);
     const allowMediaTimestamps = allowVideoTimestamps || allowAudioTimestamps;
     const { timeFormat, fps } = useTimeFormat(isVideo);
 
@@ -391,15 +391,19 @@ const ActivityFeedV2 = ({
         formattedTimestamp,
         isPressed: isTimestampPressed,
         onPressedChange,
+        resetRange,
         timestampEndMs,
         timestampMs,
-    } = useMediaTimestamp(allowMediaTimestamps, timeFormat, fps);
+    } = useMediaTimestamp(allowMediaTimestamps, timeFormat, fps, {
+        getViewer,
+        isAudioPlayerV2,
+    });
 
     const editorMediaTimestamp = allowMediaTimestamps
         ? { formattedTimestamp, isPressed: isTimestampPressed, onPressedChange }
         : undefined;
 
-    const allowCommentMarkers = isVideo || (isAudio && isAudioPlayerV2Enabled);
+    const allowCommentMarkers = isVideo || isAudioPlayerV2;
 
     React.useEffect(() => {
         if (!getViewer || !allowCommentMarkers) return undefined;
@@ -479,6 +483,7 @@ const ActivityFeedV2 = ({
                 const snapshot = new Set(filteredItems.map(item => item.id));
                 await onCommentCreate(text, serialized.hasMention);
                 knownIdsBeforePostRef.current = snapshot;
+                resetRange();
             } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error('ActivityFeedV2: failed to post comment', error);
@@ -491,6 +496,7 @@ const ActivityFeedV2 = ({
             isRichTextEnabled,
             isTimestampPressed,
             onCommentCreate,
+            resetRange,
             timestampEndMs,
             timestampMs,
         ],

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/ActivityFeedV2.test.tsx
@@ -1149,6 +1149,169 @@ describe('elements/content-sidebar/activity-feed-v2/ActivityFeedV2', () => {
         });
     });
 
+    describe('audio comment ranges', () => {
+        const mountAudio = (currentTime: number = 0) => {
+            const container = document.createElement('div');
+            container.className = 'bp-media-container';
+            const media = document.createElement('audio');
+            Object.defineProperty(media, 'currentTime', { configurable: true, value: currentTime, writable: true });
+            Object.defineProperty(media, 'paused', { configurable: true, value: true, writable: true });
+            media.pause = jest.fn();
+            container.appendChild(media);
+            document.body.appendChild(container);
+            return { cleanup: () => container.remove(), media };
+        };
+
+        const createRangeViewer = () => {
+            const listeners: Record<string, ((payload: unknown) => void) | undefined> = {};
+            const viewer = {
+                addListener: jest.fn((event: string, handler: (payload: unknown) => void) => {
+                    listeners[event] = handler;
+                }),
+                emit: jest.fn(),
+                removeListener: jest.fn((event: string) => {
+                    delete listeners[event];
+                }),
+            };
+            return {
+                commitDrag: (payload: unknown) => listeners.comment_range_draft_change?.(payload),
+                getViewer: () => viewer,
+                rangeEmits: () =>
+                    viewer.emit.mock.calls.filter(([event]) => String(event).startsWith('comment_range_draft')),
+                viewer,
+            };
+        };
+
+        const audioFile = { extension: 'mp3', file_version: { id: '99' }, permissions: { can_comment: true } };
+        const videoFile = { extension: 'mp4', file_version: { id: '99' }, permissions: { can_comment: true } };
+
+        test('should ask the viewer for handles when the audio toggle is pressed', async () => {
+            const { cleanup, media } = mountAudio();
+            const { getViewer, rangeEmits } = createRangeViewer();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={audioFile}
+                        getViewer={getViewer}
+                        isAudioPlayerV2Enabled
+                        isTimestampedCommentsEnabled
+                    />,
+                );
+                Object.defineProperty(media, 'currentTime', { configurable: true, value: 8.055, writable: true });
+                await act(async () => {
+                    lastEditorProps.videoTimestamp?.onPressedChange(true);
+                });
+
+                expect(rangeEmits()).toEqual([['comment_range_draft', { endMs: null, startMs: 8055 }]]);
+            } finally {
+                cleanup();
+            }
+        });
+
+        test('should never ask for handles on a video file', async () => {
+            const { cleanup, media } = mountAudio();
+            const { getViewer, rangeEmits } = createRangeViewer();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={videoFile}
+                        getViewer={getViewer}
+                        isAudioPlayerV2Enabled
+                        isTimestampedCommentsEnabled
+                    />,
+                );
+                Object.defineProperty(media, 'currentTime', { configurable: true, value: 8.055, writable: true });
+                await act(async () => {
+                    lastEditorProps.videoTimestamp?.onPressedChange(true);
+                });
+
+                expect(rangeEmits()).toEqual([]);
+            } finally {
+                cleanup();
+            }
+        });
+
+        test('should post range markup after a handle drag commits', async () => {
+            const { cleanup, media } = mountAudio();
+            const { commitDrag, getViewer } = createRangeViewer();
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: 'great take' });
+            const onCommentCreate = jest.fn();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={audioFile}
+                        getViewer={getViewer}
+                        isAudioPlayerV2Enabled
+                        isTimestampedCommentsEnabled
+                        onCommentCreate={onCommentCreate}
+                    />,
+                );
+                Object.defineProperty(media, 'currentTime', { configurable: true, value: 8.055, writable: true });
+                await act(async () => {
+                    lastEditorProps.videoTimestamp?.onPressedChange(true);
+                });
+                await act(async () => {
+                    commitDrag({ endMs: 12000, startMs: 8055 });
+                });
+                await act(async () => {
+                    await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+                });
+
+                expect(onCommentCreate).toHaveBeenCalledWith(
+                    '#[timestamp:8055,endTimestamp:12000,versionId:99] great take',
+                    false,
+                );
+            } finally {
+                cleanup();
+            }
+        });
+
+        test('should drop the range back to a single timestamp after a successful post', async () => {
+            const { cleanup, media } = mountAudio();
+            const { commitDrag, getViewer, rangeEmits } = createRangeViewer();
+            mockSerializeMentionMarkup.mockReturnValue({ hasMention: false, text: 'great take' });
+            const onCommentCreate = jest.fn();
+            try {
+                render(
+                    <ActivityFeedV2
+                        currentUser={mockCurrentUser}
+                        feedItems={[] as ActivityFeedV2Props['feedItems']}
+                        file={audioFile}
+                        getViewer={getViewer}
+                        isAudioPlayerV2Enabled
+                        isTimestampedCommentsEnabled
+                        onCommentCreate={onCommentCreate}
+                    />,
+                );
+                Object.defineProperty(media, 'currentTime', { configurable: true, value: 8.055, writable: true });
+                await act(async () => {
+                    lastEditorProps.videoTimestamp?.onPressedChange(true);
+                });
+                await act(async () => {
+                    commitDrag({ endMs: 12000, startMs: 8055 });
+                });
+                await act(async () => {
+                    await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+                });
+                onCommentCreate.mockClear();
+                await act(async () => {
+                    await lastEditorProps.onPost?.({ type: 'doc', content: [] });
+                });
+
+                expect(rangeEmits().pop()).toEqual(['comment_range_draft', { endMs: null, startMs: 8055 }]);
+                expect(onCommentCreate).toHaveBeenCalledWith('#[timestamp:8055,versionId:99] great take', false);
+            } finally {
+                cleanup();
+            }
+        });
+    });
+
     describe('filter controls', () => {
         test('should default showResolved and showOnlyMentionsMe to false in the filter menu', () => {
             render(<ActivityFeedV2 currentUser={mockCurrentUser} feedItems={[] as ActivityFeedV2Props['feedItems']} />);

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
@@ -736,25 +736,19 @@ describe('useMediaTimestamp range selection', () => {
         }
     });
 
-    test('should follow the replacement viewer preview builds on a file-version switch', () => {
+    test('should stop polling once the viewer is found', () => {
         jest.useFakeTimers();
         const audio = createMediaElement('audio', 43.5);
         const cleanup = mountMediaInDom(audio);
-        const first = createViewer();
-        const second = createViewer();
-        let current = first;
+        const harness = createViewer();
+        const getViewer = jest.fn(() => harness.viewer);
         try {
-            render(<TestHarness enabled getViewer={() => current.viewer} isAudioPlayerV2 />);
-            expect(first.hasListener('comment_range_draft_change')).toBe(true);
+            render(<TestHarness enabled getViewer={getViewer} isAudioPlayerV2 />);
+            expect(getViewer).toHaveBeenCalledTimes(1);
 
-            current = second;
-            act(() => jest.advanceTimersByTime(500));
+            act(() => jest.advanceTimersByTime(5000));
 
-            expect(first.hasListener('comment_range_draft_change')).toBe(false);
-            act(() => screen.getByText('press').click());
-            act(() => second.emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
-
-            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
+            expect(getViewer).toHaveBeenCalledTimes(1);
         } finally {
             cleanup();
             jest.useRealTimers();

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
@@ -712,6 +712,55 @@ describe('useMediaTimestamp range selection', () => {
         }
     });
 
+    test('should pick up drags from a viewer that only becomes available after mount', () => {
+        // Preview loads its media well after the sidebar mounts, so the handle starts out null.
+        jest.useFakeTimers();
+        const audio = createMediaElement('audio', 43.5);
+        const cleanup = mountMediaInDom(audio);
+        const harness = createViewer();
+        let isPreviewLoaded = false;
+        try {
+            render(<TestHarness enabled getViewer={() => (isPreviewLoaded ? harness.viewer : null)} isAudioPlayerV2 />);
+            expect(harness.hasListener('comment_range_draft_change')).toBe(false);
+
+            isPreviewLoaded = true;
+            act(() => jest.advanceTimersByTime(500));
+
+            act(() => screen.getByText('press').click());
+            act(() => harness.emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+
+            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
+        } finally {
+            cleanup();
+            jest.useRealTimers();
+        }
+    });
+
+    test('should follow the replacement viewer preview builds on a file-version switch', () => {
+        jest.useFakeTimers();
+        const audio = createMediaElement('audio', 43.5);
+        const cleanup = mountMediaInDom(audio);
+        const first = createViewer();
+        const second = createViewer();
+        let current = first;
+        try {
+            render(<TestHarness enabled getViewer={() => current.viewer} isAudioPlayerV2 />);
+            expect(first.hasListener('comment_range_draft_change')).toBe(true);
+
+            current = second;
+            act(() => jest.advanceTimersByTime(500));
+
+            expect(first.hasListener('comment_range_draft_change')).toBe(false);
+            act(() => screen.getByText('press').click());
+            act(() => second.emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+
+            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
+        } finally {
+            cleanup();
+            jest.useRealTimers();
+        }
+    });
+
     test('should not touch the viewer when range selection is disabled', () => {
         const audio = createMediaElement('audio', 43.5);
         const cleanup = mountMediaInDom(audio);

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen } from '@testing-library/react';
 
 import { seekMediaToMs, useMediaTimestamp } from '../useMediaTimestamp';
 import type { TimeFormat } from '../useTimeFormat';
+import type { ViewerHandle } from '../types';
 
 const createMediaElement = (tag: 'video' | 'audio' = 'video', currentTime: number = 0): HTMLMediaElement => {
     const media = document.createElement(tag);
@@ -40,17 +41,23 @@ const mountVideoInDom = (video: HTMLVideoElement) => mountMediaInDom(video);
 const TestHarness = ({
     enabled,
     fps = 24,
+    getViewer,
+    isAudioPlayerV2 = false,
     timeFormat = 'standard',
 }: {
     enabled: boolean;
     fps?: number;
+    getViewer?: () => ViewerHandle | null;
+    isAudioPlayerV2?: boolean;
     timeFormat?: TimeFormat;
 }) => {
-    const { formattedTimestamp, isPressed, onPressedChange, timestampMs } = useMediaTimestamp(enabled, timeFormat, fps);
+    const { formattedTimestamp, isPressed, onPressedChange, resetRange, timestampEndMs, timestampMs } =
+        useMediaTimestamp(enabled, timeFormat, fps, { getViewer, isAudioPlayerV2 });
     return (
         <div>
             <span data-testid="timestamp">{formattedTimestamp}</span>
             <span data-testid="ms">{String(timestampMs)}</span>
+            <span data-testid="end-ms">{String(timestampEndMs)}</span>
             <span data-testid="pressed">{String(isPressed)}</span>
             <button onClick={() => onPressedChange(true)} type="button">
                 press
@@ -58,9 +65,35 @@ const TestHarness = ({
             <button onClick={() => onPressedChange(false)} type="button">
                 unpress
             </button>
+            <button onClick={() => resetRange()} type="button">
+                reset
+            </button>
         </div>
     );
 };
+
+type ViewerListeners = Record<string, ((payload: unknown) => void) | undefined>;
+
+const createViewer = () => {
+    const listeners: ViewerListeners = {};
+    const viewer: ViewerHandle = {
+        addListener: (event, handler) => {
+            listeners[event] = handler;
+        },
+        emit: jest.fn(),
+        removeListener: event => {
+            delete listeners[event];
+        },
+    };
+    return {
+        emitFromViewer: (event: string, payload: unknown) => listeners[event]?.(payload),
+        getViewer: () => viewer,
+        hasListener: (event: string) => Boolean(listeners[event]),
+        viewer,
+    };
+};
+
+const emittedEvents = (viewer: ViewerHandle) => (viewer.emit as jest.Mock).mock.calls;
 
 describe('useMediaTimestamp', () => {
     afterEach(() => {
@@ -458,6 +491,271 @@ describe('seekMediaToMs', () => {
             expect(audio.pause).toHaveBeenCalled();
         } finally {
             cleanup();
+        }
+    });
+});
+
+describe('useMediaTimestamp range selection', () => {
+    afterEach(() => {
+        document.querySelectorAll('.bp-media-container').forEach(node => node.remove());
+    });
+
+    const renderWithRange = (currentTime = 43.5) => {
+        const audio = createMediaElement('audio', currentTime);
+        const cleanup = mountMediaInDom(audio);
+        const harness = createViewer();
+        const view = render(<TestHarness enabled getViewer={harness.getViewer} isAudioPlayerV2 />);
+        return { audio, cleanup, ...harness, ...view };
+    };
+
+    test('should emit a collapsed draft when the toggle is pressed', () => {
+        const { cleanup, viewer } = renderWithRange();
+        try {
+            expect(emittedEvents(viewer)).toHaveLength(0);
+            act(() => screen.getByText('press').click());
+            expect(emittedEvents(viewer)).toEqual([['comment_range_draft', { endMs: null, startMs: 43500 }]]);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should clear the draft when the toggle is released', () => {
+        const { cleanup, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => screen.getByText('unpress').click());
+            expect(emittedEvents(viewer)[1]).toEqual(['comment_range_draft_clear', undefined]);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should hold the range reported by a committed drag', () => {
+        const { cleanup, emitFromViewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+
+            expect(screen.getByTestId('ms').textContent).toBe('44000');
+            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should not echo a committed drag back to the viewer that reported it', () => {
+        const { cleanup, emitFromViewer, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            const afterPress = emittedEvents(viewer).length;
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+
+            expect(emittedEvents(viewer)).toHaveLength(afterPress);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should pin the start against pause and seek once a drag commits', () => {
+        const { audio, cleanup, emitFromViewer, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+            const afterDrag = emittedEvents(viewer).length;
+
+            Object.defineProperty(audio, 'currentTime', { configurable: true, value: 90, writable: true });
+            act(() => {
+                audio.dispatchEvent(new Event('seeked'));
+                audio.dispatchEvent(new Event('pause'));
+            });
+
+            expect(screen.getByTestId('ms').textContent).toBe('44000');
+            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
+            // Scrubbing to re-listen must not drag the user's chosen boundaries along with it.
+            expect(emittedEvents(viewer)).toHaveLength(afterDrag);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should let the start follow pause and seek before any drag', () => {
+        const { audio, cleanup, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            Object.defineProperty(audio, 'currentTime', { configurable: true, value: 12, writable: true });
+            act(() => audio.dispatchEvent(new Event('pause')));
+
+            expect(screen.getByTestId('ms').textContent).toBe('12000');
+            // The handles have to be told: they stayed put while the media played.
+            expect(emittedEvents(viewer).pop()).toEqual(['comment_range_draft', { endMs: null, startMs: 12000 }]);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should ignore a drag reported while the toggle is off', () => {
+        const { cleanup, emitFromViewer } = renderWithRange();
+        try {
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+            expect(screen.getByTestId('ms').textContent).toBe('0');
+            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test.each([
+        ['a malformed payload', undefined],
+        ['a non-numeric start', { endMs: 50000, startMs: 'nope' }],
+        ['a negative start', { endMs: 50000, startMs: -1 }],
+    ])('should ignore %s', (_label, payload) => {
+        const { cleanup, emitFromViewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', payload));
+
+            expect(screen.getByTestId('ms').textContent).toBe('43500');
+            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test.each([
+        ['an end before the start', 40000],
+        ['an end equal to the start', 44000],
+    ])('should drop %s back to a single timestamp', (_label, endMs) => {
+        const { cleanup, emitFromViewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', { endMs, startMs: 44000 }));
+
+            expect(screen.getByTestId('ms').textContent).toBe('44000');
+            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should stay a single timestamp when the viewer never reports a drag', () => {
+        const { cleanup, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+
+            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
+            expect(emittedEvents(viewer)).toEqual([['comment_range_draft', { endMs: null, startMs: 43500 }]]);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should drop back to a collapsed draft after the range is reset', () => {
+        const { cleanup, emitFromViewer, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+            act(() => screen.getByText('reset').click());
+
+            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
+            expect(emittedEvents(viewer).pop()).toEqual(['comment_range_draft', { endMs: null, startMs: 44000 }]);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should let the start follow playback again after the range is reset', () => {
+        const { audio, cleanup, emitFromViewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+            act(() => screen.getByText('reset').click());
+
+            Object.defineProperty(audio, 'currentTime', { configurable: true, value: 61, writable: true });
+            act(() => audio.dispatchEvent(new Event('pause')));
+
+            expect(screen.getByTestId('ms').textContent).toBe('61000');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should keep a dragged range across a new src on the same element', () => {
+        // Same element, new src means a token refresh, which is meant to be invisible to the user.
+        const { audio, cleanup, emitFromViewer, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+            const afterDrag = emittedEvents(viewer).length;
+
+            act(() => audio.dispatchEvent(new Event('loadstart')));
+            act(() => audio.dispatchEvent(new Event('loadeddata')));
+            Object.defineProperty(audio, 'currentTime', { configurable: true, value: 44, writable: true });
+            act(() => audio.dispatchEvent(new Event('seeked')));
+
+            expect(screen.getByTestId('ms').textContent).toBe('44000');
+            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
+            expect(emittedEvents(viewer)).toHaveLength(afterDrag);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should reset an undragged start when a new media src loads', () => {
+        const { audio, cleanup } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => audio.dispatchEvent(new Event('loadstart')));
+
+            expect(screen.getByTestId('ms').textContent).toBe('0');
+            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should clear the draft on unmount', () => {
+        const { cleanup, unmount, viewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            unmount();
+
+            expect(emittedEvents(viewer).pop()).toEqual(['comment_range_draft_clear', undefined]);
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should not touch the viewer when range selection is disabled', () => {
+        const audio = createMediaElement('audio', 43.5);
+        const cleanup = mountMediaInDom(audio);
+        const { getViewer, hasListener, viewer } = createViewer();
+        try {
+            render(<TestHarness enabled getViewer={getViewer} />);
+            act(() => screen.getByText('press').click());
+
+            expect(emittedEvents(viewer)).toHaveLength(0);
+            expect(hasListener('comment_range_draft_change')).toBe(false);
+            expect(screen.getByTestId('ms').textContent).toBe('43500');
+        } finally {
+            cleanup();
+        }
+    });
+
+    test('should drop the range when preview swaps in a new media element', async () => {
+        const { cleanup, emitFromViewer } = renderWithRange();
+        try {
+            act(() => screen.getByText('press').click());
+            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
+            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
+
+            await act(async () => {
+                cleanup();
+                mountMediaInDom(createMediaElement('audio', 0));
+            });
+
+            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
+        } finally {
+            document.querySelectorAll('.bp-media-container').forEach(node => node.remove());
         }
     });
 });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
@@ -767,7 +767,6 @@ describe('useMediaTimestamp range selection', () => {
             expect(hasListener('comment_range_draft_change')).toBe(false);
             expect(screen.getByTestId('ms').textContent).toBe('43500');
         } finally {
-            ``;
             cleanup();
         }
     });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
@@ -767,25 +767,8 @@ describe('useMediaTimestamp range selection', () => {
             expect(hasListener('comment_range_draft_change')).toBe(false);
             expect(screen.getByTestId('ms').textContent).toBe('43500');
         } finally {
+            ``;
             cleanup();
-        }
-    });
-
-    test('should drop the range when preview swaps in a new media element', async () => {
-        const { cleanup, emitFromViewer } = renderWithRange();
-        try {
-            act(() => screen.getByText('press').click());
-            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
-            expect(screen.getByTestId('end-ms').textContent).toBe('50000');
-
-            await act(async () => {
-                cleanup();
-                mountMediaInDom(createMediaElement('audio', 0));
-            });
-
-            expect(screen.getByTestId('end-ms').textContent).toBe('undefined');
-        } finally {
-            document.querySelectorAll('.bp-media-container').forEach(node => node.remove());
         }
     });
 });

--- a/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
+++ b/src/elements/content-sidebar/activity-feed-v2/__tests__/useMediaTimestamp.test.tsx
@@ -543,19 +543,6 @@ describe('useMediaTimestamp range selection', () => {
         }
     });
 
-    test('should not echo a committed drag back to the viewer that reported it', () => {
-        const { cleanup, emitFromViewer, viewer } = renderWithRange();
-        try {
-            act(() => screen.getByText('press').click());
-            const afterPress = emittedEvents(viewer).length;
-            act(() => emitFromViewer('comment_range_draft_change', { endMs: 50000, startMs: 44000 }));
-
-            expect(emittedEvents(viewer)).toHaveLength(afterPress);
-        } finally {
-            cleanup();
-        }
-    });
-
     test('should pin the start against pause and seek once a drag commits', () => {
         const { audio, cleanup, emitFromViewer, viewer } = renderWithRange();
         try {

--- a/src/elements/content-sidebar/activity-feed-v2/types.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/types.ts
@@ -83,6 +83,15 @@ export type ActivityFeedV2File = {
     };
 };
 
+/**
+ * Draft range the composer is holding, sent to the viewer so it can draw handles on the waveform.
+ * A null end means the composer still holds a single timestamp and the handles sit collapsed at the start.
+ */
+export type CommentRangeDraft = {
+    endMs: number | null;
+    startMs: number;
+};
+
 export type ViewerHandle = {
     addListener: (event: string, handler: (payload: unknown) => void) => void;
     emit: (event: string, payload: unknown) => void;

--- a/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
@@ -2,7 +2,11 @@ import * as React from 'react';
 
 import { formatByTimeFormat, MEDIA_CONTAINER_SELECTOR, MEDIA_ELEMENT_SELECTOR } from './useTimeFormat';
 import type { TimeFormat } from './useTimeFormat';
-import type { ViewerHandle } from './types';
+import type { CommentRangeDraft, ViewerHandle } from './types';
+
+export const EVENT_RANGE_DRAFT = 'comment_range_draft';
+export const EVENT_RANGE_DRAFT_CHANGE = 'comment_range_draft_change';
+export const EVENT_RANGE_DRAFT_CLEAR = 'comment_range_draft_clear';
 
 const findMediaElement = (): HTMLMediaElement | null => {
     if (typeof document === 'undefined') {
@@ -38,10 +42,27 @@ export interface UseMediaTimestampResult {
     formattedTimestamp: string;
     isPressed: boolean;
     onPressedChange: (pressed: boolean) => void;
+    /** Drops back to a collapsed single timestamp. Call after a comment is posted. */
+    resetRange: () => void;
     /** End of the composer's selected range. Undefined until the user drags a waveform handle. */
     timestampEndMs?: number;
     timestampMs: number;
 }
+
+export interface UseMediaTimestampOptions {
+    getViewer?: () => ViewerHandle | null;
+    isAudioPlayerV2?: boolean;
+}
+
+const readRangeChange = (payload: unknown): { endMs?: number; startMs: number } | null => {
+    const { endMs, startMs } = (payload ?? {}) as Partial<CommentRangeDraft>;
+    if (!Number.isSafeInteger(startMs) || (startMs as number) < 0) {
+        return null;
+    }
+    const start = startMs as number;
+    const hasEnd = Number.isSafeInteger(endMs) && (endMs as number) > start;
+    return { endMs: hasEnd ? (endMs as number) : undefined, startMs: start };
+};
 
 /**
  * Behavior:
@@ -49,13 +70,50 @@ export interface UseMediaTimestampResult {
  * - Pressed on while media is playing: captured value frozen until pause/seek.
  * - Pressed on while media is paused: captured value updates on pause/seek.
  * - Toggle off->on: captures current time and pauses the media if it was playing.
- * - New media src: captured value resets to 0; pressed state persists.
+ * - New media src: captured value resets to 0; pressed state persists. A dragged range survives
+ *   untouched, since a src change on the same element is a token refresh, not different content.
+ * - New media element: any selected range is dropped.
  */
-export const useMediaTimestamp = (enabled: boolean, timeFormat: TimeFormat, fps: number): UseMediaTimestampResult => {
+export const useMediaTimestamp = (
+    enabled: boolean,
+    timeFormat: TimeFormat,
+    fps: number,
+    { getViewer, isAudioPlayerV2 = false }: UseMediaTimestampOptions = {},
+): UseMediaTimestampResult => {
     const [isPressed, setIsPressed] = React.useState(false);
     const [timestampMs, setTimestampMs] = React.useState(0);
+    const [timestampEndMs, setTimestampEndMs] = React.useState<number | undefined>(undefined);
     const isPressedRef = React.useRef(isPressed);
     const isLoadingRef = React.useRef(false);
+
+    const isRangePinnedRef = React.useRef(false);
+    const isRangeEnabled = enabled && isAudioPlayerV2;
+
+    /** Tells the viewer to show range handles at these positions. An absent end draws them collapsed. */
+    const emitDraft = React.useCallback(
+        (startMs: number, endMs?: number) => {
+            if (!isRangeEnabled) {
+                return;
+            }
+            getViewer?.()?.emit(EVENT_RANGE_DRAFT, { endMs: endMs ?? null, startMs });
+        },
+        [getViewer, isRangeEnabled],
+    );
+
+    /** Tells the viewer to hide the range handles. */
+    const emitClear = React.useCallback(() => {
+        if (!isRangeEnabled) {
+            return;
+        }
+        getViewer?.()?.emit(EVENT_RANGE_DRAFT_CLEAR, undefined);
+    }, [getViewer, isRangeEnabled]);
+
+    const resetRange = React.useCallback(() => {
+        isRangePinnedRef.current = false;
+        setTimestampEndMs(undefined);
+        // The message editor retains checkbox state after a post, so we emit another event to keep handles up.
+        emitDraft(timestampMs);
+    }, [emitDraft, timestampMs]);
 
     // Reset state when disabled (e.g. switching from a media file to a non-media file)
     // so a re-enable does not leak the previous file's pressed state or captured ms.
@@ -65,6 +123,8 @@ export const useMediaTimestamp = (enabled: boolean, timeFormat: TimeFormat, fps:
             setIsPressed(false);
             setTimestampMs(0);
             isLoadingRef.current = false;
+            isRangePinnedRef.current = false;
+            setTimestampEndMs(undefined);
         }
     }, [enabled]);
 
@@ -76,6 +136,9 @@ export const useMediaTimestamp = (enabled: boolean, timeFormat: TimeFormat, fps:
             if (!pressed) {
                 isPressedRef.current = false;
                 setIsPressed(false);
+                isRangePinnedRef.current = false;
+                setTimestampEndMs(undefined);
+                emitClear();
                 return;
             }
             const media = findMediaElement();
@@ -85,11 +148,15 @@ export const useMediaTimestamp = (enabled: boolean, timeFormat: TimeFormat, fps:
             if (!media.paused) {
                 media.pause();
             }
+            const capturedMs = captureCurrentMs(media);
             isPressedRef.current = true;
             setIsPressed(true);
-            setTimestampMs(captureCurrentMs(media));
+            setTimestampMs(capturedMs);
+            isRangePinnedRef.current = false;
+            setTimestampEndMs(undefined);
+            emitDraft(capturedMs);
         },
-        [enabled],
+        [emitClear, emitDraft, enabled],
     );
 
     React.useEffect(() => {
@@ -106,13 +173,23 @@ export const useMediaTimestamp = (enabled: boolean, timeFormat: TimeFormat, fps:
             if (isLoadingRef.current) {
                 return;
             }
+            // The user has dragged handles, so playhead no longer moves the start value.
+            if (isRangePinnedRef.current) {
+                return;
+            }
             if (isPressedRef.current && attached) {
-                setTimestampMs(captureCurrentMs(attached));
+                const capturedMs = captureCurrentMs(attached);
+                setTimestampMs(capturedMs);
+                // Update the position of handles to the current time.
+                emitDraft(capturedMs);
             }
         };
 
         const handleLoadStart = () => {
             isLoadingRef.current = true;
+            if (isRangePinnedRef.current) {
+                return;
+            }
             setTimestampMs(0);
         };
 
@@ -136,6 +213,11 @@ export const useMediaTimestamp = (enabled: boolean, timeFormat: TimeFormat, fps:
             }
             if (media === attached) {
                 return true;
+            }
+            // A replaced element is a different file or version, so the selected range no longer applies.
+            if (attached) {
+                isRangePinnedRef.current = false;
+                setTimestampEndMs(undefined);
             }
             detach();
             media.addEventListener('pause', handlePauseOrSeek);
@@ -164,12 +246,48 @@ export const useMediaTimestamp = (enabled: boolean, timeFormat: TimeFormat, fps:
             observer?.disconnect();
             detach();
         };
-    }, [enabled]);
+    }, [emitDraft, enabled]);
+
+    React.useEffect(() => {
+        if (!isRangeEnabled) {
+            return undefined;
+        }
+        const viewer = getViewer?.();
+        if (!viewer) {
+            return undefined;
+        }
+
+        const handleRangeChange = (payload: unknown) => {
+            const change = readRangeChange(payload);
+            if (!change || !isPressedRef.current) {
+                return;
+            }
+            isRangePinnedRef.current = true;
+            // Nothing is emitted back: the viewer reported this range, so it is already drawing it.
+            setTimestampMs(change.startMs);
+            setTimestampEndMs(change.endMs);
+        };
+
+        viewer.addListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+        return () => viewer.removeListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+    }, [getViewer, isRangeEnabled]);
+
+    // Take down any handles still up for a composer that is going away.
+    React.useEffect(
+        () => () => {
+            if (isPressedRef.current) {
+                emitClear();
+            }
+        },
+        [emitClear],
+    );
 
     return {
         formattedTimestamp: formatByTimeFormat(timestampMs, timeFormat, fps),
         isPressed,
         onPressedChange,
+        resetRange,
+        timestampEndMs,
         timestampMs,
     };
 };

--- a/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
@@ -4,6 +4,12 @@ import { formatByTimeFormat, MEDIA_CONTAINER_SELECTOR, MEDIA_ELEMENT_SELECTOR } 
 import type { TimeFormat } from './useTimeFormat';
 import type { CommentRangeDraft, ViewerHandle } from './types';
 
+/**
+ * Preview exposes no viewer-ready event to the sidebar, and its viewer handle is null until the
+ * media finishes loading, which is usually well after this sidebar has mounted. Poll for it.
+ */
+const VIEWER_POLL_MS = 500;
+
 export const EVENT_RANGE_DRAFT = 'comment_range_draft';
 export const EVENT_RANGE_DRAFT_CHANGE = 'comment_range_draft_change';
 export const EVENT_RANGE_DRAFT_CLEAR = 'comment_range_draft_clear';
@@ -252,11 +258,6 @@ export const useMediaTimestamp = (
         if (!isRangeEnabled) {
             return undefined;
         }
-        const viewer = getViewer?.();
-        if (!viewer) {
-            return undefined;
-        }
-
         const handleRangeChange = (payload: unknown) => {
             const change = readRangeChange(payload);
             if (!change || !isPressedRef.current) {
@@ -267,8 +268,27 @@ export const useMediaTimestamp = (
             setTimestampEndMs(change.endMs);
         };
 
-        viewer.addListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
-        return () => viewer.removeListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+        // Follow whichever viewer is current rather than attaching once: the handle starts out null
+        // while preview loads, and preview builds a replacement on a file-version switch. Missing
+        // either moment silently costs the user their drags, since nothing else reports them.
+        let listening: ViewerHandle | null = null;
+        const followCurrentViewer = () => {
+            const viewer = getViewer?.() ?? null;
+            if (viewer === listening) {
+                return;
+            }
+            listening?.removeListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+            viewer?.addListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+            listening = viewer;
+        };
+
+        followCurrentViewer();
+        const pollId = setInterval(followCurrentViewer, VIEWER_POLL_MS);
+
+        return () => {
+            clearInterval(pollId);
+            listening?.removeListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+        };
     }, [getViewer, isRangeEnabled]);
 
     // Take down any handles still up for a composer that is going away.

--- a/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
@@ -4,10 +4,6 @@ import { formatByTimeFormat, MEDIA_CONTAINER_SELECTOR, MEDIA_ELEMENT_SELECTOR } 
 import type { TimeFormat } from './useTimeFormat';
 import type { CommentRangeDraft, ViewerHandle } from './types';
 
-/**
- * Preview exposes no viewer-ready event to the sidebar, and its viewer handle is null until the
- * media finishes loading, which is usually well after this sidebar has mounted. Poll for it.
- */
 const VIEWER_POLL_MS = 500;
 
 export const EVENT_RANGE_DRAFT = 'comment_range_draft';
@@ -220,11 +216,6 @@ export const useMediaTimestamp = (
             if (media === attached) {
                 return true;
             }
-            // A replaced element is a different file or version, so the selected range no longer applies.
-            if (attached) {
-                isRangePinnedRef.current = false;
-                setTimestampEndMs(undefined);
-            }
             detach();
             media.addEventListener('pause', handlePauseOrSeek);
             media.addEventListener('seeked', handlePauseOrSeek);
@@ -268,26 +259,28 @@ export const useMediaTimestamp = (
             setTimestampEndMs(change.endMs);
         };
 
-        // Follow whichever viewer is current rather than attaching once: the handle starts out null
-        // while preview loads, and preview builds a replacement on a file-version switch. Missing
-        // either moment silently costs the user their drags, since nothing else reports them.
-        let listening: ViewerHandle | null = null;
-        const followCurrentViewer = () => {
+        // Poll for the viewer until we find one.
+        let attachedViewer: ViewerHandle | null = null;
+        let pollId: ReturnType<typeof setInterval> | undefined;
+
+        const attachWhenReady = () => {
             const viewer = getViewer?.() ?? null;
-            if (viewer === listening) {
+            if (!viewer) {
                 return;
             }
-            listening?.removeListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
-            viewer?.addListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
-            listening = viewer;
+            viewer.addListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+            attachedViewer = viewer;
+            clearInterval(pollId);
         };
 
-        followCurrentViewer();
-        const pollId = setInterval(followCurrentViewer, VIEWER_POLL_MS);
+        attachWhenReady();
+        if (!attachedViewer) {
+            pollId = setInterval(attachWhenReady, VIEWER_POLL_MS);
+        }
 
         return () => {
             clearInterval(pollId);
-            listening?.removeListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
+            attachedViewer?.removeListener(EVENT_RANGE_DRAFT_CHANGE, handleRangeChange);
         };
     }, [getViewer, isRangeEnabled]);
 

--- a/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
@@ -111,8 +111,9 @@ export const useMediaTimestamp = (
     const resetRange = React.useCallback(() => {
         isRangePinnedRef.current = false;
         setTimestampEndMs(undefined);
-        // The message editor retains checkbox state after a post, so we emit another event to keep handles up.
-        emitDraft(timestampMs);
+        if (isPressedRef.current) {
+            emitDraft(timestampMs);
+        }
     }, [emitDraft, timestampMs]);
 
     // Reset state when disabled (e.g. switching from a media file to a non-media file)

--- a/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
+++ b/src/elements/content-sidebar/activity-feed-v2/useMediaTimestamp.ts
@@ -82,12 +82,12 @@ export const useMediaTimestamp = (
 ): UseMediaTimestampResult => {
     const [isPressed, setIsPressed] = React.useState(false);
     const [timestampMs, setTimestampMs] = React.useState(0);
-    const [timestampEndMs, setTimestampEndMs] = React.useState<number | undefined>(undefined);
     const isPressedRef = React.useRef(isPressed);
     const isLoadingRef = React.useRef(false);
 
-    const isRangePinnedRef = React.useRef(false);
     const isRangeEnabled = enabled && isAudioPlayerV2;
+    const isRangePinnedRef = React.useRef(false);
+    const [timestampEndMs, setTimestampEndMs] = React.useState<number | undefined>(undefined);
 
     /** Tells the viewer to show range handles at these positions. An absent end draws them collapsed. */
     const emitDraft = React.useCallback(
@@ -180,8 +180,7 @@ export const useMediaTimestamp = (
             if (isPressedRef.current && attached) {
                 const capturedMs = captureCurrentMs(attached);
                 setTimestampMs(capturedMs);
-                // Update the position of handles to the current time.
-                emitDraft(capturedMs);
+                emitDraft(capturedMs); // Update position of handles to the current paused/seeked time.
             }
         };
 
@@ -262,8 +261,7 @@ export const useMediaTimestamp = (
             if (!change || !isPressedRef.current) {
                 return;
             }
-            isRangePinnedRef.current = true;
-            // Nothing is emitted back: the viewer reported this range, so it is already drawing it.
+            isRangePinnedRef.current = change.endMs !== undefined;
             setTimestampMs(change.startMs);
             setTimestampEndMs(change.endMs);
         };


### PR DESCRIPTION
## Summary

Toggling the timestamp checkbox on an audio file now asks the preview viewer to draw range handles on the waveform. Dragging a handle turns the pending single timestamp into a range, and the comment is posted with the end-timestamp markup added in #4814.

Range selection is audio-only and rides the v2 audio player. Video takes exactly the path it takes today.

This is the composer half only. The checkbox still displays just the start time, and the posted badge still renders a single timestamp — both are follow-ups.

## Viewer contract

Follows the existing `comment_markers` pattern: `viewer.emit` outbound, `viewer.addListener` inbound.

| Direction | Event | Payload | Meaning |
| --- | --- | --- | --- |
| Sidebar → viewer | `comment_range_draft` | `{ startMs, endMs: number \| null }` | Show or update the handles. A null end draws them collapsed at the start. |
| Sidebar → viewer | `comment_range_draft_clear` | – | Hide the handles. |
| Viewer → sidebar | `comment_range_draft_change` | `{ startMs, endMs }` | A drag finished. Mouseup only, not during the drag. |

The viewer side of this does not exist yet, which is the point of the degradation note below.

## Structural decisions

**The viewer owns the drag; we only tell it what it cannot know.** There are exactly three of those moments, and each emits at the point that causes it rather than from an effect deriving emissions from state: the checkbox opening, the start tracking the playhead before any drag, and the range collapsing after a post. An effect-based version needs bookkeeping to distinguish a transition from a steady state — otherwise it clears handles on mount that were never drawn. Emitting at the moment removes the need for that entirely.

**The start pins after the first drag.** Until then it follows `pause` and `seeked` so scrubbing fine-tunes it, and the handles are told to catch up because they deliberately sit still during playback. After a drag the boundaries are the user's, and scrubbing away to re-listen leaves them alone.

**A token refresh preserves a dragged range.** `MediaBaseViewer.restartPlayback` reassigns `src` on the same media element when the media token expires, then restores the playhead — an event the user is not meant to perceive, and one that a long audio file being commented on will hit. The start is left alone too: a pinned range suppresses the restore-seek capture, so zeroing it would strand the start at 0 with the end still where the user put it.

**A replaced media element drops the range.** That means a different file or version, where the viewer is rebuilt and draws nothing. No draft is resynced to it.

**After a successful post the range collapses rather than clearing.** The checkbox stays checked, matching today's behavior, so the handles stay up and collapse to the start ready for the next comment.

**Degrades cleanly.** The viewer is the only source of an end value. Against a preview build that never emits `comment_range_draft_change` this stays exactly a single-timestamp composer, so this can land ahead of the viewer work.

## Testing

`yarn test src/elements/content-sidebar/activity-feed-v2` — 461 passing.

New coverage for the emit sequence on toggle, the drag round trip and the absence of an echo, pinning against pause and seek, range survival across a token refresh with zero viewer traffic, the range dropping on a media element swap, clearing on unmount, and the whole thing being inert on video and with the flag off. Malformed, negative, and non-advancing payloads from the viewer are covered too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting start and end timestamps when composing comments on audio in the updated audio player.
  - Audio comment ranges update as waveform handles are adjusted and are included when comments are posted.
  - Added controls to clear or reset an in-progress audio range selection.

- **Bug Fixes**
  - After posting a timestamped audio comment, the composer now resets to a single timestamp.
  - Video timestamp behavior remains unchanged and does not use audio range selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->