### PR TITLE
fix(content-uploader): show locked file error in uploads manager

### DIFF
--- a/i18n/en-US.properties
+++ b/i18n/en-US.properties
@@ -1002,6 +1002,8 @@ be.uploadsFileSizeLimitExceededErrorMessageForUpgradeCta = This file exceeds you
 be.uploadsFileSizeLimitExceededUpgradeMessageForUpgradeCta = Upgrade
 # Error message shown when the user lacks permission to upload to the destination folder
 be.uploadsInsufficientPermissionsErrorMessage = You don't have permission to upload to this folder
+# Error message shown when attempting to upload a new version of a locked file
+be.uploadsItemLockedErrorMessage = File is locked
 # Error message shown when attempting to upload a file which name already exists
 be.uploadsItemNameInUseErrorMessage = A file with this name already exists.
 # Text shown when uploads are completed

--- a/src/constants.js
+++ b/src/constants.js
@@ -278,6 +278,7 @@ export const OVERLAY_WRAPPER_CLASS = 'overlay-wrapper';
 export const ERROR_CODE_ITEM_NAME_INVALID = 'item_name_invalid';
 export const ERROR_CODE_ITEM_NAME_TOO_LONG = 'item_name_too_long';
 export const ERROR_CODE_ITEM_NAME_IN_USE = 'item_name_in_use';
+export const ERROR_CODE_UPLOAD_ITEM_LOCKED = 'access_denied_item_locked';
 export const ERROR_CODE_UPLOAD_FILE_LIMIT = 'upload_file_limit';
 export const ERROR_CODE_UPLOAD_CHILD_FOLDER_FAILED = 'child_folder_failed_upload';
 export const ERROR_CODE_UPLOAD_INSUFFICIENT_PERMISSIONS = 'access_denied_insufficient_permissions';

--- a/src/elements/common/messages.js
+++ b/src/elements/common/messages.js
@@ -762,6 +762,11 @@ const messages = defineMessages({
         description: 'Error message shown when attempting to upload a file which name already exists',
         defaultMessage: 'A file with this name already exists.',
     },
+    uploadsItemLockedErrorMessage: {
+        id: 'be.uploadsItemLockedErrorMessage',
+        description: 'Error message shown when attempting to upload a new version of a locked file',
+        defaultMessage: 'File is locked',
+    },
     uploadsProvidedFolderNameInvalidMessage: {
         id: 'be.uploadsProvidedFolderNameInvalidMessage',
         description: 'Error message shown when pending folder upload contains invalid characters',

--- a/src/elements/content-uploader/utils/__tests__/getUploadErrorMessage.test.ts
+++ b/src/elements/content-uploader/utils/__tests__/getUploadErrorMessage.test.ts
@@ -7,6 +7,7 @@ import {
     ERROR_CODE_UPLOAD_FAILED_PACKAGE,
     ERROR_CODE_UPLOAD_FILE_SIZE_LIMIT_EXCEEDED,
     ERROR_CODE_UPLOAD_INSUFFICIENT_PERMISSIONS,
+    ERROR_CODE_UPLOAD_ITEM_LOCKED,
     ERROR_CODE_UPLOAD_PENDING_APP_FOLDER_SIZE_LIMIT,
     ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED,
 } from '../../../../constants';
@@ -47,6 +48,7 @@ describe('elements/content-uploader/utils/getUploadErrorMessage', () => {
                 'be.uploadsItemNameInUseErrorMessage',
                 'A file with this name already exists.',
             ],
+            [ERROR_CODE_UPLOAD_ITEM_LOCKED, 'be.uploadsItemLockedErrorMessage', 'File is locked'],
             [
                 ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED,
                 'be.uploadsStorageLimitErrorMessage',

--- a/src/elements/content-uploader/utils/getUploadErrorMessage.ts
+++ b/src/elements/content-uploader/utils/getUploadErrorMessage.ts
@@ -10,6 +10,7 @@ import {
     ERROR_CODE_UPLOAD_FAILED_PACKAGE,
     ERROR_CODE_UPLOAD_FILE_SIZE_LIMIT_EXCEEDED,
     ERROR_CODE_UPLOAD_INSUFFICIENT_PERMISSIONS,
+    ERROR_CODE_UPLOAD_ITEM_LOCKED,
     ERROR_CODE_UPLOAD_PENDING_APP_FOLDER_SIZE_LIMIT,
     ERROR_CODE_UPLOAD_STORAGE_LIMIT_EXCEEDED,
 } from '../../../constants';
@@ -55,6 +56,8 @@ export const getUploadErrorMessage = (
             };
         case ERROR_CODE_ITEM_NAME_IN_USE:
             return { descriptor: messages.uploadsItemNameInUseErrorMessage };
+        case ERROR_CODE_UPLOAD_ITEM_LOCKED:
+            return { descriptor: messages.uploadsItemLockedErrorMessage };
         case ERROR_CODE_ITEM_NAME_INVALID:
             return {
                 descriptor: messages.uploadsProvidedFolderNameInvalidMessage,


### PR DESCRIPTION
Uploading a new version of a locked file returned a 403 with code access_denied_item_locked, which had no dedicated copy and fell back to the generic upload failure message. Map it to "File is locked" so the row explains the cause. Both the legacy and modernized uploads manager read this mapping.

<!--
Please add the `ready-to-merge` label when the pull request has received the appropriate approvals.
Using the `ready-to-merge` label adds your approved pull request to the merge queue where it waits to be merged.
Mergify will merge your pull request based on the queue assuming your pull request is still in a green state after the previous merge.

What to do when the `ready-to-merge` label is not working:

- Do you have two approvals?
  - At least two approvals are required in order to merge to the master branch.
- Are there any reviewers that are still requested for review?
  - If the pull request has received the necessary approvals, remove any additional reviewer requests that are pending.
    - e.g.
      - Three reviewers added comments but you already have two necessary approvals and the third reviewer's comments are no longer applicable. You can remove the third person as a reviewer or have them approve the pull request.
      - A team was added as a reviewer because of a change to a file but the file change has been undone. At this point, it should be safe to remove the team as a reviewer.
- Are there other pull requests at the front of the merge queue?
  - Mergify handles the queueing, your pull request will eventually get merged.

When to contact someone for assistance when trying to merge via `ready-to-merge` label:

- There are no other pull requests in the merge queue and your pull request has been sitting there with the `ready-to-merge` label for longer than a couple of hours.
- If you are unable to remove unnecessary reviewers from the pull request.
- If you are unable to add the `ready-to-merge` label.
  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear “File is locked” message when uploading a new version of a locked file.
  * Improved handling of locked-file upload errors so they display the appropriate localized message across supported languages.
  * Users now receive more specific feedback when an upload is blocked because the file is locked.

* **Tests**
  * Added coverage to verify that locked-file errors map to the correct localized message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->