### PR TITLE
feat(content-preview): Add host-owned comparison banner slots

### DIFF
--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -137,11 +137,8 @@ type Props = {
     hasProviders?: boolean,
     hideSidebar?: boolean,
     isComparing?: boolean,
-    // Arbitrary host content rendered at the top of this pane, above the viewer.
-    // ContentPreview renders it verbatim; consumers own its markup and behavior.
     banner?: React.Node,
     comparedSlotRef?: (?HTMLDivElement) => mixed,
-    // Host content for the compared pane's banner; forwarded as that pane's `banner`.
     comparedBanner?: React.Node,
     comparedVersion?: BoxItemVersion,
     isLarge: boolean,

--- a/src/elements/content-preview/ContentPreview.js
+++ b/src/elements/content-preview/ContentPreview.js
@@ -137,7 +137,12 @@ type Props = {
     hasProviders?: boolean,
     hideSidebar?: boolean,
     isComparing?: boolean,
+    // Arbitrary host content rendered at the top of this pane, above the viewer.
+    // ContentPreview renders it verbatim; consumers own its markup and behavior.
+    banner?: React.Node,
     comparedSlotRef?: (?HTMLDivElement) => mixed,
+    // Host content for the compared pane's banner; forwarded as that pane's `banner`.
+    comparedBanner?: React.Node,
     comparedVersion?: BoxItemVersion,
     isLarge: boolean,
     isVeryLarge?: boolean,
@@ -1727,6 +1732,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
             hasHeader,
             hasProviders,
             hideSidebar,
+            banner,
             comparedSlotRef,
             isComparing,
             history,
@@ -1830,6 +1836,7 @@ class ContentPreview extends React.PureComponent<Props, State> {
                                         onMouseMove={this.onMouseMove}
                                         ref={this.containerRef}
                                     >
+                                        {banner && <div className="bcpr-banner">{banner}</div>}
                                         {file && (
                                             <Measure bounds onResize={this.onResize}>
                                                 {({ measureRef: previewRef }) => {
@@ -1932,7 +1939,7 @@ const ConnectedContentPreview = flow([
 const MemoConnectedContentPreview = React.memo(ConnectedContentPreview);
 
 function ContentPreviewWithComparison(props: ContentPreviewProps) {
-    const { comparedVersion, ...rest } = props;
+    const { comparedBanner, comparedVersion, ...rest } = props;
     const [comparedSlot, setComparedSlot] = React.useState<?HTMLDivElement>(null);
     const comparedVersionId = comparedVersion && comparedVersion.id;
     const isComparing = comparedVersionId != null && comparedVersionId !== '';
@@ -1953,6 +1960,7 @@ function ContentPreviewWithComparison(props: ContentPreviewProps) {
                           accessPattern={undefined}
                           advancedContentInsights={undefined}
                           autoFocus={false}
+                          banner={comparedBanner}
                           boxAnnotations={undefined}
                           collection={EMPTY_COLLECTION}
                           componentRef={undefined}

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -44,7 +44,7 @@
         .bp:not(.bp-dark),
         .bp-doc,
         .bp-document-preload-wrapper {
-            background-color: var(--bcpr-compared-pane-background, #f5f5f5);
+            background-color: var(--bcpr-compared-pane-background, transparent);
         }
     }
 

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -15,7 +15,7 @@
             min-width: 0;
 
             // Hosts set --bcpr-*-pane-background (e.g. preview-client).
-            // Do not paint over .bp-dark (video / 3D); those stay black.
+            // Do not paint over .bp-dark (video). 3D is .bp-box3d and gets the host fill.
             .bp:not(.bp-dark),
             .bp-doc,
             .bp-document-preload-wrapper {
@@ -140,6 +140,11 @@
         // the compared pane.
         .bcpr-body:not(.bcpr-body--comparing) .bcpr-container {
             position: static;
+        }
+
+        // Compared instance is not --comparing. Keep the banner's containing block.
+        .bcpr-body:not(.bcpr-body--comparing) .bcpr-container:has(.bcpr-banner) {
+            position: relative;
         }
 
         &.bcpr-thumbnails-open .bcpr-navigate-left {

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -19,7 +19,7 @@
             .bp:not(.bp-dark),
             .bp-doc,
             .bp-document-preload-wrapper {
-                background-color: var(--bcpr-current-pane-background, #f5f5f5);
+                background-color: var(--bcpr-current-pane-background);
             }
         }
     }
@@ -29,7 +29,7 @@
         flex: 1 1 50%;
         min-width: 0;
         min-height: 0;
-        background-color: var(--bcpr-compared-pane-background, transparent);
+        background-color: var(--bcpr-compared-pane-background);
 
         &:not(:empty) {
             display: flex;
@@ -44,7 +44,7 @@
         .bp:not(.bp-dark),
         .bp-doc,
         .bp-document-preload-wrapper {
-            background-color: var(--bcpr-compared-pane-background, transparent);
+            background-color: var(--bcpr-compared-pane-background);
         }
     }
 
@@ -64,10 +64,7 @@
         z-index: 1;
     }
 
-    // Overlay banners cover the top of the viewer. Hosts must set
-    // --bcpr-banner-height to the overlay height so the first page /
-    // thumbnail can sit below it. `.pdfViewer` is PDF.js; `.bp-vs-list`
-    // is box-content-preview's thumbnail VirtualScroller.
+    // Hosts set --bcpr-banner-height so the overlay does not cover the first page or thumbnail.
     .bcpr-container:has(.bcpr-banner) {
         .pdfViewer {
             padding-top: var(--bcpr-banner-height);

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -64,16 +64,17 @@
         z-index: 1;
     }
 
-    // Overlay banners cover the top of the viewer. Add scroll room so the first
-    // page / thumbnail can sit below the banner. `.pdfViewer` is PDF.js;
-    // `.bp-vs-list` is box-content-preview's thumbnail VirtualScroller.
+    // Overlay banners cover the top of the viewer. Hosts must set
+    // --bcpr-banner-height to the overlay height so the first page /
+    // thumbnail can sit below it. `.pdfViewer` is PDF.js; `.bp-vs-list`
+    // is box-content-preview's thumbnail VirtualScroller.
     .bcpr-container:has(.bcpr-banner) {
         .pdfViewer {
-            padding-top: 4.5rem;
+            padding-top: var(--bcpr-banner-height);
         }
 
         .bp-vs-list {
-            margin-top: 4.5rem;
+            margin-top: var(--bcpr-banner-height);
         }
     }
 

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -13,15 +13,6 @@
         &--comparing > .bcpr-container {
             flex: 1 1 50%;
             min-width: 0;
-
-            // Hosts set --bcpr-*-pane-background (e.g. preview-client).
-            // Unset vars keep BCP's .bp default (#f5f5f5). Skip .bp-dark (video).
-            // 3D is .bp-box3d and gets the host fill.
-            .bp:not(.bp-dark),
-            .bp-doc,
-            .bp-document-preload-wrapper {
-                background-color: var(--bcpr-current-pane-background, #f5f5f5);
-            }
         }
     }
 
@@ -30,7 +21,6 @@
         flex: 1 1 50%;
         min-width: 0;
         min-height: 0;
-        background-color: var(--bcpr-compared-pane-background, #f5f5f5);
 
         &:not(:empty) {
             display: flex;
@@ -41,20 +31,12 @@
             min-width: 0;
             min-height: 0;
         }
-
-        .bp:not(.bp-dark),
-        .bp-doc,
-        .bp-document-preload-wrapper {
-            background-color: var(--bcpr-compared-pane-background, #f5f5f5);
-        }
     }
 
     .bcpr-container {
         position: relative;
         display: flex;
         flex: 1;
-        flex-direction: column;
-        min-height: 0;
     }
 
     .bcpr-banner {
@@ -65,20 +47,8 @@
         z-index: 1;
     }
 
-    // Hosts set --bcpr-banner-height so the overlay does not cover the first page or thumbnail.
-    .bcpr-container:has(.bcpr-banner) {
-        .pdfViewer {
-            padding-top: var(--bcpr-banner-height);
-        }
-
-        .bp-vs-list {
-            margin-top: var(--bcpr-banner-height);
-        }
-    }
-
     .bcpr-content {
         flex: 1;
-        min-height: 0;
     }
 
     .bp-navigate {

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -13,6 +13,14 @@
         &--comparing > .bcpr-container {
             flex: 1 1 50%;
             min-width: 0;
+
+            // Hosts set --bcpr-*-pane-background (e.g. preview-client).
+            // Do not paint over .bp-dark (video / 3D); those stay black.
+            .bp:not(.bp-dark),
+            .bp-doc,
+            .bp-document-preload-wrapper {
+                background-color: var(--bcpr-current-pane-background, #f5f5f5);
+            }
         }
     }
 
@@ -21,6 +29,7 @@
         flex: 1 1 50%;
         min-width: 0;
         min-height: 0;
+        background-color: var(--bcpr-compared-pane-background, transparent);
 
         &:not(:empty) {
             display: flex;
@@ -31,16 +40,46 @@
             min-width: 0;
             min-height: 0;
         }
+
+        .bp:not(.bp-dark),
+        .bp-doc,
+        .bp-document-preload-wrapper {
+            background-color: var(--bcpr-compared-pane-background, #f5f5f5);
+        }
     }
 
     .bcpr-container {
         position: relative;
         display: flex;
         flex: 1;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    .bcpr-banner {
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        z-index: 1;
+    }
+
+    // Overlay banners cover the top of the viewer. Add scroll room so the first
+    // page / thumbnail can sit below the banner. `.pdfViewer` is PDF.js;
+    // `.bp-vs-list` is box-content-preview's thumbnail VirtualScroller.
+    .bcpr-container:has(.bcpr-banner) {
+        .pdfViewer {
+            padding-top: 4.5rem;
+        }
+
+        .bp-vs-list {
+            margin-top: 4.5rem;
+        }
     }
 
     .bcpr-content {
         flex: 1;
+        min-height: 0;
     }
 
     .bp-navigate {

--- a/src/elements/content-preview/ContentPreview.scss
+++ b/src/elements/content-preview/ContentPreview.scss
@@ -15,11 +15,12 @@
             min-width: 0;
 
             // Hosts set --bcpr-*-pane-background (e.g. preview-client).
-            // Do not paint over .bp-dark (video). 3D is .bp-box3d and gets the host fill.
+            // Unset vars keep BCP's .bp default (#f5f5f5). Skip .bp-dark (video).
+            // 3D is .bp-box3d and gets the host fill.
             .bp:not(.bp-dark),
             .bp-doc,
             .bp-document-preload-wrapper {
-                background-color: var(--bcpr-current-pane-background);
+                background-color: var(--bcpr-current-pane-background, #f5f5f5);
             }
         }
     }
@@ -29,7 +30,7 @@
         flex: 1 1 50%;
         min-width: 0;
         min-height: 0;
-        background-color: var(--bcpr-compared-pane-background);
+        background-color: var(--bcpr-compared-pane-background, #f5f5f5);
 
         &:not(:empty) {
             display: flex;
@@ -44,7 +45,7 @@
         .bp:not(.bp-dark),
         .bp-doc,
         .bp-document-preload-wrapper {
-            background-color: var(--bcpr-compared-pane-background);
+            background-color: var(--bcpr-compared-pane-background, #f5f5f5);
         }
     }
 

--- a/src/elements/content-preview/__tests__/ContentPreview.test.js
+++ b/src/elements/content-preview/__tests__/ContentPreview.test.js
@@ -2802,6 +2802,57 @@ describe('elements/content-preview/ContentPreview', () => {
             expect(bodyDiv.find('.bcpr-compared-slot').exists()).toBe(false);
         });
 
+        test('should render the banner above the viewer content when provided', () => {
+            const wrapper = getWrapper({
+                banner: <div className="test-banner">v12</div>,
+                fileId: '123',
+            });
+            wrapper.setState({
+                currentFileId: '123',
+                file: { id: '123', name: 'test.pdf' },
+            });
+
+            const container = wrapper.find('.bcpr-container');
+            const bannerDiv = container.children().at(0);
+            expect(bannerDiv.hasClass('bcpr-banner')).toBe(true);
+            expect(bannerDiv.find('.test-banner').exists()).toBe(true);
+        });
+
+        test('should not render a banner element when the banner prop is omitted', () => {
+            const wrapper = getWrapper({
+                fileId: '123',
+            });
+            wrapper.setState({
+                currentFileId: '123',
+                file: { id: '123', name: 'test.pdf' },
+            });
+
+            expect(wrapper.find('.bcpr-banner').exists()).toBe(false);
+        });
+
+        test('should forward comparedBanner as the compared instance banner only', () => {
+            const banner = <div className="main-banner" />;
+            const comparedBanner = <div className="compared-banner" />;
+            const wrapper = shallow(
+                <ContentPreviewWithComparison
+                    banner={banner}
+                    comparedBanner={comparedBanner}
+                    comparedVersion={{ id: '456' }}
+                    fileId="123"
+                    logger={{ onReadyMetric: jest.fn(), onPreviewMetric: jest.fn() }}
+                />,
+            );
+
+            wrapper.childAt(0).props().comparedSlotRef(document.createElement('div'));
+            wrapper.update();
+
+            const mainProps = wrapper.childAt(0).props();
+            const comparedProps = wrapper.childAt(1).props().children.props;
+            expect(mainProps.banner).toBe(banner);
+            expect(mainProps.comparedBanner).toBeUndefined();
+            expect(comparedProps.banner).toBe(comparedBanner);
+        });
+
         test('should not render PreviewNavigation when isComparing', () => {
             const wrapper = getWrapper({
                 fileId: '456',


### PR DESCRIPTION
## Summary

- Add `banner` and `comparedBanner` props and forward them to box-content-preview as `{ reactNode, height, background }`.
- ContentPreview does not render banner chrome or own pane/overlay CSS. BCP mounts `reactNode`, applies `height` as `--bp-banner-height` (PDF / thumbnail inset), and applies `background` on the pane (skipping `.bp-dark` / `.bp-box3d` / `.bp-media-mp3`).
- `comparedBanner` is forwarded as the compared instance `banner` only.

## Test Plan

- [ ] Open side-by-side version comparison for a document and confirm each pane shows the host banner without covering the first page or thumbnails after scroll.
- [ ] Compare a video or audio file and confirm the viewer stays on its dark stage.
- [ ] Omit `banner` / `comparedBanner` and confirm comparison still renders as before.
- [ ] `yarn test src/elements/content-preview/__tests__/ContentPreview.test.js`