### PR TITLE
feat(feed): request wrapping markdown on flag-on GETs

### DIFF
--- a/src/api/Annotations.js
+++ b/src/api/Annotations.js
@@ -207,6 +207,7 @@ export default class Annotations extends MarkerBasedApi {
         successCallback: (annotation: Annotation) => void,
         errorCallback: (e: ElementsXhrError, code: string) => void,
         shouldFetchReplies?: boolean,
+        shouldEnableRichText?: boolean,
     ): void {
         this.errorCode = ERROR_CODE_FETCH_ANNOTATION;
 
@@ -217,7 +218,11 @@ export default class Annotations extends MarkerBasedApi {
             return;
         }
 
-        const requestData = shouldFetchReplies ? { params: { fields: 'replies' } } : undefined;
+        const params = {
+            ...(shouldFetchReplies ? { fields: 'replies' } : {}),
+            ...(shouldEnableRichText ? { enable_rich_text: true } : {}),
+        };
+        const requestData = Object.keys(params).length ? { params } : undefined;
 
         this.get({
             id: fileId,
@@ -237,6 +242,7 @@ export default class Annotations extends MarkerBasedApi {
         limit?: number,
         shouldFetchAll?: boolean,
         shouldFetchReplies?: boolean,
+        shouldEnableRichText?: boolean,
     ): void {
         this.errorCode = ERROR_CODE_FETCH_ANNOTATIONS;
 
@@ -251,6 +257,7 @@ export default class Annotations extends MarkerBasedApi {
             file_id: fileId,
             file_version_id: fileVersionId,
             ...(shouldFetchReplies ? { fields: 'replies' } : null),
+            ...(shouldEnableRichText ? { enable_rich_text: true } : null),
         };
 
         this.markerGet({
@@ -269,6 +276,7 @@ export default class Annotations extends MarkerBasedApi {
         permissions: BoxItemPermission,
         successCallback: (comments: ThreadedComments) => void,
         errorCallback: (e: ElementsXhrError, code: string) => void,
+        shouldEnableRichText?: boolean,
     ): void {
         this.errorCode = ERROR_CODE_FETCH_REPLIES;
 
@@ -284,6 +292,7 @@ export default class Annotations extends MarkerBasedApi {
             errorCallback,
             successCallback,
             url: this.getUrlWithRepliesForId(annotationId),
+            ...(shouldEnableRichText ? { requestData: { params: { enable_rich_text: true } } } : {}),
         });
     }
 

--- a/src/api/Feed.js
+++ b/src/api/Feed.js
@@ -348,6 +348,11 @@ class Feed extends Base {
     fileActivitiesAPI: FileActivitiesAPI;
 
     /**
+     * @property {boolean}
+     */
+    shouldEnableRichText: boolean;
+
+    /**
      * @property {BoxItem}
      */
     file: BoxItem;
@@ -362,6 +367,7 @@ class Feed extends Base {
         this.taskCollaboratorsAPI = [];
         this.taskLinksAPI = [];
         this.errors = [];
+        this.shouldEnableRichText = false;
     }
 
     /**
@@ -581,6 +587,7 @@ class Feed extends Base {
             shouldShowVersions = true,
             shouldUseEnhancedActivities = false,
             shouldUseUAA = false,
+            shouldEnableRichText = false,
         }: {
             shouldShowAnnotations?: boolean,
             shouldShowAppActivity?: boolean,
@@ -589,6 +596,7 @@ class Feed extends Base {
             shouldShowVersions?: boolean,
             shouldUseEnhancedActivities?: boolean,
             shouldUseUAA?: boolean,
+            shouldEnableRichText?: boolean,
         } = {},
     ): void {
         const { id, permissions = {} } = file;
@@ -609,15 +617,18 @@ class Feed extends Base {
         this.file = file;
         this.errors = [];
         this.errorCallback = onError;
+        this.shouldEnableRichText = shouldEnableRichText;
 
         // Using the UAA File Activities endpoint replaces the need for these calls
         const annotationsPromise =
             !shouldUseUAA && shouldShowAnnotations
-                ? this.fetchAnnotations(permissions, shouldShowReplies)
+                ? this.fetchAnnotations(permissions, shouldShowReplies, shouldEnableRichText)
                 : Promise.resolve();
         const commentsPromise = () => {
             if (shouldUseUAA) return Promise.resolve();
-            return shouldShowReplies ? this.fetchThreadedComments(permissions) : this.fetchComments(permissions);
+            return shouldShowReplies
+                ? this.fetchThreadedComments(permissions, shouldEnableRichText)
+                : this.fetchComments(permissions);
         };
         const tasksPromise = !shouldUseUAA && shouldShowTasks ? this.fetchTasksNew() : Promise.resolve();
         const appActivityPromise =
@@ -652,6 +663,7 @@ class Feed extends Base {
                       filteredActivityTypes,
                       shouldShowReplies,
                       shouldUseEnhancedActivities,
+                      shouldEnableRichText,
                   )
                 : Promise.resolve();
 
@@ -698,7 +710,11 @@ class Feed extends Base {
         }
     }
 
-    fetchAnnotations(permissions: BoxItemPermission, shouldFetchReplies?: boolean): Promise<?Annotations> {
+    fetchAnnotations(
+        permissions: BoxItemPermission,
+        shouldFetchReplies?: boolean,
+        shouldEnableRichText?: boolean = this.shouldEnableRichText,
+    ): Promise<?Annotations> {
         this.annotationsAPI = new AnnotationsAPI(this.options);
         return new Promise(resolve => {
             this.annotationsAPI.getAnnotations(
@@ -710,6 +726,7 @@ class Feed extends Base {
                 undefined,
                 undefined,
                 shouldFetchReplies,
+                shouldEnableRichText,
             );
         });
     }
@@ -746,6 +763,7 @@ class Feed extends Base {
         commentId: string,
         successCallback: (comment: Comment) => void,
         errorCallback: ErrorCallback,
+        shouldEnableRichText?: boolean = this.shouldEnableRichText,
     ): Promise<?Comment> {
         const { id, permissions } = file;
         if (!id || !permissions) {
@@ -759,6 +777,7 @@ class Feed extends Base {
                 errorCallback,
                 fileId: id,
                 permissions,
+                shouldEnableRichText,
                 successCallback: this.fetchThreadedCommentSuccessCallback.bind(this, resolve, successCallback),
             });
         });
@@ -783,13 +802,17 @@ class Feed extends Base {
      * @param {Object} permissions - the file permissions
      * @return {Promise} - the file comments
      */
-    fetchThreadedComments(permissions: BoxItemPermission): Promise<?ThreadedCommentsType> {
+    fetchThreadedComments(
+        permissions: BoxItemPermission,
+        shouldEnableRichText?: boolean = this.shouldEnableRichText,
+    ): Promise<?ThreadedCommentsType> {
         this.threadedCommentsAPI = new ThreadedCommentsAPI(this.options);
         return new Promise(resolve => {
             this.threadedCommentsAPI.getComments({
                 errorCallback: this.fetchFeedItemErrorCallback.bind(this, resolve),
                 fileId: this.file.id,
                 permissions,
+                shouldEnableRichText,
                 successCallback: resolve,
             });
         });
@@ -808,6 +831,7 @@ class Feed extends Base {
         activityTypes: FileActivityTypes[],
         shouldShowReplies?: boolean = false,
         shouldUseEnhancedActivities?: boolean = false,
+        shouldEnableRichText?: boolean = this.shouldEnableRichText,
     ): Promise<Object> {
         this.fileActivitiesAPI = new FileActivitiesAPI(this.options);
         return new Promise(resolve => {
@@ -819,6 +843,7 @@ class Feed extends Base {
                 activityTypes,
                 shouldShowReplies,
                 shouldUseEnhancedActivities,
+                shouldEnableRichText,
             });
         });
     }
@@ -839,6 +864,7 @@ class Feed extends Base {
         commentFeedItemType: CommentFeedItemType,
         successCallback: (comments: Array<Comment>) => void,
         errorCallback: ErrorCallback,
+        shouldEnableRichText?: boolean = this.shouldEnableRichText,
     ): void {
         const { id, permissions } = file;
         if (!id || !permissions) {
@@ -870,6 +896,7 @@ class Feed extends Base {
                 permissions,
                 successCallbackFn,
                 errorCallbackFn,
+                shouldEnableRichText,
             );
         } else if (commentFeedItemType === FEED_ITEM_TYPE_COMMENT) {
             this.threadedCommentsAPI = new ThreadedCommentsAPI(this.options);
@@ -878,6 +905,7 @@ class Feed extends Base {
                 fileId: file.id,
                 commentId: commentFeedItemId,
                 permissions,
+                shouldEnableRichText,
                 successCallback: successCallbackFn,
                 errorCallback: errorCallbackFn,
             });

--- a/src/api/FileActivities.js
+++ b/src/api/FileActivities.js
@@ -24,6 +24,7 @@ const getFileActivityQueryParams = (
     activityTypes?: FileActivityTypes[] = [],
     shouldShowReplies?: boolean = false,
     shouldUseEnhancedActivities?: boolean = false,
+    shouldEnableRichText?: boolean = false,
 ) => {
     const baseEndpoint = `/file_activities?file_id=${fileID}`;
     const hasActivityTypes = !!activityTypes && !!activityTypes.length;
@@ -31,8 +32,9 @@ const getFileActivityQueryParams = (
     const replyLimit = shouldUseEnhancedActivities ? V2_REPLY_LIMIT : V1_REPLY_LIMIT;
     const enabledRepliesQueryParam = `&enable_replies=${enableReplies}&reply_limit=${replyLimit}`;
     const activityTypeQueryParam = hasActivityTypes ? `&activity_types=${activityTypes.join()}` : '';
+    const richTextQueryParam = shouldEnableRichText ? '&enable_rich_text=true' : '';
 
-    return `${baseEndpoint}${activityTypeQueryParam}${enabledRepliesQueryParam}`;
+    return `${baseEndpoint}${activityTypeQueryParam}${enabledRepliesQueryParam}${richTextQueryParam}`;
 };
 
 class FileActivities extends Base {
@@ -49,8 +51,9 @@ class FileActivities extends Base {
         activityTypes?: FileActivityTypes[],
         shouldShowReplies?: boolean,
         shouldUseEnhancedActivities?: boolean,
+        shouldEnableRichText?: boolean,
     ): string {
-        return `${this.getBaseApiUrl()}${getFileActivityQueryParams(id, activityTypes, shouldShowReplies, shouldUseEnhancedActivities)}`;
+        return `${this.getBaseApiUrl()}${getFileActivityQueryParams(id, activityTypes, shouldShowReplies, shouldUseEnhancedActivities, shouldEnableRichText)}`;
     }
 
     /**
@@ -73,6 +76,7 @@ class FileActivities extends Base {
         repliesCount,
         shouldShowReplies,
         shouldUseEnhancedActivities,
+        shouldEnableRichText,
         successCallback,
     }: {
         activityTypes: FileActivityTypes[],
@@ -82,6 +86,7 @@ class FileActivities extends Base {
         repliesCount?: number,
         shouldShowReplies?: boolean,
         shouldUseEnhancedActivities?: boolean,
+        shouldEnableRichText?: boolean,
         successCallback: (activity: FileActivity) => void,
     }): void {
         this.errorCode = ERROR_CODE_FETCH_ACTIVITY;
@@ -108,7 +113,13 @@ class FileActivities extends Base {
             requestData: {
                 ...(repliesCount ? { replies_count: repliesCount } : null),
             },
-            url: this.getFilteredUrl(fileID, activityTypes, shouldShowReplies, shouldUseEnhancedActivities),
+            url: this.getFilteredUrl(
+                fileID,
+                activityTypes,
+                shouldShowReplies,
+                shouldUseEnhancedActivities,
+                shouldEnableRichText,
+            ),
         });
     }
 }

--- a/src/api/ThreadedComments.js
+++ b/src/api/ThreadedComments.js
@@ -244,12 +244,14 @@ class ThreadedComments extends MarkerBasedApi {
         errorCallback,
         fileId,
         permissions,
+        shouldEnableRichText,
         successCallback,
     }: {
         commentId: string,
         errorCallback: (e: ElementsXhrError, code: string) => void,
         fileId: string,
         permissions: BoxItemPermission,
+        shouldEnableRichText?: boolean,
         successCallback: (comment: Comment) => void,
     }): void {
         this.errorCode = ERROR_CODE_FETCH_COMMENT;
@@ -265,6 +267,7 @@ class ThreadedComments extends MarkerBasedApi {
             errorCallback,
             successCallback,
             url: this.getUrlForId(commentId),
+            ...(shouldEnableRichText ? { requestData: { params: { enable_rich_text: true } } } : {}),
         });
     }
 
@@ -291,6 +294,7 @@ class ThreadedComments extends MarkerBasedApi {
         limit,
         shouldFetchAll,
         repliesCount,
+        shouldEnableRichText,
     }: {
         errorCallback: (e: ElementsXhrError, code: string) => void,
         fileId: string,
@@ -298,6 +302,7 @@ class ThreadedComments extends MarkerBasedApi {
         marker?: string,
         permissions: BoxItemPermission,
         repliesCount?: number,
+        shouldEnableRichText?: boolean,
         shouldFetchAll?: boolean,
         successCallback: (threadedComments: ThreadedCommentsType) => void,
     }): void {
@@ -317,6 +322,7 @@ class ThreadedComments extends MarkerBasedApi {
             limit,
             requestData: {
                 ...(repliesCount ? { replies_count: repliesCount } : null),
+                ...(shouldEnableRichText ? { enable_rich_text: true } : null),
             },
             shouldFetchAll,
         });
@@ -333,6 +339,7 @@ class ThreadedComments extends MarkerBasedApi {
         fileId,
         commentId,
         permissions,
+        shouldEnableRichText,
         successCallback,
         errorCallback,
     }: {
@@ -340,6 +347,7 @@ class ThreadedComments extends MarkerBasedApi {
         errorCallback: (e: ElementsXhrError, code: string) => void,
         fileId: string,
         permissions: BoxItemPermission,
+        shouldEnableRichText?: boolean,
         successCallback: (comments: ThreadedCommentsType) => void,
     }): void {
         this.errorCode = ERROR_CODE_FETCH_REPLIES;
@@ -356,6 +364,7 @@ class ThreadedComments extends MarkerBasedApi {
             errorCallback,
             successCallback,
             url: this.getUrlWithRepliesForId(commentId),
+            ...(shouldEnableRichText ? { requestData: { params: { enable_rich_text: true } } } : {}),
         });
     }
 

--- a/src/api/__tests__/Annotations.test.js
+++ b/src/api/__tests__/Annotations.test.js
@@ -293,6 +293,39 @@ describe('api/Annotations', () => {
             });
         });
 
+        test('should pass enable_rich_text when shouldEnableRichText is true', () => {
+            const permissions = {
+                can_create_annotations: true,
+                can_view_annotations: true,
+            };
+
+            annotations.getAnnotations(
+                '12345',
+                '67890',
+                permissions,
+                successCallback,
+                errorCallback,
+                100,
+                false,
+                true,
+                true,
+            );
+
+            expect(annotations.markerGet).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                successCallback: expect.any(Function),
+                limit: 100,
+                shouldFetchAll: false,
+                requestData: {
+                    file_id: '12345',
+                    file_version_id: '67890',
+                    fields: 'replies',
+                    enable_rich_text: true,
+                },
+            });
+        });
+
         test.each([
             { can_create_annotations: true, can_view_annotations: false },
             { can_create_annotations: false, can_view_annotations: false },

--- a/src/api/__tests__/Feed.test.js
+++ b/src/api/__tests__/Feed.test.js
@@ -529,7 +529,7 @@ describe('api/Feed', () => {
                     shouldShowAnnotations: true,
                     shouldShowReplies,
                 });
-                expect(feed.fetchAnnotations).toBeCalledWith(expect.anything(), expected);
+                expect(feed.fetchAnnotations).toBeCalledWith(expect.anything(), expected, false);
             },
         );
 
@@ -544,7 +544,7 @@ describe('api/Feed', () => {
         test('should use the threaded comments api if shouldShowReplies is true', done => {
             feed.feedItems(file, false, successCb, errorCb, errorCb, { shouldShowReplies: true });
             setImmediate(() => {
-                expect(feed.fetchThreadedComments).toBeCalledWith(file.permissions);
+                expect(feed.fetchThreadedComments).toBeCalledWith(file.permissions, false);
                 done();
             });
         });
@@ -631,6 +631,7 @@ describe('api/Feed', () => {
                     ],
                     true,
                     false,
+                    false,
                 );
                 expect(feed.fetchComments).not.toBeCalled();
                 expect(feed.fetchThreadedComments).not.toBeCalled();
@@ -665,6 +666,7 @@ describe('api/Feed', () => {
                     ],
                     true,
                     true,
+                    false,
                 );
                 done();
             });
@@ -695,6 +697,7 @@ describe('api/Feed', () => {
                 undefined,
                 undefined,
                 true,
+                false,
             );
         });
     });
@@ -736,6 +739,7 @@ describe('api/Feed', () => {
                 errorCallback,
                 fileId: file.id,
                 permissions: file.permissions,
+                shouldEnableRichText: false,
                 successCallback: boundFetchThreadedCommentSuccessCallback,
             });
             expect(feed.fetchThreadedCommentSuccessCallback.bind).toBeCalledWith(
@@ -773,6 +777,7 @@ describe('api/Feed', () => {
                 errorCallback: expect.any(Function),
                 fileId: feed.file.id,
                 permissions,
+                shouldEnableRichText: false,
                 successCallback: expect.any(Function),
             });
         });
@@ -802,6 +807,7 @@ describe('api/Feed', () => {
                 fileId: feed.file.id,
                 commentId,
                 permissions: feed.file.permissions,
+                shouldEnableRichText: false,
                 successCallback: expect.any(Function),
                 errorCallback: expect.any(Function),
             });
@@ -820,6 +826,7 @@ describe('api/Feed', () => {
                 feed.file.permissions,
                 expect.any(Function),
                 expect.any(Function),
+                false,
             );
             expect(feed.updateFeedItem).toHaveBeenNthCalledWith(1, { isRepliesLoading: true }, annotationId);
             expect(feed.updateFeedItem).toHaveBeenNthCalledWith(
@@ -912,6 +919,7 @@ describe('api/Feed', () => {
                     permissions,
                     shouldShowReplies: false,
                     shouldUseEnhancedActivities: false,
+                    shouldEnableRichText: false,
                     successCallback: expect.any(Function),
                 });
                 expect(fileActivityItems).resolves.toEqual({ entries: mockFileActivities });

--- a/src/api/__tests__/FileActivities.test.js
+++ b/src/api/__tests__/FileActivities.test.js
@@ -56,6 +56,12 @@ describe('api/FileActivities', () => {
                 'https://api.box.com/2.0/file_activities?file_id=1&activity_types=comment&enable_replies=true&reply_limit=1',
             );
         });
+
+        test('should append enable_rich_text=true when shouldEnableRichText is true', () => {
+            expect(fileActivities.getFilteredUrl('1', ['comment'], true, true, true)).toBe(
+                'https://api.box.com/2.0/file_activities?file_id=1&activity_types=comment&enable_replies=true&reply_limit=1000&enable_rich_text=true',
+            );
+        });
     });
 
     describe('getActivities()', () => {

--- a/src/api/__tests__/ThreadedComments.test.js
+++ b/src/api/__tests__/ThreadedComments.test.js
@@ -220,6 +220,32 @@ describe('api/ThreadedComments', () => {
             });
         });
 
+        test('should pass enable_rich_text when shouldEnableRichText is true', () => {
+            const permissions = {
+                can_comment: true,
+            };
+            const url = 'http://test-url.com';
+
+            threadedComments.getUrlForId = jest.fn().mockImplementationOnce(() => url);
+
+            threadedComments.getComment({
+                commentId: '123',
+                fileId: '12345',
+                permissions,
+                shouldEnableRichText: true,
+                successCallback,
+                errorCallback,
+            });
+
+            expect(threadedComments.get).toBeCalledWith({
+                id: '12345',
+                errorCallback,
+                successCallback,
+                url,
+                requestData: { params: { enable_rich_text: true } },
+            });
+        });
+
         test('should reject with an error code for calls with invalid permissions', () => {
             const permissions = {
                 can_comment: false,

--- a/src/elements/content-sidebar/ActivitySidebar.js
+++ b/src/elements/content-sidebar/ActivitySidebar.js
@@ -800,6 +800,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
         const shouldShowAppActivity = isFeatureEnabled(features, 'activityFeed.appActivity.enabled');
         const shouldShowAnnotations = isFeatureEnabled(features, 'activityFeed.annotations.enabled');
         const shouldUseUAA = isFeatureEnabled(features, 'activityFeed.uaaIntegration.enabled');
+        const shouldEnableRichText = isFeatureEnabled(features, 'activityFeed.richText.enabled');
 
         api.getFeedAPI(shouldDestroy).feedItems(
             file,
@@ -815,6 +816,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                 shouldShowVersions,
                 shouldUseEnhancedActivities: isThreadedRepliesV2Enabled,
                 shouldUseUAA,
+                shouldEnableRichText,
             },
         );
     }
@@ -904,7 +906,8 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
     });
 
     getFeedItemsWithReplies = (feedItems: FeedItems, id?: string, type?: CommentFeedItemType): Promise<FeedItems> => {
-        const { api, file } = this.props;
+        const { api, file, features } = this.props;
+        const shouldEnableRichText = isFeatureEnabled(features, 'activityFeed.richText.enabled');
 
         return new Promise((resolve, reject) => {
             if (!id || !type) {
@@ -932,6 +935,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                 error => {
                     reject(error);
                 },
+                shouldEnableRichText,
             );
         });
     };
@@ -1178,7 +1182,8 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
      * @return {Promise<{ id: string, type?: FocusableFeedItemType }>}
      */
     getActiveFeedEntryData = (feedItems: FeedItems): Promise<{ id?: string, type?: FeedItemType }> => {
-        const { activeFeedEntryId, activeFeedEntryType, api, file } = this.props;
+        const { activeFeedEntryId, activeFeedEntryType, api, file, features } = this.props;
+        const shouldEnableRichText = isFeatureEnabled(features, 'activityFeed.richText.enabled');
         return new Promise((resolve, reject) => {
             if (!activeFeedEntryId || !activeFeedEntryType || !this.isItemTypeFocusable(activeFeedEntryType)) {
                 resolve({});
@@ -1218,6 +1223,7 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
                         reject(error);
                     }
                 },
+                shouldEnableRichText,
             );
         });
     };
@@ -1241,9 +1247,17 @@ class ActivitySidebar extends React.PureComponent<Props, State> {
      * @return {void}
      */
     getReplies = (id: string, type: CommentFeedItemType): void => {
-        const { api, file } = this.props;
+        const { api, file, features } = this.props;
+        const shouldEnableRichText = isFeatureEnabled(features, 'activityFeed.richText.enabled');
 
-        api.getFeedAPI(false).fetchReplies(file, id, type, this.feedSuccessCallback, this.feedErrorCallback);
+        api.getFeedAPI(false).fetchReplies(
+            file,
+            id,
+            type,
+            this.feedSuccessCallback,
+            this.feedErrorCallback,
+            shouldEnableRichText,
+        );
 
         // need to load the pending item
         this.fetchFeedItems();

--- a/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
+++ b/src/elements/content-sidebar/__tests__/ActivitySidebar.test.js
@@ -805,6 +805,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                         shouldShowVersions: expectedVersions,
                         shouldUseEnhancedActivities: false,
                         shouldUseUAA: expectedUseUAA,
+                        shouldEnableRichText: false,
                     },
                 );
             },
@@ -839,6 +840,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                     shouldShowVersions: true,
                     shouldUseEnhancedActivities: false,
                     shouldUseUAA: false,
+                    shouldEnableRichText: false,
                 },
             );
         });
@@ -866,6 +868,31 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 instance.fetchFeedItemsErrorCallback,
                 instance.errorCallback,
                 expect.objectContaining({ shouldShowReplies: true, shouldUseEnhancedActivities: true }),
+            );
+        });
+
+        test('should set shouldEnableRichText when activityFeed.richText is enabled', () => {
+            wrapper = getWrapper({
+                features: {
+                    activityFeed: {
+                        richText: { enabled: true },
+                    },
+                },
+            });
+            instance = wrapper.instance();
+            instance.errorCallback = jest.fn();
+            instance.fetchFeedItemsErrorCallback = jest.fn();
+            instance.fetchFeedItemsSuccessCallback = jest.fn();
+
+            instance.fetchFeedItems();
+
+            expect(feedAPI.feedItems).toHaveBeenCalledWith(
+                file,
+                false,
+                instance.fetchFeedItemsSuccessCallback,
+                instance.fetchFeedItemsErrorCallback,
+                instance.errorCallback,
+                expect.objectContaining({ shouldEnableRichText: true }),
             );
         });
 
@@ -1052,6 +1079,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 type,
                 expect.any(Function),
                 expect.any(Function),
+                false,
             );
             expect(result).toMatchObject(expectedItems);
         });
@@ -1372,6 +1400,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 '123',
                 expect.any(Function),
                 expect.any(Function),
+                false,
             );
             expect(result).toMatchObject(expectedData);
         });
@@ -1477,6 +1506,7 @@ describe('elements/content-sidebar/ActivitySidebar', () => {
                 itemType,
                 expect.any(Function),
                 expect.any(Function),
+                false,
             );
             expect(instance.fetchFeedItems).toBeCalled();
         });


### PR DESCRIPTION
<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->

### Description

Activity Feed V2 GETs append `enable_rich_text=true` when `activityFeed.richText.enabled` is on, and omit the key when it is off. Optional last args on the GET helpers so existing callers default to omit. Create and update stay param-free.

Quirk: do not send `enable_rich_text=false`. Absent key is the unwrap path for flag-off and older clients.
