### PR TITLE
fix(deps): Bump immutable resolution to 3.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,7 +393,7 @@
         "@box/box-ai-agent-selector": "2.2.23",
         "@box/blueprint-web-assets": "5.7.14",
         "@sigstore/core": "3.2.1",
-        "draft-js/immutable": "^3.8.3",
+        "draft-js/immutable": "^3.8.4",
         "eslint-plugin-formatjs/**/minimatch": "^9.0.9",
         "tar": "^7.5.19"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11646,10 +11646,10 @@ ilib-tree-node@^1.2.0, ilib-tree-node@^1.3.2:
   resolved "https://registry.yarnpkg.com/ilib-tree-node/-/ilib-tree-node-1.3.2.tgz#eff1ab83588911ece401b5dbd8c8d13c52da59d0"
   integrity sha512-Dbg9rIOhd8TazHFwk3lFA0Gi6+fe3+YSqiuMRT46D7fomjf429vwzRzbHJB4uMyk8+bEsFUdQV23dbNvjkIdgw==
 
-immutable@^3.8.3, immutable@~3.7.4:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
-  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
+immutable@^3.8.4, immutable@~3.7.4:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.4.tgz#af27c93537f09629c9d154a173cd55f7bfdc75fd"
+  integrity sha512-ZQv17KolYrYmsDoDB8N67zhIKsNi9mGYlk96y/yuxyAqJB2hLzSGSM7k/sB0/ZvO4kx27U9+fBeD/XlLGh/uXQ==
 
 immutable@^4.0.0, immutable@^4.3.9:
   version "4.3.9"


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Draft.js Immutable dependency to version 3.8.4 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->